### PR TITLE
 Fix over-head quest progress toast: track item count proxy-side

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -58,27 +58,40 @@ public partial class WorldClient
             item.QuantityInInventory = packet.ReadUInt32();
         else
         {
-            uint currentCount = 0;
+            //MIRASU - Vanilla legacy SMSG_ITEM_PUSH_RESULT doesn't carry running QuantityInInventory.
+            //MIRASU   Original code read the count from the player's PLAYER_QUEST_LOG_x_3 cache, but
+            //MIRASU   Kronos never refreshes that field on item pickups -- so QuantityInInventory was
+            //MIRASU   always equal to the per-pickup delta (1), and the modern over-head quest toast
+            //MIRASU   rendered "Item: 1/N" forever. Prefer the proxy's QuestItemObjectiveProgress
+            //MIRASU   running total (kept in sync by HandleQuestUpdateAddItem, which fires before
+            //MIRASU   SMSG_ITEM_PUSH_RESULT in Kronos's pickup burst). Fall back to legacy cache +
+            //MIRASU   delta when the running total hasn't been populated yet (e.g. first pickup of
+            //MIRASU   a quest whose template wasn't cached).
+            uint quantityInInventory = item.Quantity;
             QuestObjective? objective = GameData.GetQuestObjectiveForItem(item.Item.ItemID);
             if (objective != null)
             {
-                var updateFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
-                int questsCount = LegacyVersion.GetQuestLogSize();
-                for (int i = 0; i < questsCount; i++)
+                var key = (objective.QuestID, objective.StorageIndex);
+                if (GetSession().GameState.QuestItemObjectiveProgress.TryGetValue(key, out uint runningTotal))
                 {
-                    QuestLog? logEntry = ReadQuestLogEntry(i, null, updateFields!);
-                    if (logEntry == null || logEntry.QuestID == null)
-                        continue;
-                    if (logEntry.QuestID != objective.QuestID)
-                        continue;
-                    if (logEntry.ObjectiveProgress[objective.StorageIndex] == null)
-                        continue;
-
-                    currentCount = (uint)logEntry.ObjectiveProgress[objective.StorageIndex]!;
-                    break;
+                    quantityInInventory = runningTotal;
+                }
+                else
+                {
+                    var updateFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
+                    int questsCount = LegacyVersion.GetQuestLogSize();
+                    for (int i = 0; i < questsCount; i++)
+                    {
+                        QuestLog? logEntry = ReadQuestLogEntry(i, null, updateFields!);
+                        if (logEntry == null || logEntry.QuestID != objective.QuestID)
+                            continue;
+                        if (logEntry.ObjectiveProgress[objective.StorageIndex] != null)
+                            quantityInInventory = item.Quantity + (uint)logEntry.ObjectiveProgress[objective.StorageIndex]!;
+                        break;
+                    }
                 }
             }
-            item.QuantityInInventory = item.Quantity + currentCount;
+            item.QuantityInInventory = quantityInInventory;
         }
 
         if (item.Slot == Enums.Classic.InventorySlots.Bag0 && item.SlotInBag >= 0 &&

--- a/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
@@ -1,10 +1,10 @@
 ﻿using Framework;
-using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
+using System.Linq;
 
 namespace HermesProxy.World.Client;
 
@@ -393,6 +393,14 @@ public partial class WorldClient
         QuestUpdateStatus quest = new QuestUpdateStatus(packet.GetUniversalOpcode(false));
         quest.QuestID = packet.ReadUInt32();
         SendPacketToClient(quest);
+
+        //MIRASU - clear our per-objective running totals for this quest so a future re-accept
+        //MIRASU   (or a parallel quest sharing the same item) starts fresh instead of inheriting
+        //MIRASU   stale counts. Applies to COMPLETE / FAILED / FAILED_TIMER -- in all three cases
+        //MIRASU   the quest is leaving the active log and any running total is no longer valid.
+        var progressMap = GetSession().GameState.QuestItemObjectiveProgress;
+        foreach (var k in progressMap.Keys.Where(k => k.QuestID == quest.QuestID).ToList())
+            progressMap.Remove(k);
     }
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_ADD_ITEM)]
     void HandleQuestUpdateAddItem(WorldPacket packet)
@@ -401,7 +409,6 @@ public partial class WorldClient
         uint count = packet.ReadUInt32(); //MIRASU - delta, not total
 
         QuestObjective? objective = GameData.GetQuestObjectiveForItem(itemId);
