### PR TITLE
Fix realm swap PTR↔Live cascading session teardown

### DIFF
--- a/HermesProxy/Realm/RealmManager.cs
+++ b/HermesProxy/Realm/RealmManager.cs
@@ -264,12 +264,41 @@ public sealed class RealmManager
 
     public BattlenetRpcErrorCode JoinRealm(GlobalSessionData globalSession, uint realmAddress, uint build, IPAddress clientAddress, byte[] clientSecret, string accountName, Bgs.Protocol.GameUtilities.V1.ClientResponse response)
     {
+        // JimsProxy: realm-swap diagnostics. Snapshot the pre-swap state so the
+        // emitted event tells us (a) whether this is an actual swap or initial join,
+        // (b) whether the prior realm's WorldClient is still alive at swap time,
+        // and (c) what stale GameSessionData carries over (no reset happens here).
+        // hadPriorRealm is the right "is this a swap" signal — the old logic compared
+        // oldRealmId.Index against 0, but Index=0 is the Live realm, not "no realm".
+        // Using HadPlayerLogin OR a non-default RealmId would be cleaner; for now we
+        // gate on whether a WorldClient already exists, which only happens after the
+        // first realm has been picked.
+        var oldRealmId = globalSession.RealmId;
+        var oldGameState = globalSession.GameState;
+        bool hadWorldClient = globalSession.WorldClient != null;
+        bool hadPriorRealm = hadWorldClient;
+        bool worldClientWasConnected = globalSession.WorldClient?.IsConnected() ?? false;
+        bool worldClientWasAuthenticated = globalSession.WorldClient?.IsAuthenticated() ?? false;
+        bool authClientWasConnected = globalSession.AuthClient != null && globalSession.AuthClient.IsConnected();
+        string authKeyPrefix = SafeAuthKeyPrefixForRealm(globalSession.AuthClient);
+        string bnetKeyBefore = SafeKeyPrefix(globalSession.SessionKey);
+
         globalSession.RealmId = new RealmId(realmAddress);
         Realm? realm = GetRealm(globalSession.RealmId);
         if (realm != null)
         {
             if (realm.Flags.HasAnyFlag(RealmFlags.Offline) || realm.Build != build)
+            {
+                Framework.Logging.Log.Event("realm.swap.join_realm", new
+                {
+                    phase = "rejected_offline_or_build",
+                    new_realm_index = (uint)globalSession.RealmId.Index,
+                    realm_offline = realm.Flags.HasAnyFlag(RealmFlags.Offline),
+                    realm_build = realm.Build,
+                    client_build = build,
+                });
                 return BattlenetRpcErrorCode.UserServerNotPermittedOnRealm;
+            }
 
             RealmListServerIPAddresses serverAddresses = new RealmListServerIPAddresses();
             AddressFamily addressFamily = new AddressFamily();
@@ -290,6 +319,44 @@ public sealed class RealmManager
 
             globalSession.SessionKey = keyData;
 
+            // JimsProxy: emit AFTER setting the new BNet session key so we capture both
+            // the old and new prefixes. is_swap=true when old realm id != new id (a real
+            // PTR↔Live swap rather than initial join). gamestate.* fields surface stale
+            // state that JoinRealm intentionally does NOT reset today — useful for
+            // diagnosing carryover bugs (cached players from old realm, lingering auras,
+            // pending casts, etc.).
+            int pendingNormalCasts = oldGameState != null ? oldGameState.PendingNormalCasts.Count : 0;
+            int pendingPetCasts = oldGameState != null ? oldGameState.PendingPetCasts.Count : 0;
+            int cachedPlayers = oldGameState != null ? oldGameState.CachedPlayers.Count : 0;
+            int objectCacheLegacy = oldGameState != null ? oldGameState.ObjectCacheLegacy.Count : 0;
+            int objectCacheModern = oldGameState != null ? oldGameState.ObjectCacheModern.Count : 0;
+            uint? currentMapId = oldGameState?.CurrentMapId;
+            string playerGuid = oldGameState != null ? oldGameState.CurrentPlayerGuid.ToString() : "<null>";
+
+            Framework.Logging.Log.Event("realm.swap.join_realm", new
+            {
+                phase = "ok",
+                old_realm_index = (uint)oldRealmId.Index,
+                new_realm_index = (uint)globalSession.RealmId.Index,
+                new_realm_name = realm.Name,
+                is_swap = hadPriorRealm && oldRealmId.Index != globalSession.RealmId.Index,
+                is_reconnect = hadPriorRealm && oldRealmId.Index == globalSession.RealmId.Index,
+                had_world_client = hadWorldClient,
+                world_client_was_connected = worldClientWasConnected,
+                world_client_was_authenticated = worldClientWasAuthenticated,
+                auth_client_was_connected = authClientWasConnected,
+                auth_key_prefix = authKeyPrefix,
+                bnet_key_prefix_before = bnetKeyBefore,
+                bnet_key_prefix_after = SafeKeyPrefix(keyData),
+                gamestate_player_guid = playerGuid,
+                gamestate_current_map_id = currentMapId,
+                gamestate_cached_players = cachedPlayers,
+                gamestate_pending_normal_casts = pendingNormalCasts,
+                gamestate_pending_pet_casts = pendingPetCasts,
+                gamestate_object_cache_legacy = objectCacheLegacy,
+                gamestate_object_cache_modern = objectCacheModern,
+            });
+
             response.Attribute.AddBlob("Param_RealmJoinTicket", ByteString.CopyFrom(accountName, Encoding.UTF8));
             response.Attribute.AddBlob("Param_ServerAddresses", ByteString.CopyFrom(compressed));
             response.Attribute.AddBlob("Param_JoinSecret", ByteString.CopyFrom(serverSecret));
@@ -297,7 +364,36 @@ public sealed class RealmManager
             return BattlenetRpcErrorCode.Ok;
         }
 
+        Framework.Logging.Log.Event("realm.swap.join_realm", new
+        {
+            phase = "rejected_unknown_realm",
+            requested_realm_address = realmAddress,
+        });
         return BattlenetRpcErrorCode.UtilServerUnknownRealm;
+    }
+
+    // JimsProxy: 4-byte hex prefix of the SRP-derived auth-client session key.
+    // Mirrors the helper in WorldSocket.SessionHandler so realm.swap.* events
+    // produce comparable prefixes across the two emit sites.
+    private static string SafeAuthKeyPrefixForRealm(HermesProxy.Auth.AuthClient? authClient)
+    {
+        if (authClient == null) return "<null>";
+        try
+        {
+            var key = authClient.GetSessionKey();
+            return SafeKeyPrefix(key);
+        }
+        catch
+        {
+            return "<error>";
+        }
+    }
+
+    private static string SafeKeyPrefix(byte[]? key)
+    {
+        if (key == null || key.Length == 0) return "<empty>";
+        int n = Math.Min(4, key.Length);
+        return Convert.ToHexString(key, 0, n);
     }
 
     public ICollection<Realm> GetRealms() { return _realms.Values; }

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -228,7 +228,19 @@ public partial class WorldClient
         else
         {
             Disconnect();
-            GetSession().OnDisconnect();
+            // JimsProxy realm-swap fix: previously called GetSession().OnDisconnect()
+            // here, which tore down the entire BNet session including any newly-created
+            // WorldClient for a different realm during a swap. Now: only null our slot
+            // if it's still pointing at us (a fresh swap may have already replaced it
+            // with a new WorldClient — don't clobber that).
+            var session = GetSession();
+            if (session != null && ReferenceEquals(session.WorldClient, this))
+                session.WorldClient = null;
+            Log.Event("session.ondisconnect.suppressed", new
+            {
+                reason = "worldclient_legacy_disconnect",
+                disconnect_reason = reason,
+            });
         }
     }
 
