### PR TITLE
Tallstrider fix

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -209,6 +209,15 @@ public sealed class GameSessionData
     // packets for it get the hover override regardless of HOVERHEIGHT.
     public HashSet<WowGuid128> KnownHoveringMobs = [];
 
+    // JimsProxy (Tallstrider-Fix): per-GUID last-known facing orientation, populated from
+    // any MovementInfo we observe (spawn, heartbeat, ObjectUpdate movement block). Used by
+    // MovementHandler.HandleMonsterMove to compare the creature's current facing against
+    // the spline's first-segment direction — if the angle change is large, we treat the
+    // move as a state-transition (aggro/turn-to-target) and skip SplineFlagModern.Steering
+    // so the modern client snaps to the new heading instead of slowly rotating the body
+    // through the path. Small angle changes get Steering for smooth patrol corners.
+    public Dictionary<WowGuid128, float> LastKnownOrientation = new();
+
     private GameSessionData()
     {
 

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -82,6 +82,9 @@ public partial class WorldClient
         moveUpdate.MoveInfo = new();
         moveUpdate.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
         ApplyHoverOverrideIfNeeded(moveUpdate.MoverGUID, moveUpdate.MoveInfo);
+        // JimsProxy (Tallstrider-Fix): cache facing for the spline-angle check.
+        if (!moveUpdate.MoverGUID.IsEmpty())
+            GetSession().GameState.LastKnownOrientation[moveUpdate.MoverGUID] = moveUpdate.MoveInfo.Orientation;
         moveUpdate.MoveInfo.Flags = (uint)(((MovementFlagWotLK)moveUpdate.MoveInfo.Flags).CastFlags<MovementFlagModern>());
         moveUpdate.MoveInfo.ValidateMovementInfo();
         SendPacketToClient(moveUpdate);
@@ -487,6 +490,12 @@ public partial class WorldClient
         bool hasTrajectory;
         bool hasCatmullRom;
         bool hasTaxiFlightFlags;
+        // JimsProxy (Tallstrider-Fix): true if this is a vanilla default-Runmode spline
+        // for a non-combat Normal-type move. Steering is held in suspense until path
+        // points are parsed below; we only apply it when SplineCount > 1 (multi-segment
+        // patrol path), never on point-to-point direct moves which are typical of
+        // aggro/state transitions where the legacy server hasn't yet pushed InCombat.
+        bool steeringCandidate = false;
         if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
             var splineFlags = (SplineFlagVanilla)packet.ReadUInt32();
@@ -516,7 +525,7 @@ public partial class WorldClient
                 if (unitFlags.HasFlag(UnitFlagsVanilla.CanSwim))
                     moveSpline.SplineFlags |= SplineFlagModern.CanSwim;
                 if (type == SplineTypeLegacy.Normal && !unitFlags.HasFlag(UnitFlagsVanilla.InCombat))
-                    moveSpline.SplineFlags |= SplineFlagModern.Steering | SplineFlagModern.Unknown10;
+                    steeringCandidate = true; // resolved after path parsing — see Steering apply block below
             }
             else
             {
@@ -604,6 +613,46 @@ public partial class WorldClient
                     vec = moveSpline.EndPosition - vec;
 
                 moveSpline.SplinePoints.Add(vec);
+            }
+        }
+
+        // JimsProxy (Tallstrider-Fix): decide Steering using two gates that together
+        // separate patrol corners (Steering = smooth, looks vanilla) from aggro chases
+        // (no Steering = snap to heading, also looks vanilla).
+        //
+        //   Gate 1 — angle change at first segment, threshold 90°. Patrol corner
+        //   turns at intersections rarely exceed this; large state-transition turns
+        //   (creature was facing N, now charges S to reach player) blow past it.
+        //
+        //   Gate 2 — total path distance, threshold 20 yd. Patrol segments are short
+        //   (~5-10 yd between waypoints); aggro chases are typically 15-40 yd to the
+        //   target. The distance gate catches aggro paths whose first-segment angle
+        //   happens to be small (creature already facing-ish toward player) — those
+        //   would otherwise pass Gate 1 and re-trigger the sideways-running bug.
+        //
+        // Fallback: skip Steering when we have no cached orientation. Snap is the
+        // vanilla default and the safer mis-classification.
+        if (steeringCandidate && moveSpline.SplineCount >= 1)
+        {
+            Vector3 firstSegmentEnd = moveSpline.SplinePoints.Count > 0
+                ? moveSpline.SplinePoints[0]
+                : moveSpline.EndPosition;
+            Vector3 firstDelta = firstSegmentEnd - moveSpline.StartPosition;
+            Vector3 totalDelta = moveSpline.EndPosition - moveSpline.StartPosition;
+            float firstDist2D = MathF.Sqrt(firstDelta.X * firstDelta.X + firstDelta.Y * firstDelta.Y);
+            float totalDist2D = MathF.Sqrt(totalDelta.X * totalDelta.X + totalDelta.Y * totalDelta.Y);
+            const float STEERING_ANGLE_THRESHOLD_RAD = 1.5708f; // 90°
+            const float STEERING_DISTANCE_THRESHOLD_YD = 20.0f;
+            if (firstDist2D > 0.1f
+                && totalDist2D < STEERING_DISTANCE_THRESHOLD_YD
+                && GetSession().GameState.LastKnownOrientation.TryGetValue(guid, out float currentOri))
+            {
+                float pathHeading = MathF.Atan2(firstDelta.Y, firstDelta.X);
+                float diff = pathHeading - currentOri;
+                while (diff > MathF.PI) diff -= 2 * MathF.PI;
+                while (diff < -MathF.PI) diff += 2 * MathF.PI;
+                if (MathF.Abs(diff) < STEERING_ANGLE_THRESHOLD_RAD)
+                    moveSpline.SplineFlags |= SplineFlagModern.Steering | SplineFlagModern.Unknown10;
             }
         }
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -793,6 +793,14 @@ public partial class WorldClient
             moveInfo = new MovementInfo();
             moveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
 
