### PR TITLE
Warrior charge revisit

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -751,6 +751,28 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy (Mount-Button-Stuck-Lit): returns true if any pending normal cast — started OR
+    /// merely in flight to the legacy server — matches the given SpellId (or its LegacySpellId
+    /// for SoM-renumbered USE_ITEMs). HasStartedNormalCast only catches duplicates AFTER
+    /// SMSG_SPELL_START matches the queue entry; rapid mashing within the c→s→c round-trip slips
+    /// past it and the duplicate USE_ITEM/CAST_SPELL gets forwarded. The legacy server then rejects
+    /// the duplicate with SpellInProgress, and the FIFO dequeue (TryDequeuePendingNormalCast picks
+    /// the oldest match) binds the failure to the in-flight cast's IDs — the bug commit 7b9e8aa
+    /// originally fixed and that resurfaced when 8998c39 switched HandleUseItem to silent-drop
+    /// gated on HasStartedNormalCast only. Used by HandleCastSpell and HandleUseItem to silent-drop
+    /// the in-flight same-spell duplicate before it ever reaches the queue.
+    /// </summary>
+    public bool HasInFlightNormalCastForSpell(uint spellId)
+    {
+        foreach (var item in PendingNormalCasts)
+        {
+            if (CastMatchesSpellId(item, spellId))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Store a cast in the held slot unconditionally (even if GCD has expired). Used by the
     /// HasForwardedPendingCast guard to hold casts during the post-GCD window while waiting
     /// for the server to respond. Returns any displaced cast.

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -826,21 +826,6 @@ public sealed class GameSessionData
     }
 
     /// <summary>
-    /// JimsProxy (Mount-Button-Stuck-Lit): returns true if any pending normal cast — started OR
-    /// merely in flight to the legacy server — matches the given SpellId (or its LegacySpellId
-    /// for SoM-renumbered USE_ITEMs).
-    /// </summary>
-    public bool HasInFlightNormalCastForSpell(uint spellId)
-    {
-        foreach (var item in PendingNormalCasts)
-        {
-            if (CastMatchesSpellId(item, spellId))
-                return true;
-        }
-        return false;
-    }
-
-    /// <summary>
     /// Returns true if any pending normal cast has been forwarded to the legacy server but
     /// hasn't received SMSG_SPELL_START yet. Covers the post-GCD-expiry window where
     /// IsGcdHoldActive() returns false but the server hasn't confirmed the forwarded cast.
@@ -929,11 +914,38 @@ public sealed class GameSessionData
             if (serial != _lastPingSerial || _lastPingSendTickMs == 0) return;
             long rttMs = Environment.TickCount64 - _lastPingSendTickMs;
             _lastPingSendTickMs = 0;
-            if (rttMs > 5000) return;
+            // Reject outliers above 300ms: any sample that high is connection-setup
+            // overhead (TCP handshake + auth + world-entry on a fresh WorldClient connect
+            // or realm swap), not a real GCD-relevant network RTT. The previous 5000ms
+            // ceiling let realm-swap startup pings poison the EMA — measured 672ms then
+            // 641ms on a realm swap, smoothing pinned at 588ms for the rest of the session.
+            if (rttMs > 300)
+            {
+                Log.Event("rtt.sample.rejected", new { serial, raw_ms = rttMs, reason = "outlier_above_300ms" });
+                return;
+            }
             const double alpha = 0.2;
             _smoothedRttMs = _rttSampleCount == 0 ? rttMs : (_smoothedRttMs * (1 - alpha) + rttMs * alpha);
             _rttSampleCount++;
             Log.Event("rtt.sample", new { serial, raw_ms = rttMs, smoothed_ms = Math.Round(_smoothedRttMs, 1), samples = _rttSampleCount });
+        }
+    }
+
+    /// <summary>
+    /// Reset RTT smoothing state. Called when the proxy connects/reconnects to the legacy
+    /// world server (login, realm swap) so accumulated bad samples from the prior connection
+    /// don't pollute the new session — particularly the cap-bound 100ms fire offset that
+    /// becomes unsafe when applied with a stale-high smoothed RTT.
+    /// </summary>
+    public void ResetRttSmoothing()
+    {
+        lock (_rttLock)
+        {
+            _smoothedRttMs = 0;
+            _rttSampleCount = 0;
+            _lastPingSendTickMs = 0;
+            _lastPingSerial = 0;
+            Log.Event("rtt.smoothing.reset", new { });
         }
     }
 