@@ -281,7 +293,16 @@ public partial class WorldClient
             else
             {
                 Disconnect();
-                GetSession().OnDisconnect();
+                // JimsProxy realm-swap fix: see WorldClient.HandleDisconnect.
+                var session = GetSession();
+                if (session != null && ReferenceEquals(session.WorldClient, this))
+                    session.WorldClient = null;
+                Log.Event("session.ondisconnect.suppressed", new
+                {
+                    reason = "worldclient_receive_loop_exception",
+                    exception_type = e.GetType().Name,
+                    exception_message = e.Message,
+                });
             }
         }
     }

--- a/HermesProxy/World/Server/PacketHandlers/SessionHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SessionHandler.cs
@@ -24,14 +24,52 @@ public partial class WorldSocket
         ChangeRealmTicketResponse response = new();
         response.Token = request.Token;
 
-        if (!GetSession().AuthClient.IsConnected() && GetSession().AuthClient.Reconnect() != AuthResult.SUCCESS)
+        // JimsProxy: realm-swap diagnostics. CHANGE_REALM_TICKET is the modern client's
+        // signal that it intends to (re)select a realm — fires both on initial pick from
+        // the realm list and on any subsequent swap (e.g. PTR↔Live). The Reconnect()
+        // below only runs if AuthClient is currently disconnected; if it's still alive
+        // the ticket reuses the existing SRP-derived session key. The session key prefix
+        // before/after lets us see whether a fresh SRP key was actually derived, since
+        // the new realm will reject reuse of the prior realm's key.
+        bool authWasConnected = GetSession().AuthClient != null && GetSession().AuthClient.IsConnected();
+        string keyBefore = SafeAuthKeyPrefix(GetSession().AuthClient);
+        bool reconnectAttempted = false;
+        string? reconnectResult = null;
+
+        if (GetSession().AuthClient != null && !GetSession().AuthClient.IsConnected())
         {
-            Log.Print(LogType.Error, "Failed to reconnect to auth server.");
-            response.Allow = false;
-            SendPacket(response);
-            return;
+            reconnectAttempted = true;
+            var rc = GetSession().AuthClient.Reconnect();
+            reconnectResult = rc.ToString();
+            if (rc != AuthResult.SUCCESS)
+            {
+                Log.Event("realm.swap.change_ticket", new
+                {
+                    phase = "reconnect_failed",
+                    auth_was_connected = authWasConnected,
+                    reconnect_attempted = reconnectAttempted,
+                    reconnect_result = reconnectResult,
+                    auth_key_prefix_before = keyBefore,
+                });
+                Log.Print(LogType.Error, "Failed to reconnect to auth server.");
+                response.Allow = false;
+                SendPacket(response);
+                return;
+            }
         }
         // GetSession().AuthClient.SendRealmListUpdateRequest();
