### PR TITLE
Pet scale vanilla parity

### DIFF
--- a/HermesProxy/Configuration/ConfigurationParser.cs
+++ b/HermesProxy/Configuration/ConfigurationParser.cs
@@ -93,6 +93,20 @@ public class ConfigurationParser
         return defValue;
     }
 
+    public float GetFloat(string key, float defValue)
+    {
+        KeyValueConfigurationElement s = _settingsCollection[key];
+        if (string.IsNullOrEmpty(s?.Value))
+            return defValue;
+
+        float aux;
+        if (float.TryParse(s.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out aux))
+            return aux;
+
+        Console.WriteLine("Warning: \"{0}\" is not a valid float value for key \"{1}\"", s.Value, key);
+        return defValue;
+    }
+
     public TEnum GetEnum<TEnum>(string key, TEnum defValue) where TEnum : struct
     {
         KeyValueConfigurationElement s = _settingsCollection[key];

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -751,6 +751,28 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy (Mount-Button-Stuck-Lit): returns true if any pending normal cast — started OR
+    /// merely in flight to the legacy server — matches the given SpellId (or its LegacySpellId
+    /// for SoM-renumbered USE_ITEMs). HasStartedNormalCast only catches duplicates AFTER
+    /// SMSG_SPELL_START matches the queue entry; rapid mashing within the c→s→c round-trip slips
+    /// past it and the duplicate USE_ITEM/CAST_SPELL gets forwarded. The legacy server then rejects
+    /// the duplicate with SpellInProgress, and the FIFO dequeue (TryDequeuePendingNormalCast picks
+    /// the oldest match) binds the failure to the in-flight cast's IDs — the bug commit 7b9e8aa
+    /// originally fixed and that resurfaced when 8998c39 switched HandleUseItem to silent-drop
+    /// gated on HasStartedNormalCast only. Used by HandleCastSpell and HandleUseItem to silent-drop
+    /// the in-flight same-spell duplicate before it ever reaches the queue.
+    /// </summary>
+    public bool HasInFlightNormalCastForSpell(uint spellId)
+    {
+        foreach (var item in PendingNormalCasts)
+        {
+            if (CastMatchesSpellId(item, spellId))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Store a cast in the held slot unconditionally (even if GCD has expired). Used by the
     /// HasForwardedPendingCast guard to hold casts during the post-GCD window while waiting
     /// for the server to respond. Returns any displaced cast.

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -826,21 +826,6 @@ public sealed class GameSessionData
     }
 
     /// <summary>
-    /// JimsProxy (Mount-Button-Stuck-Lit): returns true if any pending normal cast — started OR
-    /// merely in flight to the legacy server — matches the given SpellId (or its LegacySpellId
-    /// for SoM-renumbered USE_ITEMs).
-    /// </summary>
-    public bool HasInFlightNormalCastForSpell(uint spellId)
-    {
-        foreach (var item in PendingNormalCasts)
-        {
-            if (CastMatchesSpellId(item, spellId))
-                return true;
-        }
-        return false;
-    }
-
-    /// <summary>
     /// Returns true if any pending normal cast has been forwarded to the legacy server but
     /// hasn't received SMSG_SPELL_START yet. Covers the post-GCD-expiry window where
     /// IsGcdHoldActive() returns false but the server hasn't confirmed the forwarded cast.
@@ -929,11 +914,38 @@ public sealed class GameSessionData
             if (serial != _lastPingSerial || _lastPingSendTickMs == 0) return;
             long rttMs = Environment.TickCount64 - _lastPingSendTickMs;
             _lastPingSendTickMs = 0;
-            if (rttMs > 5000) return;
+            // Reject outliers above 300ms: any sample that high is connection-setup
+            // overhead (TCP handshake + auth + world-entry on a fresh WorldClient connect
+            // or realm swap), not a real GCD-relevant network RTT. The previous 5000ms
+            // ceiling let realm-swap startup pings poison the EMA — measured 672ms then
+            // 641ms on a realm swap, smoothing pinned at 588ms for the rest of the session.
+            if (rttMs > 300)
+            {
+                Log.Event("rtt.sample.rejected", new { serial, raw_ms = rttMs, reason = "outlier_above_300ms" });
+                return;
+            }
             const double alpha = 0.2;
             _smoothedRttMs = _rttSampleCount == 0 ? rttMs : (_smoothedRttMs * (1 - alpha) + rttMs * alpha);
             _rttSampleCount++;
             Log.Event("rtt.sample", new { serial, raw_ms = rttMs, smoothed_ms = Math.Round(_smoothedRttMs, 1), samples = _rttSampleCount });
+        }
+    }
+
+    /// <summary>
+    /// Reset RTT smoothing state. Called when the proxy connects/reconnects to the legacy
+    /// world server (login, realm swap) so accumulated bad samples from the prior connection
+    /// don't pollute the new session — particularly the cap-bound 100ms fire offset that
+    /// becomes unsafe when applied with a stale-high smoothed RTT.
+    /// </summary>
+    public void ResetRttSmoothing()
+    {
+        lock (_rttLock)
+        {
+            _smoothedRttMs = 0;
+            _rttSampleCount = 0;
+            _lastPingSendTickMs = 0;
+            _lastPingSerial = 0;
+            Log.Event("rtt.smoothing.reset", new { });
         }
     }
 