@@ -943,7 +955,23 @@ public sealed class GameSessionData
         {
             if (_rttSampleCount < 3)
                 return Framework.Settings.SpellCastEarlyFireOffsetMs;
-            return (int)Math.Clamp(Math.Round(_smoothedRttMs * 0.5), 0, 100);
+            // Max safe offset is full RTT: cast leaves proxy at gcd_expire-X, arrives at server
+            // at gcd_expire-X+rtt/2; server's GCD ended rtt/2 before client's, so X<=rtt is safe.
+            // Server-side margin = RTT - offset; we want a CONSTANT 10ms minimum margin to
+            // absorb server-processing jitter regardless of RTT. The earlier multiplier formula
+            // (RTT * 0.95) gave 0.05*RTT margin — fine at high RTT but only ~2ms at 35ms RTT
+            // where Twinstar's ~30ms jitter would flood NOT_READY for low-latency euro players.
+            // Predictive SMSG_SPELL_GO synth was tried to push past this floor but caused
+            // legacy-server DCs (see memory/project_predictive_spell_go_synth_dc.md).
+            const int safetyMs = 10;
+            // Cap at 100ms: realm-swap startup pings can briefly inflate smoothed RTT to
+            // 500ms+ (EMA α=0.2 recovers slowly), and a high cap with bogus RTT fires the
+            // held cast far before the server's GCD ends — the legacy server then queues
+            // the cast and replies late, producing the "stuck button" perceived as sluggish
+            // even with zero NOT_READY events. 100ms keeps the worst-case early-arrival
+            // bounded to roughly safe territory at all realistic actual RTTs.
+            double offset = _smoothedRttMs - safetyMs;
+            return (int)Math.Clamp(Math.Round(offset), 0, 100);
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -824,6 +824,27 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }
+
+            // JimsProxy (Pickpocket-Macros): off-GCD instants (Pickpocket, Distract, etc.)
+            // skip BeginGcd, so a follow-up cast held by HasForwardedPendingCast() never gets
+            // a release signal on success — it sat in the held slot until the next press
+            // displaced it. Mirror HandleCastFailed's TakeHeldCastIfReady release on success.
+            // TakeHeldCastIfReady self-guards against active GCDs, so when an on-GCD cast
+            // just called BeginGcd above, this is a no-op and the timer handles the release.
+            var gameStateAfter = GetSession().GameState;
+            if (!gameStateAfter.HasForwardedPendingCast())
+            {
+                var heldCast = gameStateAfter.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_success", new
+                    {
+                        success_spell_id = spell.Cast.SpellID,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameStateAfter.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.CurrentClientNextMeleeCast != null &&

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -909,6 +909,33 @@ public partial class WorldClient
         if (spell.LogData == null)
             spell.LogData = new SpellCastLogData();
 
+        // JimsProxy (warrior-charge-revisit): vanilla Twinstar/Kronos broadcast a second
+        // SMSG_SPELL_GO ~1ms after the parent Charge/Intercept GO for the triggered stun
+        // sub-effect (7922 Charge Stun / 20615 Intercept Stun) with caster=local player.
+        // The modern 1.14 client kicks the sub-effect's SpellVisualKit on the caster on
+        // top of the Charge/Intercept lunge kit — two overlapping caster-side animations
+        // read as the warrior twitching ("on crack"). We want both visuals: Charge lunge
+        // on the warrior (parent spell 100/20252 GO already handled that), stun pose on
+        // the mob. Solution: rewrite CasterGUID/CasterUnit to the hit target so the
+        // modern client plays the stun kit's caster events on the mob instead of the
+        // warrior. Stun aura/icon on the mob is unaffected (SMSG_AURA_UPDATE drives that
+        // independently). CLEU will show spell 7922/20615 source=mob, but damage meters
+        // attribute Charge/Intercept damage to the parent spell, not this sub-effect.
+        if ((spell.Cast.SpellID == 7922 || spell.Cast.SpellID == 20615) &&
+            GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
+            spell.Cast.HitTargets.Count > 0)
+        {
+            WowGuid128 stunTarget = spell.Cast.HitTargets[0];
+            Log.Event("spell.go.stun_subeffect_redirected", new
+            {
+                spell_id = spell.Cast.SpellID,
+                spell_visual_id = spell.Cast.SpellXSpellVisualID,
+                redirected_to = stunTarget.ToString(),
+            });
+            spell.Cast.CasterGUID = stunTarget;
+            spell.Cast.CasterUnit = stunTarget;
+        }
+
         SendPacketToClient(spell);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -805,6 +805,26 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }
+
+            // JimsProxy (Macro-GCD-Fix): off-GCD completions (trinkets, racials, etc.) don't
+            // trigger BeginGcd, so a cast held via spell.held_pending while the off-GCD cast
+            // was in flight gets stranded — _heldGcdCast sits until the next press/failure.
+            // Bundle 20260430-150846 showed SS held 7563ms after a trinket completed. If the
+            // queue is now drained and no GCD is active, release the held cast immediately.
+            var gameState = GetSession().GameState;
+            if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
+            {
+                var heldCast = gameState.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_go", new
+                    {
+                        completed_spell_id = spell.Cast.SpellID,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameState.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.CurrentClientNextMeleeCast != null &&

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -113,6 +113,10 @@ public partial class WorldClient
                 port = (int)realm.Port,
                 realm_name = realm.Name,
             });
+            // JimsProxy: clear stale RTT smoothing on every connect so realm-swap
+            // startup pings (TCP+auth+world-entry overhead) don't pollute the new
+            // session's adaptive fire offset.
+            globalSession.GameState.ResetRttSmoothing();
             _clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             // Connect to the specified host.
             var endPoint = new IPEndPoint(ip, realm.Port);

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -81,7 +81,7 @@ public partial class WorldSocket
         if (targetFlags.HasAnyFlag(SpellCastTargetFlags.String))
             packet.WriteCString(target.Name);
     }
