### PR TITLE
Macro gcd fix

### DIFF
--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -1,4 +1,4 @@
-## Interface: 11400
+## Interface: 11402
 ## Title: JimsPlus
 ## Notes: Bundled client-side fixes for JimsProxy / Classic WoW 1.14 Launcher
 ## SavedVariables: JimsPlusDB, JimsPlusCastbarsDB

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,3 +67,49 @@ Three observation-layer improvements applied on top of the rebase commits above.
 3. **Benign realmd close re-tag:** every successful login produced a red `Error | AuthClient | Socket Closed By Server` after auth completion because Kronos realmd intentionally closes the socket after serving the realmlist. `ReceiveCallback` now checks `_response.Task.IsCompleted` — if true, logs `Network` with "Realmd disconnected after successful auth (expected)"; if false, keeps the `Error` + `SetAuthResponse(FAIL_INTERNAL_ERROR)` path for real auth failures.
 
 No behaviour changes to dispatch or translation; all three are observation-layer improvements.
+
+## 2026-04-29 — Latency fixes: Nagle ignore + GCD double-cast window + RTT-adaptive offset
+
+Three related latency improvements, shipped as PR #87 targeting beta.
+
+### CMSG_ENABLE_NAGLE ignore
+
+**Issue:** The 1.14 client sends `CMSG_ENABLE_NAGLE` when the user unchecks "Optimize Network for Speed," re-enabling Nagle's algorithm (~200ms write coalescing) on both the client-facing and server-facing sockets. For a game proxy that needs low-latency bidirectional forwarding, this adds pure delay.
+
+**Change:** `World/Server/WorldSocket.cs` — the `CMSG_ENABLE_NAGLE` case no longer calls `SetNoDelay(false)`. The packet is still processed through decryption so the AES-GCM nonce counter stays in sync (per Xian55 fix `2960e77`). TCP_NODELAY, set at connection time in `WorldSocketManager` and `WorldClient.ConnectCallback`, is now permanent for the session.
+
+**Verification:** JSONL confirms two `CMSG_ENABLE_NAGLE` events in test session when the setting is unchecked. No latency degradation observed post-fix.
+
+### GCD double-cast window fix
+
+**Issue:** `OnGcdTimerElapsed` (GlobalSessionData.cs) was clearing `_gcdExpireTimestampMs = 0` when the hold timer fired, removing GCD protection during the ~RTT window before the server responded with `SMSG_SPELL_GO`. Spam-presses during this window bypassed all guards (`IsGcdHoldActive()` and `HasStartedNormalCast()` both returned false) and sent duplicate casts to the server.
+
+**Change:** Three sub-fixes in `GlobalSessionData.cs` and `World/Server/PacketHandlers/SpellHandler.cs`:
+
+1. **Don't clear `_gcdExpireTimestampMs` on timer fire** — GCD stays active until natural expiry. Presses between `fireAt` and `expireAt` are caught by `IsGcdHoldActive()` and stored in the now-empty `_heldGcdCast` slot. The next `BeginGcd` (from incoming `SMSG_SPELL_GO`) picks them up.
+
+2. **`HasForwardedPendingCast()` guard** (position 3 in HandleCastSpell) — catches presses after local GCD expires but before `SMSG_SPELL_GO` arrives. Uses `ForceHoldCast()` to store in `_heldGcdCast` and `SendCastRequestFailed` for displaced casts.
+
+3. **Fire held cast on failure** — `TakeHeldCastIfReady()` in `HandleCastFailed` fires any held cast immediately when the server rejects the forwarded cast and GCD is no longer active, preventing the player from getting stuck.
+
+Guard ordering in HandleCastSpell:
+1. `HasStartedNormalCast()` → DROP (cast-time duplicates)
+2. `IsGcdHoldActive()` → HOLD (instant-cast GCD window)
+3. `HasForwardedPendingCast()` → HOLD (post-GCD forwarded cast window)
+4. *(reserved for PR #86's `HasInFlightNormalCastForSpell()` → DROP)*
+5. Normal forward path
+
+**Verification:** Arcane Explosion spam on Kronos — each GCD window should produce exactly one `spell.held_fire` event. LoS-fail during spam should fire the held cast on failure.
+
+### RTT-adaptive GCD fire offset
+
+**Issue:** With `SpellCastEarlyFireOffsetMs = 0`, the held cast fires at exact local GCD expiry. Since `SMSG_SPELL_GO` must travel back from the server (~RTT/2) before the next GCD starts, each GCD cycle takes ~1700ms instead of 1500ms (verified: Arcane Explosion JSONL data shows consistent ~1700ms intervals, implying ~200ms RTT to Kronos).
+
+**Change:** `GlobalSessionData.cs` + `World/Client/PacketHandlers/MiscHandler.cs` + `World/Client/WorldClient.cs` + `World/Client/PacketHandlers/SpellHandler.cs`:
+
+- **RTT measurement:** Timestamps forwarded `CMSG_PING` sends in `WorldClient.SendPing` (covers both client-originated and proxy keepalive pings), measures `SMSG_PONG` returns in `MiscHandler.HandlePingResponse`. EMA-smoothed (alpha=0.2), requires 3 samples before activating (~45s warm-up at 30s ping interval with both client and keepalive pings contributing).
+- **Adaptive offset:** `GetAdaptiveFireOffsetMs()` returns `Clamp(Round(smoothedRtt * 0.5), 0, 100)`. RTT/2 means the cast arrives at the server right as the server-side GCD expires. Capped at 100ms (covers up to 200ms RTT).
+- **Static fallback:** During warm-up (`< 3` samples), falls back to the `SpellCastEarlyFireOffsetMs` config value (default 0, manual clamp 0–50ms). The adaptive path can reach 100ms because EMA smoothing provides its safety margin; the manual path stays conservative at 50ms max.
+- **Diagnostics:** `rtt.sample` events log each measurement. `gcd.begin` events now emit `fire_offset_ms` (adaptive) and `smoothed_rtt_ms` for post-session analysis.
+
+**Verification:** After 2+ minutes of play, `gcd.begin` events should show `fire_offset_ms > 0`. Arcane Explosion GCD intervals should decrease from ~1700ms to ~1600ms. Zero or near-zero `NOT_READY` failures expected.

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -60,7 +60,7 @@ public static class Settings
         // JimsProxy: structured logging defaults on; toggle VerboseLog to enable per-packet Verbose console output
         StructuredLog = config.GetBoolean("StructuredLog", true);
         VerboseLog = config.GetBoolean("VerboseLog", false);
-        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
+        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 100);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;
         // Open the JSONL file now so session.start's payload can include the full path.

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -60,7 +60,7 @@ public static class Settings
         // JimsProxy: structured logging defaults on; toggle VerboseLog to enable per-packet Verbose console output
         StructuredLog = config.GetBoolean("StructuredLog", true);
         VerboseLog = config.GetBoolean("VerboseLog", false);
