### PR TITLE
Flying Mob Fix - FInal

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -139,6 +139,12 @@ public sealed class GameSessionData
     public HashSet<uint> RequestedItemHotfixes = [];
     public HashSet<uint> RequestedItemSparseHotfixes = [];
 
+    // Mobs we've seen send Flying spline or FixedZ movement flags. Vanilla servers
+    // don't populate UNIT_FIELD_HOVERHEIGHT consistently (Twinstar e.g. leaves it at 0),
+    // so we need a server-agnostic hover signal. Once a guid lands here, all subsequent
+    // packets for it get the hover override regardless of HOVERHEIGHT.
+    public HashSet<WowGuid128> KnownHoveringMobs = [];
+
     private GameSessionData()
     {
         

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -10,6 +10,34 @@ namespace HermesProxy.World.Client;
 
 public partial class WorldClient
 {
+    // Returns true if the mob should be treated as hovering. Detection is OR of:
+    //   - UNIT_FIELD_HOVERHEIGHT > 0 (works on cores that populate it)
+    //   - KnownHoveringMobs membership (seeded when we see Flying spline / FixedZ flag)
+    private bool IsHoveringMob(WowGuid128 guid)
+    {
+        if (GetSession().GameState.KnownHoveringMobs.Contains(guid))
+            return true;
+        return GetSession().GameState.GetLegacyFieldValueFloat(guid, UnitField.UNIT_FIELD_HOVERHEIGHT) > 0.0f;
+    }
+
+    // Strips Falling/FallingFar and forces DisableGravity on a hovering mob's movement
+    // flags. Call BEFORE casting WotLK flags to Modern. Vanilla servers don't have
+    // AnimTier/HoverHeight in their movement protocol, so hovering mobs bleed Falling
+    // into every heartbeat/spline-stop, causing the modern client to ground-snap and
+    // basketball-bounce them between flight legs.
+    private bool ApplyHoverOverrideIfNeeded(WowGuid128 guid, MovementInfo moveInfo)
+    {
+        if (!IsHoveringMob(guid))
+            return false;
+
+        moveInfo.Flags &= ~(uint)(MovementFlagWotLK.Falling | MovementFlagWotLK.FallingFar);
+        moveInfo.Flags |= (uint)MovementFlagWotLK.DisableGravity;
+        moveInfo.FallTime = 0;
+        moveInfo.JumpVerticalSpeed = 0.0f;
+        moveInfo.JumpHorizontalSpeed = 0.0f;
+        return true;
+    }
+
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.MSG_MOVE_START_FORWARD)]
     [PacketHandler(Opcode.MSG_MOVE_START_BACKWARD)]
@@ -53,6 +81,7 @@ public partial class WorldClient
         moveUpdate.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         moveUpdate.MoveInfo = new();
         moveUpdate.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
+        ApplyHoverOverrideIfNeeded(moveUpdate.MoverGUID, moveUpdate.MoveInfo);
         moveUpdate.MoveInfo.Flags = (uint)(((MovementFlagWotLK)moveUpdate.MoveInfo.Flags).CastFlags<MovementFlagModern>());
         moveUpdate.MoveInfo.ValidateMovementInfo();
         SendPacketToClient(moveUpdate);
@@ -308,6 +337,7 @@ public partial class WorldClient
         speed.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         speed.MoveInfo = new MovementInfo();
         speed.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
+        ApplyHoverOverrideIfNeeded(speed.MoverGUID, speed.MoveInfo);
         var newFlags = ((MovementFlagWotLK)speed.MoveInfo.Flags).CastFlags<MovementFlagModern>();
         speed.MoveInfo.Flags = (uint)(newFlags);
         speed.MoveInfo.ValidateMovementInfo();