-    public void SendCastRequestFailed(ClientCastRequest castRequest, bool isPet)
+    public void SendCastRequestFailed(ClientCastRequest castRequest, bool isPet, SpellCastResultClassic reason = SpellCastResultClassic.SpellInProgress)
     {
         if (!castRequest.HasStarted)
         {
@@ -95,7 +95,7 @@ public partial class WorldSocket
         {
             PetCastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = (uint)reason;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
         }
@@ -104,10 +104,10 @@ public partial class WorldSocket
             CastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
             failed.SpellXSpellVisualID = castRequest.SpellXSpellVisualId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = (uint)reason;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
-        }    
+        }
     }
     // JimsProxy: Hunter tame-class spell IDs in vanilla — used to log tame attempts
     // for the pet deep-dive. 1515 = "Tame Beast" player ability; the rest are
@@ -202,11 +202,27 @@ public partial class WorldSocket
             // 1.12 client would fire these mid-cast-bar and mid-GCD, so we match that.
             if (!isOffGcd)
             {
-                // Silently drop re-clicks while a cast is in progress. Sending
-                // CastFailed(SpellInProgress) causes the 1.14 client to dismiss
-                // the active cast bar even though the server-side cast continues.
-                if (GetSession().GameState.HasStartedNormalCast())
+                // JimsProxy (Mount-Button-Stuck-Lit): drop re-clicks but resolve the modern
+                // client's tracking via the duplicate's own unique ClientGUID/ServerGUID. The
+                // earlier silent-drop approach (commit 8998c39) avoided dismissing the running
+                // cast bar but left the duplicate's action-button state pending forever. Sending
+                // SpellPrepare + CastFailed(DontReport) bound to the DUPLICATE's IDs releases the
+                // queued state without showing an error toast. The running cast's ServerCastID is
+                // distinct, so its cast bar should be unaffected.
+                bool gateStarted = GetSession().GameState.HasStartedNormalCast();
+                bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
+                if (gateStarted || gateInFlight)
+                {
+                    Log.Event("cast.dropped.duplicate", new
+                    {
+                        spell_id = cast.Cast.SpellID,
+                        reason = gateInFlight ? "in_flight_same_spell_cast_spell" : "another_cast_started",
+                        client_cast_id = cast.Cast.CastID.ToString(),
+                        queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+                    });
+                    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
                     return;
+                }
 
                 // JimsProxy (issue #43): if we're inside a GCD hold window, build the CMSG_CAST_SPELL
                 // packet now but don't forward it — store it as the pending held cast. The Timer
@@ -418,9 +434,29 @@ public partial class WorldSocket
         castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, use.Cast.SpellID, 10000 + use.Cast.CastID.GetCounter());
         castRequest.ItemGUID = use.CastItem;
 
