### PR TITLE
Fix quest item toast: persist progress across logout, relog, and proxy restart

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Framework.Logging;
 using Framework.Realm;
 using HermesProxy.World.Server.Packets;
 using ArenaTeamInspectData = HermesProxy.World.Server.Packets.ArenaTeamInspectData;
@@ -127,8 +128,17 @@ public sealed class GameSessionData
     // MSG_CHANNEL_START to the caster, not to nearby players).
     public ConcurrentDictionary<WowGuid128, int> UnitChannelSpells = new();
     public WowGuid64 LastLootTargetGuid;
-    public Dictionary<(uint QuestID, sbyte StorageIndex), uint> QuestItemObjectiveProgress = new(); //MIRASU - proxy-local running totals for quest item pickups; legacy update-field cache isn't refreshed on partial updates, so we track ourselves
-    public List<(uint ItemId, uint Count)> PendingQuestItemCredits = new(); //MIRASU - SMSG_QUEST_UPDATE_ADD_ITEM credits received before the QuestTemplate was cached; replayed on QueryQuestInfoResponse so the toast doesn't drop the first pickup of an unfamiliar quest item
+    //MIRASU - ConcurrentDictionary because abandon-clear runs on the modern-server thread
+    //MIRASU   (CMSG_QUEST_LOG_REMOVE_QUEST handler in Server/QuestHandler.cs) while item-credit
+    //MIRASU   reads/writes and COMPLETE/FAILED clears run on the WorldClient thread. Plain
+    //MIRASU   Dictionary risks torn-state corruption on cross-thread enumeration.
+    public ConcurrentDictionary<(uint QuestID, sbyte StorageIndex), uint> QuestItemObjectiveProgress = new();
+    //MIRASU - PendingQuestItemCredits is a List (no concurrent equivalent supports predicate-remove).
+    //MIRASU   Guard with PendingQuestItemCreditsLock for cross-thread safety. Cleared on
+    //MIRASU   COMPLETE/FAILED/abandon for the affected quest's item objectives so a stale buffered
+    //MIRASU   credit can't be replayed against a re-accept (or a different quest sharing the item).
+    public List<(uint ItemId, uint Count)> PendingQuestItemCredits = new();
+    public readonly object PendingQuestItemCreditsLock = new();
     public uint CurrentLootCoins; //MIRASU - remembers coin amount from SMSG_LOOT_RESPONSE so proxy can synthesize SMSG_LOOT_MONEY_NOTIFY when client picks up gold (Kronos/TC-1.12 doesn't emit it)
     public List<WowGuid128>? MasterLootCandidates;
     public WowGuid64 LastMasterLootSentTarget;
@@ -1244,12 +1254,17 @@ public class GlobalSessionData
     //MIRASU   logout-to-charselect-relog flow, we snapshot the dict here keyed by character guid before
     //MIRASU   the reset, and restore lazily on first item pickup post-relog if the new CurrentPlayerGuid
     //MIRASU   matches. Char-switch (Char A → Char B) is handled naturally by the per-character key.
-    public Dictionary<WowGuid128, Dictionary<(uint QuestID, sbyte StorageIndex), uint>> SavedQuestItemProgressByCharacter = new();
+    //MIRASU - ConcurrentDictionary (outer + inner) because the saved snapshot is mutated from
+    //MIRASU   both the modern-server thread (abandon-clear in Server/QuestHandler.cs) and the
+    //MIRASU   WorldClient thread (snapshot/restore + COMPLETE-clear in Client/QuestHandler.cs).
+    public ConcurrentDictionary<WowGuid128, ConcurrentDictionary<(uint QuestID, sbyte StorageIndex), uint>> SavedQuestItemProgressByCharacter = new();
     //MIRASU - track restore by GameSessionData *instance* (reference equality), not by playerGuid.
     //MIRASU   Logging out and back in to the SAME character produces a fresh GameSessionData with the
     //MIRASU   same CurrentPlayerGuid; a guid-based guard would skip the restore on relog and the
     //MIRASU   running totals would be lost. New GameState reference => restore runs once.
-    private GameSessionData? _lastRestoredForGameState;
+    //MIRASU   volatile gives us a memory barrier on read/write so a future caller off the WorldClient
+    //MIRASU   thread can't see a stale reference.
+    private volatile GameSessionData? _lastRestoredForGameState;
 
     public RealmId RealmId;
     public RealmManager RealmManager = new();
@@ -1337,14 +1352,91 @@ public class GlobalSessionData
             return;
 
         var live = GameState.QuestItemObjectiveProgress;
-        SavedQuestItemProgressByCharacter[guid] = new Dictionary<(uint QuestID, sbyte StorageIndex), uint>(live);
+        //MIRASU - copy into a fresh ConcurrentDictionary so subsequent abandon-clears on the saved
+        //MIRASU   inner dict are thread-safe. The seed copy from `live` is itself a CDict snapshot
+        //MIRASU   (weakly-consistent enumeration, safe under concurrent writes).
+        var snapshot = new ConcurrentDictionary<(uint QuestID, sbyte StorageIndex), uint>(live);
+        SavedQuestItemProgressByCharacter[guid] = snapshot;
+
+        bool persisted = TryPersistQuestItemProgressToDisk(guid, snapshot);
 
         Framework.Logging.Log.Event("quest.progress.snapshot", new
         {
             player_guid_low = guid.Low,
             player_guid_high = guid.High,
             entries = live.Count,
+            persisted,
         });
