### PR TITLE
Fix stuck button on off-GCD spell LoS failure

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1478,6 +1478,8 @@ public class ClientCastRequest
     // Diagnostic only — used by spell.held_fire to compute hold duration. 0 if never held.
     public long HeldAtTickMs;
 
+    public bool HasSentPrepare;
+
     // JimsProxy: cast time (ms) reported by SMSG_SPELL_START. 0 means instant.
     // Distinguishes truly cast-time spells (Frostbolt, Polymorph) from instants that
     // *also* emit SMSG_SPELL_START on Kronos 1.12 (Arcane Explosion, Counterspell, etc.).

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -730,8 +730,9 @@ public partial class WorldClient
                 spell.Cast.SpellID = (int)pendingCast.SpellId;
 
             // For instant spells that skip SPELL_START, we need to send SpellPrepare
-            // before SpellGo so the client knows which cast completed
-            if (!pendingCast.HasStarted)
+            // before SpellGo so the client knows which cast completed.
+            // Off-GCD casts already sent SpellPrepare at forward time (HasSentPrepare).
+            if (!pendingCast.HasStarted && !pendingCast.HasSentPrepare)
             {
                 SpellPrepare prepare = new();
                 prepare.ClientCastID = pendingCast.ClientGUID;

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -375,6 +375,16 @@ public partial class WorldSocket
                 // Off-GCD path: still enqueue so SMSG_SPELL_GO can match back to the ClientGUID,
                 // but skip the cast-bar gate and the GCD hold.
                 GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
+
+                // Off-GCD spells bypass the hold system, so SpellPrepare must be sent now
+                // (on-GCD casts defer SpellPrepare to SPELL_START/SPELL_GO time to avoid
+                // premature GCD sweep). Without this, if the server rejects the cast (LoS,
+                // range), the client has no SpellPrepare to match against SpellFailure and
+                // the button stays in a pending/lit state permanently.
+                SpellPrepare prepare = new SpellPrepare();
+                prepare.ClientCastID = castRequest.ClientGUID;
+                prepare.ServerCastID = castRequest.ServerGUID;
+                SendPacket(prepare);
             }
         }
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -385,6 +385,7 @@ public partial class WorldSocket
                 prepare.ClientCastID = castRequest.ClientGUID;
                 prepare.ServerCastID = castRequest.ServerGUID;
                 SendPacket(prepare);
+                castRequest.HasSentPrepare = true;
             }
         }
 


### PR DESCRIPTION
## Summary

Off-GCD spells (Sprint, Evasion, Trinket, racials, targeted instants) bypass the hold system and defer SpellPrepare to SPELL_GO time. If the server rejects the cast before SPELL_GO (LoS, range, etc.), the client never receives SpellPrepare and has no tracking entry to resolve against the incoming SpellFailure — the action button stays in a pending/lit state permanently.

## Root cause

Found via JSONL analysis on v5.1.0-beta.2: two `spell.failure.routed` events for spell 7322 with `dequeued=false` after confirmed LoS failure. The cast was enqueued in PendingNormalCasts but the hidden-queue approach meant no SpellPrepare was sent at forward time. The client had no way to match SpellFailure to its pending button press.

## Fix

Send SpellPrepare immediately for off-GCD casts. This doesn't affect GCD sweep timing (off-GCD spells don't trigger GCD), so the hidden-queue rationale for deferring SpellPrepare on on-GCD casts doesn't apply here.

## Test plan

- [ ] Target something behind LoS, cast a targeted spell — button should release after failure
- [ ] Verify AE spam still works (GCD sweep locked at 12 o'clock)
- [ ] Verify off-GCD spells (Sprint, Evasion, Trinket) work normally
- [ ] `dotnet test` 320/320 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)