-        // Silently drop re-clicks while a cast is in progress (same as HandleCastSpell).
-        if (GetSession().GameState.HasStartedNormalCast())
+        // JimsProxy (Mount-Button-Stuck-Lit): drop the duplicate USE_ITEM but resolve the modern
+        // client's per-click tracking so the action button doesn't stay "queued/lit" forever.
+        // Bind SpellPrepare + CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built
+        // a few lines above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if
+        // any) has its OWN distinct ServerCastID, so the modern client should resolve only the
+        // duplicate's tracking and leave the active cast bar alone. Reason=DontReport suppresses
+        // the "Another action is in progress" error toast — silent drop semantics, but now with
+        // the IDs the client needs to release the queued state.
+        bool gateStarted = GetSession().GameState.HasStartedNormalCast();
+        bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)use.Cast.SpellID);
+        if (gateStarted || gateInFlight)
+        {
+            Log.Event("cast.dropped.duplicate", new
+            {
+                spell_id = use.Cast.SpellID,
+                reason = gateInFlight ? "in_flight_same_spell_use_item" : "another_cast_started",
+                client_cast_id = use.Cast.CastID.ToString(),
+                item_guid = use.CastItem.ToString(),
+                queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+            });
+            SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
             return;
+        }
 
         // Some items had their on-use spell id renumbered in SoM 1.14.1+ (e.g. Diamond Flask 17626 → 363880).
         // The 1.12 emulator only knows the legacy id, so resolve it now and remember both

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -140,6 +140,42 @@ public partial class WorldSocket
             });
         }
 
+        // JimsProxy (Rupture-DoT-Lingering-Icon): snapshot CP for vanilla CP-scaling
+        // finishers before the server consumes them. The legacy server applies
+        // (base + perCp × CP) ms duration server-side and never echoes it back for enemy
+        // debuffs, so the proxy synthesizes the correct duration locally on aura apply.
+        // Snapshotting on the keypress (before any GCD-hold path) covers both immediate
+        // forwards and held-then-released casts. TTL on the lookup side bounds staleness.
+        uint castSpellId = (uint)cast.Cast.SpellID;
+        if (GameData.IsComboPointFinisher(castSpellId))
+        {
+            byte cp = GetSession().GameState.CurrentComboPoints;
+            WowGuid128 target = cast.Cast.Target.Unit;
+            bool targetEmpty = target.IsEmpty();
+            // Unconditional diagnostic so we can see which guard failed when no snapshot fires.
+            Log.Event("finisher.cmsg_cast", new
+            {
+                spell_id = castSpellId,
+                combo_points = cp,
+                target_low = targetEmpty ? 0 : target.GetCounter(),
+                target_empty = targetEmpty,
+                target_flags = (uint)cast.Cast.Target.Flags,
+                cached_combo_target_low = GetSession().GameState.CurrentComboTarget.IsEmpty()
+                    ? 0
+                    : GetSession().GameState.CurrentComboTarget.GetCounter(),
+            });
+            if (cp > 0 && !targetEmpty)
+            {
+                GetSession().GameState.StorePendingFinisherCast(castSpellId, target, cp);
+                Log.Event("finisher.snapshot", new
+                {
+                    spell_id = castSpellId,
+                    target_low = target.GetCounter(),
+                    combo_points = cp,
+                });
+            }
+        }
+
         bool isNextMelee = GameData.NextMeleeSpells.Contains(cast.Cast.SpellID);
         bool isAutoRepeat = GameData.AutoRepeatSpells.Contains(cast.Cast.SpellID);
         // JimsProxy (issue #43): the GCD hold-and-fire path is vanilla-only. On TBC+ the