+    }
+
+    //MIRASU - public entry point for the QuestHandler clear paths (COMPLETE/FAILED/abandon) so the
+    //MIRASU   on-disk file stays consistent with the in-memory saved snapshot. Without this, a
+    //MIRASU   crash between an abandon and the next graceful logout would leave stale entries on
+    //MIRASU   disk that get restored on the next session and credited against a re-accept.
+    public void PersistQuestItemProgressForCurrentPlayer()
+    {
+        var guid = GameState.CurrentPlayerGuid;
+        if (guid == default)
+            return;
+        //MIRASU - if there's no in-memory entry for this player, persist an empty file -- that's
+        //MIRASU   correct: it tells the next session "no in-flight totals." File creation is cheap.
+        if (!SavedQuestItemProgressByCharacter.TryGetValue(guid, out var saved))
+            saved = new ConcurrentDictionary<(uint QuestID, sbyte StorageIndex), uint>();
+        TryPersistQuestItemProgressToDisk(guid, saved);
+    }
+
+    //MIRASU - resolves realm + character name from OwnCharacters, then writes via AccountMetaDataMgr.
+    //MIRASU   Returns false (with a log line) if any prerequisite is missing rather than throwing,
+    //MIRASU   so a transient init-order issue doesn't tear down logout/disconnect cleanup.
+    private bool TryPersistQuestItemProgressToDisk(WowGuid128 guid, ConcurrentDictionary<(uint QuestID, sbyte StorageIndex), uint> entries)
+    {
+        if (AccountMetaDataMgr == null)
+            return false;
+        var charInfo = GameState.OwnCharacters.FirstOrDefault(c => c.CharacterGuid == guid);
+        if (charInfo == null || string.IsNullOrEmpty(charInfo.Name) || charInfo.Realm == null || string.IsNullOrEmpty(charInfo.Realm.Name))
+            return false;
+
+        try
+        {
+            AccountMetaDataMgr.SaveQuestItemProgress(charInfo.Realm.Name, charInfo.Name, entries);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Framework.Logging.Log.Print(LogType.Error, $"Failed to persist quest item progress for '{charInfo.Name}@{charInfo.Realm.Name}': {ex.Message}");
+            return false;
+        }
+    }
+
+    //MIRASU - lazy-load disk-persisted progress into SavedQuestItemProgressByCharacter on the first
+    //MIRASU   restore-attempt of a session. Returns true if anything was loaded. Stale entries for
+    //MIRASU   quests no longer in the player's quest log get pruned by a subsequent abandon/COMPLETE
+    //MIRASU   path -- here we just trust the disk file (it was last written by a previous logout or
+    //MIRASU   a quest-clear, so it should already be consistent absent a crash mid-session).
+    private bool TryLoadQuestItemProgressFromDisk(WowGuid128 guid)
+    {
+        if (AccountMetaDataMgr == null)
+            return false;
+        var charInfo = GameState.OwnCharacters.FirstOrDefault(c => c.CharacterGuid == guid);
+        if (charInfo == null || string.IsNullOrEmpty(charInfo.Name) || charInfo.Realm == null || string.IsNullOrEmpty(charInfo.Realm.Name))
+            return false;
+
+        var loaded = AccountMetaDataMgr.LoadQuestItemProgress(charInfo.Realm.Name, charInfo.Name);
+        if (loaded == null || loaded.Count == 0)
+            return false;
+
+        var inner = new ConcurrentDictionary<(uint QuestID, sbyte StorageIndex), uint>(loaded);
+        SavedQuestItemProgressByCharacter[guid] = inner;
+
+        Framework.Logging.Log.Event("quest.progress.disk.loaded", new
+        {
+            player_guid_low = guid.Low,
+            player_guid_high = guid.High,
+            char_name = charInfo.Name,
+            realm = charInfo.Realm.Name,
+            entries = loaded.Count,
+        });
+        return true;
     }
 
     //MIRASU - restore saved QuestItemObjectiveProgress entries for the current player on first call
@@ -1362,6 +1454,12 @@ public class GlobalSessionData
             return;
 
         _lastRestoredForGameState = GameState;
