### PR TITLE
Healing logs overhealing effective

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -71,6 +71,11 @@ public sealed class GameSessionData
     public uint LastEnteredAreaTrigger;
     public uint LastDispellSpellId;
     public Dictionary<WowGuid128, uint[]> CachedPlayerEnchants = new();
+    // JimsProxy: per-unit HP cache used to compute overhealing on legacy servers
+    // that don't include OverHeal in SMSG_SPELL_HEAL_LOG (1.12 vanilla). Authoritative
+    // source is UNIT_FIELD_HEALTH / UNIT_FIELD_MAXHEALTH from SMSG_UPDATE_OBJECT;
+    // we also bump current HP forward on heal events to stay accurate between pushes.
+    public ConcurrentDictionary<WowGuid128, (int Hp, int MaxHp)> UnitHealthCache = new();
     public string LeftChannelName = "";
     public bool IsPassingOnLoot;
     public int GroupUpdateCounter;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1270,10 +1270,13 @@ public partial class WorldClient
         spell.HealAmount = packet.ReadInt32();
         spell.OriginalHealAmount = spell.HealAmount;
 
-        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_3_9183))
+        bool wireHasOverheal = LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_3_9183);
+        bool wireHasAbsorbed = LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192);
+
+        if (wireHasOverheal)
             spell.OverHeal = packet.ReadUInt32();
 
-        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
+        if (wireHasAbsorbed)
             spell.Absorbed = packet.ReadUInt32();
 
         spell.Crit = packet.ReadBool();
@@ -1288,7 +1291,66 @@ public partial class WorldClient
             }
         }
 
+        ComputeOverHealFromCache(spell.TargetGUID, spell.HealAmount, wireHasOverheal,
+            out uint computedOverHeal, out bool cacheHit, out int cachedHp, out int cachedMaxHp);
+        if (!wireHasOverheal)
+            spell.OverHeal = computedOverHeal;
+
+        Log.Event("combat.heal.log", new
+        {
+            spell_id = spell.SpellID,
+            target = spell.TargetGUID.ToString(),
+            caster = spell.CasterGUID.ToString(),
+            heal_amount = spell.HealAmount,
+            over_heal_sent = spell.OverHeal,
+            absorbed_sent = spell.Absorbed,
+            crit = spell.Crit,
+            wire_has_overheal = wireHasOverheal,
+            wire_has_absorbed = wireHasAbsorbed,
+            cache_hit = cacheHit,
+            cached_hp = cachedHp,
+            cached_max_hp = cachedMaxHp,
+        });
+
         SendPacketToClient(spell);
+    }
+
+    // Computes overhealing for a heal event by looking up the target's current HP
+    // in our cache (populated from SMSG_UPDATE_OBJECT). On 1.12 servers the wire
+    // doesn't carry overheal, so we synthesize it: overheal = max(0, heal - (maxHp - hp)).
+    // After computing, we bump the cached HP forward by the effective amount so
+    // back-to-back heals (faster than UPDATE_OBJECT can resync) compute accurately.
+    // If the cache has no entry for the target (e.g., never received a UPDATE_OBJECT
+    // for them), we leave overheal at 0 and don't touch the cache.
+    private void ComputeOverHealFromCache(
+        WowGuid128 target, int healAmount, bool wireHadOverheal,
+        out uint computedOverHeal, out bool cacheHit, out int cachedHp, out int cachedMaxHp)
+    {
+        computedOverHeal = 0;
+        cacheHit = false;
+        cachedHp = 0;
+        cachedMaxHp = 0;
+
+        if (wireHadOverheal || healAmount <= 0)
+            return;
+
+        var cache = GetSession().GameState.UnitHealthCache;
+        if (!cache.TryGetValue(target, out var state) || state.MaxHp <= 0)
+            return;
+
+        cacheHit = true;
+        cachedHp = state.Hp;
+        cachedMaxHp = state.MaxHp;
+
+        int missing = state.MaxHp - state.Hp;
+        if (missing < 0) missing = 0;
+        int effective = Math.Min(healAmount, missing);
+        int overheal = healAmount - effective;
+        computedOverHeal = (uint)overheal;
+
+        int newHp = state.Hp + effective;
+        if (newHp > state.MaxHp) newHp = state.MaxHp;
+        cache[target] = (newHp, state.MaxHp);
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_PERIODIC_AURA_LOG)]
@@ -1338,7 +1400,9 @@ public partial class WorldClient
                         effect.Amount = packet.ReadInt32();
                         effect.OriginalDamage = effect.Amount;
 
-                        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
+                        bool wireHasOverhealHot = LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056);
+
+                        if (wireHasOverhealHot)
                             effect.OverHealOrKill = packet.ReadUInt32();
 
                         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_3_0_10958))
