### PR TITLE
More interrupt fixes

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -439,6 +439,7 @@ public partial class WorldClient
         uint spellVisual;
         bool dequeued = false;
         bool wasStarted = false;
+        bool foundActiveCastId = false;
         if (GetSession().GameState.CurrentPlayerGuid == casterUnit &&
             GetSession().GameState.TryDequeuePendingNormalCast(spellId, out var pendingNormal))
         {
@@ -480,7 +481,20 @@ public partial class WorldClient
         }
         else
         {
-            castId = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, spellId, spellId + casterUnit.GetCounter());
+            //MIRASU - Non-local caster (enemy player in PvP, or any third-party unit). Vanilla
+            //MIRASU   1.12 broadcasts SMSG_SPELL_FAILURE to ALL nearby observers via
+            //MIRASU   SendMessageToSet(true), not just the caster. So when you Counterspell/Kick
+            //MIRASU   an enemy player, this handler runs for THEIR cast. Pull the unique CastID
+            //MIRASU   minted at SPELL_START from OtherCasterActiveCastIds so the dismiss
+            //MIRASU   references the same in-flight cast the modern client is tracking;
+            //MIRASU   otherwise the deterministic seed mismatches and the target-frame cast bar
+            //MIRASU   keeps filling until movement triggers a separate dismiss path.
+            var activeKey = (casterUnit, spellId);
+            foundActiveCastId = GetSession().GameState.OtherCasterActiveCastIds.TryRemove(activeKey, out var trackedCastId);
+            if (foundActiveCastId)
+                castId = trackedCastId;
+            else
+                castId = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, spellId, spellId + casterUnit.GetCounter());
             spellVisual = GameData.GetSpellVisual(spellId);
         }
 
@@ -492,6 +506,38 @@ public partial class WorldClient
         spell.Reason = reason;
         SendPacketToClient(spell);
 
+        //MIRASU - Mirror the FAILED_OTHER interrupt synthesis for the broadcasted FAILURE path.
+        //MIRASU   PvP scenario: you Counterspell an enemy player -> Kronos broadcasts
+        //MIRASU   SMSG_SPELL_FAILURE for the victim to nearby observers. Without these synthesized
+        //MIRASU   modern packets the 1.14 target-frame cast bar doesn't dismiss until movement.
+        //MIRASU   Gate on foundActiveCastId so we don't double-fire if FAILED_OTHER already
+        //MIRASU   consumed the entry and synthesized the same packets.
+        bool casterIsPlayer = GetSession().GameState.CurrentPlayerGuid == casterUnit;
+        bool casterIsPet = GetSession().GameState.CurrentPetGuid == casterUnit;
+        bool sentInterruptLog = false;
+        bool sentCancelVisual = false;
+        uint resolvedSpellVisualId = 0;
+        if (reason == 61 /* Interrupted */ && foundActiveCastId && !casterIsPlayer && !casterIsPet)
+        {
+            SpellInterruptLog interruptLog = new SpellInterruptLog();
+            interruptLog.Caster = GetSession().GameState.CurrentPlayerGuid;
+            interruptLog.Victim = casterUnit;
+            interruptLog.InterruptedSpellID = (int)spellId;
+            interruptLog.BackfireSpellID = (int)spellId;
+            SendPacketToClient(interruptLog);
+            sentInterruptLog = true;
+
+            resolvedSpellVisualId = GameData.GetSpellVisualIdFromXSpellVisual(spellVisual);
+            if (resolvedSpellVisualId != 0)
+            {
+                CancelSpellVisual cancelVisual = new CancelSpellVisual();
+                cancelVisual.Source = casterUnit;
+                cancelVisual.SpellVisualID = (int)resolvedSpellVisualId;
+                SendPacketToClient(cancelVisual);
+                sentCancelVisual = true;
+            }
+        }
+
         Log.Event("spell.failure.routed", new
         {
             spellId,
@@ -500,6 +546,10 @@ public partial class WorldClient
             isPetCaster = GetSession().GameState.CurrentPetGuid == casterUnit,
             dequeued,
             wasStarted,
+            foundActiveCastId,
+            sentInterruptLog,
+            sentCancelVisual,
+            resolvedSpellVisualId,
         });
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -695,6 +695,13 @@ public partial class WorldClient
             }
         }
 
+        // Vanilla 1.12 doesn't include SpellCastLogData in SMSG_SPELL_GO, but the
+        // modern 1.14 client needs it present to populate CLEU spell IDs. Without it,
+        // CombatLogGetCurrentEventInfo() returns spellId=0 for non-self spells, breaking
+        // every addon that reads CLEU spell IDs (damage meters, cast bars, WeakAuras).
+        if (spell.LogData == null)
+            spell.LogData = new SpellCastLogData();
+
         SendPacketToClient(spell);
     }
 
@@ -1066,6 +1073,78 @@ public partial class WorldClient
         }
 
         SendPacketToClient(spell);