@@ -943,7 +955,23 @@ public sealed class GameSessionData
         {
             if (_rttSampleCount < 3)
                 return Framework.Settings.SpellCastEarlyFireOffsetMs;
-            return (int)Math.Clamp(Math.Round(_smoothedRttMs * 0.5), 0, 100);
+            // Max safe offset is full RTT: cast leaves proxy at gcd_expire-X, arrives at server
+            // at gcd_expire-X+rtt/2; server's GCD ended rtt/2 before client's, so X<=rtt is safe.
+            // Server-side margin = RTT - offset; we want a CONSTANT 10ms minimum margin to
+            // absorb server-processing jitter regardless of RTT. The earlier multiplier formula
+            // (RTT * 0.95) gave 0.05*RTT margin — fine at high RTT but only ~2ms at 35ms RTT
+            // where Twinstar's ~30ms jitter would flood NOT_READY for low-latency euro players.
+            // Predictive SMSG_SPELL_GO synth was tried to push past this floor but caused
+            // legacy-server DCs (see memory/project_predictive_spell_go_synth_dc.md).
+            const int safetyMs = 10;
+            // Cap at 100ms: realm-swap startup pings can briefly inflate smoothed RTT to
+            // 500ms+ (EMA α=0.2 recovers slowly), and a high cap with bogus RTT fires the
+            // held cast far before the server's GCD ends — the legacy server then queues
+            // the cast and replies late, producing the "stuck button" perceived as sluggish
+            // even with zero NOT_READY events. 100ms keeps the worst-case early-arrival
+            // bounded to roughly safe territory at all realistic actual RTTs.
+            double offset = _smoothedRttMs - safetyMs;
+            return (int)Math.Clamp(Math.Round(offset), 0, 100);
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -824,6 +824,27 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }
+
+            // JimsProxy (Pickpocket-Macros): off-GCD instants (Pickpocket, Distract, etc.)
+            // skip BeginGcd, so a follow-up cast held by HasForwardedPendingCast() never gets
+            // a release signal on success — it sat in the held slot until the next press
+            // displaced it. Mirror HandleCastFailed's TakeHeldCastIfReady release on success.
+            // TakeHeldCastIfReady self-guards against active GCDs, so when an on-GCD cast
+            // just called BeginGcd above, this is a no-op and the timer handles the release.
+            var gameStateAfter = GetSession().GameState;
+            if (!gameStateAfter.HasForwardedPendingCast())
+            {
+                var heldCast = gameStateAfter.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_success", new
+                    {
+                        success_spell_id = spell.Cast.SpellID,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameStateAfter.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.CurrentClientNextMeleeCast != null &&

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -909,6 +909,33 @@ public partial class WorldClient
         if (spell.LogData == null)
             spell.LogData = new SpellCastLogData();
 
+        // JimsProxy (warrior-charge-revisit): vanilla Twinstar/Kronos broadcast a second
+        // SMSG_SPELL_GO ~1ms after the parent Charge/Intercept GO for the triggered stun
+        // sub-effect (7922 Charge Stun / 20615 Intercept Stun) with caster=local player.
+        // The modern 1.14 client kicks the sub-effect's SpellVisualKit on the caster on
+        // top of the Charge/Intercept lunge kit — two overlapping caster-side animations
+        // read as the warrior twitching ("on crack"). We want both visuals: Charge lunge
+        // on the warrior (parent spell 100/20252 GO already handled that), stun pose on
+        // the mob. Solution: rewrite CasterGUID/CasterUnit to the hit target so the
+        // modern client plays the stun kit's caster events on the mob instead of the
+        // warrior. Stun aura/icon on the mob is unaffected (SMSG_AURA_UPDATE drives that
+        // independently). CLEU will show spell 7922/20615 source=mob, but damage meters
+        // attribute Charge/Intercept damage to the parent spell, not this sub-effect.
+        if ((spell.Cast.SpellID == 7922 || spell.Cast.SpellID == 20615) &&
+            GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
+            spell.Cast.HitTargets.Count > 0)
+        {
+            WowGuid128 stunTarget = spell.Cast.HitTargets[0];
+            Log.Event("spell.go.stun_subeffect_redirected", new
+            {
+                spell_id = spell.Cast.SpellID,
+                spell_visual_id = spell.Cast.SpellXSpellVisualID,
+                redirected_to = stunTarget.ToString(),
+            });
+            spell.Cast.CasterGUID = stunTarget;
+            spell.Cast.CasterUnit = stunTarget;
+        }
+
         SendPacketToClient(spell);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -805,6 +805,26 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
             }
+
+            // JimsProxy (Macro-GCD-Fix): off-GCD completions (trinkets, racials, etc.) don't
+            // trigger BeginGcd, so a cast held via spell.held_pending while the off-GCD cast
+            // was in flight gets stranded — _heldGcdCast sits until the next press/failure.
+            // Bundle 20260430-150846 showed SS held 7563ms after a trinket completed. If the
+            // queue is now drained and no GCD is active, release the held cast immediately.
+            var gameState = GetSession().GameState;
+            if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
+            {
+                var heldCast = gameState.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    Log.Event("spell.held_fire_on_go", new
+                    {
+                        completed_spell_id = spell.Cast.SpellID,
+                        held_spell_id = heldCast.SpellId,
+                    });
+                    gameState.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.CurrentClientNextMeleeCast != null &&

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1,5 +1,6 @@
 ﻿//#define DEBUG_UPDATES
 
+using Framework;
 using Framework.GameMath;
 using Framework.Logging;
 using Framework.Util;
@@ -3560,6 +3561,86 @@ public partial class WorldClient
             if (CORPSE_FIELD_DYNAMIC_FLAGS >= 0 && updateMaskArray[CORPSE_FIELD_DYNAMIC_FLAGS])
             {
                 updateData.CorpseData.DynamicFlags = updates[CORPSE_FIELD_DYNAMIC_FLAGS].UInt32Value;
+            }
+        }
+
+        // JimsProxy (pet-scale-vanilla-parity): the local player's pet (warlock or hunter)
+        // renders visibly smaller in modern 1.14 Classic than the vanilla 1.12 reference,
+        // even though CreatureDisplayInfo and CreatureModelData scale data is byte-
+        // identical between the two builds (extracted both sets and diffed — only 39 of
+        // ~10,500 DisplayIDs differ in CreatureModelScale, none of them pet display IDs).
+        // Root cause unverified — likely an undocumented client-side scale modifier on
+        // local-player pet units in modern Classic. A flat global multiplier doesn't work
+        // because the modern client compounds it with the per-display CreatureModelScale:
+        // a Felhunter (CMS 0.5) at 1.5× still renders too small while a Dire Wolf (CMS
+        // 1.5) at 1.5× ends up at ~2.2 effective and looks ridiculous.
+        //
+        // Inverse-CMS scaling cancels that variance: emit (wire / CreatureModelScale) × K
+        // so the modern client's wire × ModelScale × CMS multiply collapses to wire ×
+        // ModelScale × K — every pet gets a uniform K bump regardless of its CMS quirks.
+        // K = 1.5 is the empirical "felt right at 1.12" tuning value for hunter pets.
+        //
+        // Server-side combat reach and bounding radius are untouched, so range checks,
+        // melee hit detection, and ability targeting are unchanged. Only the visual scale
+        // forwarded to the client is modified; click hitbox grows with the visual.
+        //
+        // Detection: prefer CurrentPetGuid match (set when SMSG_PET_SPELLS_MESSAGE arrives,
+        // typically before the pet's first CREATE_OBJECT). Fallback to SUMMONEDBY in this
+        // update matching CurrentPlayerGuid so the first CREATE_OBJECT for a pet (which
+        // carries SUMMONEDBY) gets normalized even if CurrentPetGuid hasn't latched yet.
+        // Only fires when SCALE_X is present in this update (Scale != null) — a delta
+        // values update without SCALE_X leaves the already-normalized scale sticky on the
+        // client and avoids compounding multiplications across updates.
+        const float PetScaleK = 1.5f;
+        if (LegacyVersion.ExpansionVersion == 1
+            && updateData.ObjectData.Scale != null
+            && (objectType == ObjectType.Unit || objectType == ObjectType.Player || objectType == ObjectType.ActivePlayer))
+        {
+            var localPlayerGuid = Session.GameState.CurrentPlayerGuid;
+            var currentPetGuid = Session.GameState.CurrentPetGuid;
+            bool isLocalPet = (currentPetGuid != default && guid == currentPetGuid)
+                              || (localPlayerGuid != default
+                                  && updateData.UnitData.SummonedBy != null
+                                  && (WowGuid128)updateData.UnitData.SummonedBy == localPlayerGuid);
+
+            if (isLocalPet)
+            {
+                // DisplayID for CMS lookup. Prefer current update (most up-to-date for
+                // shapeshift/morph cases); fall back to GameState cache for delta updates.
+                int displayId = 0;
+                int UNIT_FIELD_DISPLAYID_idx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_DISPLAYID);
+                if (UNIT_FIELD_DISPLAYID_idx >= 0
+                    && UNIT_FIELD_DISPLAYID_idx < updateMaskArray.Length
+                    && updateMaskArray[UNIT_FIELD_DISPLAYID_idx])
+                    displayId = updates[UNIT_FIELD_DISPLAYID_idx].Int32Value;
+                else
+                    displayId = Session.GameState.GetLegacyFieldValueInt32(guid, UnitField.UNIT_FIELD_DISPLAYID);
+
+                float rawScale = (float)updateData.ObjectData.Scale;
+                float cms = 0f;
+                if (displayId > 0)
+                    cms = GameData.GetDisplayInfo((uint)displayId).DisplayScale;
+
+                // Skip normalization if CMS data is missing/invalid — fall back to a flat
+                // K multiply so the pet still gets a size bump rather than passing through
+                // un-modified (and rendering small).
+                float emit = (cms > 0)
+                    ? (rawScale / cms) * PetScaleK
+                    : rawScale * PetScaleK;
+
+                updateData.ObjectData.Scale = emit;
+
+                Log.Event("unit.pet_scale.applied", new
+                {
+                    guid = guid.ToString(),
+                    display_id = displayId,
+                    creature_model_scale = cms,
+                    k = PetScaleK,
+                    raw_scale = rawScale,
+                    emitted_scale = emit,
+                    matched_via = (currentPetGuid != default && guid == currentPetGuid) ? "current_pet_guid" : "summoned_by",
+                    cms_fallback = cms <= 0,
+                });
             }
         }
     }

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -113,6 +113,10 @@ public partial class WorldClient
                 port = (int)realm.Port,
                 realm_name = realm.Name,
             });
