### PR TITLE
Fix explored areas reverting to unexplored on partial field updates

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2751,13 +2751,17 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_EXPLORED_ZONES_1 + i])
                     {
+                        // Two legacy uint32 zone fields pack into one modern ulong: even i → low 32,
+                        // odd i → high 32. On a partial UPDATE_FIELDS we must replace only the
+                        // targeted half and PRESERVE the other half — otherwise the paired field's
+                        // explored bits get clobbered, causing previously-explored areas to revert
+                        // to unexplored on the world map (WowLegacyCore/HermesProxy#331).
+                        ulong existing = updateData.ActivePlayerData.ExploredZones[i / 2] ?? 0UL;
+                        uint newValue = updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value;
                         if ((i & 1) != 0)
-                        {
-                            ulong oldValue = updateData.ActivePlayerData.ExploredZones[i / 2] != null ? (ulong)updateData.ActivePlayerData.ExploredZones[i / 2]! : 0;
-                            updateData.ActivePlayerData.ExploredZones[i / 2] = oldValue | ((ulong)updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value << 32);
-                        }
+                            updateData.ActivePlayerData.ExploredZones[i / 2] = (existing & 0xFFFFFFFFUL) | ((ulong)newValue << 32);
                         else
-                            updateData.ActivePlayerData.ExploredZones[i / 2] = updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value;
+                            updateData.ActivePlayerData.ExploredZones[i / 2] = (existing & 0xFFFFFFFF00000000UL) | (ulong)newValue;
                     }
                 }
             }


### PR DESCRIPTION
Two legacy uint32 zone fields pack into one modern ulong (even i → low 32,
  odd i → high 32). The handler had asymmetric logic:

  - Odd branch: oldValue | (new << 32)  → preserved the existing low half ✓
  - Even branch: ExploredZones[i/2] = uint32  → auto-widens to ulong with high 32 = 0, clobbering the paired odd field ✗

  When vMangos (or any 1.12 server) sent a partial UPDATE_FIELDS for a single
  even-indexed zone field — which happens whenever the player explores a new
  bit in that field — the proxy zeroed the paired odd-indexed field's bits
  in the modern ulong. Areas covered by zone fields 2, 4, 6, ... reverted to
  unexplored on the world map. Intermittent and hard to repro because it
  required (a) a partial update (not a full snapshot), (b) hitting an even
  index, and (c) a non-empty paired odd field.

  Fix: each branch now replaces only its half and preserves the other half
  via masking. Symmetric, correct, no behavior change for full updates.