### PR TITLE
Random afk dcs - Tested in SW, normal server kick after 45mins

### DIFF
--- a/HermesProxy/BnetServer/Services/Services/Presence.cs
+++ b/HermesProxy/BnetServer/Services/Services/Presence.cs
@@ -1,0 +1,54 @@
+// Copyright (c) CypherCore <http://github.com/CypherCore> All rights reserved.
+// Licensed under the GNU GENERAL PUBLIC LICENSE. See LICENSE file in the project root for full license information.
+
+using Bgs.Protocol;
+using Bgs.Protocol.Presence.V1;
+using Framework.Constants;
+
+namespace BNetServer.Services;
+
+// PresenceService stubs. The 1.14.x retail client expects PresenceService to be
+// available; without these the client logs "disconnected because no presence"
+// and drops the BNet session after some idle threshold (the AFK-DC bug).
+//
+// We do not actually maintain presence state — these handlers ack with Ok and
+// (for query/batch-subscribe) an empty payload. That is enough for the client
+// to consider presence "alive" and stop trying to renegotiate.
+public partial class BnetServices
+{
+    [Service(ServiceRequirement.LoggedIn, OriginalHash.PresenceService, 1)]
+    BattlenetRpcErrorCode HandlePresenceSubscribe(SubscribeRequest request)
+    {
+        return BattlenetRpcErrorCode.Ok;
+    }
+
+    [Service(ServiceRequirement.LoggedIn, OriginalHash.PresenceService, 2)]
+    BattlenetRpcErrorCode HandlePresenceUnsubscribe(UnsubscribeRequest request)
+    {
+        return BattlenetRpcErrorCode.Ok;
+    }
+
+    [Service(ServiceRequirement.LoggedIn, OriginalHash.PresenceService, 3)]
+    BattlenetRpcErrorCode HandlePresenceUpdate(UpdateRequest request)
+    {
+        return BattlenetRpcErrorCode.Ok;
+    }
+
+    [Service(ServiceRequirement.LoggedIn, OriginalHash.PresenceService, 4)]
+    BattlenetRpcErrorCode HandlePresenceQuery(QueryRequest request, QueryResponse response)
+    {
+        return BattlenetRpcErrorCode.Ok;
+    }
+
+    [Service(ServiceRequirement.LoggedIn, OriginalHash.PresenceService, 8)]
+    BattlenetRpcErrorCode HandlePresenceBatchSubscribe(BatchSubscribeRequest request, BatchSubscribeResponse response)
+    {
+        return BattlenetRpcErrorCode.Ok;
+    }
+
+    [Service(ServiceRequirement.LoggedIn, OriginalHash.PresenceService, 9)]
+    BattlenetRpcErrorCode HandlePresenceBatchUnsubscribe(BatchUnsubscribeRequest request)
+    {
+        return BattlenetRpcErrorCode.Ok;
+    }
+}

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -38,6 +38,15 @@ public partial class WorldClient
     uint _keepAlivePingSerial;
     const int KeepAliveIntervalMs = 30_000;
 
+    // JimsProxy: last-inbound-opcode tracking for disconnect diagnostics. When
+    // the legacy connection dies unexpectedly (zombie state, AFK DC), capturing
+    // the most recent server-to-proxy opcode + its arrival tick narrows down
+    // whether the death was idle (no traffic in N seconds), correlated with a
+    // specific opcode (parser bug), or mid-flight on a known packet.
+    Opcode _lastInboundOpcode;
+    uint _lastInboundOpcodeRaw;
+    int _lastInboundOpcodeTick;
+
     // packet order is not always the same as new client, sometimes we need to delay packet until another one
     Dictionary<Opcode, List<WorldPacket>> _delayedPacketsToServer = null!;
     Dictionary<Opcode, List<ServerPacket>> _delayedPacketsToClient = null!;
@@ -240,6 +249,9 @@ public partial class WorldClient
             {
                 reason = "worldclient_legacy_disconnect",
                 disconnect_reason = reason,
+                last_opcode = _lastInboundOpcode.ToString(),
+                last_opcode_raw = _lastInboundOpcodeRaw,
+                ms_since_last_opcode = _lastInboundOpcodeTick == 0 ? -1 : Environment.TickCount - _lastInboundOpcodeTick,
             });
         }
     }
@@ -302,6 +314,9 @@ public partial class WorldClient
                     reason = "worldclient_receive_loop_exception",
                     exception_type = e.GetType().Name,
                     exception_message = e.Message,
+                    last_opcode = _lastInboundOpcode.ToString(),
+                    last_opcode_raw = _lastInboundOpcodeRaw,
+                    ms_since_last_opcode = _lastInboundOpcodeTick == 0 ? -1 : Environment.TickCount - _lastInboundOpcodeTick,
                 });
             }
         }
@@ -477,6 +492,9 @@ public partial class WorldClient
     private void HandlePacket(WorldPacket packet)
     {
         Opcode universalOpcode = packet.GetUniversalOpcode(false);
+        _lastInboundOpcode = universalOpcode;
+        _lastInboundOpcodeRaw = packet.GetOpcode();
+        _lastInboundOpcodeTick = Environment.TickCount;
         Log.PrintNet(LogType.Debug, LogNetDir.S2P, $"Received opcode {universalOpcode} ({packet.GetOpcode()}).");
 
         // JimsProxy: structured packet.in (s2c — from legacy server)


### PR DESCRIPTION
 Description:
  ## Summary

  Two changes targeting the random AFK-disconnect bug ("zombie state", "disconnected because no
  presence"):

  1. **PresenceService stub handlers.** Adds the six `PresenceService` methods
  (Subscribe/Unsubscribe/Update/Query/BatchSubscribe/BatchUnsubscribe) to
  `BnetServer/Services/Services/Presence.cs`. They ack with `Ok` and an empty payload — enough for
   the modern client to consider presence "alive" and stop tearing down the session. Previously
  these calls returned `RpcNotImplemented` and produced `Client requested service
  PresenceService/m:3 but this service is not implemented?` warnings, which the client treats as a
   fatal "no presence" condition after some idle threshold.

  2. **Disconnect-log diagnostics.** `WorldClient` now tracks the most recent inbound opcode +
  arrival tick. The two `session.ondisconnect.suppressed` events are enriched with `last_opcode`,
  `last_opcode_raw`, and `ms_since_last_opcode`, so the next mystery DC has a real fingerprint
  instead of just a generic stack trace.

  ## Why

  Community report and observed warning logs both pointed at PresenceService as the culprit for
  the AFK DC class. Empirical confirmation in test session: the warning is gone, no
  PresenceService events fire, and the test session's only disconnect was a clean client-initiated
   idle-logout (the modern client's own AFK feature, unrelated).