+
+        string keyAfter = SafeAuthKeyPrefix(GetSession().AuthClient);
+        Log.Event("realm.swap.change_ticket", new
+        {
+            phase = "ok",
+            auth_was_connected = authWasConnected,
+            reconnect_attempted = reconnectAttempted,
+            reconnect_result = reconnectResult,
+            auth_key_prefix_before = keyBefore,
+            auth_key_prefix_after = keyAfter,
+            auth_key_changed = keyBefore != keyAfter,
+        });
 
         _bnetRpc.SetClientSecret(request.Secret);
 
@@ -39,6 +77,25 @@ public partial class WorldSocket
         response.Ticket = new ByteBuffer(new byte[1]);
 
         SendPacket(response);
+    }
+
+    // JimsProxy: 4-byte hex prefix of the SRP-derived session key. Safe against null
+    // AuthClient and empty key arrays. Used by realm.swap.* events so we can correlate
+    // whether the key actually rotated between phases without leaking the full secret.
+    private static string SafeAuthKeyPrefix(HermesProxy.Auth.AuthClient? authClient)
+    {
+        if (authClient == null) return "<null>";
+        try
+        {
+            var key = authClient.GetSessionKey();
+            if (key == null || key.Length == 0) return "<empty>";
+            int n = Math.Min(4, key.Length);
+            return Convert.ToHexString(key, 0, n);
+        }
+        catch
+        {
+            return "<error>";
+        }
     }
 
     [PacketHandler(Opcode.CMSG_BATTLENET_REQUEST)]

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -447,11 +447,28 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             Log.PrintNet(LogType.Error, LogNetDir.P2C, $"Can't send {packet.GetUniversalOpcode()}, socket is closed!");
             if (GetSession() != null)
             {
-                if (GetSession().RealmSocket == this)
+                bool wasRealmSocket = GetSession().RealmSocket == this;
+                bool wasInstanceSocket = GetSession().InstanceSocket == this;
+                if (wasRealmSocket)
                     GetSession().RealmSocket = null!;
-                else if (GetSession().InstanceSocket == this)
+                else if (wasInstanceSocket)
                     GetSession().InstanceSocket = null!;
-                GetSession().OnDisconnect();
+                // JimsProxy realm-swap fix: previously GetSession().OnDisconnect() ran
+                // unconditionally here, tearing down AuthClient + WorldClient + GameState
+                // whenever ANY per-realm socket entered its send-on-closed path. The
+                // 2026-04-26 bundle showed this firing 153ms after the new realm's
+                // WorldClient came up during a PTR↔Live swap, killing the new connection
+                // mid-handshake. Per-realm-socket closure no longer cascades to global
+                // teardown; the BNet account session lives on so the swap can complete.
+                // Legitimate full-session teardown still runs from BnetSessionTicketStorage
+                // when the BNet TCP itself disconnects.
+                Log.Event("session.ondisconnect.suppressed", new
+                {
+                    reason = "worldsocket_send_on_closed",
+                    was_realm_socket = wasRealmSocket,
+                    was_instance_socket = wasInstanceSocket,
+                    packet = packet.GetUniversalOpcode().ToString(),
+                });
             }
             return;
         }
