### PR TITLE
Hunter fixes v1

### DIFF
--- a/Addons/JimsPlus/Core.lua
+++ b/Addons/JimsPlus/Core.lua
@@ -1,6 +1,6 @@
 local ADDON_NAME, namespace = ...
 
-namespace.BUILD = 12
+namespace.BUILD = 18
 
 print("|cFF00FF00[JimsPlus]|r Core loaded (build " .. namespace.BUILD .. ")")
 

--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -7,6 +7,7 @@
 ## Version: 1.0.1
 
 Core.lua
+PetFix.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua
 castbars/Data.lua

--- a/Addons/JimsPlus/PetFix.lua
+++ b/Addons/JimsPlus/PetFix.lua
@@ -1,0 +1,85 @@
+local ADDON_NAME, namespace = ...
+
+-- Hotfix for a FrameXML bug present in Classic Era 1.14.2 (build 42597):
+--   Interface_Vanilla\FrameXML\PetPaperDollFrame.lua:149
+--     local classFileName = select(2, UnitClass("pet"));
+--     classStatText = _G[strupper(classFileName).."_"..frame.stat.."_".."TOOLTIP"];
+-- When the modern client returns nil for the pet class file name (which it
+-- does for hunter pets coming through legacy Vanilla servers — pets have
+-- creature classes, not player classes), strupper(nil) errors with
+--   "bad argument #1 to 'strupper' (string expected, got nil)"
+-- and the Lua error popup spams every frame the pet pane is open.
+--
+-- Blizzard fixed this post-1.14.2 by adding `if(classFileName) then` around
+-- the assignment (visible in the Gethe wow-ui-source classic_era branch),
+-- but the user's installed client doesn't have that guard.
+--
+-- We wrap PetPaperDollFrame_SetStats in pcall so the function still runs as
+-- far as it can, but a strupper-nil failure inside it is swallowed instead
+-- of bubbling up as a Lua error popup. The pet stat panel may render with
+-- missing tooltips for the affected stat, but everything else (cast bar,
+-- pet bar, pet HP) keeps working.
+
+-- Sister bug in Interface_Vanilla\FrameXML\PetStable.lua:168 — same root cause:
+-- `family` (and similar fields) come back nil for legacy-server hunter pets,
+-- and PetStable_Update does string concatenation without a guard:
+--     PetStableCurrentPet.tooltipSubtext = level.." "..family.." "..loyalty
+-- which throws "attempt to concatenate a nil value".
+--
+-- Both functions are wrapped in pcall so a nil-arg failure inside FrameXML
+-- code is silently absorbed instead of bubbling up as a Lua error popup.
+-- The frame may render with missing fields (a stat tooltip or stable subtext),
+-- but every other pet UI keeps working.
+
+local installed = {}
+
+local function WrapInPcall(funcName)
+    if installed[funcName] then return true end
+    local original = _G[funcName]
+    if type(original) ~= "function" then
+        return false
+    end
+    _G[funcName] = function(...)
+        local ok, err = pcall(original, ...)
+        if not ok and namespace.PET_FIX_DEBUG then
+            print("|cFFFFAA00[JimsPlus]|r " .. funcName .. " swallowed: " .. tostring(err))
+        end
+    end
+    installed[funcName] = true
+    return true
+end
+
+local TARGETS = {
+    "PetPaperDollFrame_SetStats",
+    "PetStable_Update",
+}
+
+local function InstallAll()
+    local installedAny = false
+    for _, name in ipairs(TARGETS) do
+        if WrapInPcall(name) then
+            installedAny = true
+        end
+    end
+    return installedAny
+end
+
+local installer = CreateFrame("Frame")
+installer:RegisterEvent("PLAYER_LOGIN")
+installer:RegisterEvent("ADDON_LOADED")
+installer:SetScript("OnEvent", function(self, event, addonName)
+    InstallAll()
+    -- Only stop listening once every target has been wrapped. Some FrameXML
+    -- functions are defined lazily when the related panel is first shown
+    -- (e.g. PetStable_Update is in Blizzard_PetStables which loads on demand).
+    local allDone = true
+    for _, name in ipairs(TARGETS) do
+        if not installed[name] then
+            allDone = false
+            break
+        end
+    end
+    if allDone then
+        self:UnregisterAllEvents()
+    end
+end)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -71,6 +71,15 @@ public sealed class GameSessionData
     public uint LastEnteredAreaTrigger;
     public uint LastDispellSpellId;
     public Dictionary<WowGuid128, uint[]> CachedPlayerEnchants = new();
+    // JimsProxy: pet creature family cache. SMSG_PET_SPELLS_MESSAGE on pre-3.1
+    // servers doesn't carry the family on the wire — we derive it from the
+    // creature template via GetItemId(petGuid). For quest-tame pets the
+    // GUID→entry mapping can drop out of cache between updates, so a follow-up
+    // SMSG_PET_SPELLS_MESSAGE comes through with creature_family=0. The modern
+    // client's PetPaperDollFrame_SetStats then calls strupper on a nil family
+    // name and errors. This cache stickies the first successful family lookup
+    // so we always send a valid family, cleared only on explicit pet dismiss.
+    public ConcurrentDictionary<WowGuid128, ushort> CachedPetCreatureFamily = new();
     public string LeftChannelName = "";
     public bool IsPassingOnLoot;
     public int GroupUpdateCounter;

