### PR TITLE
 Fix master-loot state cleared on leader change / instance re-entry

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
@@ -69,9 +69,19 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_GROUP_LIST, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]
     void HandleGroupListVanilla(WorldPacket packet)
     {
-
-        GetSession().GameState.MasterLootCandidates = null;
-        GetSession().GameState.LastMasterLootSentTarget = default;
+        // JimsProxy: master-loot state used to be cleared unconditionally here, which
+        // meant every SMSG_GROUP_LIST -- raid leader change, instance re-entry resync,
+        // member join/leave -- would null out MasterLootCandidates and reset
+        // LastMasterLootSentTarget. The vanilla server only emits SMSG_LOOT_MASTER_LIST
+        // once per corpse (to whoever opens loot first; see comment in HandleLootMasterList),
+        // so after the clear the next SMSG_LOOT_RESPONSE for that corpse fell back to
+        // group.PlayerList -- the entire 40-player raid, not the real in-range candidate
+        // list -- and re-emitted LootList for an already-displayed corpse, auto-opening
+        // the popup for a stale item. Net effect: leader can't distribute loot after
+        // promotion or instance re-entry. The natural lifecycle (LOOT_RELEASE clears the
+        // sent-target, fresh SMSG_LOOT_MASTER_LIST overwrites candidates) covers cleanup
+        // for active sessions; we only need to reset when the group is fully destroyed
+        // (membersCount == 0 branch below).
         PartyUpdate party = new PartyUpdate();
         party.SequenceNum = GetSession().GameState.GroupUpdateCounter++;
         bool isRaid = packet.ReadBool();
@@ -181,6 +191,11 @@ public partial class WorldClient
             party.MyIndex = -1;
             GetSession().GameState.CurrentGroups[party.PartyIndex] = null;
 
+            // JimsProxy: group fully destroyed (kick / disband / leave) -- drop any cached
+            // master-loot state so a future group doesn't inherit stale candidates.
+            GetSession().GameState.MasterLootCandidates = null;
+            GetSession().GameState.LastMasterLootSentTarget = default;
+
             if (hadActiveGroupM && !GetSession().GameState.WeWantToLeaveGroup) //MIRASU - was: if (!WeWantToLeaveGroup)
                 SendPacketToClient(new GroupUninvite()); // Send kick message
 
@@ -198,8 +213,9 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_GROUP_LIST, ClientVersionBuild.V2_0_1_6180)]
     void HandleGroupListTBC(WorldPacket packet)
     {
-        GetSession().GameState.MasterLootCandidates = null;
-        GetSession().GameState.LastMasterLootSentTarget = default;
+        // JimsProxy: see HandleGroupListVanilla -- master-loot state clear moved into
+        // the membersCount == 0 (group destroyed) branch so leader change / instance
+        // re-entry don't break an active master-loot session.
         PartyUpdate party = new PartyUpdate();
         party.SequenceNum = GetSession().GameState.GroupUpdateCounter++;
         bool isRaid = packet.ReadBool();
@@ -291,6 +307,11 @@ public partial class WorldClient
             party.LeaderGUID = WowGuid128.Empty;
             party.MyIndex = -1;
             GetSession().GameState.CurrentGroups[party.PartyIndex] = null;
+
+            // JimsProxy: group fully destroyed -- drop cached master-loot state so a future
+            // group doesn't inherit stale candidates. See HandleGroupListVanilla for full note.
+            GetSession().GameState.MasterLootCandidates = null;
+            GetSession().GameState.LastMasterLootSentTarget = default;
 
             if (hadActiveGroupM && !GetSession().GameState.WeWantToLeaveGroup) //MIRASU
                 SendPacketToClient(new GroupUninvite()); // Send kick message


### PR DESCRIPTION
## Summary

  Tester report: in a master-loot raid, the leader cannot distribute items
  upon re-entering the instance OR after a raid leader change. The
  "Give to" popup either shows wrong/stale items or the give silently
  fails. Verified fixed in-game.

  ## Root cause

  `HandleGroupListVanilla` and `HandleGroupListTBC` had unconditional
  clears at the top of every `SMSG_GROUP_LIST`:

  ```csharp
  GetSession().GameState.MasterLootCandidates = null;
  GetSession().GameState.LastMasterLootSentTarget = default;

  SMSG_GROUP_LIST fires not just on group form/disband but also on:
  - raid leader change
  - instance re-entry resync (after SMSG_NEW_WORLD)
  - any composition / loot-method / setting change

  Two things break after the clear:

  1. MasterLootCandidates = null — next SMSG_LOOT_RESPONSE runs SendMasterLootListIfApplicable, which falls back to group.PlayerList (line 248 of Client/PacketHandlers/LootHandler.cs). PlayerList is the entire 40-player raid; the server's actual eligible candidate list is typically only those in range. Per the comment in HandleLootMasterList:207-210, vanilla emulators send SMSG_LOOT_MASTER_LIST exactly once per corpse (to the first looter), so it doesn't get refreshed for an already-looted corpse — the proxy is stuck with the wrong fallback.

  2. LastMasterLootSentTarget = default — proxy re-sends LootList
  - MasterLootCandidateList for the same corpse already showing in the leader's UI. Per the in-code warning at LootHandler.cs:222-224: "re-sending LootList would cause the client to auto-open the master loot popup for the wrong (stale) item." That's exactly what the user sees — they click "Give to X" and the popup is for a stale item, the give fails.

  The natural lifecycle already handles cleanup correctly:
  - LastMasterLootSentTarget is cleared on SMSG_LOOT_RELEASE (corpse loot session ends).
  - MasterLootCandidates is overwritten when a fresh SMSG_LOOT_MASTER_LIST arrives.

  The unconditional clears were over-defensive — they fire on transient
  group updates that don't actually invalidate the cached state.

  Fix

  Move the clears out of the unconditional path in both
  HandleGroupListVanilla and HandleGroupListTBC. Active master-loot
  sessions now survive raid leader changes and instance re-entries.

  The clears are kept in the membersCount == 0 (group-destroyed)
  branches in both handlers, so leaving / disbanding the group still
  drops stale state before the player joins a different group.

  Files

  - HermesProxy/World/Client/PacketHandlers/GroupHandler.cs — removed unconditional clears at the top of both Vanilla and TBC handlers, added equivalent clears inside both group-destroyed branches with inline notes pointing at the long explanation in the Vanilla handler.

  Test plan

  - Tester verified in-game: master-loot distribution works after raid leader change.
  - Tester verified in-game: master-loot distribution works after instance re-entry.
  - Build clean (0 warnings, 0 errors), all 312 tests pass.
  - Group disband / kick: cached master-loot state still drops cleanly (membersCount == 0 branch).
  - Corpse loot session normal lifecycle: open → distribute → release → reopen with new corpse works as before (LastMasterLootSentTarget cleared on LOOT_RELEASE per the existing path, unchanged).

  Out of scope (vanilla-faithful)

  Tester noted that non-master raid members can't view loot or see
  sparkles on the corpse in master-loot mode. This is vanilla-faithful
  behavior — vmangos / Twinstar's Player::isAllowedToLoot() returns
  false for non-masters in master-loot mode, so the server doesn't
  broadcast UNIT_DYNFLAG_LOOTABLE to them and rejects their
  CMSG_LOOT_UNIT. The 1.14 modern client allows read-only viewing
  because retail/modern Classic loosened that rule, but the goal of this
  proxy is faithful 1.12 emulation, so we're keeping the 1.12 strict
  behavior. Not changing in this PR or any follow-up.