+        //MIRASU - if no in-memory snapshot exists for this player yet (cold proxy start, or first
+        //MIRASU   session for this character), try the on-disk file. Disk persistence is what makes
+        //MIRASU   the toast survive a full proxy restart -- the in-memory dict is empty after restart.
+        if (!SavedQuestItemProgressByCharacter.ContainsKey(guid))
+            TryLoadQuestItemProgressFromDisk(guid);
+
         if (!SavedQuestItemProgressByCharacter.TryGetValue(guid, out var saved) || saved.Count == 0)
         {
             Framework.Logging.Log.Event("quest.progress.restore.empty", new
@@ -1379,12 +1477,10 @@ public class GlobalSessionData
         {
             //MIRASU - don't clobber an entry the new GameState already saw (e.g. an SMSG_QUEST_UPDATE_ADD_ITEM
             //MIRASU   that arrived before this restore call would have populated it -- shouldn't happen because
-            //MIRASU   restore runs at the top of ProcessQuestItemCredit, but defend anyway).
-            if (!live.ContainsKey(kvp.Key))
-            {
-                live[kvp.Key] = kvp.Value;
+            //MIRASU   restore runs at the top of ProcessQuestItemCredit, but defend anyway). TryAdd is the
+            //MIRASU   atomic equivalent on ConcurrentDictionary.
+            if (live.TryAdd(kvp.Key, kvp.Value))
                 restored++;
-            }
         }
 
         Framework.Logging.Log.Event("quest.progress.restored", new
@@ -1412,6 +1508,13 @@ public class GlobalSessionData
         // JimsProxy (issue #43): cancel any held GCD cast and dispose its timer so it can't
         // fire after InstanceSocket has been torn down.
         GameState?.CancelGcdHold();
+
+        //MIRASU - capture quest item running totals before GameState is recreated so an unexpected
+        //MIRASU   network disconnect followed by reconnect-to-same-character preserves the toast
+        //MIRASU   total, mirroring the graceful logout-to-charselect path. Without this, a Wi-Fi
+        //MIRASU   blip resets the quest toast to "1/N" on the next pickup post-reconnect.
+        if (GameState != null)
+            SnapshotQuestItemProgressForRestore();
 
         if (ModernSniff != null)
         {

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -128,6 +128,7 @@ public sealed class GameSessionData
     public ConcurrentDictionary<WowGuid128, int> UnitChannelSpells = new();
     public WowGuid64 LastLootTargetGuid;
     public Dictionary<(uint QuestID, sbyte StorageIndex), uint> QuestItemObjectiveProgress = new(); //MIRASU - proxy-local running totals for quest item pickups; legacy update-field cache isn't refreshed on partial updates, so we track ourselves
+    public List<(uint ItemId, uint Count)> PendingQuestItemCredits = new(); //MIRASU - SMSG_QUEST_UPDATE_ADD_ITEM credits received before the QuestTemplate was cached; replayed on QueryQuestInfoResponse so the toast doesn't drop the first pickup of an unfamiliar quest item
     public uint CurrentLootCoins; //MIRASU - remembers coin amount from SMSG_LOOT_RESPONSE so proxy can synthesize SMSG_LOOT_MONEY_NOTIFY when client picks up gold (Kronos/TC-1.12 doesn't emit it)
     public List<WowGuid128>? MasterLootCandidates;
     public WowGuid64 LastMasterLootSentTarget;
@@ -1237,7 +1238,19 @@ public class GlobalSessionData
     public string OS = null!;
     public uint Build;
     public GameSessionData GameState;
-    
+
+    //MIRASU - GameState gets recreated on SMSG_LOGOUT_COMPLETE (CharacterHandler.HandleLogoutComplete)
+    //MIRASU   which wipes QuestItemObjectiveProgress. To preserve quest item running totals across a
+    //MIRASU   logout-to-charselect-relog flow, we snapshot the dict here keyed by character guid before
+    //MIRASU   the reset, and restore lazily on first item pickup post-relog if the new CurrentPlayerGuid
+    //MIRASU   matches. Char-switch (Char A → Char B) is handled naturally by the per-character key.
+    public Dictionary<WowGuid128, Dictionary<(uint QuestID, sbyte StorageIndex), uint>> SavedQuestItemProgressByCharacter = new();
+    //MIRASU - track restore by GameSessionData *instance* (reference equality), not by playerGuid.
+    //MIRASU   Logging out and back in to the SAME character produces a fresh GameSessionData with the
+    //MIRASU   same CurrentPlayerGuid; a guid-based guard would skip the restore on relog and the
+    //MIRASU   running totals would be lost. New GameState reference => restore runs once.
+    private GameSessionData? _lastRestoredForGameState;
+
     public RealmId RealmId;
     public RealmManager RealmManager = new();
     public Realm? Realm => RealmManager.GetRealm(RealmId);
@@ -1311,6 +1324,76 @@ public class GlobalSessionData
             return WowGuid128.Create(HighGuidType703.BNetAccount, AccountInfo.Id);
         else
             return WowGuid128.Create(HighGuidType703.BNetAccount, playerGuid.GetCounter());
+    }
+
+    //MIRASU - capture the current player's QuestItemObjectiveProgress before GameState is wiped,
+    //MIRASU   so we can restore it on re-login (logout-to-charselect-relog flow). Called from
+    //MIRASU   HandleLogoutComplete BEFORE the GameState reassignment, while CurrentPlayerGuid is
+    //MIRASU   still pointed at the outgoing character. Idempotent on default/empty guid (no-op).
+    public void SnapshotQuestItemProgressForRestore()
+    {
+        var guid = GameState.CurrentPlayerGuid;
+        if (guid == default)
+            return;
+
+        var live = GameState.QuestItemObjectiveProgress;
+        SavedQuestItemProgressByCharacter[guid] = new Dictionary<(uint QuestID, sbyte StorageIndex), uint>(live);
+
+        Framework.Logging.Log.Event("quest.progress.snapshot", new
+        {
+            player_guid_low = guid.Low,
+            player_guid_high = guid.High,
+            entries = live.Count,
+        });
+    }
+
+    //MIRASU - restore saved QuestItemObjectiveProgress entries for the current player on first call
+    //MIRASU   per (player, GameState) combination. Called from ProcessQuestItemCredit at the top of
+    //MIRASU   the live-pickup path so the very first item credit post-relog sees the running total
+    //MIRASU   from before the logout. After restore the live dict is authoritative -- subsequent
+    //MIRASU   abandon/COMPLETE clears (which already touch live + saved) keep both in sync.
+    public void EnsureQuestItemProgressRestored()
+    {
+        var guid = GameState.CurrentPlayerGuid;
+        //MIRASU - reference-equality on the GameSessionData instance is intentional: a relog
+        //MIRASU   produces a fresh GameState reference even when the playerGuid is identical,
+        //MIRASU   which is how we detect "first item credit of a new session" reliably.
+        if (guid == default || ReferenceEquals(_lastRestoredForGameState, GameState))
+            return;
+
+        _lastRestoredForGameState = GameState;
+        if (!SavedQuestItemProgressByCharacter.TryGetValue(guid, out var saved) || saved.Count == 0)
+        {
+            Framework.Logging.Log.Event("quest.progress.restore.empty", new
+            {
+                player_guid_low = guid.Low,
+                player_guid_high = guid.High,
+                saved_characters = SavedQuestItemProgressByCharacter.Count,
+            });
+            return;
+        }
+
+        var live = GameState.QuestItemObjectiveProgress;
+        int restored = 0;
+        foreach (var kvp in saved)
+        {
+            //MIRASU - don't clobber an entry the new GameState already saw (e.g. an SMSG_QUEST_UPDATE_ADD_ITEM
+            //MIRASU   that arrived before this restore call would have populated it -- shouldn't happen because
+            //MIRASU   restore runs at the top of ProcessQuestItemCredit, but defend anyway).
+            if (!live.ContainsKey(kvp.Key))
+            {
+                live[kvp.Key] = kvp.Value;
+                restored++;
+            }
+        }
+
+        Framework.Logging.Log.Event("quest.progress.restored", new
+        {
+            player_guid_low = guid.Low,
+            player_guid_high = guid.High,
+            saved_entries = saved.Count,
+            restored_entries = restored,
+        });
     }
 
     public void OnDisconnect()

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -343,6 +343,11 @@ public partial class WorldClient
         // GameState, leaking a ClientCastRequest into the new PendingNormalCasts and sending
         // a ghost CMSG_CAST_SPELL to the server after logout. Mirrors OnDisconnect.
         GetSession().GameState.CancelGcdHold();
+        //MIRASU - capture quest item running totals before the GameState reset so they can be
+        //MIRASU   restored on re-login (logout-to-charselect-relog flow). Must run BEFORE the
+        //MIRASU   reassignment because we read CurrentPlayerGuid + QuestItemObjectiveProgress
+        //MIRASU   off the outgoing GameState.
+        GetSession().SnapshotQuestItemProgressForRestore();
         GetSession().GameState = GameSessionData.CreateNewGameSessionData(GetSession());
         GetSession().InstanceSocket.CloseSocket();
         GetSession().InstanceSocket = null!;

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -261,6 +261,11 @@ public partial class WorldClient
 
         GameData.StoreQuestTemplate(response.QuestID, quest);
         SendPacketToClient(response);
+
+        //MIRASU - any SMSG_QUEST_UPDATE_ADD_ITEM credits buffered while this template was missing
+        //MIRASU   can now resolve their QuestObjective. Replay them so the over-head toast doesn't
+        //MIRASU   drop the first pickup of an unfamiliar quest item (off-by-1 bug).
+        ReplayPendingQuestItemCredits();
     }
 
     [PacketHandler(Opcode.SMSG_QUERY_CREATURE_RESPONSE)]

--- a/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
@@ -5,6 +5,7 @@ using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace HermesProxy.World.Client;
@@ -400,12 +401,57 @@ public partial class WorldClient
         //MIRASU   stale counts. Applies to COMPLETE / FAILED / FAILED_TIMER -- in all three cases
         //MIRASU   the quest is leaving the active log and any running total is no longer valid.
         //MIRASU   Clear from the saved snapshot too, so a logout/login can't restore stale entries.
+        //MIRASU   ConcurrentDictionary's TryRemove is the atomic equivalent of Dictionary.Remove.
         var progressMap = GetSession().GameState.QuestItemObjectiveProgress;
         foreach (var k in progressMap.Keys.Where(k => k.QuestID == quest.QuestID).ToList())
-            progressMap.Remove(k);
+            progressMap.TryRemove(k, out _);
         if (GetSession().SavedQuestItemProgressByCharacter.TryGetValue(GetSession().GameState.CurrentPlayerGuid, out var savedForPlayer))
             foreach (var k in savedForPlayer.Keys.Where(k => k.QuestID == quest.QuestID).ToList())
-                savedForPlayer.Remove(k);
+                savedForPlayer.TryRemove(k, out _);
+        //MIRASU - persist the post-clear saved snapshot to disk so a crash before next graceful
+        //MIRASU   logout can't restore a stale entry for the just-completed/failed quest on the
+        //MIRASU   next proxy start.
+        GetSession().PersistQuestItemProgressForCurrentPlayer();
+        //MIRASU - drop pending buffered credits whose itemId matches an item-objective in the
+        //MIRASU   ending quest's template, so a deferred ReplayPendingQuestItemCredits can't
+        //MIRASU   misattribute the count to a re-accept (or another active quest sharing the
+        //MIRASU   item). If the template isn't cached we conservatively skip -- that means the
+        //MIRASU   pending entry was for a quest the proxy never learned about, so attribution
+        //MIRASU   is already ambiguous and dropping would be guesswork.
+        DropPendingQuestItemCreditsForQuest(quest.QuestID);
+    }
+
+    //MIRASU - shared helper: removes any (itemId, count) pending entries whose item appears in the
+    //MIRASU   given quest's item-objectives. Lock-protected because callers run on different threads
+    //MIRASU   (client thread for COMPLETE/FAILED/replay, server thread for abandon).
+    public void DropPendingQuestItemCreditsForQuest(uint questId)
+    {
+        var template = GameData.GetQuestTemplate(questId);
+        if (template == null)
+            return;
+        var itemIds = new HashSet<uint>();
+        foreach (var obj in template.Objectives)
+        {
+            if (obj.Type == QuestObjectiveType.Item)
+                itemIds.Add((uint)obj.ObjectID);
+        }
+        if (itemIds.Count == 0)
+            return;
+
+        int removed;
+        lock (GetSession().GameState.PendingQuestItemCreditsLock)
+        {
+            removed = GetSession().GameState.PendingQuestItemCredits.RemoveAll(p => itemIds.Contains(p.ItemId));
+        }
+        if (removed > 0)
+        {
+            Log.Event("quest.item.pending.dropped", new
+            {
+                quest_id = questId,
+                item_ids = itemIds.ToArray(),
+                removed,
+            });
+        }
     }
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_ADD_ITEM)]
     void HandleQuestUpdateAddItem(WorldPacket packet)