@@ -436,6 +466,17 @@ public partial class WorldClient
             case SplineTypeLegacy.Stop:
             {
                 moveSpline.SplineType = SplineTypeModern.None;
+                // Hovering mobs: tell the client to settle in hover state on stop, otherwise
+                // it falls back to cached MovementInfo flags (which may still have Falling)
+                // and basketball-bounces between flight legs.
+                if (IsHoveringMob(guid))
+                {
+                    moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierHover;
+                    Framework.Logging.Log.Event("hover.spline_stop_override", new
+                    {
+                        guid = guid.ToString(),
+                    });
+                }
                 MonsterMove moveStop = new MonsterMove(guid, moveSpline);
                 SendPacketToClient(moveStop);
                 return;
@@ -454,6 +495,20 @@ public partial class WorldClient
             hasCatmullRom = splineFlags.HasAnyFlag(SplineFlagVanilla.Flying);
             hasTaxiFlightFlags = splineFlags == (SplineFlagVanilla.Runmode | SplineFlagVanilla.Flying);
 
+            // Seed hover detection: any vanilla spline with Flying flag means this is a
+            // hovering/flying mob. Mark it so all future packets (heartbeats, Stop, etc.)
+            // for this guid carry hover state, even if HOVERHEIGHT field is never set.
+            if (splineFlags.HasAnyFlag(SplineFlagVanilla.Flying) && guid != GetSession().GameState.CurrentPlayerGuid)
+            {
+                if (GetSession().GameState.KnownHoveringMobs.Add(guid))
+                {
+                    Framework.Logging.Log.Event("hover.detect_flying_spline", new
+                    {
+                        guid = guid.ToString(),
+                    });
+                }
+            }
+
             if (splineFlags == SplineFlagVanilla.Runmode) // Default spline flags used by Vanilla and TBC servers
             {
                 moveSpline.SplineFlags = SplineFlagModern.Unknown5;
@@ -467,12 +522,15 @@ public partial class WorldClient
             {
                 moveSpline.SplineFlags = splineFlags.CastFlags<SplineFlagModern>();
             }
-            // Hovering mobs: force native hover spline to prevent ground-bounce and barrel-roll
-            float hoverHeight = GetSession().GameState.GetLegacyFieldValueFloat(guid, UnitField.UNIT_FIELD_HOVERHEIGHT);
-            if (hoverHeight > 0.0f)
+            if (IsHoveringMob(guid))
             {
                 moveSpline.SplineFlags &= ~(SplineFlagModern.Unknown5 | SplineFlagModern.Falling | SplineFlagModern.FallingSlow | SplineFlagModern.SmoothGroundPath | SplineFlagModern.CatmullRom);
                 moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierHover;
+                Framework.Logging.Log.Event("hover.spline_override", new
+                {
+                    guid = guid.ToString(),
+                    spline_type = moveSpline.SplineType.ToString(),
+                });
             }
         }
         else if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V3_0_2_9056))

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -793,15 +793,21 @@ public partial class WorldClient
             moveInfo = new MovementInfo();
             moveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
 
-            // Hovering mobs: strip falling flag so client doesn't trigger landing/ground-snap
-            float hoverHeight = GetSession().GameState.GetLegacyFieldValueFloat(guid, UnitField.UNIT_FIELD_HOVERHEIGHT);
-            if (hoverHeight > 0.0f)
+            // Vanilla 1.12 carries hover state via MovementFlagVanilla.FixedZ. Seed our
+            // hover registry from it, since some 1.12 cores never populate UNIT_FIELD_HOVERHEIGHT.
+            if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180) && moveInfo.Hover &&
+                guid != GetSession().GameState.CurrentPlayerGuid)
             {
-                moveInfo.Flags &= ~0x00000800u;
-                moveInfo.FallTime = 0;
-                moveInfo.JumpVerticalSpeed = 0.0f;
-                moveInfo.JumpHorizontalSpeed = 0.0f;
+                if (GetSession().GameState.KnownHoveringMobs.Add(guid))
+                {
+                    Framework.Logging.Log.Event("hover.detect_fixedz_flag", new
+                    {
+                        guid = guid.ToString(),
+                    });
+                }
             }
+
+            ApplyHoverOverrideIfNeeded(guid, moveInfo);
 
             var moveFlags = moveInfo.Flags;
 
@@ -1816,31 +1822,26 @@ public partial class WorldClient
                     updateData.UnitData.ShapeshiftForm = (byte)((updates[UNIT_FIELD_BYTES_1].UInt32Value >> 16) & 0xFF);
                     updateData.UnitData.VisFlags = (byte)((updates[UNIT_FIELD_BYTES_1].UInt32Value >> 24) & 0xFF);
                 }
-                // --- Mirasu Native Hover DNA ---
+                // Hovering mobs need AnimTier=Hover(2) on the modern client, otherwise
+                // the unit's anim falls back to Ground when not actively splined and
+                // basketball-bounces between flight legs. Vanilla doesn't carry AnimTier
+                // in BYTES_1, so we synthesize it from either UNIT_FIELD_HOVERHEIGHT (when
+                // the core sets it) or the KnownHoveringMobs registry (seeded from
+                // SplineFlagVanilla.Flying / MovementFlagVanilla.FixedZ).
                 float hoverHeight = 0.0f;
                 int hoverField = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_HOVERHEIGHT);
-
                 if (hoverField >= 0 && updateMaskArray[hoverField])
-                {
                     hoverHeight = updates[hoverField].FloatValue;
-                }
                 else
-                {
                     hoverHeight = Session.GameState.GetLegacyFieldValueFloat(guid, UnitField.UNIT_FIELD_HOVERHEIGHT);
-                }
 