@@ -1347,6 +1411,26 @@ public partial class WorldClient
 
                         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_2_9901))
                             effect.Crit = packet.ReadBool();
+
+                        ComputeOverHealFromCache(spell.TargetGUID, effect.Amount, wireHasOverhealHot,
+                            out uint computedOverHealHot, out bool cacheHitHot, out int cachedHpHot, out int cachedMaxHotHp);
+                        if (!wireHasOverhealHot)
+                            effect.OverHealOrKill = computedOverHealHot;
+
+                        Log.Event("combat.heal.periodic", new
+                        {
+                            spell_id = spell.SpellID,
+                            target = spell.TargetGUID.ToString(),
+                            caster = spell.CasterGUID.ToString(),
+                            aura = aura.ToString(),
+                            amount = effect.Amount,
+                            over_heal_sent = effect.OverHealOrKill,
+                            crit = effect.Crit,
+                            wire_has_overheal = wireHasOverhealHot,
+                            cache_hit = cacheHitHot,
+                            cached_hp = cachedHpHot,
+                            cached_max_hp = cachedMaxHotHp,
+                        });
 
                         spell.Effects.Add(effect);
                         break;

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1566,14 +1566,31 @@ public partial class WorldClient
                 updateData.UnitData.ChannelObject = GetGuidValue(updates, UnitField.UNIT_FIELD_CHANNEL_OBJECT).To128(GetSession().GameState);
             }
             int UNIT_FIELD_HEALTH = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_HEALTH);
-            if (UNIT_FIELD_HEALTH >= 0 && updateMaskArray[UNIT_FIELD_HEALTH])
+            bool healthUpdated = UNIT_FIELD_HEALTH >= 0 && updateMaskArray[UNIT_FIELD_HEALTH];
+            if (healthUpdated)
             {
                 updateData.UnitData.Health = updates[UNIT_FIELD_HEALTH].Int32Value;
             }
             int UNIT_FIELD_MAXHEALTH = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_MAXHEALTH);
-            if (UNIT_FIELD_MAXHEALTH >= 0 && updateMaskArray[UNIT_FIELD_MAXHEALTH])
+            bool maxHealthUpdated = UNIT_FIELD_MAXHEALTH >= 0 && updateMaskArray[UNIT_FIELD_MAXHEALTH];
+            if (maxHealthUpdated)
             {
                 updateData.UnitData.MaxHealth = updates[UNIT_FIELD_MAXHEALTH].Int32Value;
+            }
+            // JimsProxy: feed our HP cache so SpellHandler.HandleSpellHealLog can compute
+            // overhealing on 1.12 servers (which don't carry it on the wire). The server
+            // is authoritative — every push here resets any drift accumulated by our
+            // post-heal optimistic updates.
+            if (healthUpdated || maxHealthUpdated)
+            {
+                var cache = GetSession().GameState.UnitHealthCache;
+                cache.AddOrUpdate(guid,
+                    _ => (
+                        healthUpdated ? updates[UNIT_FIELD_HEALTH].Int32Value : 0,
+                        maxHealthUpdated ? updates[UNIT_FIELD_MAXHEALTH].Int32Value : 0),
+                    (_, existing) => (
+                        healthUpdated ? updates[UNIT_FIELD_HEALTH].Int32Value : existing.Hp,
+                        maxHealthUpdated ? updates[UNIT_FIELD_MAXHEALTH].Int32Value : existing.MaxHp));
             }
             int UNIT_FIELD_LEVEL = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_LEVEL);
             if (UNIT_FIELD_LEVEL >= 0 && updateMaskArray[UNIT_FIELD_LEVEL])


