### PR TITLE
Fix Rupture/Kidney Shot duration on vanilla: snapshot CP at cast time

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -162,6 +162,17 @@ public sealed class GameSessionData
     public Dictionary<WowGuid128, Dictionary<byte, int>> UnitAuraDurationLeft = [];
     public Dictionary<WowGuid128, Dictionary<byte, int>> UnitAuraDurationFull = [];
     public Dictionary<WowGuid128, Dictionary<byte, WowGuid128>> UnitAuraCaster = [];
+
+    // JimsProxy (Rupture-DoT-Lingering-Icon): combo-point cache + finisher-cast snapshot.
+    // Vanilla servers don't send aura duration for enemy debuffs, and CP-scaling finishers
+    // (Rupture, Kidney Shot) compute their duration server-side as (base + perCp × CP).
+    // We cache CP from SMSG_UPDATE_COMBO_POINTS and snapshot it on the outgoing
+    // CMSG_CAST_SPELL — at that moment the server hasn't consumed CP yet, so the cached
+    // value is the real CP that will be applied. Aura-apply paths consult the snapshot to
+    // synthesize the correct duration locally before the legacy server clears the CP.
+    public byte CurrentComboPoints;
+    public WowGuid128 CurrentComboTarget;
+    private (uint SpellId, WowGuid128 Target, byte ComboPoints, int Tick)? _pendingFinisherCast;
     public Dictionary<WowGuid128, PlayerCache> CachedPlayers = [];
     public HashSet<WowGuid128> IgnoredPlayers = [];
     public Dictionary<WowGuid128, uint> PlayerGuildIds = [];
@@ -621,6 +632,34 @@ public sealed class GameSessionData
         ref var dict = ref CollectionsMarshal.GetValueRefOrAddDefault(LastAuraCasterOnTarget, target, out _);
         dict ??= [];
         dict[spellId] = caster;