--- a/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Framework;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -10,70 +11,162 @@ namespace HermesProxy.World.Client;
 public partial class WorldClient
 {
     // Handlers for SMSG opcodes coming the legacy world server
+    private static string HexDump(byte[] data, int max = 256)
+    {
+        if (data == null || data.Length == 0) return "";
+        int len = Math.Min(data.Length, max);
+        var sb = new System.Text.StringBuilder(len * 2);
+        for (int i = 0; i < len; i++)
+            sb.Append(data[i].ToString("X2"));
+        return sb.ToString();
+    }
+
     [PacketHandler(Opcode.SMSG_PET_SPELLS_MESSAGE)]
     void HandlePetSpellsMessage(WorldPacket packet)
     {
-        WowGuid64 guid = packet.ReadGuid();
-        GetSession().GameState.CurrentPetGuid = guid.To128(GetSession().GameState);
-        GetSession().GameState.ClearPendingPetCasts();
-
-        // Equal to "Clear spells" pre cataclysm
-        if (guid.IsEmpty())
+        // Defensive wrapper: a quest tame on Kronos (e.g. spell 19684 used via
+        // quest item) sends SMSG_PET_SPELLS_MESSAGE in a shape we don't fully
+        // parse — reading runs off the end of the buffer and throws
+        // ArgumentOutOfRangeException, killing the WorldClient ReceiveLoop and
+        // DCing the player. Until we figure out the exact format mismatch, keep
+        // the parser self-contained so a malformed packet drops the pet bar
+        // instead of DCing the session.
+        uint dbgPacketSize = packet.GetSize();
+        // Capture the raw bytes BEFORE reading so the hex dump on failure is
+        // useful even if the packet has already been consumed past the failure
+        // point. ReadToEnd / GetData semantics differ across packet types; we
+        // call GetData which returns the full underlying buffer.
+        byte[] dbgRawBytes = packet.GetData();
+        try
         {
-            PetClearSpells clear = new();
-            SendPacketToClient(clear);
-            return;
-        }
+            WowGuid64 guid = packet.ReadGuid();
+            GetSession().GameState.CurrentPetGuid = guid.To128(GetSession().GameState);
+            GetSession().GameState.ClearPendingPetCasts();
 
-        PetSpells spells = new();
-        spells.PetGUID = guid.To128(GetSession().GameState);
-        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_0_9767))
-            spells.CreatureFamily = packet.ReadUInt16();
-        else
-        {
-            // For pre-3.1.0 servers (Vanilla/TBC), CreatureFamily is not in the packet.
-            // Look it up from the creature template using the pet's entry ID.
-            uint creatureEntry = GetSession().GameState.GetItemId(spells.PetGUID);
-            if (creatureEntry != 0)
+            // Equal to "Clear spells" pre cataclysm
+            if (guid.IsEmpty())
             {
-                CreatureTemplate? template = GameData.GetCreatureTemplate(creatureEntry);
-                if (template != null)
-                    spells.CreatureFamily = (ushort)template.Family;
+                Log.Event("pet.spells.cleared", new { packet_size = dbgPacketSize });
+                // Pet dismissed/lost — drop family cache so a new pet at the
+                // same low-counter (unlikely but possible) doesn't inherit the
+                // old family.
+                GetSession().GameState.CachedPetCreatureFamily.Clear();
+                PetClearSpells clear = new();
+                SendPacketToClient(clear);
+                return;
             }
-        }
 
-        spells.TimeLimit = packet.ReadUInt32();
-        spells.ReactState = (ReactStates)packet.ReadUInt8();
-        spells.CommandState = (CommandStates)packet.ReadUInt8();
-        packet.ReadUInt8(); // unused
-        spells.Flag = packet.ReadUInt8();
-
-        const int maxCreatureSpells = 10;
-        for (int i = 0; i < maxCreatureSpells; i++) // Read pet/vehicle spell ids
-            spells.ActionButtons[i] = packet.ReadUInt32();
-
-        byte spellCount = packet.ReadUInt8();
-        for (int i = 0; i < spellCount; i++)
-            spells.Actions.Add(packet.ReadUInt32());
-
-        byte cdCount = packet.ReadUInt8();
-        for (int i = 0; i < cdCount; i++)
-        {
-            PetSpellCooldown cooldown = new();
-
+            PetSpells spells = new();
+            spells.PetGUID = guid.To128(GetSession().GameState);
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_0_9767))
-                cooldown.SpellID = packet.ReadUInt32();
+                spells.CreatureFamily = packet.ReadUInt16();
             else
