### PR TITLE
Unplanned-DC auto-reconnect: try cached-key resume, fall back to clea…

### DIFF
--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -35,6 +35,16 @@ public static class Settings
     // releases a held cast. 0 = fire exactly at expiry (cast lands ~RTT late at server).
     // Clamped to 0..50 in LoadAndVerifyFrom.
     public static int SpellCastEarlyFireOffsetMs;
+    // JimsProxy (unplanned-dc-auto-reconnect): when the legacy world server forcibly
+    // closes the proxy's TCP socket mid-session (anticheat, server crash, transient
+    // network reset), attempt one cached-session-key reconnect before giving up. If
+    // false, fall straight through to clean DC propagation (close modern InstanceSocket
+    // so the user sees "Disconnected" within a second instead of being stuck in a
+    // ghost world for tens of seconds).
+    public static bool EnableUnplannedReconnect;
+    // Hard timeout on the reconnect attempt — beyond this, abandon and propagate DC.
+    // Clamped to 1000..30000 in LoadAndVerifyFrom.
+    public static int UnplannedReconnectTimeoutMs;
 
     public static bool LoadAndVerifyFrom(ConfigurationParser config)
     {
@@ -61,6 +71,8 @@ public static class Settings
         StructuredLog = config.GetBoolean("StructuredLog", true);
         VerboseLog = config.GetBoolean("VerboseLog", false);
         SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
+        EnableUnplannedReconnect = config.GetBoolean("EnableUnplannedReconnect", true);
+        UnplannedReconnectTimeoutMs = Math.Clamp(config.GetInt("UnplannedReconnectTimeoutMs", 5000), 1000, 30000);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;
         // Open the JSONL file now so session.start's payload can include the full path.

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1825,124 +1825,198 @@ public class GlobalSessionData
     // to investigate). Bundle the reconnect attempt as a self-contained sequence
     // tagged with a unique attempt_id so multiple attempts in a session can be
     // correlated.
-    public void TryUnplannedReconnectAndPropagate(World.Client.WorldClient deadClient)
+    // Per-session guard: ensures only one reconnect attempt runs at a time even if
+    // HandleDisconnect and the ReceiveLoop catch fire simultaneously from the same TCP RST.
+    // 0 = idle, 1 = attempt in flight. Compare-and-swapped at entry; reset in finally.
+    private int _reconnectInProgress;
+
+    public void TryUnplannedReconnectAndPropagate(
+        World.Client.WorldClient deadClient,
+        string? originalExceptionType = null,
+        string? originalExceptionMessage = null,
+        int? originalSocketErrorCode = null)
     {
         var attemptId = Guid.NewGuid().ToString("N").Substring(0, 8);
-        var realm = RealmManager.GetRealm(RealmId);
-        var playerGuid = GameState?.CurrentPlayerGuid ?? default;
 
-        Framework.Logging.Log.Event("session.unplanned_dc.detected", new
+        // Race guard FIRST — HandleDisconnect and ReceiveLoop's catch can both fire from
+        // the same TCP RST on different threads. Only one wins the CAS; the loser exits
+        // immediately without re-emitting `detected`, propagating, or queueing a Task.
+        if (Interlocked.CompareExchange(ref _reconnectInProgress, 1, 0) != 0)
         {
-            attempt_id = attemptId,
-            realm_name = realm?.Name,
-            player_guid = playerGuid.ToString(),
-            has_authclient = AuthClient != null,
-            has_instance_socket = InstanceSocket != null,
-            reconnect_enabled = Framework.Settings.EnableUnplannedReconnect,
-            reconnect_timeout_ms = Framework.Settings.UnplannedReconnectTimeoutMs,
-        });
-
-        if (!Framework.Settings.EnableUnplannedReconnect)
-        {
-            Framework.Logging.Log.Event("session.unplanned_reconnect.skipped_disabled", new { attempt_id = attemptId });
-            PropagateUnplannedDcToModern(attemptId, "reconnect_disabled");
+            Framework.Logging.Log.Event("session.unplanned_reconnect.skipped_in_progress", new { attempt_id = attemptId });
             return;
         }
 
-        if (realm == null || playerGuid == default || AuthClient == null)
+        bool taskQueued = false;
+        try
         {
-            Framework.Logging.Log.Event("session.unplanned_reconnect.skipped_state", new
+            var realm = RealmManager.GetRealm(RealmId);
+            var playerGuid = GameState?.CurrentPlayerGuid ?? default;
+
+            Framework.Logging.Log.Event("session.unplanned_dc.detected", new
             {
                 attempt_id = attemptId,
-                has_realm = realm != null,
-                has_player_guid = playerGuid != default,
+                realm_name = realm?.Name,
+                player_guid = playerGuid.ToString(),
                 has_authclient = AuthClient != null,
+                has_instance_socket = InstanceSocket != null,
+                reconnect_enabled = Framework.Settings.EnableUnplannedReconnect,
+                reconnect_timeout_ms = Framework.Settings.UnplannedReconnectTimeoutMs,
+                // JimsProxy: forward the underlying disconnect cause so a JSONL bundle shows
+                // *why* the legacy server cut us off, not just *that* it did. Helps spot
+                // patterns (mid-session Warden kicks, repeated RSTs after specific opcodes).
+                original_exception_type = originalExceptionType,
+                original_exception_message = originalExceptionMessage,
+                original_socket_error_code = originalSocketErrorCode,
             });
-            PropagateUnplannedDcToModern(attemptId, "missing_state");
-            return;
-        }
 
-        // Run the reconnect off the receive-loop thread so we don't block the catch.
-        _ = System.Threading.Tasks.Task.Run(() =>
-        {
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            World.Client.WorldClient? newClient = null;
-            try
+            if (!Framework.Settings.EnableUnplannedReconnect)
             {
-                Framework.Logging.Log.Event("session.unplanned_reconnect.start", new
+                Framework.Logging.Log.Event("session.unplanned_reconnect.skipped_disabled", new { attempt_id = attemptId });
+                PropagateUnplannedDcToModern(attemptId, "reconnect_disabled");
+                return;
+            }
+
+            if (realm == null || playerGuid == default || AuthClient == null)
+            {
+                Framework.Logging.Log.Event("session.unplanned_reconnect.skipped_state", new
                 {
                     attempt_id = attemptId,
-                    realm_name = realm!.Name,
-                    realm_address = realm.ExternalAddress,
-                    realm_port = (int)realm.Port,
+                    has_realm = realm != null,
+                    has_player_guid = playerGuid != default,
+                    has_authclient = AuthClient != null,
                 });
+                PropagateUnplannedDcToModern(attemptId, "missing_state");
+                return;
+            }
 
-                newClient = new World.Client.WorldClient();
-
-                // Bound the connect+auth handshake by the configured timeout. ConnectToWorldServer
-                // blocks until _isSuccessful is set; if the legacy server's listener is dead, the
-                // OS-level TCP timeout (~21s on Windows) would otherwise stall us.
-                var connectTask = System.Threading.Tasks.Task.Run(() => newClient.ConnectToWorldServer(realm, this));
-                bool completed = connectTask.Wait(Framework.Settings.UnplannedReconnectTimeoutMs);
-                if (!completed)
+            // Run the reconnect off the receive-loop thread so we don't block the catch.
+            // Ownership of _reconnectInProgress transfers to the Task — its finally resets it.
+            _ = System.Threading.Tasks.Task.Run(() =>
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                World.Client.WorldClient? newClient = null;
+                bool reconnectSucceeded = false;
+                try
                 {
-                    Framework.Logging.Log.Event("session.unplanned_reconnect.timeout", new
+                    Framework.Logging.Log.Event("session.unplanned_reconnect.start", new
+                    {
+                        attempt_id = attemptId,
+                        realm_name = realm!.Name,
+                        realm_address = realm.ExternalAddress,
+                        realm_port = (int)realm.Port,
+                    });
+
+                    newClient = new World.Client.WorldClient();
+
+                    // Bound the connect+auth handshake by the configured timeout. ConnectToWorldServer
+                    // blocks until _isSuccessful is set; if the legacy server's listener is dead, the
+                    // OS-level TCP timeout (~21s on Windows) would otherwise stall us.
+                    var connectTask = System.Threading.Tasks.Task.Run(() => newClient.ConnectToWorldServer(realm, this));
+                    bool completed = connectTask.Wait(Framework.Settings.UnplannedReconnectTimeoutMs);
+                    if (!completed)
+                    {
+                        Framework.Logging.Log.Event("session.unplanned_reconnect.timeout", new
+                        {
+                            attempt_id = attemptId,
+                            elapsed_ms = sw.ElapsedMilliseconds,
+                            timeout_ms = Framework.Settings.UnplannedReconnectTimeoutMs,
+                        });
+                        PropagateUnplannedDcToModern(attemptId, "timeout");
+                        return;
+                    }
+                    bool authed = connectTask.Result;
+                    Framework.Logging.Log.Event("session.unplanned_reconnect.connect_completed", new
                     {
                         attempt_id = attemptId,
                         elapsed_ms = sw.ElapsedMilliseconds,
-                        timeout_ms = Framework.Settings.UnplannedReconnectTimeoutMs,
+                        authed = authed,
                     });
-                    PropagateUnplannedDcToModern(attemptId, "timeout");
-                    return;
+                    if (!authed)
+                    {
+                        PropagateUnplannedDcToModern(attemptId, "auth_failed");
+                        return;
+                    }
+
+                    // CRITICAL: register the new client with the session BEFORE sending CMSG_PLAYER_LOGIN.
+                    // Modern→legacy CMSGs route via session.WorldClient (set null when the dead client
+                    // was unregistered in WorldClient.HandleDisconnect/ReceiveLoop). Without this,
+                    // any movement/cast/chat the player attempts after spawn-back is silently dropped,
+                    // AND a subsequent unplanned DC won't recover (the new client wouldn't pass the
+                    // `wasActiveWorldClient` check). Doing it before the login send also covers any
+                    // CMSGs the modern client emits between login-sent and the server's spawn burst.
+                    WorldClient = newClient;
+
+                    // Re-issue CMSG_PLAYER_LOGIN with the cached character GUID so the legacy
+                    // server places the character back in the world. The modern client's
+                    // InstanceSocket stays open across this — the legacy server's ensuing
+                    // SMSG_LOGIN_VERIFY_WORLD + spawn burst will be forwarded to the modern
+                    // client, which may visibly flash a loading screen or briefly desync.
+                    // That's acceptable vs the alternative (37s frozen world).
+                    var loginPacket = new World.WorldPacket(World.Enums.Opcode.CMSG_PLAYER_LOGIN);
+                    loginPacket.WriteGuid(playerGuid.To64());
+                    newClient.SendPacketToServer(loginPacket);
+
+                    Framework.Logging.Log.Event("session.unplanned_reconnect.player_login_sent", new
+                    {
+                        attempt_id = attemptId,
+                        elapsed_ms = sw.ElapsedMilliseconds,
+                        player_guid = playerGuid.ToString(),
+                    });
+
+                    Framework.Logging.Log.Event("session.unplanned_reconnect.success", new
+                    {
+                        attempt_id = attemptId,
+                        elapsed_ms = sw.ElapsedMilliseconds,
+                    });
+                    reconnectSucceeded = true;
                 }
-                bool authed = connectTask.Result;
-                Framework.Logging.Log.Event("session.unplanned_reconnect.connect_completed", new
+                catch (Exception ex)
                 {
-                    attempt_id = attemptId,
-                    elapsed_ms = sw.ElapsedMilliseconds,
-                    authed = authed,
-                });
-                if (!authed)
-                {
-                    PropagateUnplannedDcToModern(attemptId, "auth_failed");
-                    return;
+                    Framework.Logging.Log.Event("session.unplanned_reconnect.exception", new
+                    {
+                        attempt_id = attemptId,
+                        elapsed_ms = sw.ElapsedMilliseconds,
+                        exception_type = ex.GetType().Name,
+                        exception_message = ex.Message,
+                    });
+                    PropagateUnplannedDcToModern(attemptId, "exception");
                 }
-
-                // Re-issue CMSG_PLAYER_LOGIN with the cached character GUID so the legacy
-                // server places the character back in the world. The modern client's
-                // InstanceSocket stays open across this — the legacy server's ensuing
-                // SMSG_LOGIN_VERIFY_WORLD + spawn burst will be forwarded to the modern
-                // client, which may visibly flash a loading screen or briefly desync.
-                // That's acceptable vs the alternative (37s frozen world).
-                var loginPacket = new World.WorldPacket(World.Enums.Opcode.CMSG_PLAYER_LOGIN);
-                loginPacket.WriteGuid(playerGuid.To64());
-                newClient.SendPacketToServer(loginPacket);
-
-                Framework.Logging.Log.Event("session.unplanned_reconnect.player_login_sent", new
+                finally
                 {
-                    attempt_id = attemptId,
-                    elapsed_ms = sw.ElapsedMilliseconds,
-                    player_guid = playerGuid.ToString(),
-                });
+                    // Release the in-progress flag so a future unplanned DC on this session
+                    // can attempt another reconnect.
+                    Volatile.Write(ref _reconnectInProgress, 0);
 
-                Framework.Logging.Log.Event("session.unplanned_reconnect.success", new
-                {
-                    attempt_id = attemptId,
-                    elapsed_ms = sw.ElapsedMilliseconds,
-                });
-            }
-            catch (Exception ex)
-            {
-                Framework.Logging.Log.Event("session.unplanned_reconnect.exception", new
-                {
-                    attempt_id = attemptId,
-                    elapsed_ms = sw.ElapsedMilliseconds,
-                    exception_type = ex.GetType().Name,
-                    exception_message = ex.Message,
-                });
-                PropagateUnplannedDcToModern(attemptId, "exception");
-            }
-        });
+                    // Close the orphaned newClient's socket on any failure path so it doesn't
+                    // linger in CLOSE_WAIT. On success the new client is the live one — leave it.
+                    if (!reconnectSucceeded && newClient != null)
+                    {
+                        try
+                        {
+                            newClient.Disconnect();
+                        }
+                        catch (Exception ex)
+                        {
+                            Framework.Logging.Log.Event("session.unplanned_reconnect.cleanup_error", new
+                            {
+                                attempt_id = attemptId,
+                                exception_type = ex.GetType().Name,
+                                exception_message = ex.Message,
+                            });
+                        }
+                    }
+                }
+            });
+            taskQueued = true;
+        }
+        finally
+        {
+            // If we returned without queueing the Task (disabled / missing state / threw),
+            // the Task's own finally never runs — release the flag here so future DCs aren't blocked.
+            if (!taskQueued)
+                Volatile.Write(ref _reconnectInProgress, 0);
+        }
     }
 
     // Close the modern client's InstanceSocket so the user sees "Disconnected"

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1807,6 +1807,174 @@ public class GlobalSessionData
         });
     }
 
