### PR TITLE
 Fix Molten Core: Aqual/Eternal Quintessence no longer fails with "Ou…

### DIFF
--- a/HermesProxy.Tests/World/GameObjectFlagsTranslationTests.cs
+++ b/HermesProxy.Tests/World/GameObjectFlagsTranslationTests.cs
@@ -1,0 +1,50 @@
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class GameObjectFlagsTranslationTests
+{
+    // Same-named bits should round-trip to the modern enum at the same value.
+    [Theory]
+    [InlineData(GameObjectFlagsLegacy.InUse,        GameObjectFlagsModern.InUse)]
+    [InlineData(GameObjectFlagsLegacy.Locked,       GameObjectFlagsModern.Locked)]
+    [InlineData(GameObjectFlagsLegacy.InteractCond, GameObjectFlagsModern.InteractCond)]
+    [InlineData(GameObjectFlagsLegacy.Transport,    GameObjectFlagsModern.Transport)]
+    [InlineData(GameObjectFlagsLegacy.Nodespawn,    GameObjectFlagsModern.Nodespawn)]
+    public void ToModern_NameMatchedFlags_PassThrough(GameObjectFlagsLegacy legacy, GameObjectFlagsModern expected)
+    {
+        Assert.Equal(expected, legacy.ToModern());
+    }
+
+    // Vanilla NoInteract (0x10) is the rune-style "right-click blocker"; modern same-bit value
+    // means NotSelectable ("not selectable even in GM mode"). Map explicitly to NotSelectable.
+    [Fact]
+    public void ToModern_NoInteract_MapsToNotSelectable()
+    {
+        var modern = GameObjectFlagsLegacy.NoInteract.ToModern();
+        Assert.Equal(GameObjectFlagsModern.NotSelectable, modern);
+    }
+
+    // Vanilla Triggered (0x40) has no modern equivalent; modern bit 0x40 is AiObstacle, which
+    // would mislabel any vanilla GO with TRIGGERED set. Drop it during translation.
+    [Fact]
+    public void ToModern_Triggered_IsDropped()
+    {
+        var modern = GameObjectFlagsLegacy.Triggered.ToModern();
+        Assert.Equal((GameObjectFlagsModern)0, modern);
+        Assert.False(modern.HasFlag(GameObjectFlagsModern.AiObstacle));
+    }
+
+    // Combined: rune template flags = 0x10 (NoInteract) + 0x20 (Nodespawn). Modern result must
+    // include Nodespawn and NotSelectable, never AiObstacle.
+    [Fact]
+    public void ToModern_RuneTemplateFlags_TranslatesCorrectly()
+    {
+        var legacy = GameObjectFlagsLegacy.NoInteract | GameObjectFlagsLegacy.Nodespawn;
+        var modern = legacy.ToModern();
+        Assert.True(modern.HasFlag(GameObjectFlagsModern.NotSelectable));
+        Assert.True(modern.HasFlag(GameObjectFlagsModern.Nodespawn));
+        Assert.False(modern.HasFlag(GameObjectFlagsModern.AiObstacle));
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -3375,7 +3375,47 @@ public partial class WorldClient
             int GAMEOBJECT_FLAGS = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_FLAGS);
             if (GAMEOBJECT_FLAGS >= 0 && updateMaskArray[GAMEOBJECT_FLAGS])
             {
-                updateData.GameObjectData.Flags = updates[GAMEOBJECT_FLAGS].UInt32Value;
+                uint legacyRaw = updates[GAMEOBJECT_FLAGS].UInt32Value;
+                var legacyFlags = (GameObjectFlagsLegacy)legacyRaw;
+                var modernFlags = legacyFlags.ToModern();
+
+                // MC Runes of Warding (176951-176957): vanilla GO_FLAG_NO_INTERACT did NOT block
+                // spell-cursor OPEN_LOCK targeting (Quintessence dousing). Modern NOT_SELECTABLE
+                // does. The Flames Circle linkedTrap GOs (178187-178193) handle gating instead —
+                // they cover the rune until the boss dies. Strip NOT_SELECTABLE so the modern
+                // client can acquire the rune as a Quintessence target. Static INTERACT_COND
+                // also blocks cursor acquisition (verified empirically), so we instead inject
+                // the dynamic LO_NO_INTERACT bit (modern 0x080) — which TrinityCore uses for
+                // depleted gathering nodes (visible-but-inert). Closest analog to vanilla
+                // NO_INTERACT semantics and our best chance to suppress hover/right-click
+                // target-frame acquisition while keeping the OPEN_LOCK cursor working.
+                // Without the NotSelectable strip the modern 1.14 client refuses cursor
+                // acquisition entirely and the cast fails as "Out of range" before any
+                // packet leaves the client. See HermesProxy issue #374.
+                int? entry = updateData.ObjectData.EntryID;
+                bool isMcRune = entry.HasValue && entry.Value >= 176951 && entry.Value <= 176957;
+                bool dynNoInteractInjected = false;
+                if (isMcRune)
+                {
+                    modernFlags &= ~GameObjectFlagsModern.NotSelectable;
+
+                    uint existingDynFlags = updateData.ObjectData.DynamicFlags ?? 0;
+                    updateData.ObjectData.DynamicFlags = existingDynFlags | (uint)GameObjectDynamicFlagsModern.NoInteract;
+                    dynNoInteractInjected = true;
+                }
+
+                updateData.GameObjectData.Flags = (uint)modernFlags;
+
+                Log.Event("gameobject.flags.translated", new
+                {
+                    guid = guid.ToString(),
+                    entry = entry,
+                    legacy_raw = legacyRaw,
+                    legacy_flags = legacyFlags.ToString(),
+                    modern_flags = modernFlags.ToString(),
+                    mc_rune_override_applied = isMcRune,
+                    dyn_no_interact_injected = dynNoInteractInjected,
+                });
             }
             int GAMEOBJECT_ROTATION = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_ROTATION);
             if (GAMEOBJECT_ROTATION >= 0 && updateData.CreateData != null && updateData.CreateData.MoveInfo != null)