@@ -421,12 +467,17 @@ public partial class WorldClient
         //MIRASU   is permanently off-by-one for the first pickup of any unfamiliar quest item, since
         //MIRASU   the legacy server only sends the credit packet once per pickup. Then fire the
         //MIRASU   template queries (modeled on the original "Next pickup will find it" path).
-        GetSession().GameState.PendingQuestItemCredits.Add((itemId, count));
+        int pendingCount;
+        lock (GetSession().GameState.PendingQuestItemCreditsLock)
+        {
+            GetSession().GameState.PendingQuestItemCredits.Add((itemId, count));
+            pendingCount = GetSession().GameState.PendingQuestItemCredits.Count;
+        }
         Log.Event("quest.item.add.buffered", new
         {
             item_id = itemId,
             wire_count = count,
-            pending_count = GetSession().GameState.PendingQuestItemCredits.Count,
+            pending_count = pendingCount,
         });
 
         var pendingFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
@@ -453,16 +504,28 @@ public partial class WorldClient
     //MIRASU   quest) so it'll be tried again on the next QueryQuestInfoResponse.
     public void ReplayPendingQuestItemCredits()
     {
-        var pending = GetSession().GameState.PendingQuestItemCredits;
-        if (pending.Count == 0)
-            return;
-
-        var snapshot = pending.ToList();
-        pending.Clear();
+        var gameState = GetSession().GameState;
+        //MIRASU - drain under lock to avoid racing with abandon-clear (server thread) or
+        //MIRASU   another buffered Add (client thread). Replay processing then runs without
+        //MIRASU   the lock so ProcessQuestItemCredit doesn't have to be lock-aware.
+        List<(uint ItemId, uint Count)> snapshot;
+        lock (gameState.PendingQuestItemCreditsLock)
+        {
+            if (gameState.PendingQuestItemCredits.Count == 0)
+                return;
+            snapshot = new List<(uint, uint)>(gameState.PendingQuestItemCredits);
+            gameState.PendingQuestItemCredits.Clear();
+        }
+        var unresolved = new List<(uint ItemId, uint Count)>();
         foreach (var (itemId, count) in snapshot)
         {
             if (!ProcessQuestItemCredit(itemId, count, replayed: true))
-                pending.Add((itemId, count));
+                unresolved.Add((itemId, count));
+        }
+        if (unresolved.Count > 0)
+        {
+            lock (gameState.PendingQuestItemCreditsLock)
+                gameState.PendingQuestItemCredits.AddRange(unresolved);
         }
     }
 
@@ -568,6 +631,14 @@ public partial class WorldClient
         credit.Required = (ushort)objective.Amount;
         credit.VictimGUID = default; //MIRASU - no victim for item pickups; modern client ignores VictimGUID for Item objectives
         SendPacketToClient(credit);
+
+        //MIRASU - eager disk persist: write the latest running totals to disk after every credit so
+        //MIRASU   a launcher-induced proxy kill (close-game-on-logout option) can't lose progress.
+        //MIRASU   The previous batched-on-logout model only worked when SMSG_LOGOUT_COMPLETE arrived
+        //MIRASU   before the proxy died, which doesn't happen when the launcher kills mid-session.
+        //MIRASU   SnapshotQuestItemProgressForRestore copies live -> SavedQuestItemProgressByCharacter
+        //MIRASU   AND writes to disk in one call. Cost is ~one tiny JSON file write per pickup.
+        GetSession().SnapshotQuestItemProgressForRestore();
         return true;
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Framework;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -398,9 +399,13 @@ public partial class WorldClient
         //MIRASU   (or a parallel quest sharing the same item) starts fresh instead of inheriting
         //MIRASU   stale counts. Applies to COMPLETE / FAILED / FAILED_TIMER -- in all three cases
         //MIRASU   the quest is leaving the active log and any running total is no longer valid.