+    // JimsProxy (unplanned-dc-auto-reconnect): handle a UNPLANNED legacy-side
+    // disconnect (server-initiated TCP RST or socket exception, NOT a realm swap)
+    // by attempting one cached-session-key reconnect. If reconnect succeeds within
+    // Settings.UnplannedReconnectTimeoutMs, the modern client never knows the gap
+    // happened. If it fails or times out, close the modern InstanceSocket cleanly
+    // so the user sees "Disconnected" within a second instead of being stuck in
+    // a ghost world for tens of seconds (the prior suppress-only behavior).
+    //
+    // The reconnect uses the same realmd session key the original WorldClient
+    // captured at connect time — Kronos/cmangos may or may not honor it depending
+    // on their session policy. If they reject it, the auth handshake fails and
+    // we fall through to clean DC.
+    //
+    // Heavy Log.Event coverage at every step so a JSONL bundle from a tester
+    // shows exactly where the reconnect path succeeded or failed (no repro needed
+    // to investigate). Bundle the reconnect attempt as a self-contained sequence
+    // tagged with a unique attempt_id so multiple attempts in a session can be
+    // correlated.
+    public void TryUnplannedReconnectAndPropagate(World.Client.WorldClient deadClient)
+    {
+        var attemptId = Guid.NewGuid().ToString("N").Substring(0, 8);
+        var realm = RealmManager.GetRealm(RealmId);
+        var playerGuid = GameState?.CurrentPlayerGuid ?? default;
+
+        Framework.Logging.Log.Event("session.unplanned_dc.detected", new
+        {
+            attempt_id = attemptId,
+            realm_name = realm?.Name,
+            player_guid = playerGuid.ToString(),
+            has_authclient = AuthClient != null,
+            has_instance_socket = InstanceSocket != null,
+            reconnect_enabled = Framework.Settings.EnableUnplannedReconnect,
+            reconnect_timeout_ms = Framework.Settings.UnplannedReconnectTimeoutMs,
+        });
+
+        if (!Framework.Settings.EnableUnplannedReconnect)
+        {
+            Framework.Logging.Log.Event("session.unplanned_reconnect.skipped_disabled", new { attempt_id = attemptId });
+            PropagateUnplannedDcToModern(attemptId, "reconnect_disabled");
+            return;
+        }
+
+        if (realm == null || playerGuid == default || AuthClient == null)
+        {
+            Framework.Logging.Log.Event("session.unplanned_reconnect.skipped_state", new
+            {
+                attempt_id = attemptId,
+                has_realm = realm != null,
+                has_player_guid = playerGuid != default,
+                has_authclient = AuthClient != null,
+            });
+            PropagateUnplannedDcToModern(attemptId, "missing_state");
+            return;
+        }
+
+        // Run the reconnect off the receive-loop thread so we don't block the catch.
+        _ = System.Threading.Tasks.Task.Run(() =>
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            World.Client.WorldClient? newClient = null;
+            try
+            {
+                Framework.Logging.Log.Event("session.unplanned_reconnect.start", new
+                {
+                    attempt_id = attemptId,
+                    realm_name = realm!.Name,
+                    realm_address = realm.ExternalAddress,
+                    realm_port = (int)realm.Port,
+                });
+
+                newClient = new World.Client.WorldClient();
+
+                // Bound the connect+auth handshake by the configured timeout. ConnectToWorldServer
+                // blocks until _isSuccessful is set; if the legacy server's listener is dead, the
+                // OS-level TCP timeout (~21s on Windows) would otherwise stall us.
+                var connectTask = System.Threading.Tasks.Task.Run(() => newClient.ConnectToWorldServer(realm, this));
+                bool completed = connectTask.Wait(Framework.Settings.UnplannedReconnectTimeoutMs);
+                if (!completed)
+                {
+                    Framework.Logging.Log.Event("session.unplanned_reconnect.timeout", new
+                    {
+                        attempt_id = attemptId,
+                        elapsed_ms = sw.ElapsedMilliseconds,
+                        timeout_ms = Framework.Settings.UnplannedReconnectTimeoutMs,
+                    });
+                    PropagateUnplannedDcToModern(attemptId, "timeout");
+                    return;
+                }
+                bool authed = connectTask.Result;
+                Framework.Logging.Log.Event("session.unplanned_reconnect.connect_completed", new
+                {
+                    attempt_id = attemptId,
+                    elapsed_ms = sw.ElapsedMilliseconds,
+                    authed = authed,
+                });
+                if (!authed)
+                {
+                    PropagateUnplannedDcToModern(attemptId, "auth_failed");
+                    return;
+                }
+
+                // Re-issue CMSG_PLAYER_LOGIN with the cached character GUID so the legacy
+                // server places the character back in the world. The modern client's
+                // InstanceSocket stays open across this — the legacy server's ensuing
+                // SMSG_LOGIN_VERIFY_WORLD + spawn burst will be forwarded to the modern
+                // client, which may visibly flash a loading screen or briefly desync.
+                // That's acceptable vs the alternative (37s frozen world).
+                var loginPacket = new World.WorldPacket(World.Enums.Opcode.CMSG_PLAYER_LOGIN);
+                loginPacket.WriteGuid(playerGuid.To64());
+                newClient.SendPacketToServer(loginPacket);
+
+                Framework.Logging.Log.Event("session.unplanned_reconnect.player_login_sent", new
+                {
+                    attempt_id = attemptId,
+                    elapsed_ms = sw.ElapsedMilliseconds,
+                    player_guid = playerGuid.ToString(),
+                });
+
+                Framework.Logging.Log.Event("session.unplanned_reconnect.success", new
+                {
+                    attempt_id = attemptId,
+                    elapsed_ms = sw.ElapsedMilliseconds,
+                });
+            }
+            catch (Exception ex)
+            {
+                Framework.Logging.Log.Event("session.unplanned_reconnect.exception", new
+                {
+                    attempt_id = attemptId,
+                    elapsed_ms = sw.ElapsedMilliseconds,
+                    exception_type = ex.GetType().Name,
+                    exception_message = ex.Message,
+                });
+                PropagateUnplannedDcToModern(attemptId, "exception");
+            }
+        });
+    }
+
+    // Close the modern client's InstanceSocket so the user sees "Disconnected"
+    // immediately rather than being stuck in a ghost world. Idempotent — safe to
+    // call even if InstanceSocket has already been torn down.
+    public void PropagateUnplannedDcToModern(string attemptId, string reason)
+    {
+        var socket = InstanceSocket;
+        Framework.Logging.Log.Event("session.unplanned_dc.propagated", new
+        {
+            attempt_id = attemptId,
+            reason = reason,
+            had_instance_socket = socket != null,
+        });
+        if (socket != null)
+        {
+            try
+            {
+                socket.CloseSocket();
+            }
+            catch (Exception ex)
+            {
+                Framework.Logging.Log.Event("session.unplanned_dc.close_error", new
+                {
+                    attempt_id = attemptId,
+                    exception_type = ex.GetType().Name,
+                    exception_message = ex.Message,
+                });
+            }
+        }
+    }
+
     public void OnDisconnect()
     {
         // JimsProxy: structured session.disconnect — emitted once per cleanup with snapshot

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -241,11 +241,16 @@ public partial class WorldClient
             // here, which tore down the entire BNet session including any newly-created
             // WorldClient for a different realm during a swap. Now: only null our slot
             // if it's still pointing at us (a fresh swap may have already replaced it
-            // with a new WorldClient — don't clobber that).
+            // with a new WorldClient — don't clobber that). Done via Interlocked.CompareExchange
+            // so HandleDisconnect and the ReceiveLoop catch can't both pass the check on the
+            // same TCP RST and race to spin up duplicate reconnects.
             var session = GetSession();
-            bool wasActiveWorldClient = session != null && ReferenceEquals(session.WorldClient, this);
-            if (wasActiveWorldClient)
-                session!.WorldClient = null;
+            bool wasActiveWorldClient = false;
+            if (session != null)
+            {
+                var prior = Interlocked.CompareExchange(ref session.WorldClient, null, this);
+                wasActiveWorldClient = ReferenceEquals(prior, this);
+            }
             Log.Event("session.ondisconnect.suppressed", new
             {
                 reason = "worldclient_legacy_disconnect",
@@ -260,6 +265,9 @@ public partial class WorldClient
             // try one cached-key reconnect. If that fails, propagate cleanly to the
             // modern client. Realm-swap path (wasActiveWorldClient == false) skips this
             // — the new WorldClient is already in flight and will handle continuity.
+            // No exception to forward here — this path is hit on a clean read failure
+            // (zero bytes / FIN), not an exception. The reason string ("header"/"payload")
+            // is already in `session.ondisconnect.suppressed` as `disconnect_reason`.
             if (wasActiveWorldClient)
                 session!.TryUnplannedReconnectAndPropagate(this);
         }
@@ -316,9 +324,12 @@ public partial class WorldClient
                 Disconnect();
                 // JimsProxy realm-swap fix: see WorldClient.HandleDisconnect.
                 var session = GetSession();
-                bool wasActiveWorldClient = session != null && ReferenceEquals(session.WorldClient, this);
-                if (wasActiveWorldClient)
-                    session!.WorldClient = null;
+                bool wasActiveWorldClient = false;
+                if (session != null)
+                {
+                    var prior = Interlocked.CompareExchange(ref session.WorldClient, null, this);
+                    wasActiveWorldClient = ReferenceEquals(prior, this);
+                }
                 Log.Event("session.ondisconnect.suppressed", new
                 {
                     reason = "worldclient_receive_loop_exception",
@@ -333,9 +344,14 @@ public partial class WorldClient
                 // Bundle 20260503-195159 showed Kronos PTR forcibly closing the proxy's
                 // TCP socket mid-combat (TCP RST, last_opcode SMSG_ON_MONSTER_MOVE), then
                 // 37s of frozen ghost world before the player gave up and logged out.
-                // Now: try one reconnect, fall back to clean DC.
+                // Now: try one reconnect, fall back to clean DC. Forward the exception
+                // type/message and SocketError code so a JSONL bundle shows *why* the
+                // server cut us off (Warden mid-session vs network reset vs server crash).
                 if (wasActiveWorldClient)
-                    session!.TryUnplannedReconnectAndPropagate(this);
+                {
+                    int? socketErrorCode = (e is SocketException se) ? (int)se.SocketErrorCode : null;
+                    session!.TryUnplannedReconnectAndPropagate(this, e.GetType().Name, e.Message, socketErrorCode);
+                }
             }
         }
     }

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -243,8 +243,9 @@ public partial class WorldClient
             // if it's still pointing at us (a fresh swap may have already replaced it
             // with a new WorldClient — don't clobber that).
             var session = GetSession();
-            if (session != null && ReferenceEquals(session.WorldClient, this))
-                session.WorldClient = null;
+            bool wasActiveWorldClient = session != null && ReferenceEquals(session.WorldClient, this);
+            if (wasActiveWorldClient)
+                session!.WorldClient = null;
             Log.Event("session.ondisconnect.suppressed", new
             {
                 reason = "worldclient_legacy_disconnect",
@@ -252,7 +253,15 @@ public partial class WorldClient
                 last_opcode = _lastInboundOpcode.ToString(),
                 last_opcode_raw = _lastInboundOpcodeRaw,
                 ms_since_last_opcode = _lastInboundOpcodeTick == 0 ? -1 : Environment.TickCount - _lastInboundOpcodeTick,
+                was_active_world_client = wasActiveWorldClient,
             });
+            // JimsProxy (unplanned-dc-auto-reconnect): when this is a genuinely
+            // unplanned DC (we were the active client, no realm swap is replacing us),
+            // try one cached-key reconnect. If that fails, propagate cleanly to the
+            // modern client. Realm-swap path (wasActiveWorldClient == false) skips this
+            // — the new WorldClient is already in flight and will handle continuity.
+            if (wasActiveWorldClient)
+                session!.TryUnplannedReconnectAndPropagate(this);
         }
     }
 