+            // JimsProxy: clear stale RTT smoothing on every connect so realm-swap
+            // startup pings (TCP+auth+world-entry overhead) don't pollute the new
+            // session's adaptive fire offset.
+            globalSession.GameState.ResetRttSmoothing();
             _clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             // Connect to the specified host.
             var endPoint = new IPEndPoint(ip, realm.Port);

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -81,7 +81,7 @@ public partial class WorldSocket
         if (targetFlags.HasAnyFlag(SpellCastTargetFlags.String))
             packet.WriteCString(target.Name);
     }
-    public void SendCastRequestFailed(ClientCastRequest castRequest, bool isPet)
+    public void SendCastRequestFailed(ClientCastRequest castRequest, bool isPet, SpellCastResultClassic reason = SpellCastResultClassic.SpellInProgress)
     {
         if (!castRequest.HasStarted)
         {
@@ -95,7 +95,7 @@ public partial class WorldSocket
         {
             PetCastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = (uint)reason;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
         }
@@ -104,10 +104,10 @@ public partial class WorldSocket
             CastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
             failed.SpellXSpellVisualID = castRequest.SpellXSpellVisualId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = (uint)reason;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
-        }    
+        }
     }
     // JimsProxy: Hunter tame-class spell IDs in vanilla — used to log tame attempts
     // for the pet deep-dive. 1515 = "Tame Beast" player ability; the rest are