+        //MIRASU   Clear from the saved snapshot too, so a logout/login can't restore stale entries.
         var progressMap = GetSession().GameState.QuestItemObjectiveProgress;
         foreach (var k in progressMap.Keys.Where(k => k.QuestID == quest.QuestID).ToList())
             progressMap.Remove(k);
+        if (GetSession().SavedQuestItemProgressByCharacter.TryGetValue(GetSession().GameState.CurrentPlayerGuid, out var savedForPlayer))
+            foreach (var k in savedForPlayer.Keys.Where(k => k.QuestID == quest.QuestID).ToList())
+                savedForPlayer.Remove(k);
     }
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_ADD_ITEM)]
     void HandleQuestUpdateAddItem(WorldPacket packet)
@@ -408,38 +413,93 @@ public partial class WorldClient
         uint itemId = packet.ReadUInt32();
         uint count = packet.ReadUInt32(); //MIRASU - delta, not total
 
-        QuestObjective? objective = GameData.GetQuestObjectiveForItem(itemId);
-
-        if (objective == null)
-        {
-            //MIRASU - quest template not cached yet; fire off queries and bail. Next pickup will find it.
-            var updateFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
-            int questsCount = LegacyVersion.GetQuestLogSize();
-            for (int i = 0; i < questsCount; i++)
-            {
-                QuestLog? logEntry = ReadQuestLogEntry(i, null, updateFields!);
-                if (logEntry == null || logEntry.QuestID == null)
-                    continue;
-
-                if (GameData.GetQuestTemplate((uint)logEntry.QuestID) == null)
-                {
-                    WorldPacket packet2 = new WorldPacket(Opcode.CMSG_QUERY_QUEST_INFO);
-                    packet2.WriteUInt32((uint)logEntry.QuestID);
-                    SendPacketToServer(packet2);
-                }
-            }
+        if (ProcessQuestItemCredit(itemId, count, replayed: false))
             return;
+
+        //MIRASU - quest template not cached yet. Buffer the credit so it can be replayed once the
+        //MIRASU   template arrives via SMSG_QUERY_QUEST_INFO_RESPONSE -- otherwise the toast count
+        //MIRASU   is permanently off-by-one for the first pickup of any unfamiliar quest item, since
+        //MIRASU   the legacy server only sends the credit packet once per pickup. Then fire the
+        //MIRASU   template queries (modeled on the original "Next pickup will find it" path).
+        GetSession().GameState.PendingQuestItemCredits.Add((itemId, count));
+        Log.Event("quest.item.add.buffered", new
+        {
+            item_id = itemId,
+            wire_count = count,
+            pending_count = GetSession().GameState.PendingQuestItemCredits.Count,
+        });
+
+        var pendingFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
+        int questsCount = LegacyVersion.GetQuestLogSize();
+        for (int i = 0; i < questsCount; i++)
+        {
+            QuestLog? logEntry = ReadQuestLogEntry(i, null, pendingFields!);
+            if (logEntry == null || logEntry.QuestID == null)
+                continue;
+
+            if (GameData.GetQuestTemplate((uint)logEntry.QuestID) == null)
+            {
+                WorldPacket packet2 = new WorldPacket(Opcode.CMSG_QUERY_QUEST_INFO);
+                packet2.WriteUInt32((uint)logEntry.QuestID);
+                SendPacketToServer(packet2);
+            }
         }
+    }
+
+    //MIRASU - replays any quest item credits that were buffered because their QuestTemplate hadn't
+    //MIRASU   arrived yet. Called from HandleQueryQuestInfoResponse after StoreQuestTemplate, so
+    //MIRASU   the now-cached objective metadata can produce the deferred toast credit. Re-buffers
+    //MIRASU   any (itemId, count) pair that still doesn't resolve (template was for a different
+    //MIRASU   quest) so it'll be tried again on the next QueryQuestInfoResponse.
+    public void ReplayPendingQuestItemCredits()
+    {
+        var pending = GetSession().GameState.PendingQuestItemCredits;
+        if (pending.Count == 0)
+            return;
+
+        var snapshot = pending.ToList();
+        pending.Clear();
+        foreach (var (itemId, count) in snapshot)
+        {
+            if (!ProcessQuestItemCredit(itemId, count, replayed: true))
+                pending.Add((itemId, count));
+        }
+    }
+
+    //MIRASU - shared credit-processing path used by both the live SMSG_QUEST_UPDATE_ADD_ITEM
+    //MIRASU   handler and the buffered-replay path. Returns true if the objective was resolved
+    //MIRASU   and the toast credit was sent; false if the QuestTemplate still isn't cached.
+    private bool ProcessQuestItemCredit(uint itemId, uint count, bool replayed)
+    {
+        QuestObjective? objective = GameData.GetQuestObjectiveForItem(itemId);
+        if (objective == null)
+            return false;
+
+        //MIRASU - restore saved per-character running totals if this is the first item credit since
+        //MIRASU   a logout-to-charselect relog. No-op if already restored or nothing was saved for
+        //MIRASU   the current player guid.
+        GetSession().EnsureQuestItemProgressRestored();
 
         //MIRASU - track running total ourselves; legacy update-field cache isn't refreshed on partial updates
         var key = (objective.QuestID, objective.StorageIndex);
+        bool seededFromCache = false;
+        uint cacheValue = 0;
+        bool updateFieldsPresent = false;
+        int updateFieldsCount = 0;
+        int matchedSlot = -1;
+        sbyte? matchedSlotProgressRaw = null;
         if (!GetSession().GameState.QuestItemObjectiveProgress.TryGetValue(key, out uint stored))
         {
-            //MIRASU - first time we see this objective: seed from the legacy quest log cache.
-            //MIRASU   The cache holds the accept-time progress (e.g. 3/10 if the player logged in
-            //MIRASU   mid-quest); without seeding, the running total starts at 0 and the toast
-            //MIRASU   would render "1/10" instead of "4/10" on the next pickup.
+            //MIRASU - first time we see this objective in this session: seed from the legacy quest log cache.
+            //MIRASU   The cache holds the server's last-persisted progress (e.g. 5/10 if the player logged
+            //MIRASU   in mid-quest with 5 items already collected). Without this seed, the running total
+            //MIRASU   starts at 0 after every relog and the toast would render "1/10" instead of "6/10" on
+            //MIRASU   the next pickup. NOTE: SavedQuestItemProgressByCharacter handles the proxy-internal
+            //MIRASU   relog persistence; this seed is the second line of defense that catches mid-quest
+            //MIRASU   logins where the proxy never saw the prior session at all (server-persisted progress).
             var updateFields = GetSession().GameState.GetCachedObjectFieldsLegacy(GetSession().GameState.CurrentPlayerGuid);
+            updateFieldsPresent = updateFields != null;
+            updateFieldsCount = updateFields?.Count ?? 0;
             if (updateFields != null)
             {
                 int questsCount = LegacyVersion.GetQuestLogSize();
@@ -448,21 +508,58 @@ public partial class WorldClient
                     QuestLog? logEntry = ReadQuestLogEntry(i, null, updateFields);
                     if (logEntry == null || logEntry.QuestID != objective.QuestID)
                         continue;
-                    if (logEntry.ObjectiveProgress[objective.StorageIndex] != null)
-                        stored = (uint)logEntry.ObjectiveProgress[objective.StorageIndex]!;
+                    matchedSlot = i;
+                    var progressNullable = logEntry.ObjectiveProgress[objective.StorageIndex];
+                    matchedSlotProgressRaw = progressNullable.HasValue ? (sbyte)progressNullable.Value : (sbyte?)null;
+                    if (progressNullable != null)
+                    {
+                        stored = (uint)progressNullable!;
+                        cacheValue = stored;
+                        seededFromCache = true;
+                    }
                     break;
                 }
             }
+            Log.Event("quest.item.seed.attempt", new
+            {
+                quest_id = objective.QuestID,
+                storage_index = (int)objective.StorageIndex,
+                item_id = itemId,
+                update_fields_present = updateFieldsPresent,
+                update_fields_count = updateFieldsCount,
+                quest_log_size = LegacyVersion.GetQuestLogSize(),
+                matched_slot = matchedSlot,
+                matched_slot_progress = matchedSlotProgressRaw,
+                seeded_from_cache = seededFromCache,
+                cache_value = cacheValue,
+            });
         }
         uint runningTotal = stored + count;