@@ -307,8 +316,9 @@ public partial class WorldClient
                 Disconnect();
                 // JimsProxy realm-swap fix: see WorldClient.HandleDisconnect.
                 var session = GetSession();
-                if (session != null && ReferenceEquals(session.WorldClient, this))
-                    session.WorldClient = null;
+                bool wasActiveWorldClient = session != null && ReferenceEquals(session.WorldClient, this);
+                if (wasActiveWorldClient)
+                    session!.WorldClient = null;
                 Log.Event("session.ondisconnect.suppressed", new
                 {
                     reason = "worldclient_receive_loop_exception",
@@ -317,7 +327,15 @@ public partial class WorldClient
                     last_opcode = _lastInboundOpcode.ToString(),
                     last_opcode_raw = _lastInboundOpcodeRaw,
                     ms_since_last_opcode = _lastInboundOpcodeTick == 0 ? -1 : Environment.TickCount - _lastInboundOpcodeTick,
+                    was_active_world_client = wasActiveWorldClient,
                 });
+                // JimsProxy (unplanned-dc-auto-reconnect): same logic as HandleDisconnect.
+                // Bundle 20260503-195159 showed Kronos PTR forcibly closing the proxy's
+                // TCP socket mid-combat (TCP RST, last_opcode SMSG_ON_MONSTER_MOVE), then
+                // 37s of frozen ghost world before the player gave up and logged out.
+                // Now: try one reconnect, fall back to clean DC.
+                if (wasActiveWorldClient)
+                    session!.TryUnplannedReconnectAndPropagate(this);
             }
         }
     }


