### PR TITLE
Quest turn in DC

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
@@ -339,19 +339,37 @@ public partial class WorldClient
 
         quest.ItemReward.ItemID = itemId;
 
+        // JimsProxy: LaunchQuest must default to FALSE. The previous logic kept it true
+        // whenever the QuestTemplate was missing (which is the common 1.14-client case,
+        // since the modern client doesn't issue CMSG_QUERY_QUEST_INFO before turn-in —
+        // see the OfferedRewardChoiceItems comment above). LaunchQuest=true tells the
+        // modern client "another quest dialog is coming, keep the giver UI live"; when
+        // no follow-up data arrives the client retries the entire HELLO → COMPLETE →
+        // REQUEST_REWARD → CHOOSE_REWARD chain at ~100ms intervals to recover, which
+        // looks like spam to anti-flood-equipped servers (Twinstar/Kronos drops the
+        // socket after ~15 retries in <2s). Bundle 2026-05-02 073927 captured this
+        // exact pattern. Now: default false; opt in to true only when QuestTemplate
+        // confirms a follow-up quest exists.
         QuestTemplate? questTemplate = GameData.GetQuestTemplate((uint)quest.QuestID);
-        if (questTemplate != null && questTemplate.RewardNextQuest == 0)
-        {
-            quest.LaunchQuest = false;
+        bool hasFollowUpQuest = questTemplate != null && questTemplate.RewardNextQuest != 0;
+        quest.LaunchQuest = hasFollowUpQuest;
 
-            if (GetSession().GameState.CurrentInteractedWithNPC != default)
-            {
-                uint npcFlags = GetSession().GameState.GetLegacyFieldValueUInt32(GetSession().GameState.CurrentInteractedWithNPC, UnitField.UNIT_NPC_FLAGS);
-                if (npcFlags.HasAnyFlag(NPCFlags.Gossip))
-                    quest.LaunchGossip = true;
-            }
+        if (!hasFollowUpQuest && GetSession().GameState.CurrentInteractedWithNPC != default)
+        {
+            uint npcFlags = GetSession().GameState.GetLegacyFieldValueUInt32(GetSession().GameState.CurrentInteractedWithNPC, UnitField.UNIT_NPC_FLAGS);
+            if (npcFlags.HasAnyFlag(NPCFlags.Gossip))
+                quest.LaunchGossip = true;
         }
-        
+
+        Log.Event("quest.complete.launch_decision", new
+        {
+            quest_id = quest.QuestID,
+            has_quest_template = questTemplate != null,
+            reward_next_quest = questTemplate?.RewardNextQuest ?? 0,
+            launch_quest = quest.LaunchQuest,
+            launch_gossip = quest.LaunchGossip,
+        });
+
         SendPacketToClient(quest);
 
         DisplayToast toast = new();

--- a/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QuestHandler.cs
@@ -12,6 +12,39 @@ namespace HermesProxy.World.Server;
 
 public partial class WorldSocket
 {
+    // JimsProxy: c2s coalescing for the quest-giver CMSG family. The modern (1.14)
+    // retail client can spam the entire HELLO → COMPLETE_QUEST → REQUEST_REWARD →
+    // CHOOSE_REWARD chain at ~100ms intervals when it doesn't recognize the legacy
+    // turn-in confirmation as final (see WorldClient.HandleQuestGiverQuestComplete
+    // for the LaunchQuest fix). Twinstar/Kronos drops the socket as anti-flood after
+    // ~15 retries in <2s — bundle 2026-05-02 073927 captured this. Even with the
+    // LaunchQuest fix in place, defense-in-depth: never relay more than one of the
+    // same (opcode, NPC, quest) tuple per cooldown window. Cooldown is 750ms — wider
+    // than any plausible double-click but short enough that a legitimate "user closed
+    // dialog and reopened" still goes through.
+    private readonly Dictionary<(Opcode op, ulong npcGuidLow, uint questId), long> _questCmsgLastSent = new();
+    private const int QuestCmsgCoalesceWindowMs = 750;
+
+    private bool TryCoalesceQuestCmsg(Opcode op, WowGuid128 npcGuid, uint questId)
+    {
+        var key = (op, npcGuid.Low, questId);
+        long now = Environment.TickCount64;
+        if (_questCmsgLastSent.TryGetValue(key, out long last) && now - last < QuestCmsgCoalesceWindowMs)
+        {
+            Log.Event("quest.cmsg.coalesced", new
+            {
+                opcode = op.ToString(),
+                npc_guid_low = key.Item2,
+                quest_id = questId,
+                ms_since_last = now - last,
+                window_ms = QuestCmsgCoalesceWindowMs,
+            });
+            return true;
+        }
+        _questCmsgLastSent[key] = now;
+        return false;
+    }
+
     // Handlers for CMSG opcodes coming from the modern client
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_QUERY_QUEST)]
     void HandleQuestGiverQueryQuest(QuestGiverQueryQuest quest)
@@ -117,6 +150,8 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_HELLO)]
     void HandleQuestGiverHello(QuestGiverHello hello)
     {
+        if (TryCoalesceQuestCmsg(Opcode.CMSG_QUEST_GIVER_HELLO, hello.QuestGiverGUID, 0))
+            return;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_QUEST_GIVER_HELLO);
         packet.WriteGuid(hello.QuestGiverGUID.To64());
         SendPacketToServer(packet);