+    }
+
+    [PacketHandler(Opcode.SMSG_SPELL_EXECUTE_LOG)]
+    void HandleSpellExecuteLog(WorldPacket packet)
+    {
+        var casterGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+        uint spellId = packet.ReadUInt32();
+        uint effectCount = packet.ReadUInt32();
+
+        Log.Print(LogType.Server, $"SpellExecuteLog: caster={casterGuid} spell={spellId} effects={effectCount}");
+
+        for (uint i = 0; i < effectCount; i++)
+        {
+            uint effectType = packet.ReadUInt32();
+            uint targetCount = packet.ReadUInt32();
+
+            Log.Print(LogType.Server, $"  Effect[{i}]: type={effectType} targets={targetCount}");
+
+            for (uint t = 0; t < targetCount; t++)
+            {
+                switch (effectType)
+                {
+                    case 8: // POWER_DRAIN
+                        var pdGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                        uint pdAmount = packet.ReadUInt32();
+                        uint pdPowerType = packet.ReadUInt32();
+                        float pdMultiplier = packet.ReadFloat();
+                        Log.Print(LogType.Server, $"PowerDrain: target={pdGuid} amount={pdAmount} power={pdPowerType}");
+                        break;
+                    case 10: // HEAL
+                        var hGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                        uint hAmount = packet.ReadUInt32();
+                        uint hCrit = packet.ReadUInt32();
+                        Log.Print(LogType.Server, $"Heal: target={hGuid} amount={hAmount} crit={hCrit}");
+                        break;
+                    case 30: // ENERGIZE
+                        var eGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                        uint eAmount = packet.ReadUInt32();
+                        uint ePowerType = packet.ReadUInt32();
+                        Log.Print(LogType.Server, $"Energize: target={eGuid} amount={eAmount} power={ePowerType}");
+                        break;
+                    case 32: // EXTRA_ATTACKS (vanilla value 32)
+                        var eaGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                        uint eaCount = packet.ReadUInt32();
+                        Log.Print(LogType.Server, $"ExtraAttacks: target={eaGuid} count={eaCount}");
+                        break;
+                    case 24: // CREATE_ITEM
+                        uint ciItemId = packet.ReadUInt32();
+                        Log.Print(LogType.Server, $"CreateItem: item={ciItemId}");
+                        break;
+                    case 41: // INTERRUPT_CAST
+                        var icGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                        uint icSpellId = packet.ReadUInt32();
+                        Log.Print(LogType.Server, $"InterruptCast: target={icGuid} spell={icSpellId}");
+                        break;
+                    case 101: // FEED_PET
+                        uint fpItemId = packet.ReadUInt32();
+                        Log.Print(LogType.Server, $"FeedPet: item={fpItemId}");
+                        break;
+                    case 113: // DURABILITY_DAMAGE
+                        var ddGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                        uint ddItemId = packet.ReadUInt32();
+                        uint ddAmount = packet.ReadUInt32();
+                        Log.Print(LogType.Server, $"DurabilityDmg: target={ddGuid} item={ddItemId} amount={ddAmount}");
+                        break;
+                    default: // INSTAKILL, RESURRECT, DISPEL, SUMMON, etc — just a GUID
+                        var defaultGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                        Log.Print(LogType.Server, $"Default(type={effectType}): target={defaultGuid}");
+                        break;
+                }
+            }
+        }
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_HEAL_LOG)]


### PR DESCRIPTION
## Summary

  Follow-up to #65 (mob cast-bar dismiss). The same fix doesn't cover PvP:
  when you Counterspell/Kick an enemy player, their cast bar keeps filling
  on the target frame until the enemy moves, at which point an unrelated
  movement-driven dismiss path catches it.

  ## Root cause

  Last night's fix synthesized `SMSG_SPELL_INTERRUPT_LOG` +
  `SMSG_CANCEL_SPELL_VISUAL` only inside `HandleSpellFailedOther`. PvP
  interrupts arrive on a different opcode.

  In MaNGOS-style 1.12 servers (Kronos), `Spell::SendInterrupted` broadcasts
  `SMSG_SPELL_FAILURE` to all nearby observers via `SendMessageToSet(true)`,
  not just the caster. So when an enemy player gets interrupted, the proxy
  receives `SMSG_SPELL_FAILURE` for THEIR cast, runs `HandleSpellFailure`,
  and falls into the `else` branch (caster isn't our player or our pet).

  Two bugs in that branch:

  1. It minted a deterministic CastID (`spellId + casterCounter`) instead
     of recalling the unique CastID stored at SPELL_START in
     `OtherCasterActiveCastIds`. The `SpellFailure` packet's CastID
     therefore didn't match the cast bar the modern client was tracking,
     so the bar didn't reset.

  2. It never synthesized the modern interrupt packets
     (`SpellInterruptLog`, `CancelSpellVisual`) — those were only emitted
     from the FAILED_OTHER handler. So neither dismiss path fired.

  Result: cast bar fills visually until the next movement update on the
  enemy unit hits the modern client's movement-cancel path.

  ## Fix

  In `HandleSpellFailure`'s non-player/non-pet branch:

  - Pull the unique CastID from `OtherCasterActiveCastIds.TryRemove` —
    same dict populated by SPELL_START in `HandleSpellStartOrGo`. Falls
    back to the deterministic seed only if no entry was tracked.
  - When `reason == 61 (Interrupted)` and we successfully consumed the
    active-cast entry, synthesize `SpellInterruptLog` and
    `CancelSpellVisual` exactly like the FAILED_OTHER handler does.

  The `foundActiveCastId` gate is the dedup mechanism: if Kronos sends
  BOTH `SMSG_SPELL_FAILURE` and `SMSG_SPELL_FAILED_OTHER` for the same
  interrupt, whichever handler runs first removes the dict entry; the
  second handler sees no entry and skips synthesis. Single fire either
  way.

  `HandleSpellFailedOther` is intentionally untouched — the mob fix from
  #65 keeps working unchanged.

  ## Test plan

  - [ ] Counterspell an enemy mage casting on Kronos PvP — target-frame
        cast bar dismisses immediately (no fill-to-completion delay)
  - [ ] Pummel/Kick an enemy player casting — same
  - [ ] Counterspell a mob — still works (existing fix unaffected)
  - [ ] Get Counterspelled yourself — your own cast bar dismisses (local-
        player branch unchanged)
  - [ ] `spell.failure.routed` JSONL events show `sentInterruptLog: true`
        and `foundActiveCastId: true` for PvP interrupts

  Resolves the lingering cast bar follow-up reported after #65.