### PR TITLE
Latency fixes: Nagle ignore + GCD double-cast window + RTT-adaptive offset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,3 +67,49 @@ Three observation-layer improvements applied on top of the rebase commits above.
 3. **Benign realmd close re-tag:** every successful login produced a red `Error | AuthClient | Socket Closed By Server` after auth completion because Kronos realmd intentionally closes the socket after serving the realmlist. `ReceiveCallback` now checks `_response.Task.IsCompleted` — if true, logs `Network` with "Realmd disconnected after successful auth (expected)"; if false, keeps the `Error` + `SetAuthResponse(FAIL_INTERNAL_ERROR)` path for real auth failures.
 
 No behaviour changes to dispatch or translation; all three are observation-layer improvements.
+
+## 2026-04-29 — Latency fixes: Nagle ignore + GCD double-cast window + RTT-adaptive offset
+
+Three related latency improvements, shipped as PR #87 targeting beta.
+
+### CMSG_ENABLE_NAGLE ignore
+
+**Issue:** The 1.14 client sends `CMSG_ENABLE_NAGLE` when the user unchecks "Optimize Network for Speed," re-enabling Nagle's algorithm (~200ms write coalescing) on both the client-facing and server-facing sockets. For a game proxy that needs low-latency bidirectional forwarding, this adds pure delay.
+
+**Change:** `World/Server/WorldSocket.cs` — the `CMSG_ENABLE_NAGLE` case no longer calls `SetNoDelay(false)`. The packet is still processed through decryption so the AES-GCM nonce counter stays in sync (per Xian55 fix `2960e77`). TCP_NODELAY, set at connection time in `WorldSocketManager` and `WorldClient.ConnectCallback`, is now permanent for the session.
+
+**Verification:** JSONL confirms two `CMSG_ENABLE_NAGLE` events in test session when the setting is unchecked. No latency degradation observed post-fix.
+
+### GCD double-cast window fix
+
+**Issue:** `OnGcdTimerElapsed` (GlobalSessionData.cs) was clearing `_gcdExpireTimestampMs = 0` when the hold timer fired, removing GCD protection during the ~RTT window before the server responded with `SMSG_SPELL_GO`. Spam-presses during this window bypassed all guards (`IsGcdHoldActive()` and `HasStartedNormalCast()` both returned false) and sent duplicate casts to the server.
+
+**Change:** Three sub-fixes in `GlobalSessionData.cs` and `World/Server/PacketHandlers/SpellHandler.cs`:
+
+1. **Don't clear `_gcdExpireTimestampMs` on timer fire** — GCD stays active until natural expiry. Presses between `fireAt` and `expireAt` are caught by `IsGcdHoldActive()` and stored in the now-empty `_heldGcdCast` slot. The next `BeginGcd` (from incoming `SMSG_SPELL_GO`) picks them up.
+
+2. **`HasForwardedPendingCast()` guard** (position 3 in HandleCastSpell) — catches presses after local GCD expires but before `SMSG_SPELL_GO` arrives. Uses `ForceHoldCast()` to store in `_heldGcdCast` and `SendCastRequestFailed` for displaced casts.
+
+3. **Fire held cast on failure** — `TakeHeldCastIfReady()` in `HandleCastFailed` fires any held cast immediately when the server rejects the forwarded cast and GCD is no longer active, preventing the player from getting stuck.
+
+Guard ordering in HandleCastSpell:
+1. `HasStartedNormalCast()` → DROP (cast-time duplicates)
+2. `IsGcdHoldActive()` → HOLD (instant-cast GCD window)
+3. `HasForwardedPendingCast()` → HOLD (post-GCD forwarded cast window)
+4. *(reserved for PR #86's `HasInFlightNormalCastForSpell()` → DROP)*
+5. Normal forward path
+
+**Verification:** Arcane Explosion spam on Kronos — each GCD window should produce exactly one `spell.held_fire` event. LoS-fail during spam should fire the held cast on failure.
+
+### RTT-adaptive GCD fire offset
+
+**Issue:** With `SpellCastEarlyFireOffsetMs = 0`, the held cast fires at exact local GCD expiry. Since `SMSG_SPELL_GO` must travel back from the server (~RTT/2) before the next GCD starts, each GCD cycle takes ~1700ms instead of 1500ms (verified: Arcane Explosion JSONL data shows consistent ~1700ms intervals, implying ~200ms RTT to Kronos).
+
+**Change:** `GlobalSessionData.cs` + `World/Client/PacketHandlers/MiscHandler.cs` + `World/Client/WorldClient.cs` + `World/Client/PacketHandlers/SpellHandler.cs`:
+
+- **RTT measurement:** Timestamps forwarded `CMSG_PING` sends in `WorldClient.SendPing` (covers both client-originated and proxy keepalive pings), measures `SMSG_PONG` returns in `MiscHandler.HandlePingResponse`. EMA-smoothed (alpha=0.2), requires 3 samples before activating (~45s warm-up at 30s ping interval with both client and keepalive pings contributing).
+- **Adaptive offset:** `GetAdaptiveFireOffsetMs()` returns `Clamp(Round(smoothedRtt * 0.5), 0, 100)`. RTT/2 means the cast arrives at the server right as the server-side GCD expires. Capped at 100ms (covers up to 200ms RTT).
+- **Static fallback:** During warm-up (`< 3` samples), falls back to the `SpellCastEarlyFireOffsetMs` config value (default 0, manual clamp 0–50ms). The adaptive path can reach 100ms because EMA smoothing provides its safety margin; the manual path stays conservative at 50ms max.
+- **Diagnostics:** `rtt.sample` events log each measurement. `gcd.begin` events now emit `fire_offset_ms` (adaptive) and `smoothed_rtt_ms` for post-session analysis.
+
+**Verification:** After 2+ minutes of play, `gcd.begin` events should show `fire_offset_ms > 0`. Arcane Explosion GCD intervals should decrease from ~1700ms to ~1600ms. Zero or near-zero `NOT_READY` failures expected.

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -60,7 +60,7 @@ public static class Settings
         // JimsProxy: structured logging defaults on; toggle VerboseLog to enable per-packet Verbose console output
         StructuredLog = config.GetBoolean("StructuredLog", true);
         VerboseLog = config.GetBoolean("VerboseLog", false);
-        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
+        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 100);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;
         // Open the JSONL file now so session.start's payload can include the full path.

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -60,7 +60,7 @@ public static class Settings
         // JimsProxy: structured logging defaults on; toggle VerboseLog to enable per-packet Verbose console output
         StructuredLog = config.GetBoolean("StructuredLog", true);
         VerboseLog = config.GetBoolean("VerboseLog", false);