@@ -124,6 +159,8 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_REQUEST_REWARD)]
     void HandleQuestGiverRequestReward(QuestGiverRequestReward quest)
     {
+        if (TryCoalesceQuestCmsg(Opcode.CMSG_QUEST_GIVER_REQUEST_REWARD, quest.QuestGiverGUID, quest.QuestID))
+            return;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_QUEST_GIVER_REQUEST_REWARD);
         packet.WriteGuid(quest.QuestGiverGUID.To64());
         packet.WriteUInt32(quest.QuestID);
@@ -132,6 +169,8 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_CHOOSE_REWARD)]
     void HandleQuestGiverChooseReward(QuestGiverChooseReward quest)
     {
+        if (TryCoalesceQuestCmsg(Opcode.CMSG_QUEST_GIVER_CHOOSE_REWARD, quest.QuestGiverGUID, quest.QuestID))
+            return;
         int choiceIndex = 0;
 
         if (quest.Choice.Item.ItemID != 0)
@@ -189,6 +228,8 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_QUEST_GIVER_COMPLETE_QUEST)]
     void HandleQuestGiverCompleteQuest(QuestGiverCompleteQuest quest)
     {
+        if (TryCoalesceQuestCmsg(Opcode.CMSG_QUEST_GIVER_COMPLETE_QUEST, quest.QuestGiverGUID, quest.QuestID))
+            return;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_QUEST_GIVER_COMPLETE_QUEST);
         packet.WriteGuid(quest.QuestGiverGUID.To64());
         packet.WriteUInt32(quest.QuestID);


### PR DESCRIPTION
On 1.12 emulators with anti-flood (Twinstar / Kronos PTR observed), completing a quest at an NPC causes the modern
  (1.14) retail client to spam CMSG_QUEST_GIVER_CHOOSE_REWARD at ~100ms intervals until the legacy server drops the
  upstream socket. The proxy's realm-swap-safe disconnect suppression then leaves the modern client connected to a dead
  session — the user sees a frozen game world and only CMSG_PING going out for minutes.

  Steps to reproduce

  1. Connect a V1_14_2 retail client through HermesProxy to a 1.12.1 emulator with anti-flood (e.g. Kronos PTR).
  2. Pick up and complete any quest that has no follow-up quest in the chain.
  3. Click "Choose Reward" on the quest giver dialog.

  Expected

  Quest turns in once. Single CMSG_QUEST_GIVER_CHOOSE_REWARD relayed to the legacy server. NPC dialog closes. Player
  keeps playing.

  Actual

  - 15+ CMSG_QUEST_GIVER_CHOOSE_REWARD packets relayed in ~1.15s
  - Duplicate CMSG_QUEST_GIVER_HELLO / COMPLETE_QUEST / REQUEST_REWARD follow
  - Legacy server replies to the first SMSG_QUEST_GIVER_QUEST_COMPLETE ~98ms in, but the client keeps retrying for another full second after that
  - Legacy server closes the TCP socket ~4s later (anti-flood)
  - Proxy logs session.ondisconnect.suppressed / worldclient_legacy_disconnect and does not propagate the disconnect to the modern client
  - Modern client stays "connected", world is frozen, only periodic CMSG_PING flows for the rest of the bundle

  Root cause

  HermesProxy/World/Client/PacketHandlers/QuestHandler.cs — the SMSG_QUEST_GIVER_QUEST_COMPLETE translator defaults
  LaunchQuest = true on the modern packet and only sets it to false when the proxy has a cached QuestTemplate for the
  quest. The 1.14 client doesn't issue CMSG_QUERY_QUEST_INFO before turn-in (same condition the existing
  OfferedRewardChoiceItems fix documents), so for most turn-ins the QuestTemplate is missing, LaunchQuest=true ships,
  and the modern client interprets that as "more dialog data is coming, keep the giver UI live." When no follow-up
  arrives it falls back to a retry loop on the whole quest-giver CMSG chain.

  The 1.12 wire format for SMSG_QUESTGIVER_OFFER_REWARD doesn't carry a "next quest" field, so we can't recover the
  right answer from the offer-reward stream. Defaulting to false (no auto-launch) is strictly safer: worst case is a
  follow-up quest doesn't auto-pop and the user clicks the NPC once more.

  Diagnostic bundle

  jimsproxy-20260502-073927.jsonl. Key markers:
  - 1777705378866 → 1777705380018: 15 CMSG_QUEST_GIVER_CHOOSE_REWARD, same NPC + quest
  - 1777705378964: server sent SMSG_QUEST_GIVER_QUEST_COMPLETE (ignored by client)
  - 1777705383715: session.ondisconnect.suppressed reason=worldclient_legacy_disconnect, disconnect_reason=header, last_opcode=SMSG_ON_MONSTER_MOVE
  - After: 3.5 minutes of CMSG_PING-only c2s, zero s2c

  Fix (this PR)

  1. WorldClient.HandleQuestGiverQuestComplete — invert LaunchQuest default so it's opt-in only when QuestTemplate confirms a follow-up. Add quest.complete.launch_decision Log.Event so future bundles show whether the template was missing.
  2. WorldSocket (Server quest handler) — add per-(opcode, NPC GUID, quest ID) 750ms coalescing on the four spam-prone CMSGs (HELLO / COMPLETE_QUEST / REQUEST_REWARD / CHOOSE_REWARD). Defense-in-depth so addons or future client bugs can't reproduce the flood. Suppressions emit quest.cmsg.coalesced.

  Related

  The disconnect-suppression that hides the symptom (session.ondisconnect.suppressed / worldclient_legacy_disconnect) is
   intentional — it preserves the BNet session across PTR↔Live realm swaps. We are deliberately not changing that here;
  this PR fixes the cause so the suppression no longer masks a frozen-client failure mode.