### PR TITLE
Queue casts while another spell is casting

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -753,11 +753,13 @@ public partial class WorldClient
 
         SpellGo spell = new SpellGo();
         spell.Cast = HandleSpellStartOrGo(packet, true);
+        bool matchedLocalNormalCast = false;
 
         // Dequeue completed cast (queue-based, FIFO order)
         if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.TryDequeuePendingNormalCast((uint)spell.Cast.SpellID, out var pendingCast))
         {
+            matchedLocalNormalCast = true;
             spell.Cast.CastID = pendingCast!.ServerGUID;
             spell.Cast.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
             // SoM-renumbered item: rewrite the legacy spell id back to the modern one the client expects.
@@ -889,6 +891,19 @@ public partial class WorldClient
             spell.LogData = new SpellCastLogData();
 
         SendPacketToClient(spell);
+
+        if (matchedLocalNormalCast)
+        {
+            var gameState = GetSession().GameState;
+            if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
+            {
+                var heldCast = gameState.TakeHeldCastIfReady();
+                if (heldCast != null)
+                {
+                    gameState.OnGcdHeldCastFire?.Invoke(heldCast);
+                }
+            }
+        }
     }
 
     SpellCastData HandleSpellStartOrGo(WorldPacket packet, bool isSpellGo)

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -238,21 +238,25 @@ public partial class WorldSocket
             // 1.12 client would fire these mid-cast-bar and mid-GCD, so we match that.
             if (!isOffGcd)
             {
-                // JimsProxy (Mount-Button-Stuck-Lit): drop re-clicks but resolve the modern
-                // client's tracking via the duplicate's own unique ClientGUID/ServerGUID. The
-                // earlier silent-drop approach (commit 8998c39) avoided dismissing the running
-                // cast bar but left the duplicate's action-button state pending forever. Sending
-                // SpellPrepare + CastFailed(DontReport) bound to the DUPLICATE's IDs releases the
-                // queued state without showing an error toast. The running cast's ServerCastID is
-                // distinct, so its cast bar should be unaffected.
+                // JimsProxy: if a cast-time spell is already running, keep the latest keypress
+                // queued client-side and forward it when the running cast completes. This keeps
+                // the modern action button highlighted instead of cancelling it with a local
+                // CastFailed(DontReport), while still avoiding an early CMSG_CAST_SPELL that
+                // vanilla servers would reject with SpellInProgress.
                 bool gateStarted = GetSession().GameState.HasStartedNormalCast();
                 bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
-                if (gateStarted || gateInFlight)
+                if (gateStarted)
+                {
+                    HoldNormalCast(cast, castRequest);
+                    return;
+                }
+
+                if (gateInFlight)
                 {
                     Log.Event("cast.dropped.duplicate", new
                     {
                         spell_id = cast.Cast.SpellID,
-                        reason = gateInFlight ? "in_flight_same_spell_cast_spell" : "another_cast_started",
+                        reason = "in_flight_same_spell_cast_spell",
                         client_cast_id = cast.Cast.CastID.ToString(),
                         queue_depth = GetSession().GameState.PendingNormalCasts.Count,
                     });
@@ -394,6 +398,25 @@ public partial class WorldSocket
         }
         WriteSpellTargets(cast.Cast.Target, targetFlags, packet);
         return packet;
+    }
+
+    private void HoldNormalCast(CastSpell cast, ClientCastRequest castRequest)
+    {
+        WorldPacket heldPacket = BuildCastSpellPacket(cast);
+        castRequest.HeldPacketForReplay = heldPacket;
+        castRequest.HeldAtTickMs = Environment.TickCount64;
+
+        var displaced = GetSession().GameState.ForceHoldCast(castRequest);
+
+        if (displaced != null)
+        {
+            SendCastRequestFailed(displaced, false);
+        }
+
+        SpellPrepare heldPrepare = new SpellPrepare();
+        heldPrepare.ClientCastID = castRequest.ClientGUID;
+        heldPrepare.ServerCastID = castRequest.ServerGUID;
+        SendPacket(heldPrepare);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

This fixes spell queue behavior while the local player is already casting a spell with cast time.

Before this change, if the player pressed another spell before the current cast finished, HermesProxy treated that second `CMSG_CAST_SPELL` as a local duplicate/in-progress cast and immediately answered with `CastFailed(DontReport)`. This cancelled the modern client's queued action-button highlight and the second spell was never sent to the legacy server.

Now HermesProxy keeps the latest spell pressed during an active cast, acknowledges it with `SpellPrepare`, and forwards it after the current cast completes.

## Problem

The modern client supports spell queueing: when the player presses a spell shortly before the current cast finishes, the action button stays highlighted and the spell fires automatically when possible.

On the current HermesProxy behavior, this did not work during cast-time spells.

Observed test flow:

```text
02:28:26.102 CMSG_CAST_SPELL 10181 received
02:28:26.105 spell 10181 forwarded to the legacy server
02:28:26.160 SMSG_SPELL_START 10181 received, cast_time = 2500ms

02:28:28.048 CMSG_CAST_SPELL 10161 received during the active cast
02:28:28.048 HermesProxy dropped spell 10161 locally
reason = another_cast_started
has_started_normal_cast = true
gcd_hold_active = false
pending_normal_depth = 1

02:28:28.618 SMSG_SPELL_GO 10181 received
The important part is that the second spell was received by HermesProxy, but was never forwarded to the legacy server.

So this was not a server-side rejection. HermesProxy cancelled the queued spell locally.

Root Cause
The problematic path was in:

HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
HermesProxy checked:

bool gateStarted = GetSession().GameState.HasStartedNormalCast();
bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);

if (gateStarted || gateInFlight)
{
    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
    return;
}
This grouped two different cases together:

1. Same spell / already in-flight duplicate
2. A different spell pressed while a cast-time spell is already running
Case 1 should still be rejected to prevent duplicate client tracking and server spam.

Case 2 is the normal spell queue use case and should not be failed locally.

Because HermesProxy returned CastFailed(DontReport) for case 2, the modern client immediately released the queued action-button highlight.

Fix
The fix separates the two cases.

When HasStartedNormalCast() is true, HermesProxy now holds the new cast request instead of failing it:

if (gateStarted)
{
    HoldNormalCast(cast, castRequest);
    return;
}
The old duplicate guard remains only for actual in-flight duplicate spell cases:

if (gateInFlight)
{
    SendCastRequestFailed(castRequest, false, SpellCastResultClassic.DontReport);
    return;
}
The new HoldNormalCast(...) path:

private void HoldNormalCast(CastSpell cast, ClientCastRequest castRequest)
{
    WorldPacket heldPacket = BuildCastSpellPacket(cast);
    castRequest.HeldPacketForReplay = heldPacket;
    castRequest.HeldAtTickMs = Environment.TickCount64;

    var displaced = GetSession().GameState.ForceHoldCast(castRequest);

    if (displaced != null)
        SendCastRequestFailed(displaced, false);

    SpellPrepare heldPrepare = new SpellPrepare();
    heldPrepare.ClientCastID = castRequest.ClientGUID;
    heldPrepare.ServerCastID = castRequest.ServerGUID;
    SendPacket(heldPrepare);
}
This does three things:

1. Builds and stores the legacy CMSG_CAST_SPELL packet for later replay.
2. Replaces any previously queued spell with the latest keypress.
3. Sends SpellPrepare immediately so the modern client keeps the action button highlighted.
The displacement behavior is intentional: if the player presses multiple spells during the same cast, only the latest queued spell should remain active, and the older queued cast is failed cleanly so its client-side tracking does not leak.

Forwarding The Held Cast
The held cast is forwarded after the currently active local player cast completes.

This is handled in:

HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
When SMSG_SPELL_GO matches and dequeues the current local player cast, HermesProxy now checks if a held cast is ready:

bool matchedLocalNormalCast = false;

if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
    GetSession().GameState.TryDequeuePendingNormalCast((uint)spell.Cast.SpellID, out var pendingCast))
{
    matchedLocalNormalCast = true;
    ...
}
After the SpellGo is sent to the modern client:

if (matchedLocalNormalCast)
{
    var gameState = GetSession().GameState;
    if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
    {
        var heldCast = gameState.TakeHeldCastIfReady();
        if (heldCast != null)
            gameState.OnGcdHeldCastFire?.Invoke(heldCast);
    }
}
This reuses the existing held-cast forwarding path. The held cast is enqueued into PendingNormalCasts and sent to the legacy server only after the previous cast completed.

That avoids sending the second CMSG_CAST_SPELL too early, which a vanilla server would likely reject with SpellInProgress.

Why SpellPrepare Matters
The modern client uses ClientCastID / ServerCastID tracking to keep the queued spell visually active.

If HermesProxy sends:

SpellPrepare
CastFailed(DontReport)
the button highlight is immediately cancelled.

With this fix, HermesProxy sends:

SpellPrepare
but does not send CastFailed unless the queued spell is displaced by a newer queued spell or genuinely rejected later.

This preserves the expected spell queue highlight until HermesProxy forwards the held cast.

Scope
This change affects normal player casts while another normal cast has already started.

It does not change:

off-GCD casts
auto-repeat casts
next-melee casts
pet casts
the existing GCD hold-and-fire behavior
actual in-flight duplicate rejection
The duplicate rejection path is still kept for casts that are already in-flight for the same spell.

Verification
Manual in-game test:

1. Start a cast-time spell.
2. Press a second spell before the first cast finishes.
3. Do nothing else.
Before the fix:

Second spell was received by HermesProxy
HermesProxy sent CastFailed(DontReport)
Action button highlight was cancelled
Second spell never reached the server
After the fix:

Second spell is held by HermesProxy
SpellPrepare keeps the modern action button highlighted
When the first cast completes, HermesProxy forwards the held spell
The second spell starts automatically
Build verification:

dotnet build HermesProxy/HermesProxy.csproj --configfile NuGet.Config -c Release
Result:

Build succeeded
0 warnings
0 errors