@@ -572,7 +589,14 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             SendAuthResponseError(BattlenetRpcErrorCode.BadVersion);
             Log.Print(LogType.Error, $"WorldSocket.HandleAuthSessionCallback: Missing auth seed for realm build {GetSession().Build} ({GetRemoteIpAddress()}).");
             CloseSocket();
-            GetSession().OnDisconnect();
+            // JimsProxy realm-swap fix: per-realm auth failure no longer tears down the
+            // BNet account session — modern client gets BadVersion and can pick a different
+            // realm without losing the BNet socket. See WorldSocket.SendPacket fix.
+            Log.Event("session.ondisconnect.suppressed", new
+            {
+                reason = "auth_session_missing_buildinfo",
+                realm_build = GetSession().Build,
+            });
             return;
         }
 
@@ -597,7 +621,12 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
         {
             Log.Print(LogType.Error, $"WorldSocket.HandleAuthSession: Unknown OS for account: {GetSession().GameAccountInfo.Id} ('{authSession.RealmJoinTicket}') address: {address}");
             CloseSocket();
-            GetSession().OnDisconnect();
+            // JimsProxy realm-swap fix: see WorldSocket.SendPacket fix.
+            Log.Event("session.ondisconnect.suppressed", new
+            {
+                reason = "auth_session_unknown_os",
+                reported_os = GetSession().OS,
+            });
             return;
         }
         
@@ -609,7 +638,11 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             {
                 Log.Print(LogType.Error, $"WorldSocket.HandleAuthSession: Authentication failed for account: {GetSession().GameAccountInfo.Id} ('{authSession.RealmJoinTicket}') address: {address}");
                 CloseSocket();
-                GetSession().OnDisconnect();
+                // JimsProxy realm-swap fix: see WorldSocket.SendPacket fix.
+                Log.Event("session.ondisconnect.suppressed", new
+                {
+                    reason = "auth_session_hmac_failed",
+                });
                 return;
             }
         }
@@ -639,6 +672,23 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
         Log.Print(LogType.Server, $"WorldSocket:HandleAuthSession: Client '{authSession.RealmJoinTicket}' authenticated successfully from {address}.");
 
         _realmId = new RealmId((byte)authSession.RegionID, (byte)authSession.BattlegroupID, authSession.RealmID);