+    }
+
+    // JimsProxy (Rupture-DoT-Lingering-Icon): record the CP-scaling finisher we just sent
+    // to the server. Called from CMSG_CAST_SPELL handling, before the server has consumed
+    // the player's combo points. The aura-apply paths (SendAuraRefreshUpdate and the
+    // UpdateHandler aura-discovery loop) consult this snapshot to compute the real
+    // server-side duration for enemy debuffs that don't get SMSG_UPDATE_AURA_DURATION.
+    public void StorePendingFinisherCast(uint spellId, WowGuid128 target, byte comboPoints)
+    {
+        _pendingFinisherCast = (spellId, target, comboPoints, Environment.TickCount);
+    }
+
+    /// <summary>
+    /// JimsProxy: returns the CP-scaled aura duration in milliseconds if the matching
+    /// finisher cast was observed within ~3 s. The TTL is generous because aura discovery
+    /// can lag behind SMSG_SPELL_GO by a packet or two on busy emulators. Returns null
+    /// when no matching snapshot exists (proxy started mid-fight, off-screen mob debuff,
+    /// non-CP-scaling spell, etc.) so the caller can fall back to the CSV.
+    /// </summary>
+    public int? TryGetPendingFinisherDurationMs(uint spellId, WowGuid128 target)
+    {
+        if (_pendingFinisherCast is not { } pending)
+            return null;
+        if (pending.SpellId != spellId || pending.Target != target)
+            return null;
+        if (Environment.TickCount - pending.Tick > 3000)
+            return null;
+        return GameData.TryGetComboPointDuration(spellId, pending.ComboPoints);
     }
     public WowGuid128 GetLastAuraCasterOnTarget(WowGuid128 target, uint spellId)
     {

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -411,11 +411,17 @@ public partial class WorldClient
     void HandleUpdateComboPoints(WorldPacket packet)
     {
         ObjectUpdate updateData = new ObjectUpdate(GetSession().GameState.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
-        updateData.ActivePlayerData.ComboTarget = packet.ReadPackedGuid().To128(GetSession().GameState);
+        WowGuid128 comboTarget = packet.ReadPackedGuid().To128(GetSession().GameState);
+        updateData.ActivePlayerData.ComboTarget = comboTarget;
         byte comboPoints = packet.ReadUInt8();
         sbyte powerSlot = ClassPowerTypes.GetPowerSlotForClass(GetSession().GameState.GetUnitClass(GetSession().GameState.CurrentPlayerGuid), PowerType.ComboPoints);
         if (powerSlot >= 0)
             updateData.UnitData.Power[powerSlot] = comboPoints;
+
+        // JimsProxy (Rupture-DoT-Lingering-Icon): cache CP + target so the CMSG_CAST_SPELL
+        // handler can snapshot the value before the server consumes it on the next finisher.
+        GetSession().GameState.CurrentComboPoints = comboPoints;
+        GetSession().GameState.CurrentComboTarget = comboTarget;
 
         UpdateObject updatePacket = new UpdateObject(GetSession().GameState);
         updatePacket.ObjectUpdates.Add(updateData);

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -829,6 +829,7 @@ public partial class WorldClient
         if (!spell.Cast.CasterUnit.IsEmpty() && GameData.AuraSpells.Contains((uint)spell.Cast.SpellID))
         {
             uint spellId = (uint)spell.Cast.SpellID;
+
             foreach (WowGuid128 target in spell.Cast.HitTargets)
             {
                 // Check if this is an aura refresh (target already has this aura)
@@ -1472,6 +1473,17 @@ public partial class WorldClient
         spell.CasterGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         spell.SpellID = packet.ReadUInt32();
 
+        // JimsProxy (Rupture-DoT-Lingering-Icon): tag every periodic tick with spell + target so
+        // we can pinpoint last-tick-timestamp vs aura-removal-timestamp in the bundle. Remove
+        // once the lingering bug is rooted.
+        Framework.Logging.Log.Event("aura.tick", new
+        {
+            target_low = spell.TargetGUID.GetCounter(),
+            caster_low = spell.CasterGUID.GetCounter(),
+            spell_id = spell.SpellID,
+            caster_is_player = spell.CasterGUID == GetSession().GameState.CurrentPlayerGuid,
+        });
+
         var count = packet.ReadInt32();
         for (var i = 0; i < count; i++)
         {
@@ -1946,18 +1958,33 @@ public partial class WorldClient
         {
             // For other targets (enemy debuffs, party buffs), use best-guess duration
             // since they don't receive SMSG_UPDATE_AURA_DURATION.
-            GetSession().GameState.GetAuraDuration(target, slot, out int durationLeft, out int durationFull);
 
-            if (durationFull <= 0)
+            // JimsProxy (Rupture-DoT-Lingering-Icon): for vanilla CP-scaling finishers
+            // (Rupture, Kidney Shot), the snapshot must win over the cache because each
+            // cast can consume a different CP count and rewrite the aura. The cache holds
+            // the *previous* cast's duration; without this override a 3 CP recast on a
+            // mob that already had a 5 CP Rupture would inherit the stale 16 s. Snapshot
+            // returns null for non-finishers, so non-CP-scaling spells skip this branch.
+            int? finisherDurationMs = GetSession().GameState.TryGetPendingFinisherDurationMs(spellId, target);
+            int durationLeft;
+            int durationFull;
+            if (finisherDurationMs is int snapMs && snapMs > 0)
             {
-                durationFull = GameData.GetAuraSpellDuration(spellId);
+                durationFull = snapMs;
+                durationLeft = snapMs;
+            }
+            else
+            {
+                GetSession().GameState.GetAuraDuration(target, slot, out durationLeft, out durationFull);
+                if (durationFull <= 0)
+                    durationFull = GameData.GetAuraSpellDuration(spellId);
             }
 
             if (durationFull > 0)
             {
                 auraData.Flags |= AuraFlagsModern.Duration;
                 auraData.Duration = durationFull;
-                auraData.Remaining = durationFull;
+                auraData.Remaining = durationLeft > 0 ? durationLeft : durationFull;
 
                 GetSession().GameState.StoreAuraDurationLeft(target, slot, durationFull, Environment.TickCount);
                 GetSession().GameState.StoreAuraDurationFull(target, slot, durationFull);

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2213,6 +2213,14 @@ public partial class WorldClient
                         updateMaskArray[UNIT_FIELD_AURALEVELS + i / 4] ||
                         updateMaskArray[UNIT_FIELD_AURAAPPLICATIONS + i / 4])
                     {
+                        // JimsProxy (Rupture-DoT-Lingering-Icon): log every aura-slot touch on units
+                        // so we can see the exact packet timing of aura apply/remove vs SPELL_PERIODIC ticks.
+                        // Targeting Rupture-on-enemy lingering bug. Remove once root cause is confirmed.
+                        bool _maskAura = updateMaskArray[UNIT_FIELD_AURA + i];
+                        bool _maskLevels = updateMaskArray[UNIT_FIELD_AURALEVELS + i / 4];
+                        bool _maskApps = updateMaskArray[UNIT_FIELD_AURAAPPLICATIONS + i / 4];
+                        uint _slotSpellId = (_maskAura && updates.TryGetValue(UNIT_FIELD_AURA + i, out var _auraField)) ? _auraField.UInt32Value : 0;
+
                         AuraInfo aura = new AuraInfo();
                         aura.Slot = i;
                         aura.AuraData = ReadAuraSlot(i, guid, updates)!;
@@ -2220,13 +2228,47 @@ public partial class WorldClient
                         {
                             int durationLeft;
                             int durationFull;
-                            GetSession().GameState.GetAuraDuration(guid, i, out durationLeft, out durationFull);
+
+                            // JimsProxy (Rupture-DoT-Lingering-Icon): for vanilla CP-scaling
+                            // finishers, the snapshot must win over the cache. Each Rupture
+                            // recast can consume a different CP count and overwrites the
+                            // existing debuff with a new (potentially shorter) duration.
+                            // GetAuraDuration would return the previous cast's value, so a
+                            // 3 CP refresh after a 5 CP cast would inherit a stale 16 s.
+                            // Snapshot returns null for non-finishers (hot path bypasses).
+                            int? finisherMs = GetSession().GameState.TryGetPendingFinisherDurationMs(
+                                aura.AuraData.SpellID, guid);
+                            if (finisherMs is int snapMs && snapMs > 0)
+                            {
+                                durationFull = snapMs;
+                                durationLeft = snapMs;
+                                GetSession().GameState.StoreAuraDurationFull(guid, i, snapMs);
+                                GetSession().GameState.StoreAuraDurationLeft(guid, i, snapMs, Environment.TickCount);
+                            }
+                            else
+                            {
+                                GetSession().GameState.GetAuraDuration(guid, i, out durationLeft, out durationFull);
+                            }
+
                             if (durationLeft > 0 && durationFull > 0)
                             {
                                 aura.AuraData.Flags |= AuraFlagsModern.Duration;
                                 aura.AuraData.Duration = durationFull;
                                 aura.AuraData.Remaining = durationLeft;
                             }
+                            Framework.Logging.Log.Event("aura.slot.set", new
+                            {
+                                target_low = guid.GetCounter(),
+                                slot = i,
+                                spell_id = aura.AuraData.SpellID,
+                                slot_field_value = _slotSpellId,
+                                duration_full = durationFull,
+                                duration_left = durationLeft,
+                                mask_aura = _maskAura,
+                                mask_levels = _maskLevels,
+                                mask_apps = _maskApps,
+                                is_player_target = guid == GetSession().GameState.CurrentPlayerGuid,
+                            });
                             //MIRASU: Set NoCaster flag when caster lookup fails, or the 1.14.2 client's
                             //MIRASU: UI buff-bar treats the aura as malformed-for-display (icon hidden)
                             //MIRASU: even though the effect engine still applies stat mods from the spell
@@ -2252,6 +2294,30 @@ public partial class WorldClient
                         {
                             GetSession().GameState.ClearAuraDuration(guid, i);
                             GetSession().GameState.ClearAuraCaster(guid, i);
+                            Framework.Logging.Log.Event("aura.slot.cleared", new
+                            {
+                                target_low = guid.GetCounter(),
+                                slot = i,
+                                slot_field_value = _slotSpellId,
+                                mask_aura = _maskAura,
+                                mask_levels = _maskLevels,
+                                mask_apps = _maskApps,
+                                is_player_target = guid == GetSession().GameState.CurrentPlayerGuid,
+                            });
+                        }
+                        else
+                        {
+                            // levels or apps mask without UNIT_FIELD_AURA mask — slot likely already
+                            // empty server-side. Modern client never gets a clear for this case.
+                            Framework.Logging.Log.Event("aura.slot.skipped", new
+                            {
+                                target_low = guid.GetCounter(),
+                                slot = i,
+                                mask_aura = _maskAura,
+                                mask_levels = _maskLevels,
+                                mask_apps = _maskApps,
+                                is_player_target = guid == GetSession().GameState.CurrentPlayerGuid,
+                            });
                         }
                         if (aura.AuraData != null || updateMaskArray[UNIT_FIELD_AURA + i])
                             auraUpdate.Auras.Add(aura);
@@ -2521,7 +2587,14 @@ public partial class WorldClient
             int PLAYER_FIELD_COMBO_TARGET = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_COMBO_TARGET);
             if (PLAYER_FIELD_COMBO_TARGET >= 0 && updateMaskArray[PLAYER_FIELD_COMBO_TARGET])
             {
-                updateData.ActivePlayerData.ComboTarget = GetGuidValue(updates, PlayerField.PLAYER_FIELD_COMBO_TARGET).To128(GetSession().GameState);
+                WowGuid128 newComboTarget = GetGuidValue(updates, PlayerField.PLAYER_FIELD_COMBO_TARGET).To128(GetSession().GameState);
+                updateData.ActivePlayerData.ComboTarget = newComboTarget;
+                // JimsProxy (Rupture-DoT-Lingering-Icon): vanilla 1.12 has no
+                // SMSG_UPDATE_COMBO_POINTS opcode; CP and combo target both come through
+                // PLAYER_FIELD_* unit-field updates. Mirror the value into our finisher
+                // snapshot cache so the SMSG_SPELL_GO snapshot path knows the real CP.
+                if (guid == GetSession().GameState.CurrentPlayerGuid)
+                    GetSession().GameState.CurrentComboTarget = newComboTarget;
             }
             int PLAYER_FIELD_KNOWN_TITLES = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_KNOWN_TITLES);
             if (PLAYER_FIELD_KNOWN_TITLES >= 0)
@@ -2772,6 +2845,12 @@ public partial class WorldClient
                             powerUpdate.Powers.Add(new PowerUpdatePower(comboPoints, (byte)PowerType.ComboPoints));
                         updateData.UnitData.Power[powerSlot] = comboPoints;
                     }
+                    // JimsProxy (Rupture-DoT-Lingering-Icon): vanilla CP source — no
+                    // SMSG_UPDATE_COMBO_POINTS opcode exists in 1.12.1, so this is the
+                    // only place CurrentComboPoints gets refreshed for vanilla servers.
+                    // Cache regardless of class (non-rogue/druid will always read 0).
+                    if (guid == GetSession().GameState.CurrentPlayerGuid)
+                        GetSession().GameState.CurrentComboPoints = comboPoints;
                 }
                 else
                     updateData.ActivePlayerData.GrantableLevels = (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 8) & 0xFF);

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -401,6 +401,55 @@ public static partial class GameData
         return 0;
     }
 
+    // JimsProxy (Rupture-DoT-Lingering-Icon): vanilla 1.12 finishers whose aura duration
+    // scales with combo points consumed. The legacy server applies the scaled duration
+    // server-side at cast time but never echoes it back for *enemy* debuffs (only the
+    // player's own auras get SMSG_UPDATE_AURA_DURATION). AuraDurations{1}.csv only carries
+    // the raw SpellDuration.dbc base, which for Rupture is a flat 6000 ms with no CP info.
+    // We compute the real duration here using the combo-point count snapshotted at
+    // CMSG_CAST_SPELL time. Slice and Dice is intentionally absent — it targets self, so
+    // SMSG_UPDATE_AURA_DURATION already delivers the talented-and-CP-scaled duration; the
+    // proxy never falls back to a CSV for it. Eviscerate is absent because it has no aura.
+    private static readonly FrozenDictionary<uint, (int BaseMs, int PerCpMs)> ComboPointFinisherDurations =
+        new Dictionary<uint, (int, int)>
+        {
+            // Rupture (all 6 ranks): (6 + 2 × CP) seconds → base 6000, +2000 per CP.
+            { 1943,  (6000, 2000) },
+            { 8639,  (6000, 2000) },
+            { 8640,  (6000, 2000) },
+            { 11273, (6000, 2000) },
+            { 11274, (6000, 2000) },
+            { 11275, (6000, 2000) },
+
+            // Kidney Shot (both ranks): (1 + CP) seconds → base 1000, +1000 per CP.
+            { 408,  (1000, 1000) },
+            { 8643, (1000, 1000) },
+        }.ToFrozenDictionary();
+
+    /// <summary>
+    /// JimsProxy (Rupture-DoT-Lingering-Icon): if <paramref name="spellId"/> is a known
+    /// vanilla CP-scaling finisher, returns the actual aura duration in milliseconds for
+    /// the given combo-point count. Returns null otherwise (caller falls back to CSV).
+    /// </summary>
+    public static int? TryGetComboPointDuration(uint spellId, byte comboPoints)
+    {
+        if (comboPoints == 0)
+            return null;
+        if (!ComboPointFinisherDurations.TryGetValue(spellId, out var formula))
+            return null;
+        return formula.BaseMs + formula.PerCpMs * comboPoints;
+    }
+
+    /// <summary>
+    /// JimsProxy: true if the spell is a CP-scaling enemy-debuff finisher we compute
+    /// duration for locally. Used by the CMSG_CAST_SPELL handler to decide whether to
+    /// snapshot the player's current combo points before the server consumes them.
+    /// </summary>
+    public static bool IsComboPointFinisher(uint spellId)
+    {
+        return ComboPointFinisherDurations.ContainsKey(spellId);
+    }
+
     public static int GetTotemSlotForSpell(uint spellId)
     {
         uint slot;

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -140,6 +140,42 @@ public partial class WorldSocket
             });
         }
 
+        // JimsProxy (Rupture-DoT-Lingering-Icon): snapshot CP for vanilla CP-scaling
+        // finishers before the server consumes them. The legacy server applies
+        // (base + perCp × CP) ms duration server-side and never echoes it back for enemy
+        // debuffs, so the proxy synthesizes the correct duration locally on aura apply.
+        // Snapshotting on the keypress (before any GCD-hold path) covers both immediate
+        // forwards and held-then-released casts. TTL on the lookup side bounds staleness.
+        uint castSpellId = (uint)cast.Cast.SpellID;
+        if (GameData.IsComboPointFinisher(castSpellId))
+        {
+            byte cp = GetSession().GameState.CurrentComboPoints;
+            WowGuid128 target = cast.Cast.Target.Unit;
+            bool targetEmpty = target.IsEmpty();
+            // Unconditional diagnostic so we can see which guard failed when no snapshot fires.
+            Log.Event("finisher.cmsg_cast", new
+            {
+                spell_id = castSpellId,
+                combo_points = cp,
+                target_low = targetEmpty ? 0 : target.GetCounter(),
+                target_empty = targetEmpty,
+                target_flags = (uint)cast.Cast.Target.Flags,
+                cached_combo_target_low = GetSession().GameState.CurrentComboTarget.IsEmpty()
+                    ? 0
+                    : GetSession().GameState.CurrentComboTarget.GetCounter(),
+            });
+            if (cp > 0 && !targetEmpty)
+            {
+                GetSession().GameState.StorePendingFinisherCast(castSpellId, target, cp);
+                Log.Event("finisher.snapshot", new
+                {
+                    spell_id = castSpellId,
+                    target_low = target.GetCounter(),
+                    combo_points = cp,
+                });
+            }
+        }
+
         bool isNextMelee = GameData.NextMeleeSpells.Contains(cast.Cast.SpellID);
         bool isAutoRepeat = GameData.AutoRepeatSpells.Contains(cast.Cast.SpellID);
         // JimsProxy (issue #43): the GCD hold-and-fire path is vanilla-only. On TBC+ the


### PR DESCRIPTION
- Vanilla 1.12 servers compute CP-scaled finisher durations server-side (`base + perCp × CP`) but never echo them for enemy debuffs — only the player's own auras get `SMSG_UPDATE_AURA_DURATION`. The proxy was falling back to `AuraDurations1.csv`, which only carries the raw `SpellDuration.dbc` base (flat 6000 ms for all 6 ranks of Rupture). Result: a 5 CP Rupture's debuff icon expired at 6 s on the modern client while the server kept ticking for 16 s, leaving a "lingering" mismatch.
  - Fix: snapshot the player's combo points at `CMSG_CAST_SPELL` (before the server consumes them) and use the snapshot in the aura-apply paths to synthesize the correct duration locally. Snapshot wins over the slot cache so successive recasts with varying CP no longer inherit a stale duration.
  - Covers Rupture (6 ranks) and Kidney Shot (2 ranks). Slice and Dice is intentionally not in the table — it's a self-buff and already gets the talented duration via `SMSG_UPDATE_AURA_DURATION`. Eviscerate has no aura. Expose Armor is flat 30 s on vanilla regardless of CP.

  ## Vanilla-specific gotcha worth noting
  Vanilla 1.12 has no `SMSG_UPDATE_COMBO_POINTS` opcode — combo points and combo target both arrive as regular
  unit-field updates (`PLAYER_FIELD_BYTES >> 8` and `PLAYER_FIELD_COMBO_TARGET`). The CP cache is now populated from
  `UpdateHandler.cs` for vanilla and from the existing `CharacterHandler.cs` opcode handler for TBC/WotLK.

  ## Files touched
  - `HermesProxy/World/GameData.cs` — `ComboPointFinisherDurations` table + `TryGetComboPointDuration` / `IsComboPointFinisher` helpers
  - `HermesProxy/GlobalSessionData.cs` — `CurrentComboPoints` / `CurrentComboTarget` cache + finisher-cast snapshot with 3 s TTL
  - `HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs` — store CP/target on `SMSG_UPDATE_COMBO_POINTS` (TBC/WotLK)
  - `HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs` — store CP/target from vanilla `PLAYER_FIELD_BYTES` / `PLAYER_FIELD_COMBO_TARGET`; aura-discovery now prefers snapshot over cache for finishers
  - `HermesProxy/World/Server/PacketHandlers/SpellHandler.cs` — snapshot CP at `CMSG_CAST_SPELL` for known finishers
  - `HermesProxy/World/Client/PacketHandlers/SpellHandler.cs` — `SendAuraRefreshUpdate` prefers snapshot over cache for finishers

  ## Diagnostics added
  - `finisher.cmsg_cast` — fires on every finisher CMSG with the cached CP/target state (kept for future debugging)
  - `finisher.snapshot` — fires when the snapshot is stored

  ## Test plan
  - [x] `dotnet build` clean (0 warnings, 0 errors)
  - [x] `dotnet test` — 312 passed, 0 failed
  - [x] Live-test on Kronos, mixed CP rupture casts on the same target across slot reuse:
    - 1 CP → 8 s, 2 CP → 10 s, 3 CP → 12 s, 4 CP → 14 s, 5 CP → 16 s — all verified in `aura.slot.set` events
    - Recasts with decreasing CP correctly shorten the displayed duration (no more inheriting prior 16 s)
  - [ ] Spot-check Kidney Shot on a humanoid (1–5 CP → 2–6 s)
  - [ ] Confirm Slice and Dice unchanged (player-self path untouched, still uses `SMSG_UPDATE_AURA_DURATION`)
  - [ ] Confirm Expose Armor unchanged (flat 30 s from CSV)