@@ -202,11 +202,27 @@ public partial class WorldSocket
             // 1.12 client would fire these mid-cast-bar and mid-GCD, so we match that.
             if (!isOffGcd)
             {
-                // Silently drop re-clicks while a cast is in progress. Sending
-                // CastFailed(SpellInProgress) causes the 1.14 client to dismiss
-                // the active cast bar even though the server-side cast continues.
-                if (GetSession().GameState.HasStartedNormalCast())
+                // JimsProxy (Mount-Button-Stuck-Lit): drop re-clicks but resolve the modern
+                // client's tracking via the duplicate's own unique ClientGUID/ServerGUID. The
+                // earlier silent-drop approach (commit 8998c39) avoided dismissing the running
+                // cast bar but left the duplicate's action-button state pending forever. Sending
+                // SpellPrepare + CastFailed(DontReport) bound to the DUPLICATE's IDs releases the
+                // queued state without showing an error toast. The running cast's ServerCastID is
+                // distinct, so its cast bar should be unaffected.
+                bool gateStarted = GetSession().GameState.HasStartedNormalCast();
+                bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
+                if (gateStarted || gateInFlight)
+                {
+                    Log.Event("cast.dropped.duplicate", new
+                    {
+                        spell_id = cast.Cast.SpellID,
+                        reason = gateInFlight ? "in_flight_same_spell_cast_spell" : "another_cast_started",
+                        client_cast_id = cast.Cast.CastID.ToString(),
+                        queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+                    });
+                    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
                     return;
+                }
 
                 // JimsProxy (issue #43): if we're inside a GCD hold window, build the CMSG_CAST_SPELL
                 // packet now but don't forward it — store it as the pending held cast. The Timer
@@ -418,9 +434,29 @@ public partial class WorldSocket
         castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, use.Cast.SpellID, 10000 + use.Cast.CastID.GetCounter());
         castRequest.ItemGUID = use.CastItem;
 
