### PR TITLE
Clear mounts from dead non-player units

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1371,6 +1371,32 @@ public partial class WorldClient
             }
         }
     }
+
+    private bool ShouldClearMountDisplayOnDeadNonPlayerUnit(WowGuid128 guid, ObjectType objectType, ObjectUpdate updateData, Dictionary<int, UpdateField> updates, int mountDisplayField)
+    {
+        if (updateData.UnitData.Health.GetValueOrDefault(-1) != 0)
+            return false;
+
+        if (guid.IsPlayer() ||
+            guid == GetSession().GameState.CurrentPlayerGuid ||
+            objectType == ObjectType.Player ||
+            objectType == ObjectType.ActivePlayer)
+            return false;
+
+        bool isNonPlayerUnit =
+            objectType == ObjectType.Unit ||
+            guid.GetHighType() == HighGuidType.Creature ||
+            guid.GetHighType() == HighGuidType.Pet ||
+            guid.GetHighType() == HighGuidType.Vehicle;
+        if (!isNonPlayerUnit)
+            return false;
+
+        int mountDisplayId = updateData.UnitData.MountDisplayID.GetValueOrDefault();
+        if (mountDisplayId == 0 && mountDisplayField >= 0 && updates.TryGetValue(mountDisplayField, out var cachedMountDisplay))
+            mountDisplayId = cachedMountDisplay.Int32Value;
+
+        return mountDisplayId != 0;
+    }
     
     private void StoreObjectUpdateInternal(WowGuid128 guid, ObjectType objectType, BitArray updateMaskArray, Dictionary<int, UpdateField> updates, AuraUpdate auraUpdate, PowerUpdate? powerUpdate, bool isCreate, ObjectUpdate updateData)
     {
@@ -1893,6 +1919,12 @@ public partial class WorldClient
             if (UNIT_FIELD_MOUNTDISPLAYID >= 0 && updateMaskArray[UNIT_FIELD_MOUNTDISPLAYID])
             {
                 updateData.UnitData.MountDisplayID = updates[UNIT_FIELD_MOUNTDISPLAYID].Int32Value;
+            }
+            if (ShouldClearMountDisplayOnDeadNonPlayerUnit(guid, objectType, updateData, updates, UNIT_FIELD_MOUNTDISPLAYID))
+            {
+                updateData.UnitData.MountDisplayID = 0;
+                if (UNIT_FIELD_MOUNTDISPLAYID >= 0)
+                    updates[UNIT_FIELD_MOUNTDISPLAYID] = new UpdateField(0);
             }
             int UNIT_FIELD_MINDAMAGE = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_MINDAMAGE);
             if (UNIT_FIELD_MINDAMAGE >= 0 && updateMaskArray[UNIT_FIELD_MINDAMAGE])


### PR DESCRIPTION
## Summary

This fixes mounted legacy NPCs remaining visually mounted after death on modern clients.

On 1.12 servers, some mounted NPCs keep `UNIT_FIELD_MOUNTDISPLAYID` set after they die. HermesProxy was forwarding that state as-is, so the modern client continued rendering the dead unit with its mount until the object eventually went out of range.

The fix clears `MountDisplayID` for non-player units when their health reaches `0`.

## Investigation

The issue was reproduced with the mounted NPC `Marcus Bel`.

Relevant observed unit:

```text
Name: Marcus Bel
Entry: 5800
GUID: Creature-0-1-0-0-5800-0000004419
Low: 17433
DisplayID: 4347
At spawn, the server sent:

Health: 100
MountDisplayID: 2410
Flags: 524288
Flags2: 2048
During combat/death, the server sent health updates:

Health: 49
Health: 7
Health: 0
At death, the server also sent:

Flags: 0
However, it never sent:

UNIT_FIELD_MOUNTDISPLAYID = 0
So HermesProxy kept the cached mount value:

CachedMountDisplayID: 2410
The object was not destroyed immediately either. Marcus was only removed later through an out-of-range update:

object.out_of_range.debug
Entry: 5800
Health: 0
DisplayID: 4347
CachedMountDisplayID: 2410
There was no object.destroy.debug for this unit at death time.

Root Cause
The legacy server is authoritative and sends the NPC death state correctly through:

UNIT_FIELD_HEALTH = 0
But it does not clear the unit mount field:

UNIT_FIELD_MOUNTDISPLAYID
On the original 1.12 client this appears to be handled correctly, but the modern client relies on the converted update fields it receives from HermesProxy. Since HermesProxy preserved the stale mount display value, the modern client continued to render the dead NPC as mounted.

In other words, the converted modern update represented the unit as:

Health = 0
MountDisplayID = 2410
which is visually wrong for the modern client.

Fix
The fix is implemented in:

HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
When HermesProxy builds an outgoing modern unit update, it now detects this case:

non-player unit
Health == 0
MountDisplayID still set
and forces:

MountDisplayID = 0
This is done both on the outgoing ObjectUpdate data and in the legacy update dictionary used by the conversion path:

updateData.UnitData.MountDisplayID = 0;
updates[UNIT_FIELD_MOUNTDISPLAYID] = new UpdateField(0);
The behavior is intentionally scoped to non-player units only:

ObjectType.Unit
HighGuidType.Creature
HighGuidType.Pet
HighGuidType.Vehicle
It explicitly excludes:

players
active players
current player GUID
so it should not affect player mount state.

Why This Approach
This is a proxy-side compatibility fix for legacy server behavior.

The legacy server may not need to send UNIT_FIELD_MOUNTDISPLAYID = 0 for the 1.12 client to behave correctly, but the modern client does need the mount state cleared in the converted update stream.

Rather than changing object despawn behavior or synthesizing destroy packets, this fix only corrects the stale unit field at the moment the unit becomes dead.

That keeps the change small and avoids interfering with normal object lifetime handling.

Verification
Tested manually in game with the mounted NPC death case.

Before the fix:

NPC reached Health = 0
MountDisplayID stayed cached
Dead unit remained visually mounted
Object disappeared only when it went out of range
After the fix:

NPC reaches Health = 0
HermesProxy clears MountDisplayID
Dead mounted visual no longer persists
Build verification:

dotnet build HermesProxy/HermesProxy.csproj --configfile NuGet.Config -c Release
Result:

Build succeeded
0 warnings
0 errors