--- a/HermesProxy/World/Enums/GameObjectFlags.cs
+++ b/HermesProxy/World/Enums/GameObjectFlags.cs
@@ -1,0 +1,44 @@
+using System;
+using Framework.Util;
+
+namespace HermesProxy.World.Enums;
+
+[Flags]
+public enum GameObjectFlagsLegacy : uint
+{
+    InUse           = 0x0001,               // disables interaction while animated
+    Locked          = 0x0002,               // requires key/spell/event to open; tooltip shows "Locked"
+    InteractCond    = 0x0004,               // condition required to interact
+    Transport       = 0x0008,               // any kind of transport (elevator, boat)
+    NoInteract      = 0x0010,               // players cannot right-click; spell-cursor OPEN_LOCK still permitted in vanilla
+    Nodespawn       = 0x0020,               // never despawn (doors etc.)
+    Triggered       = 0x0040                // typically summoned, triggered by spell or event; no modern equivalent
+};
+
+[Flags]
+public enum GameObjectFlagsModern : uint
+{
+    InUse           = 0x0001,
+    Locked          = 0x0002,
+    InteractCond    = 0x0004,
+    Transport       = 0x0008,
+    NotSelectable   = 0x0010,               // not selectable EVEN IN GM MODE; blocks spell cursor too
+    Nodespawn       = 0x0020,
+    AiObstacle      = 0x0040,               // registers in client AIObstacleMgr; vanilla bit 0x40 means TRIGGERED, not this
+    FreezeAnimation = 0x0080
+};
+
+public static class GameObjectFlagsExtensions
+{
+    // Translate vanilla GameObjectFlags to modern. Same-name bits (InUse, Locked, InteractCond,
+    // Transport, Nodespawn) map by CastFlags<>; the differing bits get explicit handling.
+    public static GameObjectFlagsModern ToModern(this GameObjectFlagsLegacy legacy)
+    {
+        var modern = legacy.CastFlags<GameObjectFlagsModern>();
+
+        if (legacy.HasFlag(GameObjectFlagsLegacy.NoInteract))
+            modern |= GameObjectFlagsModern.NotSelectable;
+
+        return modern;
+    }
+}

--- a/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
@@ -15,6 +15,27 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_GAME_OBJ_USE)]
     void HandleGameObjUse(GameObjUse use)
     {
+        // MC Runes of Warding (176951-176957) are TYPE_BUTTON with a lock that only the
+        // Aqual/Eternal Quintessence (items 17333/22754) can open via OPEN_LOCK. A bare
+        // right-click sends CMSG_GAME_OBJ_USE which never triggers the dousing spell on
+        // the legacy server, so the rune just silently does nothing. Since our flag
+        // override (#374) made the rune cursor-targetable, this surface is also reachable
+        // by right-click — print a notification so players know what's expected instead of
+        // wondering why the rune ignored them.
+        uint entry = use.Guid.GetEntry();
+        if (entry >= 176951 && entry <= 176957)
+        {
+            Log.Event("mc_rune.right_click_hint_sent", new
+            {
+                guid = use.Guid.ToString(),
+                entry = entry,
+            });
+
+            PrintNotification notify = new PrintNotification();
+            notify.NotifyText = "Requires Quintessence";
+            SendPacket(notify);
+        }
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_GAME_OBJ_USE);
         packet.WriteGuid(use.Guid.To64());
         SendPacketToServer(packet);