-        // Silently drop re-clicks while a cast is in progress (same as HandleCastSpell).
-        if (GetSession().GameState.HasStartedNormalCast())
+        // JimsProxy (Mount-Button-Stuck-Lit): drop the duplicate USE_ITEM but resolve the modern
+        // client's per-click tracking so the action button doesn't stay "queued/lit" forever.
+        // Bind SpellPrepare + CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built
+        // a few lines above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if
+        // any) has its OWN distinct ServerCastID, so the modern client should resolve only the
+        // duplicate's tracking and leave the active cast bar alone. Reason=DontReport suppresses
+        // the "Another action is in progress" error toast — silent drop semantics, but now with
+        // the IDs the client needs to release the queued state.
+        bool gateStarted = GetSession().GameState.HasStartedNormalCast();
+        bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)use.Cast.SpellID);
+        if (gateStarted || gateInFlight)
+        {
+            Log.Event("cast.dropped.duplicate", new
+            {
+                spell_id = use.Cast.SpellID,
+                reason = gateInFlight ? "in_flight_same_spell_use_item" : "another_cast_started",
+                client_cast_id = use.Cast.CastID.ToString(),
+                item_guid = use.CastItem.ToString(),
+                queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+            });
+            SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
             return;
+        }
 
         // Some items had their on-use spell id renumbered in SoM 1.14.1+ (e.g. Diamond Flask 17626 → 363880).
         // The 1.12 emulator only knows the legacy id, so resolve it now and remember both

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -140,6 +140,42 @@ public partial class WorldSocket
             });
         }
 
