### PR TITLE
Inspect random suffix

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -1,4 +1,5 @@
-﻿using HermesProxy.Enums;
+﻿using Framework.Logging;
+using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
@@ -463,6 +464,13 @@ public partial class WorldClient
                             itemData.Index = i;
                             itemData.Item.ItemID = realItemId;
 
+                            // PLAYER_VISIBLE_ITEM_X_PROPERTIES holds the random property/suffix ID
+                            // (signed int32 stored in uint32 — negative = ItemRandomSuffix.dbc, positive = ItemRandomProperties.dbc).
+                            // Without it, green "of the Bear/Owl/..." gear renders without its suffix on inspect.
+                            int propertiesIndex = PLAYER_VISIBLE_ITEM_1_0 + (offset - 4) + i * offset;
+                            if (updates.ContainsKey(propertiesIndex))
+                                itemData.Item.RandomPropertiesID = updates[propertiesIndex].UInt32Value;
+
                             uint finalEnchantId = packedEnchantId;
                             if (finalEnchantId == 0 &&
                                 GetSession().GameState.CachedPlayerEnchants.TryGetValue(inspect.DisplayInfo.GUID, out var cachedEnchants))
@@ -472,6 +480,15 @@ public partial class WorldClient
 
                             if (finalEnchantId != 0)
                                 itemData.Enchants.Add(new InspectEnchantData(finalEnchantId, 0));
+
+                            Log.Event("inspect.item", new
+                            {
+                                target = inspect.DisplayInfo.GUID.ToString(),
+                                slot = i,
+                                item_id = realItemId,
+                                random_property_id = (int)itemData.Item.RandomPropertiesID,
+                                enchant = finalEnchantId
+                            });
 
                             inspect.DisplayInfo.Items.Add(itemData);
                         }


### PR DESCRIPTION
 HandleInspectResult (vanilla/TBC branch) read each visible item's ID
   and perm enchant from PLAYER_VISIBLE_ITEM_X_0 / +1 but never read the
   adjacent PLAYER_VISIBLE_ITEM_X_PROPERTIES dword that carries the random
   property/suffix ID. The modern client therefore received every
   inspected item with RandomPropertiesID = 0 and had no way to compute
   the suffix string, so green "of the Bear / Owl / ..." gear inspected
   without its suffix name.

   Within-slot offset to PROPERTIES is slot_stride - 4 in both eras
   (verified against V1_12_1_5875 UpdateFields: 0x50 - 0x48 = 8 with
   stride 12, and V2_4_3_8606: 0x7C - 0x70 = 12 with stride 16). The
   field stores a signed int32 in a uint32 dword (negative ->
   ItemRandomSuffix.dbc, positive -> ItemRandomProperties.dbc); copying
   the raw uint32 into ItemInstance.RandomPropertiesID preserves the
   sign-extension and matches the convention already used by the auction,
   loot, mail, and trade handlers.

   Seed is intentionally left at 0 -- the visible-item field block
   doesn't carry ITEM_FIELD_RANDOM_PROPERTIES_SEED, and the suffix name
   depends only on the property ID; the seed only affects rolled stat
   values, which inspect doesn't display anyway.

   Adds inspect.item Log.Event per slot so future user bug bundles
   capture target/slot/item/property/enchant.