-                if (hoverHeight > 0.0f)
+                bool isHovering = hoverHeight > 0.0f || Session.GameState.KnownHoveringMobs.Contains(guid);
+                if (isHovering)
                 {
-                    // 1. REVERT TO HOVER (2)
                     updateData.UnitData.AnimTier = 2;
-
-                    // 2. KEEP THE HOVER HEIGHT!
-                    // This naturally lifts the collision box off the NavMesh, 
-                    // permanently killing the upward bouncing panic!
-                    updateData.UnitData.HoverHeight = hoverHeight;
+                    if (hoverHeight > 0.0f)
+                        updateData.UnitData.HoverHeight = hoverHeight;
                 }
-                // -------------------------------------
-
             }
             int UNIT_FIELD_PETNUMBER = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_PETNUMBER);
             if (UNIT_FIELD_PETNUMBER >= 0 && updateMaskArray[UNIT_FIELD_PETNUMBER])


### PR DESCRIPTION
Claude code was able to finish it perfectly.

The bug

  The previous hover fix (PR #49 / commit 4954ade) gated everything on UNIT_FIELD_HOVERHEIGHT > 0. That works
  on cores that populate the field, but Twinstar's 1.12.1 server leaves it at 0 for whelps, bats, dragonhawks,
   and other hovering mobs. PTR JSONL diagnosis confirmed the silent failure: 366 SMSG_ON_MONSTER_MOVE packets
   in a single Redridge session, zero hover-override events fired.

  Whelps would fly along their splines correctly, then "basketball-bounce" up and down between flight legs —
  the modern client receiving heartbeats and Stop packets with stale Falling flags, alternating between
  gravity-snapping the unit to the navmesh and catching up to its true airborne position on the next update.

  What was leaking

  Three packet paths bypassed the original fix even when HOVERHEIGHT was set:
  1. SplineTypeLegacy.Stop early-return — sent SplineFlags = None, letting the client fall back to cached Falling state
  2. HandleMovementMessages (MSG_MOVE_HEARTBEAT and 18 other movement opcodes) — never applied any hover correction
  3. HandleMoveUpdateSpeed — same

  Plus a real bug in the original strip mask: moveInfo.Flags &= ~0x00000800u was clearing
  MovementFlagWotLK.Root (0x800), not Falling — the magic number matched MovementFlagModern.Falling but the
  flags at that point were still in WotLK space.

  The fix

  Server-agnostic detection. New GameSessionData.KnownHoveringMobs (HashSet<WowGuid128>) seeded from two
  reliable signals:
  - SplineFlagVanilla.Flying on incoming SMSG_ON_MONSTER_MOVE (every flying mob hits this)
  - MovementFlagVanilla.FixedZ on MovementInfo blocks (already captured into MovementInfo.Hover, previously unused)

  Player guid is excluded from detection so taxi flights don't mark the player.

  Single source of truth. New IsHoveringMob(guid) helper OR's the registry against UNIT_FIELD_HOVERHEIGHT > 0,
   used at every override site.

  Shared override helper. ApplyHoverOverrideIfNeeded strips Falling/FallingFar (now using named WotLK enums,
  not the buggy magic number), forces MovementFlagWotLK.DisableGravity, and zeros
  FallTime/JumpVerticalSpeed/JumpHorizontalSpeed. Called from:
  - ReadMovementUpdateBlock (UPDATE_OBJECT Living block) — was already there but with the wrong flag
  - HandleMovementMessages — heartbeats, root/swim toggles, fall_land, hover toggles (new)
  - HandleMoveUpdateSpeed — server-broadcast speed changes carrying full MovementInfo (new)

  Stop branch fix. MonsterMove Stop packets now carry Flying | AnimTierHover spline flags for hovering mobs,
  so the client settles in hover state instead of inheriting cached Falling.

  AnimTier persistence. The UNIT_FIELD_BYTES_1 block now sets AnimTier=2 based on either HOVERHEIGHT > 0 or
  KnownHoveringMobs membership, so registry-detected mobs still get the correct anim tier on subsequent
  updates.

  Diagnostics

  Four new structured events for JSONL bundles:
  - hover.detect_flying_spline — first time we see a guid's flying spline
  - hover.detect_fixedz_flag — first time we see a guid's FixedZ movement flag
  - hover.spline_override — per spline that gets the override applied
  - hover.spline_stop_override — per Stop packet that gets hover flags

  Test plan

  - Builds clean (0 warnings, 0 errors)
  - Verified on PTR (Twinstar 1.12.1) — Redridge whelps no longer bounce between flight legs, no slowfall dip at end of flight paths
  - Verify no regression on Kronos (where HOVERHEIGHT is populated) — both detection paths should fire
  - Verify no regression on player taxi flights (player guid excluded from detection)

  Files changed

  - HermesProxy/GlobalSessionData.cs — KnownHoveringMobs registry
  - HermesProxy/World/Client/PacketHandlers/MovementHandler.cs — helpers, Stop branch, heartbeat/speed-update paths, spline detection seed
  - HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs — flag-mask bug fix, FixedZ detection seed, AnimTier registry check