+
+        // JimsProxy: realm-swap diagnostics. If a previous WorldClient is still attached
+        // to the session at this point, the proxy is creating a second one alongside it
+        // — the old one isn't disconnected anywhere on the swap path, so it lingers until
+        // GC or the legacy server times out. Surface this so the bundle shows whether
+        // orphan WorldClients are happening on real swaps.
+        var previousWorldClient = GetSession().WorldClient;
+        if (previousWorldClient != null)
+        {
+            Log.Event("realm.swap.worldclient_orphan", new
+            {
+                previous_was_connected = previousWorldClient.IsConnected(),
+                previous_was_authenticated = previousWorldClient.IsAuthenticated(),
+                new_realm_index = (uint)_realmId.Index,
+            });
+        }
+
         GetSession().WorldClient = new Client.WorldClient();
         if (!GetSession().WorldClient!.ConnectToWorldServer(GetSession().RealmManager.GetRealm(_realmId)!, GetSession()))
         {
@@ -646,7 +696,15 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             Log.Print(LogType.Error, "The WorldClient failed to connect to the selected world server!");
             Session.AccountMetaDataMgr.InvalidateLastSelectedCharacter();
             CloseSocket();
-            GetSession().OnDisconnect();
+            // JimsProxy realm-swap fix: dead WorldClient just got nulled in-place; don't
+            // tear down the rest of the BNet session. Modern client gets BadServer and
+            // can pick a different realm. See WorldSocket.SendPacket fix.
+            GetSession().WorldClient = null;
+            Log.Event("session.ondisconnect.suppressed", new
+            {
+                reason = "worldclient_connect_failed",
+                realm_index = (uint)_realmId.Index,
+            });
             return;
         }
 


### PR DESCRIPTION
Claude Code was able to finish this off correctly - FInal fix 