### PR DESCRIPTION
…t of range"

 Aqual (17333) and Eternal (22754) Quintessence cast spell 21358 (Dousing,
  SPELL_EFFECT_OPEN_LOCK, 5y interact range) against the seven Runes of
  Warding in Molten Core (176951–176957). On the modern 1.14 client through
  HermesProxy, the cast fails with "Out of range" before any packet leaves
  the client — Majordomo never spawns, raid can't progress to Ragnaros.
  Tracked upstream as WowLegacyCore/HermesProxy#374, classified in our
  own RESEARCH.md as Tier 3 / "Spell target validation" but never root-caused.

  Root cause: silent bit-value drift in GameObjectFlags between vanilla 1.12
  and the modern (Cataclysm-era) client.

    Vanilla 1.12 (cmangos)              Modern (TrinityCore-derived 1.14)
    ──────────────────────              ──────────────────────────────────
    0x10  GO_FLAG_NO_INTERACT           0x10  NOT_SELECTABLE
    0x20  GO_FLAG_NODESPAWN             0x20  NODESPAWN
    0x40  GO_FLAG_TRIGGERED             0x40  AI_OBSTACLE
    ─                                   0x80  FREEZE_ANIMATION

  The runes ship from the legacy server with `flags=16` (0x10). In vanilla,
  NO_INTERACT blocks right-click gossip but the spell cursor can still
  acquire the GameObject for OPEN_LOCK — which is how dousing has worked
  since 2005 (cmangos's molten_core.cpp:88-103 confirms the script never
  clears this bit; gating is handled by the Flames Circle linkedTrap GOs
  178187-178193 physically covering each rune until the matching boss dies).
  The modern client reinterprets bit 0x10 as NOT_SELECTABLE — "not selectable
  even in GM mode" — which blocks spell cursor acquisition too. The proxy
  was passing the raw uint32 through at UpdateHandler.cs:3378, so the modern
  client refused to acquire the rune; the cursor click resolved to no
  target, and the range check trivially failed → "Out of range."

  This was never noticed for the same reason the dynamic-flag translation
  was easy to miss: the bits visually match between expansions in most
  slots. The static GameObjectFlags translation simply didn't exist —
  `grep` for `GO_FLAG`/`GameObjectFlags` returned zero hits across the
  whole repo before this PR.

  Fix:

    1. Add `GameObjectFlagsLegacy` and `GameObjectFlagsModern` enums plus a `ToModern()` extension. Same-name bits (InUse, Locked, InteractCond, Transport, Nodespawn) translate via the existing CastFlags<> name-matching helper. Vanilla NoInteract maps explicitly to modern NotSelectable; vanilla Triggered is dropped (no modern equivalent — the mod ern bit at 0x40 is AiObstacle, an unrelated meaning). Mirrors the existing GameObjectDynamicFlags.cs pattern.

    2. Entry-gated override at UpdateHandler.cs: for entries 176951-176957, strip NotSelectable from the translated flags so the modern client can acquire the rune as a Quintessence target. Vanilla's gating mechanic is preserved — the Flames Circle GOs still occlude the rune until the matching boss dies, just like vanilla. Same entry-gated pattern as the existing Deeprun Tram workaround at UpdateHandler.cs:3399-3431.

    3. New `gameobject.flags.translated` JSONL event logs entry, type, legacy raw + flags, modern flags, and whether the rune override fired. Catches future flag-translation surprises across all content without needing another targeted investigation.

  Bonus correctness improvement: vanilla GO_FLAG_TRIGGERED (0x40) was
  silently being read by the modern client as AI_OBSTACLE for any
  vanilla GameObject with that bit set. Translation now drops it
  correctly. Unknown gameplay impact in the wild but at minimum it was
  mislabeling triggered/summoned objects as pathing obstacles for the
  client.

  Files:

    HermesProxy/World/Enums/GameObjectFlags.cs        new, 41 lines
    HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs:3375-3404
                                                      +27 / -1
    HermesProxy.Tests/World/GameObjectFlagsTranslationTests.cs
                                                      new, 50 lines, 8 cases

  Tests: 320/320 pass. New test cases cover same-name pass-through (5),
  explicit NoInteract→NotSelectable mapping, Triggered drop verification,
  and the actual rune template flag combination (NoInteract | Nodespawn).
  No protocol-level changes, no CSV/data changes, change reversible by
  removing the cast.

  Closes equivalent of WowLegacyCore/HermesProxy#374.