### PR TITLE
Fix ItemEffect DBReply status: mirror hotfix instead of hard-coded Valid

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -530,13 +530,32 @@ public partial class WorldClient
                 // to actually apply the corrected ItemEffect record in the running session.
                 // Without this, SoM 1.14.1+ renumbered on-use spells (e.g. Diamond Flask) stay
                 // bound to their modern spell id even after the hotfix is sent.
+                //
+                // JimsProxy: mirror the hotfix's Status into the DBReply instead of hard-coding
+                // Valid. For slot-remap items (CSV record at modern slot N, legacy server places
+                // the spell at slot M ≠ N) the hotfix is RecordRemoved with empty content; the
+                // old behavior trailed it with a contradictory DBReply (Status=Valid, empty
+                // content) which is simply wrong on the wire even if 1.14.x clients tolerate
+                // it. Mirroring keeps removals as removals end-to-end while Valid updates
+                // (Diamond Flask path) continue unchanged.
+                var hotfix = reply.Hotfixes[0];
                 Server.Packets.DBReply replyA = new();
-                replyA.Status = HotfixStatus.Valid;
+                replyA.Status = hotfix.Status;
                 replyA.Timestamp = (uint)Time.UnixTime;
-                replyA.RecordID = reply.Hotfixes[0].RecordId;
-                replyA.TableHash = reply.Hotfixes[0].TableHash;
-                replyA.Data = reply.Hotfixes[0].HotfixContent;
+                replyA.RecordID = hotfix.RecordId;
+                replyA.TableHash = hotfix.TableHash;
+                replyA.Data = hotfix.HotfixContent;
                 SendPacketToClient(replyA);
+
+                Log.Event("hotfix.itemeffect.dbreply", new
+                {
+                    item_entry = item.Entry,
+                    slot = i,
+                    record_id = hotfix.RecordId,
+                    table_hash = hotfix.TableHash.ToString(),
+                    status = hotfix.Status.ToString(),
+                    content_size = hotfix.HotfixContent.GetSize(),
+                });
             }
         }
 


### PR DESCRIPTION
The DBReply paired with each `ItemEffect` `HotFixMessage` in `SendItemUpdatesIfNeeded` hard-coded `Status =
  HotfixStatus.Valid`, even when the hotfix itself was a removal (`Status = RecordRemoved` with empty content). For
  slot-remap items — where the legacy emulator places a spell at a slot different from the modern db2 record (e.g.
  modern db2 puts a +crit Equip at slot 1, Kronos puts it at slot 0) — `GenerateItemEffectUpdateIfNeeded` correctly
  removes the CSV record at the now-empty modern slot, but the trailing DBReply contradicted that with `Valid + empty
  content`. 1.14.x clients tolerate this so it doesn't visibly break tooltips on most setups, but it's incorrect on the
  wire and pollutes post-mortems.

  This change makes the DBReply mirror `reply.Hotfixes[0].Status`. The Diamond Flask SoM 1.14.1+ UPDATE path (which
  originally motivated the paired DBReply) is unchanged — Valid stays Valid. Only the REMOVE path flips: `RecordRemoved`
   end-to-end instead of `RecordRemoved` followed by a contradictory `Valid`.

  ## Diagnostic event

  Adds a `hotfix.itemeffect.dbreply` structured event so testers and contributors can identify slot-remap items by
  tailing the JSONL. Payload includes item entry, slot, record id, table hash, status, and content size. This is what
  was used to confirm the bug condition fires for items 22798 (Might of Menethil) and 17108 (Mark of Deflection) on
  Twinstar Kronos PTR.

  ## What this is *not*

  This is **not** a fix for the user-visible "double Equip text" tooltip bug. That bug exists, but reproduction shows
  it's caused by stale hotfix cache state on the tester's client (their `Cache/` and `WDB/` folders accumulated bad
  records from earlier proxy versions). Testers seeing the duplicate should clear those folders — clearing fixes the
  visible symptom. This commit prevents *future* accumulation of contradictory hotfix records, so the same workaround
  won't be needed again.

  ## Files

  - `HermesProxy/World/Client/PacketHandlers/QueryHandler.cs` — one substantive change (`replyA.Status = hotfix.Status`), reworded comment block, new diagnostic event

  ## Risk / merge path

  Touches the hotfix wire path for ItemEffect — every modern client that connects through the proxy hits this code on
  every item query. Behavior change is limited to the REMOVE branch (RecordRemoved hotfixes), which is a strict subset
  of items (CSV `LegacySlotIndex >= 1` with mismatched legacy data). Diamond Flask and other UPDATE-path items are
  byte-identical on the wire.

  **Beta-first** per the project's risk heuristic — packet-handler change, "feels wrong" failure mode if anything
  regresses.

  ## Test plan

  - [ ] Hover items 22798 (Might of Menethil) and 17108 (Mark of Deflection) on Twinstar Kronos PTR — tooltips remain single-line (expected: no regression)
  - [ ] Equip Diamond Flask on SoM 1.14.1+ — on-use spell binds to the renumbered legacy id (regression check on the original DBReply fix)
  - [ ] Tail JSONL during a normal play session — `hotfix.itemeffect.dbreply` events appear with `status: Valid` for adds/updates and `status: RecordRemoved` for removals (no contradictory Valid+empty pairs)
  - [ ] Testers with the historical "double tooltip" bug: delete `Cache/` and `WDB/` once, relog through this proxy build, verify the duplicate doesn't return on subsequent sessions