### PR TITLE
Fix gold chat delay: synthesize loot notify before Kronos forward

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/LootHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LootHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Framework;
-using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -84,7 +83,6 @@ public partial class WorldClient
             loot.SoleLooter = packet.ReadBool();
         else
             loot.SoleLooter = true; //MIRASU - 1.12 only sends this packet to the looter; force bit so 1.14 client prints the chat line
-        Log.Print(LogType.Network, $"MIRASU LOOT_MONEY_NOTIFY got Money={loot.Money} SoleLooter={loot.SoleLooter}"); //MIRASU
         SendPacketToClient(loot);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/LootHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/LootHandler.cs
@@ -41,11 +41,9 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_LOOT_MONEY)]
     void HandleLootMoney(LootMoney loot)
     {
-        WorldPacket packet = new WorldPacket(Opcode.CMSG_LOOT_MONEY);
-        SendPacketToServer(packet);
-
-        //MIRASU - Kronos/TC-1.12 doesn't send SMSG_LOOT_MONEY_NOTIFY back; synthesize it so the 1.14 client prints the chat line.
-        //MIRASU   The 1.12 client didn't need this because it printed the line locally when sending CMSG_LOOT_MONEY.
+        //MIRASU - Synthesize SMSG_LOOT_MONEY_NOTIFY BEFORE forwarding to Kronos so the chat line isn't gated
+        //MIRASU   behind the synchronous encrypted write to the legacy server socket. Native 1.12 clients
+        //MIRASU   printed this line locally on CMSG send (zero latency); reordering here matches that timing.
         uint coins = GetSession().GameState.CurrentLootCoins;
         if (coins > 0 && !LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
         {
@@ -55,6 +53,9 @@ public partial class WorldSocket
             SendPacket(notify);
             GetSession().GameState.CurrentLootCoins = 0; //MIRASU - consume so we don't double-print if client sends CMSG_LOOT_MONEY again
         }
+
+        WorldPacket packet = new WorldPacket(Opcode.CMSG_LOOT_MONEY);
+        SendPacketToServer(packet);
     }
 
     [PacketHandler(Opcode.CMSG_SET_LOOT_METHOD)]


### PR DESCRIPTION
 The synthesized SMSG_LOOT_MONEY_NOTIFY in HandleLootMoney was sent
  AFTER forwarding CMSG_LOOT_MONEY to the legacy server. SendPacketToServer
  performs a synchronous, locked, encrypted write to the Kronos socket,
  which gated the chat line behind the full server-write latency.

  Reorder so the synthesized notify ships to the modern client first,
  then forward CMSG_LOOT_MONEY to Kronos. This matches native 1.12 client
  behavior, which printed the chat line locally on CMSG send (zero latency).

  JSONL diagnostics across 6 loot cycles confirmed:
  - synth fires same millisecond as CMSG arrival (0-1ms)
  - ~140ms ahead of Kronos's SMSG_LOOT_CLEAR_MONEY ack
  - Kronos never sends its own SMSG_LOOT_MONEY_NOTIFY (no double-print)

  Reported by testers on beta build after the loot-failure fix shipped.