-        if (runningTotal > (uint)objective.Amount)
+        bool clamped = runningTotal > (uint)objective.Amount;
+        if (clamped)
             runningTotal = (uint)objective.Amount;
         GetSession().GameState.QuestItemObjectiveProgress[key] = runningTotal;
 
+        Log.Event("quest.item.add", new
+        {
+            item_id = itemId,
+            quest_id = objective.QuestID,
+            storage_index = (int)objective.StorageIndex,
+            wire_count = count,
+            stored_before = stored,
+            running_total = runningTotal,
+            required = objective.Amount,
+            seeded_from_cache = seededFromCache,
+            cache_value = cacheValue,
+            clamped,
+            replayed,
+        });
+
         //MIRASU - send full QuestUpdateAddCredit (not SIMPLE) so the over-head toast has explicit
-        //MIRASU   Count/Required values. SIMPLE makes the modern client read from the legacy
-        //MIRASU   UNIT_FIELD_QUEST_LOG_x cache, which Kronos doesn't refresh on partial item-pickup
-        //MIRASU   updates -- so the toast froze at whatever the cache held on quest accept (1/10).
+        //MIRASU   Count/Required values. SIMPLE makes the modern client increment its own internal
+        //MIRASU   counter, which (a) starts at 0 on every relog instead of the server's persisted
+        //MIRASU   progress, and (b) doesn't get re-seeded from PLAYER_QUEST_LOG_x_3 on login -- so
+        //MIRASU   after a logout/login the toast restarts at 1/N regardless of true progress.
         QuestUpdateAddCredit credit = new QuestUpdateAddCredit();
         credit.QuestID = objective.QuestID;
         credit.ObjectID = (int)itemId;
@@ -471,6 +568,7 @@ public partial class WorldClient
         credit.Required = (ushort)objective.Amount;
         credit.VictimGUID = default; //MIRASU - no victim for item pickups; modern client ignores VictimGUID for Item objectives
         SendPacketToClient(credit);
