### PR TITLE
Login queue bug

### DIFF
--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -650,6 +650,12 @@ public partial class WorldClient
     {
         AuthResult result = (AuthResult)packet.ReadUInt8();
 
+        // Billing/expansion fields are only present on the *first* SMSG_AUTH_RESPONSE
+        // (the full one). CMaNGOS/VMaNGOS-style 1.12 servers send subsequent
+        // queue-update packets in a stripped form: just uint8(result) + uint32(position).
+        // If a Kronos build sends billing on every packet, this branch will read
+        // the wrong bytes — flag this if launch-day logs show queue positions
+        // jumping into the millions.
         if (_isSuccessful == null)
         {
             uint billingTimeRemaining = packet.ReadUInt32();
@@ -665,10 +671,29 @@ public partial class WorldClient
         if (result == AuthResult.AUTH_OK)
         {
             Log.Print(LogType.Network, "Authentication succeeded!");
-            if (_queuePosition != 0 && GetSession().RealmSocket != null)
+            // Race fix: previously _queuePosition reset and WaitQueueFinish were
+            // BOTH gated on RealmSocket != null. If Kronos released us from queue
+            // before the modern client's EnterEncryptedModeAck arrived (which is
+            // what sets RealmSocket), _queuePosition stayed at the stale value
+            // and the next SendAuthResponse(Ok, GetQueuePosition()) embedded a
+            // bogus WaitInfo — modern client showed permanent queue UI with no
+            // follow-up WaitQueueFinish to dismiss it.
+            //
+            // Now: always reset _queuePosition. Only send WaitQueueFinish if
+            // RealmSocket exists (meaning the AuthResponse was already sent and
+            // queue UI may already be on screen). If RealmSocket is null, the
+            // deferred AuthResponse will go out with queuePos=0 and no queue UI
+            // is ever shown — no Finish needed.
+            bool wasQueued = _queuePosition != 0;
+            _queuePosition = 0;
+            if (wasQueued)
             {
-                _queuePosition = 0;
-                GetSession().RealmSocket.SendAuthWaitQue(_queuePosition);
+                var realmSocket = GetSession().RealmSocket;
+                Log.Event("auth.queue.released", new
+                {
+                    had_realm_socket = realmSocket != null,
+                });
+                realmSocket?.SendAuthWaitQue(0);
             }
             _isSuccessful = true;
             StartKeepAliveTimer();
@@ -677,8 +702,16 @@ public partial class WorldClient
         {
             _queuePosition = packet.ReadUInt32();
             Log.Print(LogType.Network, $"Position in queue is {_queuePosition}.");
-            if (_isSuccessful != null && GetSession().RealmSocket != null)
-                GetSession().RealmSocket.SendAuthWaitQue(_queuePosition);
+            bool isInitial = _isSuccessful == null;
+            var realmSocket = GetSession().RealmSocket;
+            Log.Event("auth.queue.position", new
+            {
+                position = _queuePosition,
+                is_initial = isInitial,
+                had_realm_socket = realmSocket != null,
+            });
+            if (!isInitial)
+                realmSocket?.SendAuthWaitQue(_queuePosition);
             _isSuccessful = true;
         }
         else

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -1030,6 +1030,12 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             response.WaitInfo.WaitCount = queuePos;
         }
 
+        Log.Event("auth.response_sent", new
+        {
+            result = code.ToString(),
+            queue_position = queuePos,
+            has_wait_info = response.WaitInfo != null,
+        });
         SendPacket(response);
     }
 
@@ -1041,10 +1047,14 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             waitQueueUpdate.WaitInfo.WaitCount = position;
             waitQueueUpdate.WaitInfo.WaitTime = 0;
             waitQueueUpdate.WaitInfo.HasFCM = false;
+            Log.Event("auth.queue.update_sent", new { position = position });
             SendPacket(waitQueueUpdate);
         }
         else
+        {
+            Log.Event("auth.queue.finish_sent", new { });
             SendPacket(new WaitQueueFinish());
+        }
     }
 
     public void SendSetTimeZoneInformation()


### PR DESCRIPTION
## Summary

  Preflight fix + observability for the login-queue path ahead of launch day. Found one real race
  when reading the code; added structured logging across the queue lifecycle so launch-day JSONL
  bundles can be audited end-to-end.

  ## The race

  `WorldClient.cs::HandleAuthResponse` previously gated **both** `_queuePosition = 0` and
  `WaitQueueFinish` on `RealmSocket != null`. If Kronos released a user from queue before the
  modern client's `EnterEncryptedModeAck` arrived (which is what sets `RealmSocket`), the proxy
  would:

  - Leave `_queuePosition` at its stale value
  - Skip `WaitQueueFinish`

  The deferred `SendAuthResponse(Ok, GetQueuePosition())` would then attach a bogus `WaitInfo` —
  modern client showed permanent queue UI with no follow-up `Finish` packet to dismiss it. Most
  likely on short queues where Kronos releases faster than the TLS+BNet handoff completes.

  **Fix:** `_queuePosition = 0` is now unconditional. `WaitQueueFinish` is sent only when
  `RealmSocket` exists (queue UI was actually shown). Captured `RealmSocket` into a local to avoid
   TOCTOU during realm-swap. Same local-capture pattern applied to subsequent `AUTH_WAIT_QUEUE`
  handling.

  ## Logging

  Five new `Log.Event` sites across the queue lifecycle:

  - `auth.queue.position` — every position update from Kronos (`position`, `is_initial`,
  `had_realm_socket`)
  - `auth.queue.released` — `AUTH_OK` after queue (`had_realm_socket`)
  - `auth.queue.update_sent` — `WaitQueueUpdate` to client (`position`)
  - `auth.queue.finish_sent` — `WaitQueueFinish` to client
  - `auth.response_sent` — initial `SMSG_AUTH_RESPONSE` (`result`, `queue_position`,
  `has_wait_info`)

  Lets us reconstruct any user's full queue path from a bundle: did Kronos send a position? Did we
   forward it? Was the eventual finish sent? Was queue UI surfaced via the initial AuthResponse
  vs. update packets?

  ## Known unknowns

  Added a code comment flagging that we skip billing fields only on the first
  `SMSG_AUTH_RESPONSE`. This matches CMaNGOS/VMaNGOS-style stripped queue updates (`uint8 result +
   uint32 position`). If a Kronos build sends full billing on every packet, we'd read position
  from billing bytes and report nonsense numbers — first launch-day signal would be queue
  positions in the millions. Easy to verify and fix once we have a real capture; not worth
  speculating against.

  ## What was deliberately left alone

  - `WaitTime` is hardcoded to 0 → modern client shows "unknown time". Kronos doesn't supply
  wait-time data, so any value would be a guess.
  - No `Interlocked`/locking on `_queuePosition`. `uint` reads/writes are atomic on x64 and the
  protocol-level packet ordering dominates the race surface.