-        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 100);
+        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;
         // Open the JSONL file now so session.start's payload can include the full path.

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -130,6 +130,14 @@ public sealed class GameSessionData
     private Timer? _gcdExpiryTimer;
     private uint _gcdGeneration;                        // incremented each BeginGcd; callback compares against its captured generation to detect stale fires
     public Action<ClientCastRequest>? OnGcdHeldCastFire; // set by WorldSocket at attach time; invoked on a ThreadPool thread at GCD expiry
+
+    // JimsProxy: proxy→server RTT measurement for adaptive GCD fire offset.
+    private readonly object _rttLock = new();
+    private long _lastPingSendTickMs;
+    private uint _lastPingSerial;
+    private double _smoothedRttMs;
+    private int _rttSampleCount;
+
     //MIRASU - Tracks the unique CastID assigned to in-flight non-player casts so SPELL_GO and
     //MIRASU   SPELL_FAILED_OTHER can reference the same cast the SPELL_START introduced.
     //MIRASU   Without this, mob casts reuse a deterministic CastID (spellId+casterCounter) on
@@ -728,6 +736,101 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// Returns true if any pending normal cast has been forwarded to the legacy server but
+    /// hasn't received SMSG_SPELL_START yet. Covers the post-GCD-expiry window where
+    /// IsGcdHoldActive() returns false but the server hasn't confirmed the forwarded cast.
+    /// </summary>
+    public bool HasForwardedPendingCast()
+    {
+        foreach (var item in PendingNormalCasts)
+        {
+            if (!item.HasStarted)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Store a cast in the held slot unconditionally (even if GCD has expired). Used by the
+    /// HasForwardedPendingCast guard to hold casts during the post-GCD window while waiting
+    /// for the server to respond. Returns any displaced cast.
+    /// </summary>
+    public ClientCastRequest? ForceHoldCast(ClientCastRequest cast)
+    {
+        lock (_gcdLock)
+        {
+            var displaced = _heldGcdCast;
+            _heldGcdCast = cast;
+            return displaced;
+        }
+    }
+
+    /// <summary>
+    /// Take the held cast if the GCD has expired and no forwarded cast is pending. Used by
+    /// failure handlers to fire the held cast immediately when the server rejects a cast.
+    /// Returns null if GCD is still active (timer will handle it) or if no cast is held.
+    /// </summary>
+    public ClientCastRequest? TakeHeldCastIfReady()
+    {
+        lock (_gcdLock)
+        {
+            if (_heldGcdCast == null)
+                return null;
+            if (_gcdExpireTimestampMs > Environment.TickCount64)
+                return null;
+            var cast = _heldGcdCast;
+            _heldGcdCast = null;
+            return cast;
+        }
+    }
+
+    // ── RTT measurement and adaptive GCD offset ───────────────────────
+
+    public void RecordPingSent(uint serial)
+    {
+        if ((serial & 0x80000000) != 0) return;
+        lock (_rttLock)
+        {
+            _lastPingSerial = serial;
+            _lastPingSendTickMs = Environment.TickCount64;
+        }
+    }
+
+    public void RecordPongReceived(uint serial)
+    {
+        if ((serial & 0x80000000) != 0) return;
+        lock (_rttLock)
+        {
+            if (serial != _lastPingSerial || _lastPingSendTickMs == 0) return;
+            long rttMs = Environment.TickCount64 - _lastPingSendTickMs;
+            _lastPingSendTickMs = 0;
+            if (rttMs > 5000) return;
+            const double alpha = 0.2;
+            _smoothedRttMs = _rttSampleCount == 0 ? rttMs : (_smoothedRttMs * (1 - alpha) + rttMs * alpha);
+            _rttSampleCount++;
+            Log.Event("rtt.sample", new { serial, raw_ms = rttMs, smoothed_ms = Math.Round(_smoothedRttMs, 1), samples = _rttSampleCount });
+        }
+    }
+
+    public int GetAdaptiveFireOffsetMs()
+    {
+        lock (_rttLock)
+        {
+            if (_rttSampleCount < 3)
+                return Framework.Settings.SpellCastEarlyFireOffsetMs;
+            return (int)Math.Clamp(Math.Round(_smoothedRttMs * 0.5), 0, 100);
+        }
+    }
+
+    public double GetSmoothedRttMs()
+    {
+        lock (_rttLock)
+        {
+            return Math.Round(_smoothedRttMs, 1);
+        }
+    }
+
+    /// <summary>
     /// Clear only pending normal casts that haven't started yet.
     /// Keeps started casts so SPELL_GO can dequeue them later.
     /// Returns the cleared casts so they can be failed.
@@ -979,7 +1082,10 @@ public sealed class GameSessionData
 
             toFire = _heldGcdCast;
             _heldGcdCast = null;
-            _gcdExpireTimestampMs = 0;
+            // Keep _gcdExpireTimestampMs alive — presses between fireAt and expireAt are still
+            // caught by IsGcdHoldActive() and stored in the now-empty _heldGcdCast slot. The
+            // next BeginGcd (from SPELL_GO) picks them up. Clearing it here created an unguarded
+            // RTT window where spam-presses bypassed all guards and doubled casts to the server.
             // Don't null _gcdExpiryTimer here: a concurrent BeginGcd could have already replaced it.
         }
         if (toFire != null)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -788,7 +788,6 @@ public sealed class GameSessionData
 
     public void RecordPingSent(uint serial)
     {
-        if ((serial & 0x80000000) != 0) return;
         lock (_rttLock)
         {
             _lastPingSerial = serial;
@@ -798,7 +797,6 @@ public sealed class GameSessionData
 
     public void RecordPongReceived(uint serial)
     {
-        if ((serial & 0x80000000) != 0) return;
         lock (_rttLock)
         {
             if (serial != _lastPingSerial || _lastPingSendTickMs == 0) return;

--- a/HermesProxy/World/Client/PacketHandlers/MiscHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MiscHandler.cs
@@ -14,6 +14,7 @@ public partial class WorldClient
     void HandlePingResponse(WorldPacket packet)
     {
         uint serial = packet.ReadUInt32();
+        GetSession().GameState?.RecordPongReceived(serial);
         if ((serial & 0x80000000) != 0)
             return; // keepalive pong, don't forward to modern client
         SendPacketToClient(new Pong(serial));

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -201,6 +201,21 @@ public partial class WorldClient
             failed.FailedArg1 = arg1;
             failed.FailedArg2 = arg2;
             SendPacketToClient(failed);
+
+            var gameState = GetSession().GameState;
+            if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
+            {
+                var heldCast = gameState.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_failure", new
+                    {
+                        failed_spell_id = spellId,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameState.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
     }
 
@@ -777,17 +792,16 @@ public partial class WorldClient
                 long gcdMs = GameData.GetGcdDurationMs(gcdLookupId);
                 long now = Environment.TickCount64;
                 long expireAt = now + gcdMs;
-                long fireAt = expireAt - Framework.Settings.SpellCastEarlyFireOffsetMs;
+                int adaptiveOffset = GetSession().GameState.GetAdaptiveFireOffsetMs();
+                long fireAt = expireAt - adaptiveOffset;
                 GetSession().GameState.BeginGcd(expireAt, fireAt);
 
-                // JimsProxy: gcd.begin — pairs with spell.held / spell.held_fire to reconstruct
-                // the full GCD timeline for a session. legacy_lookup_id is non-zero only for
-                // SoM-renumbered items so we can spot whitelist misses post-hoc.
                 Log.Event("gcd.begin", new
                 {
                     spell_id = spell.Cast.SpellID,
                     gcd_ms = gcdMs,
-                    fire_offset_ms = Framework.Settings.SpellCastEarlyFireOffsetMs,
+                    fire_offset_ms = adaptiveOffset,
+                    smoothed_rtt_ms = GetSession().GameState.GetSmoothedRttMs(),
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -748,6 +748,7 @@ public partial class WorldClient
         packet.WriteUInt32(ping);
         packet.WriteUInt32(latency);
         SendPacket(packet);
+        GetSession().GameState?.RecordPingSent(ping);
     }
 
     private void StartKeepAliveTimer()

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -273,6 +273,30 @@ public partial class WorldSocket
                     });
                 }
 
+                // Guard 3: a cast was forwarded to the server but hasn't received
+                // SPELL_START/SPELL_GO yet. Hold the new press so it fires when the
+                // server responds (BeginGcd creates a new timer that picks it up).
+                if (GetSession().GameState.HasForwardedPendingCast())
+                {
+                    WorldPacket heldPacket = BuildCastSpellPacket(cast);
+                    castRequest.HeldPacketForReplay = heldPacket;
+                    castRequest.HeldAtTickMs = Environment.TickCount64;
+                    var displaced = GetSession().GameState.ForceHoldCast(castRequest);
+                    Log.Event("spell.held_pending", new
+                    {
+                        spell_id = cast.Cast.SpellID,
+                        displaced_spell_id = displaced?.SpellId ?? 0,
+                        client_cast_id = castRequest.ClientGUID.ToString(),
+                    });
+                    if (displaced != null)
+                        SendCastRequestFailed(displaced, false);
+                    SpellPrepare heldPrepare = new SpellPrepare();
+                    heldPrepare.ClientCastID = castRequest.ClientGUID;
+                    heldPrepare.ServerCastID = castRequest.ServerGUID;
+                    SendPacket(heldPrepare);
+                    return;
+                }
+
                 // Enqueue the cast - responses will be matched by SpellId in FIFO order
                 GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
             }

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -276,6 +276,9 @@ public partial class WorldSocket
                 // Guard 3: a cast was forwarded to the server but hasn't received
                 // SPELL_START/SPELL_GO yet. Hold the new press so it fires when the
                 // server responds (BeginGcd creates a new timer that picks it up).
+                // NOTE: PR #86's HasInFlightNormalCastForSpell() guard belongs AFTER
+                // this block (position 4). GCD hold checks must run first so instant-
+                // cast spam is held rather than dropped.
                 if (GetSession().GameState.HasForwardedPendingCast())
                 {
                     WorldPacket heldPacket = BuildCastSpellPacket(cast);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -300,7 +300,6 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 if (_connectType == ConnectionType.Realm && GetSession().WorldClient != null && GetSession().WorldClient!.IsConnected() && GetSession().WorldClient!.IsAuthenticated())
                 {
                     GetSession().WorldClient!.SendPing(ping.Serial, ping.Latency);
-                    GetSession().GameState?.RecordPingSent(ping.Serial);
                 }
                 else
                     HandlePing(ping);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -298,7 +298,10 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 Ping ping = new(packet);
                 ping.Read();
                 if (_connectType == ConnectionType.Realm && GetSession().WorldClient != null && GetSession().WorldClient!.IsConnected() && GetSession().WorldClient!.IsAuthenticated())
+                {
                     GetSession().WorldClient!.SendPing(ping.Serial, ping.Latency);
+                    GetSession().GameState?.RecordPingSent(ping.Serial);
+                }
                 else
                     HandlePing(ping);
                 break;

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -332,8 +332,10 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                SetNoDelay(false);
-                GetSession()?.WorldClient?.SetNoDelay(false);
+                // Ignore: the proxy always needs TCP_NODELAY=true for low-latency
+                // forwarding. The packet is still processed (AES-GCM nonce stays in
+                // sync) but we don't obey the client's request to re-enable Nagle.
+                // Sent when the user unchecks "Optimize Network for Speed" in WoW.
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -332,9 +332,8 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                // Intentionally ignored. The 1.14 client sends this after entering
-                // world, re-enabling Nagle's ~200ms write coalescing on both sockets.
-                // Proxy needs low-latency forwarding; keep TCP_NODELAY=true permanently.
+                SetNoDelay(false);
+                GetSession()?.WorldClient?.SetNoDelay(false);
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -332,8 +332,9 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                SetNoDelay(false);
-                GetSession()?.WorldClient?.SetNoDelay(false);
+                // Intentionally ignored. The 1.14 client sends this after entering
+                // world, re-enabling Nagle's ~200ms write coalescing on both sockets.
+                // Proxy needs low-latency forwarding; keep TCP_NODELAY=true permanently.
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);


### PR DESCRIPTION
## Summary

- **Ignore CMSG_ENABLE_NAGLE** — the 1.14 client sends this when "Optimize Network for Speed" is unchecked, re-enabling Nagle's ~200ms write coalescing on both sockets. The proxy now ignores it and keeps TCP_NODELAY=true permanently. Verified with JSONL: opcode fires when the setting is disabled.

- **Close GCD double-cast window** — `OnGcdTimerElapsed` was clearing `_gcdExpireTimestampMs = 0` when the timer fired, removing GCD protection during the ~RTT window before the server responds. Spam-presses during this window bypassed all guards and sent duplicate casts. Three sub-fixes: keep GCD active after timer fire, add `HasForwardedPendingCast()` guard for the post-expiry window, and fire held casts immediately on server failure.

- **RTT-adaptive GCD fire offset** — measures proxy→server round-trip via CMSG_PING/SMSG_PONG timing (EMA-smoothed, 3-sample warm-up). Fires held casts RTT/2 ms early so they arrive at the server right as the server-side GCD expires. Capped at 100ms. Falls back to static `SpellCastEarlyFireOffsetMs` config during warm-up. Arcane Explosion spam data showed ~1700ms GCD intervals (on 1500ms GCD) with offset=0 — this should reduce to ~1600ms.

## Test plan

- [x] `dotnet build` clean (0 warnings)
- [x] `dotnet test` — 312/312 passing
- [ ] Mash Arcane Explosion on Kronos — verify no double casts in JSONL, one `spell.held_fire` per GCD
- [ ] After 2+ min, check `gcd.begin` events for `fire_offset_ms > 0` and `smoothed_rtt_ms`
- [ ] Check `rtt.sample` events for EMA convergence
- [ ] Verify zero NOT_READY failures during spam
- [ ] LoS fail during GCD spam — held cast fires on failure, player not stuck
- [ ] Uncheck "Optimize Network for Speed" — confirm CMSG_ENABLE_NAGLE is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)