+        return true;
     }
 
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_ADD_KILL)]

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -3120,10 +3120,10 @@ public static partial class GameData
         {
             if (//row.AllowableRace != item.AllowedRaces ||
                 !row.Description.Equals(item.Description) ||
-                !row.Name4.Equals(item.Name[3]) ||
-                !row.Name3.Equals(item.Name[2]) ||
-                !row.Name2.Equals(item.Name[1]) ||
-                !row.Name1.Equals(item.Name[0]) ||
+                !row.Name4.Equals(item.Name![3]) ||
+                !row.Name3.Equals(item.Name![2]) ||
+                !row.Name2.Equals(item.Name![1]) ||
+                !row.Name1.Equals(item.Name![0]) ||
                 row.DurationInInventory != item.Duration ||
                 row.BagFamily != item.BagFamily ||
                 row.RangeMod != item.RangedMod ||
@@ -3214,14 +3214,14 @@ public static partial class GameData
 
                 if (!row.Description.Equals(item.Description))
                     Log.Print(LogType.Storage, $"Description \"{row.Description}\" vs \"{item.Description}\"");
-                if (!row.Name4.Equals(item.Name[3]))
-                    Log.Print(LogType.Storage, $"Name4 \"{row.Name4}\" vs \"{item.Name[3]}\"");
-                if (!row.Name3.Equals(item.Name[2]))
-                    Log.Print(LogType.Storage, $"Name3 \"{row.Name3}\" vs \"{item.Name[2]}\"");
-                if (!row.Name2.Equals(item.Name[1]))
-                    Log.Print(LogType.Storage, $"Name2 \"{row.Name2}\" vs \"{item.Name[1]}\"");
-                if (!row.Name1.Equals(item.Name[0]))
-                    Log.Print(LogType.Storage, $"Name1 \"{row.Name1}\" vs \"{item.Name[0]}\"");
+                if (!row.Name4.Equals(item.Name![3]))
+                    Log.Print(LogType.Storage, $"Name4 \"{row.Name4}\" vs \"{item.Name![3]}\"");
+                if (!row.Name3.Equals(item.Name![2]))
+                    Log.Print(LogType.Storage, $"Name3 \"{row.Name3}\" vs \"{item.Name![2]}\"");
+                if (!row.Name2.Equals(item.Name![1]))
+                    Log.Print(LogType.Storage, $"Name2 \"{row.Name2}\" vs \"{item.Name![1]}\"");
+                if (!row.Name1.Equals(item.Name![0]))
+                    Log.Print(LogType.Storage, $"Name1 \"{row.Name1}\" vs \"{item.Name![0]}\"");
                 if (row.DurationInInventory != item.Duration)
                     Log.Print(LogType.Storage, $"DurationInInventory {row.DurationInInventory} vs {item.Duration}");
                 if (row.BagFamily != item.BagFamily)

--- a/HermesProxy/World/Server/AccountDataManager.cs
+++ b/HermesProxy/World/Server/AccountDataManager.cs
@@ -16,6 +16,11 @@ public class AccountMetaDataManager
     private const string LAST_CHARACTER_FILE = "last_character.txt";
     private const string COMPLETED_QUESTS_FILE = "completed_quests.csv";
     private const string SETTINGS_FILE = "settings.json";
+    //MIRASU - per-character disk persistence for quest item running totals so the modern over-head
+    //MIRASU   quest toast survives a full proxy restart (close-game-then-relaunch, or crash). The
+    //MIRASU   in-memory snapshot in GlobalSessionData covers logout-to-charselect-relog where the
+    //MIRASU   proxy stays alive; this disk file is the persistent backstop for the harder case.
+    private const string QUEST_ITEM_PROGRESS_FILE = "quest-item-progress.json";
 
     private readonly string _accountName;
 
@@ -143,6 +148,84 @@ public class AccountMetaDataManager
 
         return loadedJson!;
     }
+
+    //MIRASU - serializes concurrent calls to SaveQuestItemProgress so the temp-file/rename pair
+    //MIRASU   isn't interleaved between the WorldClient thread (item credit) and the server thread
+    //MIRASU   (abandon-clear). One static lock per process is fine: file I/O is fast and contention
+    //MIRASU   is low (only this character's session writes through here per proxy instance).
+    private static readonly object _questItemProgressFileLock = new();
+
+    //MIRASU - persist quest item running totals to disk for this character. Atomic write via
+    //MIRASU   temp-file + rename so a crash mid-write can't corrupt the file. Called eagerly from
+    //MIRASU   GlobalSessionData on every pickup increment and on COMPLETE/FAILED/abandon so the
+    //MIRASU   disk file always reflects the latest state -- the proxy can be killed mid-session
+    //MIRASU   (launcher kill on game close) and the next start sees an up-to-date file.
+    public void SaveQuestItemProgress(string realmName, string charName, IEnumerable<KeyValuePair<(uint QuestID, sbyte StorageIndex), uint>> entries)
+    {
+        var dir = GetAccountCharacterMetaDataDirectory(realmName, charName);
+        var path = Path.Combine(dir, QUEST_ITEM_PROGRESS_FILE);
+        var tmp = path + ".tmp";
+
+        var dto = new QuestItemProgressFile
+        {
+            SchemaVersion = 1,
+            Entries = entries.Select(kvp => new QuestItemProgressEntry
+            {
+                QuestId = kvp.Key.QuestID,
+                StorageIndex = kvp.Key.StorageIndex,
+                Count = kvp.Value,
+            }).ToList(),
+        };
+        var jsonString = JsonSerializer.Serialize(dto, new JsonSerializerOptions { WriteIndented = true });
+        lock (_questItemProgressFileLock)
+        {
+            File.WriteAllText(tmp, jsonString, Encoding.UTF8);
+            File.Move(tmp, path, overwrite: true);
+        }
+    }
+
+    //MIRASU - load quest item running totals from disk for this character. Returns null if no
+    //MIRASU   file exists or the file is corrupt / from a future schema; caller treats null as
+    //MIRASU   "no saved progress" (which is also the cold-start state).
+    public Dictionary<(uint QuestID, sbyte StorageIndex), uint>? LoadQuestItemProgress(string realmName, string charName)
+    {
+        var dir = GetAccountCharacterMetaDataDirectory(realmName, charName);
+        var path = Path.Combine(dir, QUEST_ITEM_PROGRESS_FILE);
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            var jsonString = File.ReadAllText(path, Encoding.UTF8);
+            var dto = JsonSerializer.Deserialize<QuestItemProgressFile>(jsonString);
+            if (dto == null || dto.SchemaVersion != 1)
+                return null;
+            var result = new Dictionary<(uint QuestID, sbyte StorageIndex), uint>(dto.Entries.Count);
+            foreach (var entry in dto.Entries)
+                result[(entry.QuestId, entry.StorageIndex)] = entry.Count;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Log.Print(LogType.Error, $"Failed to load quest item progress for '{charName}@{realmName}': {ex.Message}");
+            return null;
+        }
+    }
+}
+
+//MIRASU - DTOs for quest item progress disk persistence. Kept as a flat list rather than a dict
+//MIRASU   because System.Text.Json doesn't natively serialize tuple-keyed dictionaries.
+public class QuestItemProgressFile
+{
+    public int SchemaVersion { get; set; }
+    public List<QuestItemProgressEntry> Entries { get; set; } = new();
+}
+
+public class QuestItemProgressEntry
+{
+    public uint QuestId { get; set; }
+    public sbyte StorageIndex { get; set; }
+    public uint Count { get; set; }
 }
 
 public class AccountData

--- a/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
@@ -55,14 +55,24 @@ public partial class WorldSocket
             return;
 
         uint questId = (uint)logEntry.QuestID;
+        //MIRASU - ConcurrentDictionary.TryRemove for cross-thread safety (abandon runs on server thread,
+        //MIRASU   item-credit handlers run on client thread).
         var progressMap = GetSession().GameState.QuestItemObjectiveProgress;
         foreach (var k in progressMap.Keys.Where(k => k.QuestID == questId).ToList())
-            progressMap.Remove(k);
+            progressMap.TryRemove(k, out _);
         //MIRASU - also clear from the saved snapshot so a logout/login can't restore stale entries
         //MIRASU   for an abandoned quest (otherwise a re-accept would inherit the pre-abandon total).
         if (GetSession().SavedQuestItemProgressByCharacter.TryGetValue(GetSession().GameState.CurrentPlayerGuid, out var savedForPlayer))
             foreach (var k in savedForPlayer.Keys.Where(k => k.QuestID == questId).ToList())
-                savedForPlayer.Remove(k);
+                savedForPlayer.TryRemove(k, out _);
+        //MIRASU - persist the post-abandon saved snapshot to disk so a crash before the next
+        //MIRASU   graceful logout can't restore a stale entry for the just-abandoned quest on
+        //MIRASU   the next proxy start (otherwise a re-accept would inherit the pre-abandon total).
+        GetSession().PersistQuestItemProgressForCurrentPlayer();
+        //MIRASU - drop any buffered credits whose itemId belongs to this abandoned quest's objectives.
+        //MIRASU   Without this, a buffered credit from before the abandon could be replayed against a
+        //MIRASU   re-accept (or a different active quest sharing the item) when its template arrives.
+        worldClient.DropPendingQuestItemCreditsForQuest(questId);
     }
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_STATUS_QUERY)]
     void HandleQuestGiverStatusQuery(QuestGiverStatusQuery query)

--- a/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
@@ -58,6 +58,11 @@ public partial class WorldSocket
         var progressMap = GetSession().GameState.QuestItemObjectiveProgress;
         foreach (var k in progressMap.Keys.Where(k => k.QuestID == questId).ToList())
             progressMap.Remove(k);