### PR DESCRIPTION
…n DC

 Fixes the 37-second-frozen-world UX when the legacy server forcibly closes
  the proxy's TCP socket mid-session. Bundle 20260503-195159 from a tester on
  Kronos PTR captured the failure mode: SocketException (TCP RST) at
  19:58:55, last opcode SMSG_ON_MONSTER_MOVE 219ms earlier, then the proxy's
  prior suppress-only handling left the modern client connected to a ghost
  world for 37 seconds — no SMSG updates, no error feedback — until the
  player gave up and logged out via CMSG_LOG_DISCONNECT.

  Behavior change:

  When a legacy-side socket exception or unexpected close is detected AND
  this WorldClient is still the active session.WorldClient (i.e. it's NOT a
  realm swap, where a replacement WorldClient has already been wired up),
  attempt one cached-session-key reconnect:
    1. New WorldClient + ConnectToWorldServer (re-uses the realmd session key the original WorldClient captured at connect time).
    2. On auth success, re-issue CMSG_PLAYER_LOGIN with the cached GameState.CurrentPlayerGuid so the legacy server places the character back in the world.
    3. Bounded by Settings.UnplannedReconnectTimeoutMs (default 5000ms, clamped 1000–30000) so a dead listener doesn't stall the modern client past the OS-level TCP timeout.

  If reconnect fails, times out, or is disabled, close session.InstanceSocket
  so the modern client sees "Disconnected" within ~1 second instead of being
  stuck. Matches "proxy mimics direct 1.12 client" parity for the
  non-recoverable case.

  Realm-swap path is unchanged — the new WorldClient already in flight
  during a swap was never the active client when the old one tore down,
  so the unplanned-reconnect branch is skipped (no behavior change).

  Config:
    EnableUnplannedReconnect       (default true)  — master toggle
    UnplannedReconnectTimeoutMs    (default 5000)  — reconnect budget

  Both default in Settings.cs, so the shipped HermesProxy.config template
  doesn't need new keys to work.

  Heavy structured Log.Event coverage along the reconnect path so a JSONL
  bundle from any tester encountering this failure mode shows exactly where
  it succeeded or failed without needing a repro:
    - session.unplanned_dc.detected
    - session.unplanned_reconnect.skipped_disabled / skipped_state
    - session.unplanned_reconnect.start
    - session.unplanned_reconnect.connect_completed
    - session.unplanned_reconnect.timeout
    - session.unplanned_reconnect.player_login_sent
    - session.unplanned_reconnect.success / exception
    - session.unplanned_dc.propagated
    - session.unplanned_dc.close_error Each event carries an attempt_id so multiple attempts within a session correlate cleanly.

  Known caveats (worth follow-up bundles to validate):
    - Kronos and similar private-vanilla servers may invalidate the realmd session key server-side on disconnect; in that case the auth re-handshake will fail and we'll propagate the DC. The diagnostic events will show this clearly.
    - On reconnect success the modern client will receive a fresh SMSG_LOGIN_VERIFY_WORLD + spawn burst from the legacy server. This may visibly flash a loading screen. Acceptable vs the 37-second freeze; can be mitigated in a follow-up by suppressing select packets on the modern path during reconnect.