+        // JimsProxy (Rupture-DoT-Lingering-Icon): snapshot CP for vanilla CP-scaling
+        // finishers before the server consumes them. The legacy server applies
+        // (base + perCp × CP) ms duration server-side and never echoes it back for enemy
+        // debuffs, so the proxy synthesizes the correct duration locally on aura apply.
+        // Snapshotting on the keypress (before any GCD-hold path) covers both immediate
+        // forwards and held-then-released casts. TTL on the lookup side bounds staleness.
+        uint castSpellId = (uint)cast.Cast.SpellID;
+        if (GameData.IsComboPointFinisher(castSpellId))
+        {
+            byte cp = GetSession().GameState.CurrentComboPoints;
+            WowGuid128 target = cast.Cast.Target.Unit;
+            bool targetEmpty = target.IsEmpty();
+            // Unconditional diagnostic so we can see which guard failed when no snapshot fires.
+            Log.Event("finisher.cmsg_cast", new
+            {
+                spell_id = castSpellId,
+                combo_points = cp,
+                target_low = targetEmpty ? 0 : target.GetCounter(),
+                target_empty = targetEmpty,
+                target_flags = (uint)cast.Cast.Target.Flags,
+                cached_combo_target_low = GetSession().GameState.CurrentComboTarget.IsEmpty()
+                    ? 0
+                    : GetSession().GameState.CurrentComboTarget.GetCounter(),
+            });
+            if (cp > 0 && !targetEmpty)
+            {
+                GetSession().GameState.StorePendingFinisherCast(castSpellId, target, cp);
+                Log.Event("finisher.snapshot", new
+                {
+                    spell_id = castSpellId,
+                    target_low = target.GetCounter(),
+                    combo_points = cp,
+                });
+            }
+        }
+
         bool isNextMelee = GameData.NextMeleeSpells.Contains(cast.Cast.SpellID);
         bool isAutoRepeat = GameData.AutoRepeatSpells.Contains(cast.Cast.SpellID);
         // JimsProxy (issue #43): the GCD hold-and-fire path is vanilla-only. On TBC+ the
@@ -313,30 +349,6 @@ public partial class WorldSocket
                     heldPrepare.ClientCastID = castRequest.ClientGUID;
                     heldPrepare.ServerCastID = castRequest.ServerGUID;
                     SendPacket(heldPrepare);
-
-                    // JimsProxy (Macro-GCD-Fix): macro-batched `/use 13 /use 14 /cast SS` lands all
-                    // three CMSGs in the same ms; SS gets held_pending while a trinket is in flight.
-                    // SpellPrepare acks the click but the modern 1.14 client's GCD swipe doesn't
-                    // start until SS's own SMSG_SPELL_GO arrives — a ~300ms gap (trinket RTT + SS RTT)
-                    // where the action button is queued/lit without a sweep. Synthesize a
-                    // SMSG_COOLDOWN_EVENT so the client's swipe starts immediately at ack time.
-                    // SMSG_SPELL_COOLDOWN with ForcedCooldown was tried earlier (stash 0) and got
-                    // "anticipated-then-canceled" by the macro evaluator; SMSG_COOLDOWN_EVENT lets
-                    // the client compute the GCD locally from the spell's DBC StartRecoveryTime.
-                    // Vanilla-only: TBC+ haste-adjusted GCDs would make this wrong, and the GCD-hold
-                    // mechanism (gated on ExpansionVersion==1 in HandleSpellGo) is vanilla-only too.
-                    if (LegacyVersion.ExpansionVersion == 1)
-                    {
-                        CooldownEvent cdEvent = new();
-                        cdEvent.SpellID = (uint)cast.Cast.SpellID;
-                        cdEvent.IsPet = false;
-                        SendPacket(cdEvent);
-                        Log.Event("gcd.cooldown.synth_held", new
-                        {
-                            spell_id = cast.Cast.SpellID,
-                            client_cast_id = castRequest.ClientGUID.ToString(),
-                        });
-                    }
                     return;
                 }
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -204,11 +204,11 @@ public partial class WorldSocket
             {
                 // JimsProxy (Mount-Button-Stuck-Lit): drop re-clicks but resolve the modern
                 // client's tracking via the duplicate's own unique ClientGUID/ServerGUID. The
-                // earlier silent-drop approach (commit 8998c39) avoided dismissing the running
-                // cast bar but left the duplicate's action-button state pending forever. Sending
-                // SpellPrepare + CastFailed(DontReport) bound to the DUPLICATE's IDs releases the
-                // queued state without showing an error toast. The running cast's ServerCastID is
-                // distinct, so its cast bar should be unaffected.
+                // earlier silent-drop approach (commit 8998c39) left the duplicate's action-button
+                // state pending forever. Reason is SpellInProgress (matches the displaced-hold
+                // path below) — the 1.14 client treats it as "overridden by newer cast" and
+                // releases the duplicate's queued/lit state. The running cast's ServerCastID is
+                // distinct, so its cast bar is unaffected.
                 bool gateStarted = GetSession().GameState.HasStartedNormalCast();
                 bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
                 if (gateStarted || gateInFlight)
@@ -220,7 +220,7 @@ public partial class WorldSocket
                         client_cast_id = cast.Cast.CastID.ToString(),
                         queue_depth = GetSession().GameState.PendingNormalCasts.Count,
                     });