## Summary
  - Swapping between Kronos Live and PTR via the modern client's realm list required a full relog: the swap appeared to start, but ~150ms into the new realm's WorldClient handshake the proxy tore down the entire BNet session and the modern client hung until the user manually logged out and back in.
  - Root cause: seven separate call sites unconditionally called `GlobalSessionData.OnDisconnect()` on per-realm-socket failures, conflating per-realm-socket lifecycle with BNet account session lifecycle. When the OLD realm's `RealmSocket` entered its send-on-closed path during a swap, it fired the global teardown, which nulled the brand-new `WorldClient` that had just been created for the destination realm.
  - Fix: those seven sites now clean up only their own resource (close the socket, null the appropriate slot) and emit a structured `session.ondisconnect.suppressed` event. The legitimate full-session teardown still runs from `BnetSessionTicketStorage` when the BNet TCP itself disconnects.
  - Investigation methodology: shipped diagnostic events first (`realm.swap.change_ticket`, `realm.swap.join_realm`, `realm.swap.worldclient_orphan`), reproduced the swap, read the bundle, and let the data point to the actual root cause — which was not the SRP-key rotation hypothesis I started with.

  ## Root cause detail
  The pre-fix bundle showed:
  t=275735  realm.swap.join_realm        PTR→Live, fresh keys, world_client_authenticated=true
  t=275770  world.mangos.connect         New WorldClient connecting to Kronos Live :8087
  t=275923  session.disconnect           ← 153ms later. WIPES EVERYTHING.
                had_auth_client=true, had_world_client=true, had_realm_socket=true
  ... 5.5s of nothing — modern client hangs ...
  t=281744  auth.realmd.connect          User gives up, manually relogs
  The `had_world_client=true` on the teardown event proved it killed the
  new realm's connection mid-handshake.

  ## Sites neutralized
  | File:Line | Path | Old | New |
  |---|---|---|---|
  | `WorldSocket.cs:443` | `SendPacket` send-on-closed (the actual swap-killer) | nuke session | null
  per-realm slot only |
  | `WorldSocket.cs:572` | BadVersion auth fail | nuke session | close socket only |
  | `WorldSocket.cs:597` | Unknown OS auth fail | nuke session | close socket only |
  | `WorldSocket.cs:610` | HMAC mismatch | nuke session | close socket only |
  | `WorldSocket.cs:660` | WorldClient connect fail | nuke session | null `WorldClient` slot only |
  | `WorldClient.cs:221` | Legacy-server disconnect | nuke session | null slot **only if still us** |
  | `WorldClient.cs:285` | ReceiveLoop exception | nuke session | null slot **only if still us** |

  `ReferenceEquals(session.WorldClient, this)` guards in `WorldClient`
  prevent an old (dying) WorldClient from clobbering a freshly-created
  one during a swap race.

  ## Diagnostics added (kept in tree)
  Every step on the realm-swap path now emits a structured event:
  - `realm.swap.change_ticket` — auth state + SRP key prefix before/after `Reconnect()`, with `auth_key_changed` flag
  - `realm.swap.join_realm` — old/new realm IDs, `is_swap`/`is_reconnect` flags, key prefixes, snapshot of stale `GameSessionData` carryover
  - `realm.swap.worldclient_orphan` — fires only when a `WorldClient` already exists at the new-realm `HandleAuthSession` site
  - `session.ondisconnect.suppressed` — emitted at each of the 7 neutralized sites with the `reason` field, so future bundles immediately confirm the cascade is still suppressed

  ## Verification

  Two real PTR↔Live swaps in a single end-to-end session, no relog:

  | Signal | Pre-fix bundle | Post-fix bundle |
  |---|---|---|
  | `auth.realmd.connect` count (per session) | 2 (forced relog) | **1** |
  | `session.disconnect` events during swaps | 2 per swap | **0** |
  | `session.ondisconnect.suppressed` events | n/a | 3 (each one would have killed the swap) |
  | Successful Live↔PTR swaps end-to-end | **0** | **2 back-to-back** |
  | `auth_key_changed` per swap | true | true (unchanged — SRP rotation always worked) |

  t=309910  auth.realmd.connect              single login
  t=310548  realm.swap.join_realm             initial Kronos Live, is_swap=false
  t=314368  realm.swap.change_ticket          auth_key 363B75FB → 480EC67F
  t=316442  realm.swap.join_realm             Live → PTR, is_swap=true
  t=316603  session.ondisconnect.suppressed   worldclient_legacy_disconnect
  ... gameplay on PTR ...
  t=332535  realm.swap.change_ticket          auth_key 480EC67F → 22225EC4
  t=334331  realm.swap.join_realm             PTR → Live, is_swap=true
  t=334365  world.mangos.connect              Kronos Live ✓
  ... gameplay continues without relog ...

  ## Diagnostic bug also fixed
  The first-pass `is_swap` check in `RealmManager.JoinRealm` compared
  `oldRealmId.Index != 0`, which false-negatived when swapping FROM Live
  (index 0). Now keyed on `hadPriorRealm` (= whether a `WorldClient`
  already exists), with a sibling `is_reconnect` flag for same-realm
  rejoins.

  ## Known follow-up (not blocking)
  `gamestate_cached_players` shows 5–8 stale entries from the previous
  realm at swap time (no `GameState` reset on swap today). The swap
  works fine despite it, but a follow-up should call
  `GameSessionData.CreateNewGameSessionData(globalSession)` in
  `JoinRealm` when `is_swap=true` to drop carryover. Tracked separately.

  ## Test plan
  - [x] Build clean, no warnings
  - [x] Two real Live↔PTR swaps in one session, no manual relog
  - [x] `session.ondisconnect.suppressed` fires for each old-realm WorldClient close, **`session.disconnect` does not fire** during swaps
  - [x] `auth.realmd.connect` count = 1 across the whole session
  - [x] `is_swap` reads correctly on both swap directions
  - [ ] Confirm an actual full-session teardown (close the modern client, kill the BNet TCP) still emits the legitimate `session.disconnect` from `BnetSessionTicketStorage`