@@ -313,30 +349,6 @@ public partial class WorldSocket
                     heldPrepare.ClientCastID = castRequest.ClientGUID;
                     heldPrepare.ServerCastID = castRequest.ServerGUID;
                     SendPacket(heldPrepare);
-
-                    // JimsProxy (Macro-GCD-Fix): macro-batched `/use 13 /use 14 /cast SS` lands all
-                    // three CMSGs in the same ms; SS gets held_pending while a trinket is in flight.
-                    // SpellPrepare acks the click but the modern 1.14 client's GCD swipe doesn't
-                    // start until SS's own SMSG_SPELL_GO arrives — a ~300ms gap (trinket RTT + SS RTT)
-                    // where the action button is queued/lit without a sweep. Synthesize a
-                    // SMSG_COOLDOWN_EVENT so the client's swipe starts immediately at ack time.
-                    // SMSG_SPELL_COOLDOWN with ForcedCooldown was tried earlier (stash 0) and got
-                    // "anticipated-then-canceled" by the macro evaluator; SMSG_COOLDOWN_EVENT lets
-                    // the client compute the GCD locally from the spell's DBC StartRecoveryTime.
-                    // Vanilla-only: TBC+ haste-adjusted GCDs would make this wrong, and the GCD-hold
-                    // mechanism (gated on ExpansionVersion==1 in HandleSpellGo) is vanilla-only too.
-                    if (LegacyVersion.ExpansionVersion == 1)
-                    {
-                        CooldownEvent cdEvent = new();
-                        cdEvent.SpellID = (uint)cast.Cast.SpellID;
-                        cdEvent.IsPet = false;
-                        SendPacket(cdEvent);
-                        Log.Event("gcd.cooldown.synth_held", new
-                        {
-                            spell_id = cast.Cast.SpellID,
-                            client_cast_id = castRequest.ClientGUID.ToString(),
-                        });
-                    }
                     return;
                 }
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -204,11 +204,11 @@ public partial class WorldSocket
             {
                 // JimsProxy (Mount-Button-Stuck-Lit): drop re-clicks but resolve the modern
                 // client's tracking via the duplicate's own unique ClientGUID/ServerGUID. The
-                // earlier silent-drop approach (commit 8998c39) avoided dismissing the running
-                // cast bar but left the duplicate's action-button state pending forever. Sending
-                // SpellPrepare + CastFailed(DontReport) bound to the DUPLICATE's IDs releases the
-                // queued state without showing an error toast. The running cast's ServerCastID is
-                // distinct, so its cast bar should be unaffected.
+                // earlier silent-drop approach (commit 8998c39) left the duplicate's action-button
+                // state pending forever. Reason is SpellInProgress (matches the displaced-hold
+                // path below) — the 1.14 client treats it as "overridden by newer cast" and
+                // releases the duplicate's queued/lit state. The running cast's ServerCastID is
+                // distinct, so its cast bar is unaffected.
                 bool gateStarted = GetSession().GameState.HasStartedNormalCast();
                 bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
                 if (gateStarted || gateInFlight)
@@ -220,7 +220,7 @@ public partial class WorldSocket
                         client_cast_id = cast.Cast.CastID.ToString(),
                         queue_depth = GetSession().GameState.PendingNormalCasts.Count,
                     });
