### PR TITLE
 Add diagnostics for MC Quintessence-on-Rune cast bug (preempt #374)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -158,6 +158,18 @@ public partial class WorldClient
         if (packet.CanRead())
             arg2 = packet.ReadInt32();
 
+        // JimsProxy: MC-Quintessence-Investigation. Pair with spell.use_item.target_dump in the
+        // bundle to see exactly why a server-side cast was rejected (range/LOS/wrong-target/etc).
+        // Reason is the raw 1.12 SpellCastResult enum value; resolve via SpellCastResultClassic.
+        Log.Event("spell.cast_failed.diag", new
+        {
+            spell_id = spellId,
+            reason_raw = reason,
+            reason_name = ((SpellCastResultClassic)reason).ToString(),
+            arg1,
+            arg2,
+        });
+
         // Check special casts first - try next melee, then auto repeat
         ClientCastRequest? specialCast = null;
         bool isAutoRepeat = false;

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -504,6 +504,34 @@ public partial class WorldSocket
         // Enqueue the cast - responses will be matched by SpellId (or LegacySpellId) in FIFO order
         GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
 
+        // JimsProxy: MC-Quintessence-Investigation. Item-on-GameObject casts are the suspect path
+        // for the long-standing "out of range" bug on Aqual/Eternal Quintessence vs. Runes of
+        // Warding (WowLegacyCore/HermesProxy#374). If the modern client refuses to send CMSG_USE_ITEM
+        // at all (client-side range pre-check failure), this event will be ABSENT from the bundle —
+        // itself a strong diagnostic signal pointing at the modern client's Spell.dbc range data.
+        // Narrowly gated to GameObject targets to keep noise low.
+        if (use.Cast.Target.Flags.HasFlag(SpellCastTargetFlags.GameObject))
+        {
+            uint targetEntry = use.Cast.Target.Unit.IsEmpty() ? 0u : use.Cast.Target.Unit.GetEntry();
+            Log.Event("spell.use_item.target_dump", new
+            {
+                spell_id = use.Cast.SpellID,
+                legacy_spell_id = legacySpellId,
+                client_cast_id = use.Cast.CastID.ToString(),
+                item_guid_128 = use.CastItem.ToString(),
+                item_guid_64 = use.CastItem.To64().ToString(),
+                item_id = GetSession().GameState.GetItemId(use.CastItem),
+                target_unit_128 = use.Cast.Target.Unit.ToString(),
+                target_unit_64 = use.Cast.Target.Unit.To64().ToString(),
+                target_entry = targetEntry,
+                target_flags = (uint)use.Cast.Target.Flags,
+                target_flags_translated = (uint)ConvertSpellTargetFlags(use.Cast.Target),
+                src_loc = use.Cast.Target.SrcLocation?.Location.ToString() ?? "null",
+                dst_loc = use.Cast.Target.DstLocation?.Location.ToString() ?? "null",
+                target_name = use.Cast.Target.Name ?? "",
+            });
+        }
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_USE_ITEM);
         byte containerSlot = use.PackSlot != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(use.PackSlot) : use.PackSlot;
         byte slot = use.PackSlot == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(use.Slot) : use.Slot;


### PR DESCRIPTION
 Plant scoped Log.Event diagnostics on the item-on-GameObject cast path so
  when Molten Core opens we can root-cause the Aqual/Eternal Quintessence
  "out of range" bug from one bundle, rather than burning raid attempts on
  trial-and-error. Bug originally reported in WowLegacyCore/HermesProxy#374
  on a CMaNGOS TBC server; needs to be verified on Kronos when MC unlocks.

  - spell.use_item.target_dump (gated on Target.Flags & GameObject) — logs spell ID, item ID, target GUID 128/64, target entry, target flags, and src/dst locations for any item-on-GameObject cast. Absence of this event during a failed Quintessence attempt is itself a signal (= client-side pre-validation refused to send).
  - spell.cast_failed.diag — logs raw + named SpellCastResult reason for any cast failure, paired with spell ID. Already low-volume.