+            // JimsProxy (Tallstrider-Fix): cache the creature's current facing for the
+            // angle-change check in MovementHandler.HandleMonsterMove. Updated on every
+            // ObjectUpdate movement block (spawn, position correction, heartbeat-style
+            // refresh) so the value is reasonably fresh when the next MONSTER_MOVE
+            // arrives.
+            if (!guid.IsEmpty())
+                GetSession().GameState.LastKnownOrientation[guid] = moveInfo.Orientation;
+
             // Vanilla 1.12 carries hover state via MovementFlagVanilla.FixedZ. Seed our
             // hover registry from it, since some 1.12 cores never populate UNIT_FIELD_HOVERHEIGHT.
             if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180) && moveInfo.Hover &&


### PR DESCRIPTION
Fixes tallstriders (and other vanilla ground creatures) visibly running sideways for a few hundred ms when aggroing,
  while preserving smooth body rotation for patrolling NPCs at waypoint corners.

  Root cause

  Vanilla creatures running on a default-Runmode SplineFlagVanilla spline were unconditionally given
  SplineFlagModern.Steering | Unknown10 by the proxy whenever UnitFlagsVanilla.InCombat wasn't set. The legacy server
  pushes the InCombat flag a packet or two after the MONSTER_MOVE that initiates the chase, so the very first aggro
  spline always slipped past the guard.

  Steering tells the modern client to smoothly interpolate body rotation along the path — fine for patrol corners, wrong
   for aggro turns where vanilla snaps the creature to face the player.

  Fix

  Replaces the unit-flag check with a two-gate angle-and-distance heuristic that runs after path parsing:

  - LastKnownOrientation cache (GlobalSessionData) — populated from every Living-unit ObjectUpdate movement block and
  from MSG_MOVE_HEARTBEAT-style packets.
  - Gate 1 (angle): apply Steering only when the first spline segment direction is within 90° of the creature's cached
  facing. Patrol corners stay under this; large state-transition turns (creature was facing N, now charges S) blow past
  it.
  - Gate 2 (distance): skip Steering when the total spline distance exceeds 20 yd. Catches aggro paths whose first
  segment happens to align with the creature's current heading (would otherwise pass Gate 1) — those are typically 15–40
   yd chases to the player, while patrol segments are 5–10 yd between waypoints.

  Fallback when no orientation is cached: skip Steering. Snap is the vanilla default and the safer mis-classification.

  Tradeoff

  - Tallstrider aggro now snaps to face the player (vanilla-faithful — the bug fix).
  - Patrolling NPCs at corners still get smooth body rotation through their waypoint paths (modern-look, preserves the
  pre-fix behavior that direct 1.12 clients showed for those motions).

  Taxi-flight catmull-rom paths in MovementHandler/UpdateHandler are untouched — those legitimately need Steering for
  bezier interpolation and aren't gated on creature state.