### PR DESCRIPTION
Compute overhealing for legacy SMSG_SPELL_HEAL_LOG via HP cache

  1.12 servers don't carry overheal/absorbed on the wire, so the proxy
  was forwarding OverHeal=0 on every heal — combat-log addons (Recount,
  Details, Skada) reported all healing as 100% effective regardless of
  target HP state.

  Add a per-session ConcurrentDictionary<WowGuid128, (Hp, MaxHp)>
  populated by UNIT_FIELD_HEALTH/UNIT_FIELD_MAXHEALTH from
  SMSG_UPDATE_OBJECT (server is authoritative — every push resets any
  drift). On SMSG_SPELL_HEAL_LOG and SMSG_SPELL_PERIODIC_AURA_LOG with
  PeriodicHeal/ObsModHealth, look up the target's cached HP, compute
  overheal = max(0, heal - (maxHp - hp)), and bump the cached HP
  forward by the effective amount so back-to-back heals before the
  next UPDATE_OBJECT push remain accurate.

  Verified in-game with Paladin (Holy Light, Flash of Light) and
  Priest (Greater Heal, Renew HoT) — overheal matches expected math
  across full-HP overheal, partial-HP heal, low-HP fully-effective,
  and HoT ticks filling back to full.

  Includes structured combat.heal.log / combat.heal.periodic events
  (spell, target, caster, heal_amount, over_heal_sent, crit,
  cache_hit, cached_hp, cached_max_hp) for launch-day audit.

  PR title (under 70 chars):
  Fix overhealing reporting for Vanilla servers via HP-cache compute

  PR description:

  ## Summary

  Vanilla 1.12 `SMSG_SPELL_HEAL_LOG` doesn't carry overheal or absorbed on the wire — the protocol
   was extended in WotLK (3.0.3) and Cataclysm (3.2.0). The proxy was forwarding `OverHeal=0` on
  every heal, so combat-log addons (Recount, Details, Skada) reported all healing as 100%
  effective regardless of target HP state. Made healing parses on Vanilla servers genuinely
  useless.

  This branch synthesizes overheal proxy-side by tracking unit HP from `SMSG_UPDATE_OBJECT`.

  ## How it works

  - **HP cache** — `ConcurrentDictionary<WowGuid128, (int Hp, int MaxHp)>` on `GameSessionData`.
  - **Cache writes** — `UpdateHandler` populates the cache whenever `UNIT_FIELD_HEALTH` or
  `UNIT_FIELD_MAXHEALTH` are present in an `SMSG_UPDATE_OBJECT` block. Server is authoritative —
  every push resets drift.
  - **Heal compute** — `SpellHandler.HandleSpellHealLog` and the `PeriodicHeal`/`ObsModHealth`
  branches in `HandleSpellPeriodicAuraLog` look up the target, compute `overheal = max(0, heal -
  (maxHp - hp))`, and bump cached HP forward by the effective amount so back-to-back heals before
  the next `UPDATE_OBJECT` push stay accurate.
  - **Cache miss** — falls back to `OverHeal=0` (same as before this PR), no crash.

  ## Verified in-game

  Tested with two characters:

  **Paladin** (Holy Light, Flash of Light) — 5 casts, all math correct:
  | HP | Heal | Overheal sent | Math |
  |---|---|---|---|
  | 2345/4671 | 2141 | 0 | missing=2326, fits ✓ |
  | 3819/4671 | 883 | 31 | missing=852, ✓ |
  | 4315/4671 | 1347 (crit) | 991 | missing=356, ✓ |
  | 2835/4671 | 1336 (crit) | 0 | missing=1836, fits ✓ |
  | 3210/4671 | 3238 (crit) | 1777 | missing=1461, ✓ |

  **Priest** (Greater Heal, Renew HoT) — 39 events, including a full Renew duration filling target
   back to max with progressive overheal per tick. All math correct.

  ## Known limitations

  - **No damage tracking** — between server `UPDATE_OBJECT` pushes, our cached HP may overestimate
   (heals push it up, damage doesn't push it down). `UPDATE_OBJECT` resyncs frequently enough that
   drift should be small in practice. If complaints come in post-launch, a follow-up adds hooks to
   `SMSG_SPELLNONMELEEDAMAGELOG`, `SMSG_PERIODICAURALOG` (damage branches), and
  `SMSG_ATTACKERSTATEUPDATE`.
  - **Cache miss for never-seen targets** returns `OverHeal=0` (same as before this PR). In
  practice, a target you can heal is one you've received `UPDATE_OBJECT` for.
  - **Absorbed still always 0** — Vanilla has no absorb-tracking on the heal log. Different
  problem; not addressed.

  ## Diagnostics

  Two structured events for launch-day audit:

  - `combat.heal.log` — direct heals; fields: `spell_id`, `target`, `caster`, `heal_amount`,
  `over_heal_sent`, `absorbed_sent`, `crit`, `wire_has_overheal`, `wire_has_absorbed`,
  `cache_hit`, `cached_hp`, `cached_max_hp`
  - `combat.heal.periodic` — HoT ticks; same shape minus absorbed, plus `aura` (PeriodicHeal vs
  ObsModHealth)

  Lets us reconstruct any user's heal session and verify overheal computation against their actual
   HP.

  ## Test plan

  - [x] `dotnet build` clean
  - [x] Verified in-game with Paladin direct heals
  - [x] Verified in-game with Priest direct heals + Renew HoT
  - [ ] Verify Recount/Details/Skada show correct effective vs. overhealing on Vanilla servers
  - [ ] Long-session soak: confirm cache drift between damage/heal events doesn't accumulate
  visibly in addon parses