-        
 
         if (objective == null)
         {
@@ -426,17 +433,43 @@ public partial class WorldClient
 
         //MIRASU - track running total ourselves; legacy update-field cache isn't refreshed on partial updates
         var key = (objective.QuestID, objective.StorageIndex);
-        GetSession().GameState.QuestItemObjectiveProgress.TryGetValue(key, out uint stored);
+        if (!GetSession().GameState.QuestItemObjectiveProgress.TryGetValue(key, out uint stored))
+        {
+            //MIRASU - first time we see this objective: seed from the legacy quest log cache.
+            //MIRASU   The cache holds the accept-time progress (e.g. 3/10 if the player logged in
+            //MIRASU   mid-quest); without seeding, the running total starts at 0 and the toast
+            //MIRASU   would render "1/10" instead of "4/10" on the next pickup.
+            var updateFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
+            if (updateFields != null)
+            {
+                int questsCount = LegacyVersion.GetQuestLogSize();
+                for (int i = 0; i < questsCount; i++)
+                {
+                    QuestLog? logEntry = ReadQuestLogEntry(i, null, updateFields);
+                    if (logEntry == null || logEntry.QuestID != objective.QuestID)
+                        continue;
+                    if (logEntry.ObjectiveProgress[objective.StorageIndex] != null)
+                        stored = (uint)logEntry.ObjectiveProgress[objective.StorageIndex]!;
+                    break;
+                }
+            }
+        }
         uint runningTotal = stored + count;
         if (runningTotal > (uint)objective.Amount)
             runningTotal = (uint)objective.Amount;
         GetSession().GameState.QuestItemObjectiveProgress[key] = runningTotal;
-        
-        //MIRASU - use SIMPLE variant for item objectives; modern client auto-reads count from bags
-        QuestUpdateAddCreditSimple credit = new QuestUpdateAddCreditSimple();
+
+        //MIRASU - send full QuestUpdateAddCredit (not SIMPLE) so the over-head toast has explicit
+        //MIRASU   Count/Required values. SIMPLE makes the modern client read from the legacy
+        //MIRASU   UNIT_FIELD_QUEST_LOG_x cache, which Kronos doesn't refresh on partial item-pickup
+        //MIRASU   updates -- so the toast froze at whatever the cache held on quest accept (1/10).
+        QuestUpdateAddCredit credit = new QuestUpdateAddCredit();
         credit.QuestID = objective.QuestID;
         credit.ObjectID = (int)itemId;
         credit.ObjectiveType = QuestObjectiveType.Item;
+        credit.Count = (ushort)runningTotal;
+        credit.Required = (ushort)objective.Amount;
+        credit.VictimGUID = default; //MIRASU - no victim for item pickups; modern client ignores VictimGUID for Item objectives
         SendPacketToClient(credit);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
@@ -6,6 +6,7 @@ using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HermesProxy.World.Server;
 
@@ -38,6 +39,25 @@ public partial class WorldSocket
         WorldPacket packet = new WorldPacket(Opcode.CMSG_QUEST_LOG_REMOVE_QUEST);
         packet.WriteUInt8(quest.Slot);
         SendPacketToServer(packet);
+
+        //MIRASU - clear running-total entries for the quest in this slot so a future re-accept of
+        //MIRASU   the same quest doesn't inherit stale progress (toast was reading 7/10 on first
+        //MIRASU   pickup of a freshly-accepted quest because the prior abandon left running totals
+        //MIRASU   in QuestItemObjectiveProgress). Slot index matches the legacy quest log slot.
+        var worldClient = GetSession().WorldClient;
+        if (worldClient == null)
+            return;
+        var updateFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
+        if (updateFields == null)
+            return;
+        var logEntry = worldClient.ReadQuestLogEntry(quest.Slot, null, updateFields);
+        if (logEntry?.QuestID == null)
+            return;
+
+        uint questId = (uint)logEntry.QuestID;
+        var progressMap = GetSession().GameState.QuestItemObjectiveProgress;
+        foreach (var k in progressMap.Keys.Where(k => k.QuestID == questId).ToList())
+            progressMap.Remove(k);
     }
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_STATUS_QUERY)]
     void HandleQuestGiverStatusQuery(QuestGiverStatusQuery query)


### PR DESCRIPTION
The over-head "Item: X/N" banner was stuck at "1/N" on every pickup
  because Kronos never refreshes PLAYER_QUEST_LOG_x_3 on partial item
  pickups. Two consumers were reading from that stale cache:

    - HandleItemPushResult computed QuantityInInventory = item.Quantity
      + cachedField, which always evaluated to (1 + 0) = 1.
    - HandleQuestUpdateAddItem emitted the SIMPLE credit variant, which asks the modern client to re-read from the same dead field.

  Switch to the full SMSG_QUEST_UPDATE_ADD_CREDIT with explicit
  Count/Required, and source QuantityInInventory from the proxy's own
  QuestItemObjectiveProgress running total (kept in sync per pickup).

  Lifecycle fixes so the running total stays accurate across sessions:
    - Seed from the legacy quest log cache on first credit per objective, so logging in mid-quest at 3/10 progresses to 4/10 (was 1/10).
    - Clear running totals on CMSG_QUEST_LOG_REMOVE_QUEST (abandon) so re-accepting the same quest doesn't inherit stale counts (was showing 7/10 on the first pickup of a fresh accept).
    - Clear running totals on SMSG_QUEST_UPDATE_COMPLETE / _FAILED / _FAILED_TIMER so turn-in / failure paths reset the same way.

  Verified across fresh-accept, mid-quest-login, abandon-and-reaccept,
  and turn-in scenarios via JSONL diagnostic capture (since stripped).