### PR TITLE
 Release held cast on SMSG_SPELL_GO success for off-GCD instants

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -824,6 +824,27 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }
+
+            // JimsProxy (Pickpocket-Macros): off-GCD instants (Pickpocket, Distract, etc.)
+            // skip BeginGcd, so a follow-up cast held by HasForwardedPendingCast() never gets
+            // a release signal on success — it sat in the held slot until the next press
+            // displaced it. Mirror HandleCastFailed's TakeHeldCastIfReady release on success.
+            // TakeHeldCastIfReady self-guards against active GCDs, so when an on-GCD cast
+            // just called BeginGcd above, this is a no-op and the timer handles the release.
+            var gameStateAfter = GetSession().GameState;
+            if (!gameStateAfter.HasForwardedPendingCast())
+            {
+                var heldCast = gameStateAfter.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_success", new
+                    {
+                        success_spell_id = spell.Cast.SpellID,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameStateAfter.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.CurrentClientNextMeleeCast != null &&


### PR DESCRIPTION
Fixes rogue Pickpocket→Cheap Shot macro requiring two presses to fire on
  default autoLootRate. The held-cast mechanism in HandleCastSpell parks a
  follow-up cast in _heldGcdCast when an earlier cast is in flight
  (HasForwardedPendingCast guard). On success the held cast was never
  released for off-GCD spells (Pickpocket, Distract) because BeginGcd is
  skipped, leaving the held cast stranded until the next press displaced
  it — observed as "Cheap Shot button stays lit after Pickpocket, second
  click fires it."

  The release on the failure path already exists at HandleCastFailed via
  TakeHeldCastIfReady; this adds the symmetric release on the success path
  in HandleSpellGo. TakeHeldCastIfReady self-guards against active GCDs
  (checks _gcdExpireTimestampMs), so on-GCD instants are unaffected — the
  existing GCD timer continues to own the release as before.

  Adds spell.held_fire_on_success diagnostic event (bounded — only fires
  when the new release path actually triggers).

  Verified against bug bundles 20260501-103340 and 20260501-105811:
  4/5 macro presses fire in one click; the 1/5 whiff is a 1.14 client
  click-race (CMSG_SET_SELECTION + CMSG_CAST_SPELL same millisecond → client
  silently drops /cast Pickpocket line). Pre-targeting the mob is the
  user-side workaround; cannot be fixed proxy-side without fabricating
  client packets.