-        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 100);
+        SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;
         // Open the JSONL file now so session.start's payload can include the full path.

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -130,6 +130,14 @@ public sealed class GameSessionData
     private Timer? _gcdExpiryTimer;
     private uint _gcdGeneration;                        // incremented each BeginGcd; callback compares against its captured generation to detect stale fires
     public Action<ClientCastRequest>? OnGcdHeldCastFire; // set by WorldSocket at attach time; invoked on a ThreadPool thread at GCD expiry
+
+    // JimsProxy: proxy→server RTT measurement for adaptive GCD fire offset.
+    private readonly object _rttLock = new();
+    private long _lastPingSendTickMs;
+    private uint _lastPingSerial;
+    private double _smoothedRttMs;
+    private int _rttSampleCount;
+
     //MIRASU - Tracks the unique CastID assigned to in-flight non-player casts so SPELL_GO and
     //MIRASU   SPELL_FAILED_OTHER can reference the same cast the SPELL_START introduced.
     //MIRASU   Without this, mob casts reuse a deterministic CastID (spellId+casterCounter) on
@@ -728,6 +736,101 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// Returns true if any pending normal cast has been forwarded to the legacy server but
+    /// hasn't received SMSG_SPELL_START yet. Covers the post-GCD-expiry window where
+    /// IsGcdHoldActive() returns false but the server hasn't confirmed the forwarded cast.
+    /// </summary>
+    public bool HasForwardedPendingCast()
+    {
+        foreach (var item in PendingNormalCasts)
+        {
+            if (!item.HasStarted)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Store a cast in the held slot unconditionally (even if GCD has expired). Used by the
+    /// HasForwardedPendingCast guard to hold casts during the post-GCD window while waiting
+    /// for the server to respond. Returns any displaced cast.
+    /// </summary>
+    public ClientCastRequest? ForceHoldCast(ClientCastRequest cast)
+    {
+        lock (_gcdLock)
+        {
+            var displaced = _heldGcdCast;
+            _heldGcdCast = cast;
+            return displaced;
+        }
+    }
+
+    /// <summary>
+    /// Take the held cast if the GCD has expired and no forwarded cast is pending. Used by
+    /// failure handlers to fire the held cast immediately when the server rejects a cast.
+    /// Returns null if GCD is still active (timer will handle it) or if no cast is held.
+    /// </summary>
+    public ClientCastRequest? TakeHeldCastIfReady()
+    {
+        lock (_gcdLock)
+        {
+            if (_heldGcdCast == null)
+                return null;
+            if (_gcdExpireTimestampMs > Environment.TickCount64)
+                return null;
+            var cast = _heldGcdCast;
+            _heldGcdCast = null;
+            return cast;
+        }
+    }
+
+    // ── RTT measurement and adaptive GCD offset ───────────────────────
+
+    public void RecordPingSent(uint serial)
+    {
+        if ((serial & 0x80000000) != 0) return;
+        lock (_rttLock)
+        {
+            _lastPingSerial = serial;
+            _lastPingSendTickMs = Environment.TickCount64;
+        }
+    }
+
+    public void RecordPongReceived(uint serial)
+    {
+        if ((serial & 0x80000000) != 0) return;
+        lock (_rttLock)
+        {
+            if (serial != _lastPingSerial || _lastPingSendTickMs == 0) return;
+            long rttMs = Environment.TickCount64 - _lastPingSendTickMs;
+            _lastPingSendTickMs = 0;
+            if (rttMs > 5000) return;
+            const double alpha = 0.2;
+            _smoothedRttMs = _rttSampleCount == 0 ? rttMs : (_smoothedRttMs * (1 - alpha) + rttMs * alpha);
+            _rttSampleCount++;
+            Log.Event("rtt.sample", new { serial, raw_ms = rttMs, smoothed_ms = Math.Round(_smoothedRttMs, 1), samples = _rttSampleCount });
+        }
+    }
+
+    public int GetAdaptiveFireOffsetMs()
+    {
+        lock (_rttLock)
+        {
+            if (_rttSampleCount < 3)
+                return Framework.Settings.SpellCastEarlyFireOffsetMs;
+            return (int)Math.Clamp(Math.Round(_smoothedRttMs * 0.5), 0, 100);
+        }
+    }
+
+    public double GetSmoothedRttMs()
+    {
+        lock (_rttLock)
+        {
+            return Math.Round(_smoothedRttMs, 1);
+        }
+    }
+
+    /// <summary>
     /// Clear only pending normal casts that haven't started yet.
     /// Keeps started casts so SPELL_GO can dequeue them later.
     /// Returns the cleared casts so they can be failed.
@@ -979,7 +1082,10 @@ public sealed class GameSessionData
 
             toFire = _heldGcdCast;
             _heldGcdCast = null;
-            _gcdExpireTimestampMs = 0;
+            // Keep _gcdExpireTimestampMs alive — presses between fireAt and expireAt are still
+            // caught by IsGcdHoldActive() and stored in the now-empty _heldGcdCast slot. The
+            // next BeginGcd (from SPELL_GO) picks them up. Clearing it here created an unguarded
+            // RTT window where spam-presses bypassed all guards and doubled casts to the server.
             // Don't null _gcdExpiryTimer here: a concurrent BeginGcd could have already replaced it.
         }
         if (toFire != null)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -788,7 +788,6 @@ public sealed class GameSessionData
 
     public void RecordPingSent(uint serial)
     {
-        if ((serial & 0x80000000) != 0) return;
         lock (_rttLock)
         {
             _lastPingSerial = serial;
@@ -798,7 +797,6 @@ public sealed class GameSessionData
 
     public void RecordPongReceived(uint serial)
     {
-        if ((serial & 0x80000000) != 0) return;
         lock (_rttLock)
         {
             if (serial != _lastPingSerial || _lastPingSendTickMs == 0) return;

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -751,6 +751,28 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy (Mount-Button-Stuck-Lit): returns true if any pending normal cast — started OR
+    /// merely in flight to the legacy server — matches the given SpellId (or its LegacySpellId
+    /// for SoM-renumbered USE_ITEMs). HasStartedNormalCast only catches duplicates AFTER
+    /// SMSG_SPELL_START matches the queue entry; rapid mashing within the c→s→c round-trip slips
+    /// past it and the duplicate USE_ITEM/CAST_SPELL gets forwarded. The legacy server then rejects
+    /// the duplicate with SpellInProgress, and the FIFO dequeue (TryDequeuePendingNormalCast picks
+    /// the oldest match) binds the failure to the in-flight cast's IDs — the bug commit 7b9e8aa
+    /// originally fixed and that resurfaced when 8998c39 switched HandleUseItem to silent-drop
+    /// gated on HasStartedNormalCast only. Used by HandleCastSpell and HandleUseItem to silent-drop
+    /// the in-flight same-spell duplicate before it ever reaches the queue.
+    /// </summary>
+    public bool HasInFlightNormalCastForSpell(uint spellId)
+    {
+        foreach (var item in PendingNormalCasts)
+        {
+            if (CastMatchesSpellId(item, spellId))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Store a cast in the held slot unconditionally (even if GCD has expired). Used by the
     /// HasForwardedPendingCast guard to hold casts during the post-GCD window while waiting
     /// for the server to respond. Returns any displaced cast.

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -249,7 +249,7 @@ partial class Server
     {
         var commitDate = DateTime.Parse(GitVersionInformation.CommitDate, CultureInfo.InvariantCulture).ToUniversalTime();
 
-        string version = $"{commitDate:yyyy-MM-dd} {_buildTag}{GitVersionInformation.MajorMinorPatch}";
+        string version = $"{commitDate:yyyy-MM-dd} {_buildTag}{GitVersionInformation.SemVer}";
         if (GitVersionInformation.CommitsSinceVersionSource != "0")
             version += $"+{GitVersionInformation.CommitsSinceVersionSource}({GitVersionInformation.ShortSha})";
         if (GitVersionInformation.UncommittedChanges != "0")

--- a/HermesProxy/World/Client/PacketHandlers/MiscHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MiscHandler.cs
@@ -14,6 +14,7 @@ public partial class WorldClient
     void HandlePingResponse(WorldPacket packet)
     {
         uint serial = packet.ReadUInt32();
+        GetSession().GameState?.RecordPongReceived(serial);
         if ((serial & 0x80000000) != 0)
             return; // keepalive pong, don't forward to modern client
         SendPacketToClient(new Pong(serial));

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -201,6 +201,21 @@ public partial class WorldClient
             failed.FailedArg1 = arg1;
             failed.FailedArg2 = arg2;
             SendPacketToClient(failed);
+
+            var gameState = GetSession().GameState;
+            if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
+            {
+                var heldCast = gameState.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_failure", new
+                    {
+                        failed_spell_id = spellId,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameState.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
     }
 
@@ -777,17 +792,16 @@ public partial class WorldClient
                 long gcdMs = GameData.GetGcdDurationMs(gcdLookupId);
                 long now = Environment.TickCount64;
                 long expireAt = now + gcdMs;
-                long fireAt = expireAt - Framework.Settings.SpellCastEarlyFireOffsetMs;
+                int adaptiveOffset = GetSession().GameState.GetAdaptiveFireOffsetMs();
+                long fireAt = expireAt - adaptiveOffset;
                 GetSession().GameState.BeginGcd(expireAt, fireAt);
 
-                // JimsProxy: gcd.begin — pairs with spell.held / spell.held_fire to reconstruct
-                // the full GCD timeline for a session. legacy_lookup_id is non-zero only for
-                // SoM-renumbered items so we can spot whitelist misses post-hoc.
                 Log.Event("gcd.begin", new
                 {
                     spell_id = spell.Cast.SpellID,
                     gcd_ms = gcdMs,
-                    fire_offset_ms = Framework.Settings.SpellCastEarlyFireOffsetMs,
+                    fire_offset_ms = adaptiveOffset,
+                    smoothed_rtt_ms = GetSession().GameState.GetSmoothedRttMs(),
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -805,6 +805,26 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }
+
+            // JimsProxy (Macro-GCD-Fix): off-GCD completions (trinkets, racials, etc.) don't
+            // trigger BeginGcd, so a cast held via spell.held_pending while the off-GCD cast
+            // was in flight gets stranded — _heldGcdCast sits until the next press/failure.
+            // Bundle 20260430-150846 showed SS held 7563ms after a trinket completed. If the
+            // queue is now drained and no GCD is active, release the held cast immediately.
+            var gameState = GetSession().GameState;
+            if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
+            {
+                var heldCast = gameState.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_go", new
+                    {
+                        completed_spell_id = spell.Cast.SpellID,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameState.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.CurrentClientNextMeleeCast != null &&

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -748,6 +748,7 @@ public partial class WorldClient
         packet.WriteUInt32(ping);
         packet.WriteUInt32(latency);
         SendPacket(packet);
+        GetSession().GameState?.RecordPingSent(ping);
     }
 
     private void StartKeepAliveTimer()

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -273,6 +273,30 @@ public partial class WorldSocket
                     });
                 }
 
+                // Guard 3: a cast was forwarded to the server but hasn't received
+                // SPELL_START/SPELL_GO yet. Hold the new press so it fires when the
+                // server responds (BeginGcd creates a new timer that picks it up).
+                if (GetSession().GameState.HasForwardedPendingCast())
+                {
+                    WorldPacket heldPacket = BuildCastSpellPacket(cast);
+                    castRequest.HeldPacketForReplay = heldPacket;
+                    castRequest.HeldAtTickMs = Environment.TickCount64;
+                    var displaced = GetSession().GameState.ForceHoldCast(castRequest);
+                    Log.Event("spell.held_pending", new
+                    {
+                        spell_id = cast.Cast.SpellID,
+                        displaced_spell_id = displaced?.SpellId ?? 0,
+                        client_cast_id = castRequest.ClientGUID.ToString(),
+                    });
+                    if (displaced != null)
+                        SendCastRequestFailed(displaced, false);
+                    SpellPrepare heldPrepare = new SpellPrepare();
+                    heldPrepare.ClientCastID = castRequest.ClientGUID;
+                    heldPrepare.ServerCastID = castRequest.ServerGUID;
+                    SendPacket(heldPrepare);
+                    return;
+                }
+
                 // Enqueue the cast - responses will be matched by SpellId in FIFO order
                 GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
             }

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -276,6 +276,9 @@ public partial class WorldSocket
                 // Guard 3: a cast was forwarded to the server but hasn't received
                 // SPELL_START/SPELL_GO yet. Hold the new press so it fires when the
                 // server responds (BeginGcd creates a new timer that picks it up).
+                // NOTE: PR #86's HasInFlightNormalCastForSpell() guard belongs AFTER
+                // this block (position 4). GCD hold checks must run first so instant-
+                // cast spam is held rather than dropped.
                 if (GetSession().GameState.HasForwardedPendingCast())
                 {
                     WorldPacket heldPacket = BuildCastSpellPacket(cast);

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -81,7 +81,7 @@ public partial class WorldSocket
         if (targetFlags.HasAnyFlag(SpellCastTargetFlags.String))
             packet.WriteCString(target.Name);
     }
-    public void SendCastRequestFailed(ClientCastRequest castRequest, bool isPet)
+    public void SendCastRequestFailed(ClientCastRequest castRequest, bool isPet, SpellCastResultClassic reason = SpellCastResultClassic.SpellInProgress)
     {
         if (!castRequest.HasStarted)
         {
@@ -95,7 +95,7 @@ public partial class WorldSocket
         {
             PetCastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = (uint)reason;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
         }
@@ -104,10 +104,10 @@ public partial class WorldSocket
             CastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
             failed.SpellXSpellVisualID = castRequest.SpellXSpellVisualId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = (uint)reason;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
-        }    
+        }
     }
     // JimsProxy: Hunter tame-class spell IDs in vanilla — used to log tame attempts
     // for the pet deep-dive. 1515 = "Tame Beast" player ability; the rest are
@@ -202,11 +202,27 @@ public partial class WorldSocket
             // 1.12 client would fire these mid-cast-bar and mid-GCD, so we match that.
             if (!isOffGcd)
             {
-                // Silently drop re-clicks while a cast is in progress. Sending
-                // CastFailed(SpellInProgress) causes the 1.14 client to dismiss
-                // the active cast bar even though the server-side cast continues.
-                if (GetSession().GameState.HasStartedNormalCast())
+                // JimsProxy (Mount-Button-Stuck-Lit): drop re-clicks but resolve the modern
+                // client's tracking via the duplicate's own unique ClientGUID/ServerGUID. The
+                // earlier silent-drop approach (commit 8998c39) avoided dismissing the running
+                // cast bar but left the duplicate's action-button state pending forever. Sending
+                // SpellPrepare + CastFailed(DontReport) bound to the DUPLICATE's IDs releases the
+                // queued state without showing an error toast. The running cast's ServerCastID is
+                // distinct, so its cast bar should be unaffected.
+                bool gateStarted = GetSession().GameState.HasStartedNormalCast();
+                bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
+                if (gateStarted || gateInFlight)
+                {
+                    Log.Event("cast.dropped.duplicate", new
+                    {
+                        spell_id = cast.Cast.SpellID,
+                        reason = gateInFlight ? "in_flight_same_spell_cast_spell" : "another_cast_started",
+                        client_cast_id = cast.Cast.CastID.ToString(),
+                        queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+                    });
+                    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
                     return;
+                }
 
                 // JimsProxy (issue #43): if we're inside a GCD hold window, build the CMSG_CAST_SPELL
                 // packet now but don't forward it — store it as the pending held cast. The Timer
@@ -418,9 +434,29 @@ public partial class WorldSocket
         castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, use.Cast.SpellID, 10000 + use.Cast.CastID.GetCounter());
         castRequest.ItemGUID = use.CastItem;
 
-        // Silently drop re-clicks while a cast is in progress (same as HandleCastSpell).
-        if (GetSession().GameState.HasStartedNormalCast())
+        // JimsProxy (Mount-Button-Stuck-Lit): drop the duplicate USE_ITEM but resolve the modern
+        // client's per-click tracking so the action button doesn't stay "queued/lit" forever.
+        // Bind SpellPrepare + CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built
+        // a few lines above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if
+        // any) has its OWN distinct ServerCastID, so the modern client should resolve only the
+        // duplicate's tracking and leave the active cast bar alone. Reason=DontReport suppresses
+        // the "Another action is in progress" error toast — silent drop semantics, but now with
+        // the IDs the client needs to release the queued state.
+        bool gateStarted = GetSession().GameState.HasStartedNormalCast();
+        bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)use.Cast.SpellID);
+        if (gateStarted || gateInFlight)
+        {
+            Log.Event("cast.dropped.duplicate", new
+            {
+                spell_id = use.Cast.SpellID,
+                reason = gateInFlight ? "in_flight_same_spell_use_item" : "another_cast_started",
+                client_cast_id = use.Cast.CastID.ToString(),
+                item_guid = use.CastItem.ToString(),
+                queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+            });
+            SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
             return;
+        }
 
         // Some items had their on-use spell id renumbered in SoM 1.14.1+ (e.g. Diamond Flask 17626 → 363880).
         // The 1.12 emulator only knows the legacy id, so resolve it now and remember both

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -204,11 +204,11 @@ public partial class WorldSocket
             {
                 // JimsProxy (Mount-Button-Stuck-Lit): drop re-clicks but resolve the modern
                 // client's tracking via the duplicate's own unique ClientGUID/ServerGUID. The
-                // earlier silent-drop approach (commit 8998c39) avoided dismissing the running
-                // cast bar but left the duplicate's action-button state pending forever. Sending
-                // SpellPrepare + CastFailed(DontReport) bound to the DUPLICATE's IDs releases the
-                // queued state without showing an error toast. The running cast's ServerCastID is
-                // distinct, so its cast bar should be unaffected.
+                // earlier silent-drop approach (commit 8998c39) left the duplicate's action-button
+                // state pending forever. Reason is SpellInProgress (matches the displaced-hold
+                // path below) — the 1.14 client treats it as "overridden by newer cast" and
+                // releases the duplicate's queued/lit state. The running cast's ServerCastID is
+                // distinct, so its cast bar is unaffected.
                 bool gateStarted = GetSession().GameState.HasStartedNormalCast();
                 bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
                 if (gateStarted || gateInFlight)
@@ -220,7 +220,7 @@ public partial class WorldSocket
                         client_cast_id = cast.Cast.CastID.ToString(),
                         queue_depth = GetSession().GameState.PendingNormalCasts.Count,
                     });
-                    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
+                    SendCastRequestFailed(castRequest, false);
                     return;
                 }
 
@@ -313,6 +313,30 @@ public partial class WorldSocket
                     heldPrepare.ClientCastID = castRequest.ClientGUID;
                     heldPrepare.ServerCastID = castRequest.ServerGUID;
                     SendPacket(heldPrepare);
+
+                    // JimsProxy (Macro-GCD-Fix): macro-batched `/use 13 /use 14 /cast SS` lands all
+                    // three CMSGs in the same ms; SS gets held_pending while a trinket is in flight.
+                    // SpellPrepare acks the click but the modern 1.14 client's GCD swipe doesn't
+                    // start until SS's own SMSG_SPELL_GO arrives — a ~300ms gap (trinket RTT + SS RTT)
+                    // where the action button is queued/lit without a sweep. Synthesize a
+                    // SMSG_COOLDOWN_EVENT so the client's swipe starts immediately at ack time.
+                    // SMSG_SPELL_COOLDOWN with ForcedCooldown was tried earlier (stash 0) and got
+                    // "anticipated-then-canceled" by the macro evaluator; SMSG_COOLDOWN_EVENT lets
+                    // the client compute the GCD locally from the spell's DBC StartRecoveryTime.
+                    // Vanilla-only: TBC+ haste-adjusted GCDs would make this wrong, and the GCD-hold
+                    // mechanism (gated on ExpansionVersion==1 in HandleSpellGo) is vanilla-only too.
+                    if (LegacyVersion.ExpansionVersion == 1)
+                    {
+                        CooldownEvent cdEvent = new();
+                        cdEvent.SpellID = (uint)cast.Cast.SpellID;
+                        cdEvent.IsPet = false;
+                        SendPacket(cdEvent);
+                        Log.Event("gcd.cooldown.synth_held", new
+                        {
+                            spell_id = cast.Cast.SpellID,
+                            client_cast_id = castRequest.ClientGUID.ToString(),
+                        });
+                    }
                     return;
                 }
 
@@ -436,12 +460,12 @@ public partial class WorldSocket
 
         // JimsProxy (Mount-Button-Stuck-Lit): drop the duplicate USE_ITEM but resolve the modern
         // client's per-click tracking so the action button doesn't stay "queued/lit" forever.
-        // Bind SpellPrepare + CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built
-        // a few lines above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if
-        // any) has its OWN distinct ServerCastID, so the modern client should resolve only the
-        // duplicate's tracking and leave the active cast bar alone. Reason=DontReport suppresses
-        // the "Another action is in progress" error toast — silent drop semantics, but now with
-        // the IDs the client needs to release the queued state.
+        // Bind CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built a few lines
+        // above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if any) has its
+        // OWN distinct ServerCastID, so the modern client resolves only the duplicate's tracking
+        // and leaves the active cast bar alone. Reason is SpellInProgress (matches the displaced-
+        // hold path) — the 1.14 client treats it as "overridden by newer cast" and releases the
+        // duplicate's queued/lit state cleanly.
         bool gateStarted = GetSession().GameState.HasStartedNormalCast();
         bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)use.Cast.SpellID);
         if (gateStarted || gateInFlight)