-                    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
+                    SendCastRequestFailed(castRequest, false);
                     return;
                 }
 
@@ -313,6 +313,30 @@ public partial class WorldSocket
                     heldPrepare.ClientCastID = castRequest.ClientGUID;
                     heldPrepare.ServerCastID = castRequest.ServerGUID;
                     SendPacket(heldPrepare);
+
+                    // JimsProxy (Macro-GCD-Fix): macro-batched `/use 13 /use 14 /cast SS` lands all
+                    // three CMSGs in the same ms; SS gets held_pending while a trinket is in flight.
+                    // SpellPrepare acks the click but the modern 1.14 client's GCD swipe doesn't
+                    // start until SS's own SMSG_SPELL_GO arrives — a ~300ms gap (trinket RTT + SS RTT)
+                    // where the action button is queued/lit without a sweep. Synthesize a
+                    // SMSG_COOLDOWN_EVENT so the client's swipe starts immediately at ack time.
+                    // SMSG_SPELL_COOLDOWN with ForcedCooldown was tried earlier (stash 0) and got
+                    // "anticipated-then-canceled" by the macro evaluator; SMSG_COOLDOWN_EVENT lets
+                    // the client compute the GCD locally from the spell's DBC StartRecoveryTime.
+                    // Vanilla-only: TBC+ haste-adjusted GCDs would make this wrong, and the GCD-hold
+                    // mechanism (gated on ExpansionVersion==1 in HandleSpellGo) is vanilla-only too.
+                    if (LegacyVersion.ExpansionVersion == 1)
+                    {
+                        CooldownEvent cdEvent = new();
+                        cdEvent.SpellID = (uint)cast.Cast.SpellID;
+                        cdEvent.IsPet = false;
+                        SendPacket(cdEvent);
+                        Log.Event("gcd.cooldown.synth_held", new
+                        {
+                            spell_id = cast.Cast.SpellID,
+                            client_cast_id = castRequest.ClientGUID.ToString(),
+                        });
+                    }
                     return;
                 }
 
@@ -436,12 +460,12 @@ public partial class WorldSocket
 
         // JimsProxy (Mount-Button-Stuck-Lit): drop the duplicate USE_ITEM but resolve the modern
         // client's per-click tracking so the action button doesn't stay "queued/lit" forever.
-        // Bind SpellPrepare + CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built
-        // a few lines above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if
-        // any) has its OWN distinct ServerCastID, so the modern client should resolve only the
-        // duplicate's tracking and leave the active cast bar alone. Reason=DontReport suppresses
-        // the "Another action is in progress" error toast — silent drop semantics, but now with
-        // the IDs the client needs to release the queued state.
+        // Bind CastFailed to the DUPLICATE's unique ClientGUID/ServerGUID (built a few lines
+        // above with `10000 + use.Cast.CastID.GetCounter()`); the running cast (if any) has its
+        // OWN distinct ServerCastID, so the modern client resolves only the duplicate's tracking
+        // and leaves the active cast bar alone. Reason is SpellInProgress (matches the displaced-
+        // hold path) — the 1.14 client treats it as "overridden by newer cast" and releases the
+        // duplicate's queued/lit state cleanly.
         bool gateStarted = GetSession().GameState.HasStartedNormalCast();
         bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)use.Cast.SpellID);
         if (gateStarted || gateInFlight)