-                cooldown.SpellID = packet.ReadUInt16();
+            {
+                // For pre-3.1.0 servers (Vanilla/TBC), CreatureFamily is not in the packet.
+                // Look it up from the creature template using the pet's entry ID.
+                uint creatureEntry = GetSession().GameState.GetItemId(spells.PetGUID);
+                if (creatureEntry != 0)
+                {
+                    CreatureTemplate? template = GameData.GetCreatureTemplate(creatureEntry);
+                    if (template != null)
+                        spells.CreatureFamily = (ushort)template.Family;
+                }
+                // Layered fallbacks for creature_family. The modern client's
+                // PetPaperDollFrame_SetStats calls strupper(UnitCreatureFamily("pet"))
+                // which throws if the family ID has no name mapping. Family 0
+                // is always nil. We must always send a non-zero family.
+                //
+                //   1. If the creature template lookup succeeded, use it.
+                //   2. Else fall back to a previously-cached value for this pet.
+                //   3. Else fall back to family=1 (Wolf) — generic vanilla beast
+                //      family, guaranteed to resolve to a non-nil name.
+                //
+                // Quest tames (charm-based, e.g. spell 19686) hit case 3 because
+                // the controlled creature has no Beast family in its template;
+                // we send Wolf so the paper-doll frame doesn't error out.
+                var familyCache = GetSession().GameState.CachedPetCreatureFamily;
+                if (spells.CreatureFamily != 0)
+                {
+                    familyCache[spells.PetGUID] = spells.CreatureFamily;
+                }
+                else if (familyCache.TryGetValue(spells.PetGUID, out var cachedFamily) && cachedFamily != 0)
+                {
+                    spells.CreatureFamily = cachedFamily;
+                    Log.Event("pet.creature_family.fallback_cached", new
+                    {
+                        pet_guid = spells.PetGUID.ToString(),
+                        cached_family = cachedFamily,
+                    });
+                }
+                else
+                {
+                    spells.CreatureFamily = 1; // Wolf — generic beast fallback
+                    Log.Event("pet.creature_family.fallback_default", new
+                    {
+                        pet_guid = spells.PetGUID.ToString(),
+                        creature_entry = creatureEntry,
+                        defaulted_to = 1,
+                    });
+                }
+            }
 
-            cooldown.Category = packet.ReadUInt16();
-            cooldown.Duration = packet.ReadUInt32();
-            cooldown.CategoryDuration = packet.ReadUInt32();
+            spells.TimeLimit = packet.ReadUInt32();
+            spells.ReactState = (ReactStates)packet.ReadUInt8();
+            spells.CommandState = (CommandStates)packet.ReadUInt8();
+            packet.ReadUInt8(); // unused
+            spells.Flag = packet.ReadUInt8();
 
-            spells.Cooldowns.Add(cooldown);
+            const int maxCreatureSpells = 10;
+            for (int i = 0; i < maxCreatureSpells; i++) // Read pet/vehicle spell ids
+                spells.ActionButtons[i] = packet.ReadUInt32();
+
+            byte spellCount = packet.ReadUInt8();
+            for (int i = 0; i < spellCount; i++)
+                spells.Actions.Add(packet.ReadUInt32());
+
+            byte cdCount = packet.ReadUInt8();
+            for (int i = 0; i < cdCount; i++)
+            {
+                PetSpellCooldown cooldown = new();
+
+                if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_0_9767))
+                    cooldown.SpellID = packet.ReadUInt32();
+                else
+                    cooldown.SpellID = packet.ReadUInt16();
+
+                cooldown.Category = packet.ReadUInt16();
+                cooldown.Duration = packet.ReadUInt32();
+                cooldown.CategoryDuration = packet.ReadUInt32();
+
+                spells.Cooldowns.Add(cooldown);
+            }
+
+            Log.Event("pet.spells.parsed", new
+            {
+                pet_guid = spells.PetGUID.ToString(),
+                creature_family = spells.CreatureFamily,
+                time_limit_ms = spells.TimeLimit,
+                react_state = spells.ReactState.ToString(),
+                command_state = spells.CommandState.ToString(),
+                flag = spells.Flag,
+                spell_count = spellCount,
+                cd_count = cdCount,
+                packet_size = dbgPacketSize,
+            });
+
+            SendPacketToClient(spells);
         }
-        
-        SendPacketToClient(spells);
+        catch (Exception ex)
+        {
+            Log.Print(LogType.Error, $"PetSpellsMessage parse failed (non-fatal, packet dropped): packetSize={dbgPacketSize} {ex.GetType().Name}: {ex.Message}");
+            Log.Event("pet.spells_message.parse_failed", new
+            {
+                exception_type = ex.GetType().Name,
+                exception_message = ex.Message,
+                packet_size = dbgPacketSize,
+                packet_hex = HexDump(dbgRawBytes),
+            });
+        }
     }
 
     [PacketHandler(Opcode.SMSG_PET_ACTION_SOUND)]
@@ -82,12 +175,18 @@ public partial class WorldClient
         PetActionSound sound = new PetActionSound();
         sound.UnitGUID = packet.ReadGuid().To128(GetSession().GameState);
         sound.Action = packet.ReadUInt32();