@@ -454,7 +478,7 @@ public partial class WorldSocket
                 item_guid = use.CastItem.ToString(),
                 queue_depth = GetSession().GameState.PendingNormalCasts.Count,
             });
-            SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
+            SendCastRequestFailed(castRequest, false);
             return;
         }
 

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -300,7 +300,6 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 if (_connectType == ConnectionType.Realm && GetSession().WorldClient != null && GetSession().WorldClient!.IsConnected() && GetSession().WorldClient!.IsAuthenticated())
                 {
                     GetSession().WorldClient!.SendPing(ping.Serial, ping.Latency);
-                    GetSession().GameState?.RecordPingSent(ping.Serial);
                 }
                 else
                     HandlePing(ping);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -298,7 +298,10 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 Ping ping = new(packet);
                 ping.Read();
                 if (_connectType == ConnectionType.Realm && GetSession().WorldClient != null && GetSession().WorldClient!.IsConnected() && GetSession().WorldClient!.IsAuthenticated())
+                {
                     GetSession().WorldClient!.SendPing(ping.Serial, ping.Latency);
+                    GetSession().GameState?.RecordPingSent(ping.Serial);
+                }
                 else
                     HandlePing(ping);
                 break;

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -332,8 +332,10 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                SetNoDelay(false);
-                GetSession()?.WorldClient?.SetNoDelay(false);
+                // Ignore: the proxy always needs TCP_NODELAY=true for low-latency
+                // forwarding. The packet is still processed (AES-GCM nonce stays in
+                // sync) but we don't obey the client's request to re-enable Nagle.
+                // Sent when the user unchecks "Optimize Network for Speed" in WoW.
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -332,9 +332,8 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                // Intentionally ignored. The 1.14 client sends this after entering
-                // world, re-enabling Nagle's ~200ms write coalescing on both sockets.
-                // Proxy needs low-latency forwarding; keep TCP_NODELAY=true permanently.
+                SetNoDelay(false);
+                GetSession()?.WorldClient?.SetNoDelay(false);
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -332,8 +332,9 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                SetNoDelay(false);
-                GetSession()?.WorldClient?.SetNoDelay(false);
+                // Intentionally ignored. The 1.14 client sends this after entering
+                // world, re-enabling Nagle's ~200ms write coalescing on both sockets.
+                // Proxy needs low-latency forwarding; keep TCP_NODELAY=true permanently.
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);