@@ -454,7 +478,7 @@ public partial class WorldSocket
                 item_guid = use.CastItem.ToString(),
                 queue_depth = GetSession().GameState.PendingNormalCasts.Count,
             });
-            SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
+            SendCastRequestFailed(castRequest, false);
             return;
         }
 


### PR DESCRIPTION
 - Modern 1.14 Classic renders the local player's pet (warlock + hunter) visibly smaller than the vanilla 1.12
  reference, even though `CreatureDisplayInfo.CreatureModelScale` and `CreatureModelData.ModelScale` are byte-identical
  between the two builds (verified by extracting both sets from a 1.12.1 client and diffing against 1.14.2.42597 — only
  39 of ~10,500 DisplayIDs differ in CMS, none of them pets).
  - Root cause unverified — likely an undocumented client-side scale modifier on local-player pet units in modern
  Classic. Sugar Proxy ships an equivalent compensation knob.
  - A flat global multiplier doesn't work because the modern client compounds it with the per-display CMS: a Felhunter
  (CMS 0.5) at 1.5× still renders too small, while a Dire Wolf (CMS 1.5) at 1.5× ends up at ~2.2 effective (verified:
  tester screenshot showed wolf-on-steroids).

  ## Fix — inverse-CMS scaling
  For the local pet, emit `(wire_OBJECT_FIELD_SCALE_X / CreatureModelScale) × K` instead of the raw wire scale. The
  modern client's `wire × ModelScale × CMS` multiply collapses to `wire × ModelScale × K`, so every pet gets a uniform K
   bump regardless of its CMS quirks.

  `K = 1.5` is the empirical "matches 1.12" tuning value validated against same-pet side-by-side screenshots.

  | Pet | CMS | wire | emit | renders | matches 1.12 |
  |---|---|---|---|---|---|
  | Dire Wolf 9370 | 1.5 | 0.975 | 0.975 | 1.46 | yes |
  | Felhunter 850 | 0.5 | 0.7 | 2.1 | 1.05 | yes |
  | Voidwalker 1132 | 0.8 | wire | wire×1.875 | wire×1.5 | yes |
  | Imp 4449 | 0.5 | 0.5 | 1.5 | 0.75 | yes |

  ## Detection
  - Prefer `CurrentPetGuid` match (set when `SMSG_PET_SPELLS_MESSAGE` arrives, typically before the pet's first
  CREATE_OBJECT).
  - Fallback to `SUMMONEDBY == CurrentPlayerGuid` so the very first CREATE_OBJECT for a pet (which carries SUMMONEDBY)
  gets normalized even if `CurrentPetGuid` hasn't latched yet.
  - Only fires when `OBJECT_FIELD_SCALE_X` is present in this update — delta updates leave the already-normalized scale
  sticky on the client and avoid compounding multiplications.
  - Bounds-safe (`UNIT_FIELD_DISPLAYID_idx < updateMaskArray.Length`) so the path doesn't trip on Item/GameObject
  updates whose mask doesn't cover unit fields.

  ## Scope
  - Affects only the visual scale forwarded to the modern client. Server-side `UNIT_FIELD_BOUNDINGRADIUS` and
  `UNIT_FIELD_COMBATREACH` are untouched, so range checks, melee hit detection, and ability targeting are unchanged.
  - Click hitbox grows with the visual scale (the modern client derives the click area from the rendered model).
  - Vanilla-source-only (gated on `LegacyVersion.ExpansionVersion == 1`); no behavior change for TBC+ legacy servers.

  ## Diagnostics
  New `unit.pet_scale.applied` JSONL event per pet SCALE_X update with `display_id`, `creature_model_scale`, `k`,
  `raw_scale`, `emitted_scale`, `matched_via`, and `cms_fallback`. Lets a tester report on a single pet be triaged from
  the bundle without needing local repro.

  ## Test plan
  - [x] Hunter pet (Dire Wolf 9370): same-pet side-by-side vs 1.12 client at K=1.5 — matches.
  - [ ] Warlock pet (Felhunter): tester verification pending — math says it should be roughly correct at K=1.5; if
  reported still small, bump K or split per-family.
  - [x] Build clean (zero warnings, zero errors).
  - [x] No crash on Item/GameObject updates (bounds check verified after earlier `BitArray` index 131 regression).