+        //MIRASU - also clear from the saved snapshot so a logout/login can't restore stale entries
+        //MIRASU   for an abandoned quest (otherwise a re-accept would inherit the pre-abandon total).
+        if (GetSession().SavedQuestItemProgressByCharacter.TryGetValue(GetSession().GameState.CurrentPlayerGuid, out var savedForPlayer))
+            foreach (var k in savedForPlayer.Keys.Where(k => k.QuestID == questId).ToList())
+                savedForPlayer.Remove(k);
     }
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_STATUS_QUERY)]
     void HandleQuestGiverStatusQuery(QuestGiverStatusQuery query)


### PR DESCRIPTION
This wasnt working after relog so we took a better approach.  


## Summary
  The over-head modern quest toast was resetting to "1/N" instead of continuing from the actual
  progress in three scenarios on Kronos 1.12. This PR (two commits) fixes all three and adds disk
  persistence so the running total survives even a launcher-induced proxy kill on game close.

  ## Bugs fixed
  1. **Logout to charselect → relog (in-proxy)**: the legacy server only sends per-pickup deltas
  (not totals), and `SMSG_LOGOUT_COMPLETE` recreates `GameState`, wiping the proxy-internal
  running totals. Toast read 1/N on next pickup instead of resuming from prior count.
  2. **Off-by-one for unfamiliar quest items**: when `SMSG_QUEST_UPDATE_ADD_ITEM` arrived before
  the QuestTemplate was cached, the credit was lost (legacy server only sends each credit once).
  First pickup of an unfamiliar quest item permanently undercounted by 1.
  3. **Stale running total after re-accept**: `QuestItemObjectiveProgress` wasn't cleared on
  COMPLETE/FAILED/FAILED_TIMER/abandon, so re-accepting the same quest inherited the prior
  session's count.
  4. **Progress lost when launcher kills proxy on game close**: in-memory snapshot dies with the
  proxy. Most user installs run with kill-proxy-on-logout enabled, so the original fix didn't help
   in real-world flows.

  ## Root cause notes
  - Cache-seed fallback (read progress from `PLAYER_QUEST_LOG_x_2`) is permanently dead on Kronos:
   the legacy update-field cache populates the slot's `QuestID` but never the per-objective
  progress byte. `quest.item.seed.attempt` events confirm `matched_slot != -1` with
  `matched_slot_progress: null` every time. The proxy must own this state.
  - Switched item-credit packet from `QuestUpdateAddCreditSimple` to full `QuestUpdateAddCredit`
  with explicit `Count` / `Required`. SIMPLE makes the modern client manage its own counter, which
   (a) starts at 0 on every relog and (b) doesn't get re-seeded from `PLAYER_QUEST_LOG_x_3` on
  login.

  ## Fix architecture
  **In-memory layer** (commit 838ca8a):
  - `GlobalSessionData.SavedQuestItemProgressByCharacter` keyed by `WowGuid128` so Char A→B→A
  doesn't cross-contaminate
  - `SnapshotQuestItemProgressForRestore()` runs in `HandleLogoutComplete` AND `OnDisconnect`
  (Wi-Fi-drop path)
  - `EnsureQuestItemProgressRestored()` runs at the top of `ProcessQuestItemCredit`, idempotent
  per `GameSessionData` instance via `ReferenceEquals` (relog produces a fresh `GameState` even
  with same playerGuid — a guid-keyed guard would skip the restore)
  - COMPLETE/FAILED/FAILED_TIMER/abandon clear from both live and saved dicts

  **Buffered-credit layer** (commit 838ca8a):
  - `PendingQuestItemCredits` buffers credits whose QuestTemplate isn't cached yet
  - `ReplayPendingQuestItemCredits` runs after `StoreQuestTemplate` in
  `HandleQueryQuestInfoResponse`
  - `DropPendingQuestItemCreditsForQuest(questId)` clears buffered entries whose itemId belongs to
   a quest leaving the log, so a deferred replay can't misattribute count to a re-accept

  **Disk layer** (commit 373ac0c):
  - Per-character JSON at `AccountData/<account>/<realm>/<character>/quest-item-progress.json`,
  schema-versioned, atomic write (temp + rename)
  - Eager write: `ProcessQuestItemCredit` persists after every pickup, not batched-on-logout, so a
   launcher-induced kill loses at most one in-flight credit
  - Lazy load on first `EnsureQuestItemProgressRestored` per session
  - Static lock around the file write (server thread on abandon vs WorldClient thread on credit)
  - Cleared on COMPLETE/FAILED/abandon in both client and server handlers

  **Concurrency hardening** (commit 373ac0c):
  - `QuestItemObjectiveProgress` and `SavedQuestItemProgressByCharacter` promoted to
  `ConcurrentDictionary` (cross-thread mutation: server thread on abandon vs WorldClient thread on
   credit/COMPLETE)
  - `PendingQuestItemCredits` accesses guarded by a dedicated lock object
  - `_lastRestoredForGameState` marked `volatile`

  ## Diagnostics added
  - `quest.progress.snapshot` — fired on logout/disconnect, includes `entries` count and
  `persisted` flag
  - `quest.progress.disk.loaded` — fired when disk file is read on first session-startup credit
  - `quest.progress.restored` — fired when in-memory or disk-loaded state is copied to the new
  GameState
  - `quest.progress.restore.empty` — fired when no saved entries exist for the current playerGuid
  - `quest.item.seed.attempt` — captures `update_fields_present`, `matched_slot`,
  `matched_slot_progress` for the dead Kronos cache-seed fallback
  - `quest.item.add` — full per-credit context: `stored_before`, `running_total`,
  `seeded_from_cache`, `clamped`, `replayed`
  - `quest.item.add.buffered` — credit deferred because QuestTemplate not yet cached
  - `quest.item.pending.dropped` — buffered credit dropped because its quest is leaving the log

  ## Test plan
  - [x] In-game test: pick up 2/8 → logout to charselect → log back in → pick up 1 → toast reads
  3/8
  - [x] In-game test: pick up 2/N → close game (launcher kills proxy) → relaunch → log in → pick
  up 1 → toast continues from prior total. JSON file at
  `AccountData/<acc>/<realm>/<char>/quest-item-progress.json` shows the saved count after kill
  - [x] In-game test: abandon-then-logout-then-relog-then-re-accept doesn't restore stale entries
  - [x] Build clean (0 warnings, 0 errors)
  - [x] Test suite green (312/312)
  - [x] Bug-hunter review pass complete; concurrency, lifecycle, edge cases addressed