### PR DESCRIPTION
 Fixes a cluster of action-button quirks observed when using macro-batched
  `/use 13 + /use 14 + /cast <Spell>` patterns (and rapid double-clicks of
  mount/trinket items) against vanilla 1.12 emulators (Kronos):

  - Mount/spell button getting stuck **lit/queued forever** after a rapid
    double-click.
  - Sinister Strike (and other instant on-GCD spells) showing **no GCD
    swipe** for ~300ms after pressing a trinket-bracketed macro — the click
    was acked, but the swipe didn't appear until the trinket completed and
    SS's own SPELL_GO arrived.
  - Held casts occasionally **stranded for several seconds** (one bundle
    showed 7.5s) when the in-flight cast that was holding them happened to
    be off-GCD (e.g. a trinket).

  ## Changes

  **Mount-Button-Stuck-Lit fix (cherry-picked)** — adds a
  `HasInFlightNormalCastForSpell()` guard so duplicate `CMSG_CAST_SPELL` /
  `CMSG_USE_ITEM` presses are rejected with a `CastFailed` bound to the
  duplicate's own `ClientGUID/ServerGUID`, releasing the modern client's
  per-click queued state without disturbing the running cast bar.

  **`SpellInProgress` instead of `DontReport` on duplicate drops** — the
  mount fix originally used `DontReport` to suppress the "Another action is
  in progress" toast, but the 1.14 client kept the click queued/lit anyway.
  `SpellInProgress` matches what the displaced-hold path already uses and
  the client treats it as "overridden by newer cast" — releases the lit
  state cleanly. Cosmetic: rapid double-clicks may now show a brief red
  error toast.

  **Drain `_heldGcdCast` in `HandleSpellGo`** — when a forwarded cast
  completes with no GCD active and no other forwarded cast pending, fire
  the held cast immediately. Off-GCD trinket completions don't trigger
  `BeginGcd`, so without this the held cast sat until something else
  (usually an unrelated CastFailed) happened to drain it. New diagnostic:
  `spell.held_fire_on_go`.

  **Synthesize `SMSG_COOLDOWN_EVENT` at `held_pending` time** — when SS is
  held because a trinket is in flight ahead of it, the SpellPrepare ack
  fires at click time but the modern client's GCD swipe doesn't start
  until SS's real SPELL_GO arrives ~300ms later. Synthesizing
  `SMSG_COOLDOWN_EVENT` at hold time lets the client compute the GCD
  locally from the spell's DBC `StartRecoveryTime` and starts the swipe
  at click-ack. `SMSG_SPELL_COOLDOWN` with `ForcedCooldown` was tried
  first but got "anticipated-then-canceled" by the client's macro
  evaluator. Vanilla-only (TBC+ haste-adjusted GCDs would be wrong). New
  diagnostic: `gcd.cooldown.synth_held`.

  ## Diagnostics added

  | Event | Fires when |
  |---|---|
  | `cast.dropped.duplicate` | Mount-fix gate rejects an in-flight duplicate cast |
  | `spell.held_displaced` | A held cast was replaced by a newer press |
  | `spell.held_fire_on_go` | A held cast was released because the cast it was waiting on completed |
  | `gcd.cooldown.synth_held` | Synthesized `SMSG_COOLDOWN_EVENT` at hold time to start the macro swipe early |

  ## Test plan

  - [x] `dotnet build HermesProxy.sln` — clean
  - [x] `dotnet test` — 312/312 pass
  - [x] Live: rapid double-click mount item — button clears (no lit-stuck)
  - [x] Live: SS + `/use 13 + /use 14` macro spam — GCD swipe appears
        immediately on first press, no stuck buttons, holds resolve in
        ~140ms
  - [x] Verify against bundles 144056, 150846, 151514, 153444 (each
        iteration's diagnostic events confirmed expected behavior)
  - [ ] Sanity-check unrelated flows: solo SS spam, instant casts, plain
        `/use` (no spell), normal mounting — no regressions vs `beta`