+        Log.Event("pet.action_sound", new
+        {
+            unit_guid = sound.UnitGUID.ToString(),
+            action = sound.Action,
+        });
         SendPacketToClient(sound);
     }
 
     [PacketHandler(Opcode.SMSG_PET_BROKEN)]
     void HandlePetBroken(WorldPacket packet)
     {
+        Log.Event("pet.broken", new { });
         PrintNotification notify = new PrintNotification();
         notify.NotifyText = "Your pet has run away";
         SendPacketToClient(notify);

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -552,6 +552,14 @@ public partial class WorldClient
     {
         uint petNumber = packet.ReadUInt32();
         WowGuid128 guid = GetSession().GameState.GetPetGuidByNumber(petNumber);
+        string name = packet.ReadCString();
+        Log.Event("pet.name_query.response", new
+        {
+            pet_number = petNumber,
+            resolved_guid = guid == default ? "(none)" : guid.ToString(),
+            name_empty = name.Length == 0,
+            name = name,
+        });
         if (guid == default)
         {
             Log.Print(LogType.Error, $"Pet name query response for unknown pet {petNumber}!");
@@ -560,11 +568,15 @@ public partial class WorldClient
 
         QueryPetNameResponse response = new QueryPetNameResponse();
         response.UnitGUID = guid;
-        response.Name = packet.ReadCString();
+        response.Name = name;
         if (response.Name.Length == 0)
         {
+            // Legacy server returned empty name (typically a petnumber/guid mismatch in
+            // the CMSG). Still forward the response with Allow=false so the modern client
+            // stops retrying — without a response it spins on the query and the unit
+            // frame stays at "Unknown".
             response.Allow = false;
-            packet.ReadBytes(7); // 0s
+            SendPacketToClient(response);
             return;
         }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1191,72 +1191,134 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_SPELL_EXECUTE_LOG)]
     void HandleSpellExecuteLog(WorldPacket packet)
     {
-        var casterGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-        uint spellId = packet.ReadUInt32();
-        uint effectCount = packet.ReadUInt32();
-
-        Log.Print(LogType.Server, $"SpellExecuteLog: caster={casterGuid} spell={spellId} effects={effectCount}");
-
-        for (uint i = 0; i < effectCount; i++)
+        // SMSG_SPELL_EXECUTE_LOG is diagnostic-only — nothing here is forwarded to
+        // the modern client. So if any byte misalignment / unknown effect format
+        // trips a parse exception, we MUST NOT let it bubble up — it would tear
+        // down the entire ReceiveLoop and force a random disconnect.
+        //
+        // Two known triggers found in the wild, both effects that report targetCount
+        // > 0 on the wire but emit no per-target payload — falling through to the
+        // default GUID-read branch reads off the end of the packet:
+        //   - Effect 50 (TRANS_DOOR): Priest Lightwell, Mage portals, etc.
+        //   - Effect 69 (DISTRACT): Rogue spell 1725 — anyone in range casting it
+        //     would DC every other player.
+        // Try/catch wrapper is the durable fix for the next surprise effect type;
+        // explicit cases just keep the error log clean.
+        // Breadcrumbs for the parse-failed event — capture as much state as we
+        // got through before the exception so future captures tell us which spell
+        // / effect type we need to whitelist next.
+        uint dbgSpellId = 0;
+        uint dbgEffectIndex = 0;
+        uint dbgEffectType = 0;
+        uint dbgTargetCount = 0;
+        uint dbgTargetIndex = 0;
+        try
         {
-            uint effectType = packet.ReadUInt32();
-            uint targetCount = packet.ReadUInt32();
+            var casterGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+            uint spellId = packet.ReadUInt32();
+            dbgSpellId = spellId;
+            uint effectCount = packet.ReadUInt32();
 
-            Log.Print(LogType.Server, $"  Effect[{i}]: type={effectType} targets={targetCount}");
+            Log.Print(LogType.Server, $"SpellExecuteLog: caster={casterGuid} spell={spellId} effects={effectCount}");
 
-            for (uint t = 0; t < targetCount; t++)
+            for (uint i = 0; i < effectCount; i++)
             {
-                switch (effectType)
+                dbgEffectIndex = i;
+                uint effectType = packet.ReadUInt32();
+                uint targetCount = packet.ReadUInt32();
+                dbgEffectType = effectType;
+                dbgTargetCount = targetCount;
+
+                Log.Print(LogType.Server, $"  Effect[{i}]: type={effectType} targets={targetCount}");
+
+                for (uint t = 0; t < targetCount; t++)
                 {
-                    case 8: // POWER_DRAIN
-                        var pdGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-                        uint pdAmount = packet.ReadUInt32();
-                        uint pdPowerType = packet.ReadUInt32();
-                        float pdMultiplier = packet.ReadFloat();
-                        Log.Print(LogType.Server, $"PowerDrain: target={pdGuid} amount={pdAmount} power={pdPowerType}");
-                        break;
-                    case 10: // HEAL
-                        var hGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-                        uint hAmount = packet.ReadUInt32();
-                        uint hCrit = packet.ReadUInt32();
-                        Log.Print(LogType.Server, $"Heal: target={hGuid} amount={hAmount} crit={hCrit}");
-                        break;
-                    case 30: // ENERGIZE
-                        var eGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-                        uint eAmount = packet.ReadUInt32();
-                        uint ePowerType = packet.ReadUInt32();
-                        Log.Print(LogType.Server, $"Energize: target={eGuid} amount={eAmount} power={ePowerType}");
-                        break;
-                    case 32: // EXTRA_ATTACKS (vanilla value 32)
-                        var eaGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-                        uint eaCount = packet.ReadUInt32();
-                        Log.Print(LogType.Server, $"ExtraAttacks: target={eaGuid} count={eaCount}");
-                        break;
-                    case 24: // CREATE_ITEM
-                        uint ciItemId = packet.ReadUInt32();
-                        Log.Print(LogType.Server, $"CreateItem: item={ciItemId}");
-                        break;
-                    case 41: // INTERRUPT_CAST
-                        var icGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-                        uint icSpellId = packet.ReadUInt32();
-                        Log.Print(LogType.Server, $"InterruptCast: target={icGuid} spell={icSpellId}");
-                        break;
-                    case 101: // FEED_PET
-                        uint fpItemId = packet.ReadUInt32();
-                        Log.Print(LogType.Server, $"FeedPet: item={fpItemId}");
-                        break;
-                    case 113: // DURABILITY_DAMAGE
-                        var ddGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-                        uint ddItemId = packet.ReadUInt32();
-                        uint ddAmount = packet.ReadUInt32();
-                        Log.Print(LogType.Server, $"DurabilityDmg: target={ddGuid} item={ddItemId} amount={ddAmount}");
-                        break;
-                    default: // INSTAKILL, RESURRECT, DISPEL, SUMMON, etc — just a GUID
-                        var defaultGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
-                        Log.Print(LogType.Server, $"Default(type={effectType}): target={defaultGuid}");
-                        break;
+                    dbgTargetIndex = t;
+                    switch (effectType)
+                    {
+                        case 8: // POWER_DRAIN
+                            var pdGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                            uint pdAmount = packet.ReadUInt32();
+                            uint pdPowerType = packet.ReadUInt32();
+                            float pdMultiplier = packet.ReadFloat();
+                            Log.Print(LogType.Server, $"PowerDrain: target={pdGuid} amount={pdAmount} power={pdPowerType}");
+                            break;
+                        case 10: // HEAL
+                            var hGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                            uint hAmount = packet.ReadUInt32();
+                            uint hCrit = packet.ReadUInt32();
+                            Log.Print(LogType.Server, $"Heal: target={hGuid} amount={hAmount} crit={hCrit}");
+                            break;
+                        case 30: // ENERGIZE
+                            var eGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                            uint eAmount = packet.ReadUInt32();
+                            uint ePowerType = packet.ReadUInt32();
+                            Log.Print(LogType.Server, $"Energize: target={eGuid} amount={eAmount} power={ePowerType}");
+                            break;
+                        case 32: // EXTRA_ATTACKS (vanilla value 32)
+                            var eaGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                            uint eaCount = packet.ReadUInt32();
+                            Log.Print(LogType.Server, $"ExtraAttacks: target={eaGuid} count={eaCount}");
+                            break;
+                        case 24: // CREATE_ITEM
+                            uint ciItemId = packet.ReadUInt32();
+                            Log.Print(LogType.Server, $"CreateItem: item={ciItemId}");
+                            break;
+                        case 41: // INTERRUPT_CAST
+                            var icGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                            uint icSpellId = packet.ReadUInt32();
+                            Log.Print(LogType.Server, $"InterruptCast: target={icGuid} spell={icSpellId}");
+                            break;
+                        case 3: // DUMMY — server-side script triggers the real mechanic.
+                                // Paladin Holy Shock (20930), various Judgements, etc.
+                                // No per-target payload follows.
+                            Log.Print(LogType.Server, $"Dummy(type={effectType}): no target payload");
+                            break;
+                        case 50: // TRANS_DOOR — Lightwell, Mage Portal, etc. No per-target payload.
+                            Log.Print(LogType.Server, $"TransDoor(type={effectType}): no target payload");
+                            break;
+                        case 69: // DISTRACT — positional spell, no per-target payload.
+                            Log.Print(LogType.Server, $"Distract(type={effectType}): no target payload");
+                            break;
+                        case 77: // SCRIPT_EFFECT — Judgement (20271) and many other script-driven
+                                 // spells. Like DUMMY, the real mechanic is server-side; no
+                                 // per-target payload on the wire.
+                            Log.Print(LogType.Server, $"ScriptEffect(type={effectType}): no target payload");
+                            break;
+                        case 101: // FEED_PET
+                            uint fpItemId = packet.ReadUInt32();
+                            Log.Print(LogType.Server, $"FeedPet: item={fpItemId}");
+                            break;
+                        case 113: // DURABILITY_DAMAGE
+                            var ddGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                            uint ddItemId = packet.ReadUInt32();
+                            uint ddAmount = packet.ReadUInt32();
+                            Log.Print(LogType.Server, $"DurabilityDmg: target={ddGuid} item={ddItemId} amount={ddAmount}");
+                            break;
+                        default: // INSTAKILL, RESURRECT, DISPEL, SUMMON, etc — just a GUID
+                            var defaultGuid = packet.ReadPackedGuid().To128(GetSession().GameState);
+                            Log.Print(LogType.Server, $"Default(type={effectType}): target={defaultGuid}");
+                            break;
+                    }
                 }
             }
+        }
+        catch (Exception ex)
+        {
+            // SMSG_SPELL_EXECUTE_LOG is read for diagnostic logging only; an unknown
+            // effect format here must never disconnect the player. Log and drop.
+            Log.Print(LogType.Error, $"SpellExecuteLog parse failed (non-fatal, packet dropped): spell={dbgSpellId} effectType={dbgEffectType} {ex.GetType().Name}: {ex.Message}");
+            Log.Event("combat.execute_log.parse_failed", new
+            {
+                exception_type = ex.GetType().Name,
+                exception_message = ex.Message,
+                spell_id = dbgSpellId,
+                effect_index = dbgEffectIndex,
+                effect_type = dbgEffectType,
+                target_count = dbgTargetCount,
+                target_index = dbgTargetIndex,
+                packet_size = packet.GetSize(),
+            });
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -448,7 +448,18 @@ public partial class WorldClient
         // depends on that path for target-frame cast-bar dismiss on Kick / Counterspell.
         bool casterIsLocalPlayer = GetSession().GameState.CurrentPlayerGuid == casterUnit;
         bool casterIsLocalPet    = GetSession().GameState.CurrentPetGuid    == casterUnit;
-        if (casterIsLocalPlayer || casterIsLocalPet)
+        // Ranged auto-attack exception (mirrors the SPELL_START allowlist in
+        // HandleSpellStart): for Auto Shot (75) / Shoot (5019), the modern
+        // client requires SMSG_SPELL_FAILURE to cancel the bow-draw / wand-aim
+        // animation. Suppressing it leaves the bow drawn forever after a single
+        // out-of-range / LoS rejection, which the user sees as
+        //   "animation ready but the shot never fires".
+        // CAST_FAILED + CANCEL_AUTO_REPEAT alone are not enough to retract the
+        // ranged-attack visual on 1.14 — observed in the 2026-04-28 hunter
+        // bundle where every Auto Shot SPELL_START was paired with a suppressed
+        // SPELL_FAILURE reason=1 and the bow stuck drawn.
+        bool isRangedAutoAttack = spellId == 75 || spellId == 5019;
+        if ((casterIsLocalPlayer || casterIsLocalPet) && !isRangedAutoAttack)
         {
             Log.Event("spell.failure.suppressed_for_caster", new
             {
@@ -457,6 +468,15 @@ public partial class WorldClient
                 is_pet = casterIsLocalPet,
             });
             return;
+        }
+        if (isRangedAutoAttack && (casterIsLocalPlayer || casterIsLocalPet))
+        {
+            Log.Event("spell.failure.ranged_auto_forwarded", new
+            {
+                spellId,
+                raw_reason_byte = reason,
+                is_pet = casterIsLocalPet,
+            });
         }
 
         WowGuid128 castId;
@@ -643,7 +663,17 @@ public partial class WorldClient
         // the GCD cleanly. Successful instants still apply real GCD via SPELL_GO. Cast-
         // time spells (CastTime > 0) and NPC casts forward as before — for them, GCD has
         // genuinely been committed server-side and the cast-bar visual is needed.
-        bool suppressInstantStart = (casterIsLocalPlayer || casterIsLocalPet) && spell.Cast.CastTime == 0;
+        // Ranged auto-attack exception: spells like Auto Shot (75) and Shoot (5019)
+        // are instant casts where SMSG_SPELL_START is what plays the visible bow
+        // draw / wand aim animation. Suppressing it leaves the player firing
+        // invisibly — the shots still hit (via SPELL_GO) but the character never
+        // animates, which is what the user observed for Hunter Auto Shot.
+        // Whitelist these so they bypass the issue-#43 instant-suppression.
+        bool isRangedAutoAttack = spell.Cast.SpellID == 75      // Auto Shot
+                                  || spell.Cast.SpellID == 5019; // Shoot (Wand)
+        bool suppressInstantStart = (casterIsLocalPlayer || casterIsLocalPet)
+                                    && spell.Cast.CastTime == 0
+                                    && !isRangedAutoAttack;
         if (suppressInstantStart)
         {
             Log.Event("spell.start.instant_suppressed", new
@@ -654,6 +684,15 @@ public partial class WorldClient
                 caster_is_pet = casterIsLocalPet,
             });
             return;
+        }
+        if (isRangedAutoAttack && (casterIsLocalPlayer || casterIsLocalPet) && spell.Cast.CastTime == 0)
+        {
+            Log.Event("spell.start.ranged_auto_forwarded", new
+            {
+                spell_id = spell.Cast.SpellID,
+                caster_is_player = casterIsLocalPlayer,
+                caster_is_pet = casterIsLocalPet,
+            });
         }
 
         SendPacketToClient(spell);
@@ -1284,6 +1323,16 @@ public partial class WorldClient
                                  // spells. Like DUMMY, the real mechanic is server-side; no
                                  // per-target payload on the wire.
                             Log.Print(LogType.Server, $"ScriptEffect(type={effectType}): no target payload");
+                            break;
+                        case 56:  // SUMMON_PET — pet summon, server-side, no per-target payload
+                                  // (observed for spell 883 = Call Pet).
+                        case 63:  // TAMECREATURE (Kronos numbering) — observed for spell 1515 =
+                                  // Tame Beast. The tamed creature is summoned via the normal
+                                  // pet path; this log entry has no per-target payload.
+                        case 102: // observed for spell 2641 = Dismiss Pet — server-side, no payload.
+                        case 104: // observed for spell 14311 / various Hunter abilities — Kronos
+                                  // emits these without a per-target GUID payload.
+                            Log.Print(LogType.Server, $"NoPayload(type={effectType}): no target payload");
                             break;
                         case 101: // FEED_PET
                             uint fpItemId = packet.ReadUInt32();

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1261,6 +1261,49 @@ public partial class WorldClient
 
     private void AfterStoreObjectUpdateHook(WowGuid128 guid, ObjectType objectType, BitArray updateMaskArray, Dictionary<int, UpdateField> updates, AuraUpdate auraUpdate, PowerUpdate? powerUpdate, bool isCreate, ObjectUpdate updateData, BitArray changedValuesMask)
     {
+        // JimsProxy: comprehensive pet diagnostics for the Hunter-Pet-Stealth-Stuck
+        // investigation. Fires on every UPDATE_OBJECT block targeting a pet GUID
+        // OR the current pet (covers quest-tamed creatures which have a Creature/
+        // Unit GUID encoding rather than HighGuidType.Pet).
+        var currentPetGuid = GetSession().GameState.CurrentPetGuid;
+        bool isPetGuid = guid.GetHighType() == HighGuidType.Pet
+                         || (!currentPetGuid.IsEmpty() && guid == currentPetGuid);
+        if (isPetGuid)
+        {
+            {
+                var auraSummary = new System.Collections.Generic.List<object>();
+                if (auraUpdate != null && auraUpdate.Auras != null)
+                {
+                    foreach (var a in auraUpdate.Auras)
+                    {
+                        auraSummary.Add(new
+                        {
+                            slot = a.Slot,
+                            spell_id = a.AuraData != null ? a.AuraData.SpellID : 0,
+                            removed = a.AuraData == null,
+                            applications = a.AuraData != null ? a.AuraData.Applications : (byte)0,
+                        });
+                    }
+                }
+                Log.Event("pet.update_object", new
+                {
+                    guid = guid.ToString(),
+                    is_create = isCreate,
+                    entry_id = updateData.ObjectData.EntryID,
+                    display_id = updateData.UnitData.DisplayID,
+                    vis_flags = updateData.UnitData.VisFlags,
+                    stand_state = updateData.UnitData.StandState,
+                    shapeshift_form = updateData.UnitData.ShapeshiftForm,
+                    flags = updateData.UnitData.Flags,
+                    health = updateData.UnitData.Health,
+                    max_health = updateData.UnitData.MaxHealth,
+                    aura_full_update = auraUpdate?.UpdateAll ?? false,
+                    aura_count = auraSummary.Count,
+                    auras = auraSummary,
+                });
+            }
+        }
+
         if (objectType == ObjectType.Player || objectType == ObjectType.ActivePlayer)
         {
             int UNIT_FIELD_NATIVEDISPLAYID = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_NATIVEDISPLAYID);
@@ -1596,6 +1639,45 @@ public partial class WorldClient
 
                 if (guid.GetHighType() == HighGuidType.Pet && updateData.UnitData.DisplayPower == (uint)PowerType.Focus)
                     GetSession().GameState.HunterPetGuids.Add(guid);
+
+                // Pet ClassId fallback: Vanilla Kronos sends ClassId=0 (or an invalid
+                // value outside 1..MAX_CLASSES) for pets. The 1.14 client's
+                // PetPaperDollFrame_SetStats does
+                //   classFileName = select(2, UnitClass("pet"))   → nil
+                //   classStatText = _G[strupper(classFileName)..] → strupper(nil) ERROR
+                // killing the paper-doll frame with "bad argument #1 to 'strupper'".
+                // Clamp to 1 (Warrior) — guaranteed to resolve to a real class file name.
+                // Modern servers (3.0+) send a valid pet class so this only fires on legacy.
+                var currentPetGuid = GetSession().GameState.CurrentPetGuid;
+                bool isPetUnit = guid.GetHighType() == HighGuidType.Pet
+                                 || (!currentPetGuid.IsEmpty() && guid == currentPetGuid)
+                                 || GetSession().GameState.HunterPetGuids.Contains(guid);
+                byte rawClassId = (byte)((updates[UNIT_FIELD_BYTES_0].UInt32Value >> 8) & 0xFF);
+                if (isPetUnit)
+                {
+                    Log.Event("pet.bytes0.observed", new
+                    {
+                        guid = guid.ToString(),
+                        high_type = guid.GetHighType().ToString(),
+                        bytes0_raw = updates[UNIT_FIELD_BYTES_0].UInt32Value,
+                        race_id = updateData.UnitData.RaceId,
+                        class_id = rawClassId,
+                        sex_id = updateData.UnitData.SexId,
+                        display_power = updateData.UnitData.DisplayPower,
+                    });
+                }
+                if (isPetUnit && (rawClassId < 1 || rawClassId > 12))
+                {
+                    Log.Event("pet.class_id.fallback", new
+                    {
+                        guid = guid.ToString(),
+                        original_class_id = rawClassId,
+                        defaulted_to = 1,
+                        race_id = updateData.UnitData.RaceId,
+                        display_power = updateData.UnitData.DisplayPower,
+                    });
+                    updateData.UnitData.ClassId = 1; // Warrior — guaranteed non-nil class file name
+                }
 
                 if (objectType == ObjectType.Unit)
                     GetSession().GameState.StoreCreatureClass(guid.GetEntry(), (Class)updateData.UnitData.ClassId);

--- a/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
@@ -60,6 +60,13 @@ public partial class WorldSocket
         WorldPacket packet = new WorldPacket(Opcode.CMSG_QUERY_PET_NAME);
         packet.WriteUInt32(queryName.UnitGUID.GetEntry());
         packet.WriteGuid(queryName.UnitGUID.To64());
+        Framework.Logging.Log.Event("pet.name_query.sent", new
+        {
+            client_guid = queryName.UnitGUID.ToString(),
+            entry = queryName.UnitGUID.GetEntry(),
+            counter = queryName.UnitGUID.GetCounter(),
+            high_type = queryName.UnitGUID.GetHighType().ToString(),
+        });
         SendPacketToServer(packet);
     }
     [PacketHandler(Opcode.CMSG_WHO)]

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -109,11 +109,36 @@ public partial class WorldSocket
             SendPacket(failed);
         }    
     }
