### PR TITLE
 Fix Redemption Headpiece not rendering on char-select screen

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -70,6 +70,16 @@ public partial class WorldClient
 
                 if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
                     char1.VisualItems[j].DisplayEnchantId = packet.ReadUInt32();
+
+                // JimsProxy: Kronos 1.12 ships some DisplayIDs that have no matching
+                // ItemAppearance row in modern reference data, which the 1.14 char-select
+                // renderer requires. Substitute via the override map so affected slots
+                // render. See GameData.KronosDisplayIdOverrides.
+                if (char1.VisualItems[j].DisplayId != 0 &&
+                    GameData.TryGetKronosDisplayIdOverride(char1.VisualItems[j].DisplayId, out uint overrideDisplayId))
+                {
+                    char1.VisualItems[j].DisplayId = overrideDisplayId;
+                }
             }
 
             int bagCount = LegacyVersion.AddedInVersion(ClientVersionBuild.V3_3_3_11685) ? 4 : 1;

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -182,6 +182,25 @@ public static partial class GameData
         return 0;
     }
 
+    // JimsProxy: Kronos 1.12 ships DisplayIDs for some items that have no matching
+    // ItemAppearance row in modern reference data. The 1.14 char-select renderer goes
+    // through ItemAppearance and silently drops the slot when resolution fails — visible
+    // as "helm not showing on the character login screen". This table maps Kronos's wire
+    // DisplayID to the modern reference DisplayID for the same item, so the
+    // SMSG_ENUM_CHARACTERS_RESULT handler can substitute before forwarding to the client.
+    // Promote to a CSV at HermesProxy/CSV/KronosDisplayIdOverrides{N}.csv if the list
+    // ever grows past a handful.
+    public static readonly FrozenDictionary<uint, uint> KronosDisplayIdOverrides =
+        new Dictionary<uint, uint>
+        {
+            { 35612, 36972 }, // Item 22428 "Redemption Headpiece" — paladin T2 helm
+        }.ToFrozenDictionary();
+
+    public static bool TryGetKronosDisplayIdOverride(uint kronosDisplayId, out uint modernDisplayId)
+    {
+        return KronosDisplayIdOverrides.TryGetValue(kronosDisplayId, out modernDisplayId);
+    }
+
     public static ItemAppearance? GetItemAppearanceByDisplayId(uint displayId)
     {
         foreach (var item in ItemAppearanceStore)


### PR DESCRIPTION
  ## Summary
  - The paladin Tier 3 helm (Redemption Headpiece, item 22428) didn't render on the modern client's character-select screen on Kronos 1.12. Helm slot showed empty hair; in-game rendering was unaffected (separately fixed by commit b1f07b0).
  - Root cause: Kronos ships DisplayID 35612 for item 22428, but only 36972 has a row in the modern client's ItemAppearance table. The 1.14 char-select renderer goes through ItemAppearance and silently drops the slot when resolution fails. The proxy was forwarding Kronos's wire DisplayID verbatim in SMSG_ENUM_CHARACTERS_RESULT.
  - Fix: a static `KronosDisplayIdOverrides` map in `GameData.cs` substitutes known-divergent Kronos DisplayIDs with their modern equivalents at char-enum time. Currently one entry: `35612 → 36972`.

  ## Diagnostics added (kept in tree)
  Two structured events on `SMSG_ENUM_CHARACTERS_RESULT`, fired per
  non-empty visible-item slot per character:

  - `char_enum.visual_item` — slot index, wire DisplayID + InvType, plus reverse-lookup signals: `display_id_resolves_in_modern`, `resolved_modern_item_id`, `modern_display_id_for_item`, `display_id_matches_modern`, `was_substituted`
  - `char_enum.visual_item.substituted` — fires only when the override map applies, so future bundles immediately confirm the fix is live

  `display_id_resolves_in_modern: false` is over-inclusive — it surfaces
  any DisplayID whose item ID can't be reverse-looked-up via the modern
  reference, including Vanilla starter gear that renders fine via
  ItemDisplayInfo/FileDataId without going through ItemAppearance. Use
  it as a candidate-surface signal, then visually verify before adding
  override entries.

  ## Verification
  Two char-enum cycles in a single session (2026-04-26 14:06 bundle):

  | Pre-fix bundle (14:01) | Post-fix bundle (14:06) |
  |---|---|
  | `display_id`: 35612 | `display_id`: **36972** |
  | `display_id_resolves_in_modern`: false | **true** |
  | `resolved_modern_item_id`: 0 | **22428** |
  | `display_id_matches_modern`: false | **true** |
  | `char_enum.visual_item.substituted` count | **2** (one per char-enum cycle) |
  | Helm rendering on char-select | ❌ empty | ✅ shows |

  Negative checks confirmed: across 8 characters and ~50 visible-item
  slots in the post-fix bundle, the override fired for exactly the
  expected slot (`Mirasu` head), no other slot's DisplayID was rewritten.
  Two unrelated unresolved DisplayIDs on `Dwarftest` (body 9972, legs
  9974) were verified to render correctly in-screen — confirming our
  substitution map is correctly scoped to the head-slot ItemAppearance
  failure mode and not spraying over benign reverse-lookup misses.

  ## Adding new entries
  Any future "X doesn't show on char-select" bug:
  1. Open the JSONL bundle, grep for the affected character's slot.
  2. If `display_id_resolves_in_modern: false`, that DisplayID is a candidate.
  3. Find the modern DisplayID for the item via `HermesProxy/CSV/ItemIdToDisplayId{1,2,3}.csv`.
  4. Add a one-line entry to `GameData.KronosDisplayIdOverrides`.

  Promote to a CSV (`HermesProxy/CSV/KronosDisplayIdOverrides{N}.csv`)
  if the list ever grows past a handful.

  ## Test plan
  - [x] Redemption Headpiece visible on char-select for `Mirasu`
  - [x] Substitution event fires once per char-enum cycle, only for Kronos DisplayID 35612
  - [x] All other characters' equipment unaffected
  - [x] `Dwarftest` starter gear (false-positive in diagnostic) renders correctly without an override — confirms scope is right
  - [x] Build clean, no warnings