-                    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
+                    SendCastRequestFailed(castRequest, false);
                     return;
                 }
 
@@ -313,6 +313,30 @@ public partial class WorldSocket
                     heldPrepare.ClientCastID = castRequest.ClientGUID;
                     heldPrepare.ServerCastID = castRequest.ServerGUID;
                     SendPacket(heldPrepare);
+
+                    // JimsProxy (Macro-GCD-Fix): macro-batched `/use 13 /use 14 /cast SS` lands all
+                    // three CMSGs in the same ms; SS gets held_pending while a trinket is in flight.
+                    // SpellPrepare acks the click but the modern 1.14 client's GCD swipe doesn't
+                    // start until SS's own SMSG_SPELL_GO arrives — a ~300ms gap (trinket RTT + SS RTT)
+                    // where the action button is queued/lit without a sweep. Synthesize a
+                    // SMSG_COOLDOWN_EVENT so the client's swipe starts immediately at ack time.
+                    // SMSG_SPELL_COOLDOWN with ForcedCooldown was tried earlier (stash 0) and got
+                    // "anticipated-then-canceled" by the macro evaluator; SMSG_COOLDOWN_EVENT lets
+                    // the client compute the GCD locally from the spell's DBC StartRecoveryTime.
+                    // Vanilla-only: TBC+ haste-adjusted GCDs would make this wrong, and the GCD-hold
+                    // mechanism (gated on ExpansionVersion==1 in HandleSpellGo) is vanilla-only too.
+                    if (LegacyVersion.ExpansionVersion == 1)
+                    {
+                        CooldownEvent cdEvent = new();
+                        cdEvent.SpellID = (uint)cast.Cast.SpellID;
+                        cdEvent.IsPet = false;
+                        SendPacket(cdEvent);
+                        Log.Event("gcd.cooldown.synth_held", new
+                        {
+                            spell_id = cast.Cast.SpellID,
+                            client_cast_id = castRequest.ClientGUID.ToString(),
+                        });
+                    }
                     return;
                 }
 
@@ -436,12 +460,12 @@ public partial class WorldSocket
 
         // JimsProxy (Mount-Button-Stuck-Lit): drop the duplicate USE_ITEM but resolve the modern
         // client's per-click tracking so the action button doesn't stay "queued/lit" forever.
-        // Bind SpellPrepare + CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built
-        // a few lines above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if
-        // any) has its OWN distinct ServerCastID, so the modern client should resolve only the
-        // duplicate's tracking and leave the active cast bar alone. Reason=DontReport suppresses
-        // the "Another action is in progress" error toast — silent drop semantics, but now with
-        // the IDs the client needs to release the queued state.
+        // Bind CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built a few lines
+        // above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if any) has its
+        // OWN distinct ServerCastID, so the modern client resolves only the duplicate's tracking
+        // and leaves the active cast bar alone. Reason is SpellInProgress (matches the displaced-
+        // hold path) — the 1.14 client treats it as "overridden by newer cast" and releases the
+        // duplicate's queued/lit state cleanly.
         bool gateStarted = GetSession().GameState.HasStartedNormalCast();
         bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)use.Cast.SpellID);
         if (gateStarted || gateInFlight)
@@ -454,7 +478,7 @@ public partial class WorldSocket
                 item_guid = use.CastItem.ToString(),
                 queue_depth = GetSession().GameState.PendingNormalCasts.Count,
             });
-            SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
+            SendCastRequestFailed(castRequest, false);
             return;
         }
 


### PR DESCRIPTION
Twinstar/Kronos broadcast a second SMSG_SPELL_GO ~1ms after the parent
  ▎ Charge/Intercept GO for the triggered stun (7922 / 20615) with caster=
  ▎ local player. The modern 1.14 client kicked the stun kit's caster events
  ▎ on the warrior on top of the lunge kit, producing a visible animation
  ▎ twitch ("warrior on crack"). Rewrite CasterGUID/CasterUnit to the first
  ▎ hit target so the stun kit plays on the mob instead. Stun aura/icon and
  ▎ damage attribution are unaffected.