+    // JimsProxy: Hunter tame-class spell IDs in vanilla — used to log tame attempts
+    // for the pet deep-dive. 1515 = "Tame Beast" player ability; the rest are
+    // quest-tame variants ("Capture Beast Aspects" etc.) that target specific
+    // creature families. List is not exhaustive; if we see new tame variants in
+    // the wild, add them here.
+    private static readonly System.Collections.Generic.HashSet<uint> TameSpellIds = new()
+    {
+        1515u,   // Tame Beast (Hunter)
+        13481u,  // Tame Hyena (quest variant)
+        19484u,  // Tame Wolf (quest variant)
+        19597u, 19676u, 19677u, 19678u, // Tame quest variants
+        19684u, 19685u, 19686u, 19687u, // Confirmed quest tame variants on Kronos
+        19688u, 19689u, 19690u, 19691u, 19692u, 19693u,
+        19694u, 19696u, 19697u, 19698u, 19699u, 19700u,
+    };
+
     [PacketHandler(Opcode.CMSG_CAST_SPELL)]
     void HandleCastSpell(CastSpell cast)
     {
         if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
             GetSession().GameState.LastDispellSpellId = (uint)cast.Cast.SpellID;
+
+        if (TameSpellIds.Contains(cast.Cast.SpellID))
+        {
+            Log.Event("pet.tame.cast", new
+            {
+                spell_id = cast.Cast.SpellID,
+                cast_id_counter = cast.Cast.CastID.GetCounter(),
+            });
+        }
 
         bool isNextMelee = GameData.NextMeleeSpells.Contains(cast.Cast.SpellID);
         bool isAutoRepeat = GameData.AutoRepeatSpells.Contains(cast.Cast.SpellID);


### PR DESCRIPTION
 Six independent Hunter-related fixes shaken out while testing the
  original Hunter-Pet-Stealth-Stuck branch. The stealth bug itself
  appears already fixed in master; surfaced these along the way.

  * Auto Shot animation missing
    Allowlisted spell 75 (Auto Shot) and 5019 (Shoot) to bypass the
    issue-#43 SMSG_SPELL_START instant-cast suppressor — that gate
    was eating the bow-draw / wand-aim animation on every shot.

  * Auto Shot stuck-bow ("animation ready, never fires")
    Same allowlist applied to the SMSG_SPELL_FAILURE suppressor.
    Kronos sends FAILURE after every out-of-range / LoS rejection
    for ranged auto-attacks, and that's the only signal that retracts
    the bow on the modern client. Without it the bow stayed drawn
    forever between shot attempts.

  * Pet name shows "Unknown" after dismiss/resummon
    HandleQueryPetNameResponse was returning early without forwarding
    the response when the legacy server returned an empty name. The
    modern client kept retrying with no answer. Now sends Allow=false
    so the client moves on; added pet.name_query.sent /
    pet.name_query.response diagnostics for any future regressions.

  * PetPaperDollFrame / PetStable Lua error popups on hunter login
    Blizzard FrameXML bug in 1.14.2 (build 42597) — strupper(nil) on
    pet class file name and string concat on nil family / loyalty.
    Fixed post-1.14.2 in master FrameXML but not in shipping client.
    New JimsPlus PetFix.lua wraps PetPaperDollFrame_SetStats and
    PetStable_Update in pcall so the nil-guard failures are absorbed
    silently. Bumped JimsPlus build to 18.

  * PetSpellsMessage parse exception on quest-tame
    Wrapped the SMSG_PET_SPELLS_MESSAGE handler in try/catch (would
    DC the session on malformed quest-tame packets). Added a
    layered creature_family fallback: template lookup → cached value →
    default Wolf (1). Vanilla quest tames have no Beast family in
    the creature template; family=0 makes 1.14's UnitCreatureFamily
    return nil and crash PetPaperDollFrame_SetStats.

  * Pet ClassId clamp + diagnostics
    If a pet UPDATE_OBJECT carries ClassId outside 1..12, clamp to 1
    (Warrior). Defensive — Kronos already sends 1 for hunter pets,
    but other legacy emulators may not.

  * SMSG_SPELL_EXECUTE_LOG no-payload effect coverage
    Extended the parser allowlist to effect types 56, 63, 102, 104
    (observed for Call Pet, Tame Beast, Dismiss Pet, and various
    hunter abilities on Kronos). Previously fell through to default
    GUID reader and threw — caught by existing try/catch but spammed
    the log.

  Tested on Kronos 1.12 with: tame beast (quest item + Tame Beast),
  dismiss/resummon, stable round-trip with second pet, Auto Shot in
  multiple range/LoS scenarios, and full character relog. No Lua
  errors, no DCs, no parser failures.

  Files touched:
  - Addons/JimsPlus/Core.lua (build bump)
  - Addons/JimsPlus/JimsPlus.toc (PetFix.lua entry)
  - Addons/JimsPlus/PetFix.lua (new)
  - HermesProxy/GlobalSessionData.cs
  - HermesProxy/World/Client/PacketHandlers/PetHandler.cs
  - HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
  - HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
  - HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
  - HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
  - HermesProxy/World/Server/PacketHandlers/SpellHandler.cs