### PR TITLE
Threat translation

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1552,10 +1552,16 @@ public class GlobalSessionData
     public Dictionary<string, WowGuid128> GuildsByName = [];
     public Dictionary<uint, List<string>> GuildRanks = [];
 
+    // JimsProxy threat translation: per-session threat calculator. Vanilla 1.12
+    // doesn't broadcast threat; this engine observes combat events and synthesizes
+    // SMSG_THREAT_UPDATE so the modern client's native threat APIs populate.
+    public ThreatTracker ThreatTracker = null!;
+
     public GlobalSessionData()
     {
         GameState = GameSessionData.CreateNewGameSessionData(this);
         AuthClient = new AuthClient(this);
+        ThreatTracker = new ThreatTracker(this);
     }
 
     public void StoreGuildRankNames(uint guildId, List<string> ranks)
@@ -2141,6 +2147,9 @@ public class GlobalSessionData
         }
 
         GameState = GameSessionData.CreateNewGameSessionData(this);
+        // Threat lists are tied to the previous character's mob/unit GUIDs;
+        // wipe so the new login starts clean.
+        ThreatTracker.Reset();
     }
 
     public void SendHermesTextMessage(string message, bool isError = false)

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -351,6 +351,9 @@ public partial class WorldClient
         GetSession().SnapshotQuestItemProgressForRestore();
         GetSession().FlushQuestItemProgressToDisk();
         GetSession().GameState = GameSessionData.CreateNewGameSessionData(GetSession());
+        // Threat lists were keyed off the outgoing character's GUIDs; wipe so
+        // the next character (or the same one re-logging in) starts clean.
+        GetSession().ThreatTracker.Reset();
         GetSession().InstanceSocket.CloseSocket();
         GetSession().InstanceSocket = null!;
     }

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -197,5 +197,10 @@ public partial class WorldClient
         log.Player = packet.ReadGuid().To128(GetSession().GameState);
         log.Victim = packet.ReadGuid().To128(GetSession().GameState);
         SendPacketToClient(log);
+
+        // Mob just died — drop its threat list immediately so the modern
+        // client's threat APIs go quiet on this unit instead of waiting for
+        // the corpse-despawn SMSG_DESTROY_OBJECT.
+        GetSession().ThreatTracker.ClearMob(log.Victim);
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -140,6 +140,10 @@ public partial class WorldClient
         }
 
         SendPacketToClient(attack);
+
+        // Threat translation: feed melee swing damage into the threat tracker.
+        // Vanilla damage threat is 1.0 × raw damage, no school weighting.
+        GetSession().ThreatTracker.OnDamage(attack.AttackerGUID, attack.VictimGUID, attack.Damage);
     }
     [PacketHandler(Opcode.SMSG_ATTACKSWING_NOTINRANGE)]
     void HandleAttackSwingNotInRange(WorldPacket packet)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1303,6 +1303,9 @@ public partial class WorldClient
         }
 
         SendPacketToClient(spell);
+
+        // Threat translation: feed spell damage (direct hit) into the tracker.
+        GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, spell.Damage);
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_EXECUTE_LOG)]
@@ -1658,6 +1661,23 @@ public partial class WorldClient
             }
         }
         SendPacketToClient(spell);
+
+        // Threat translation: feed periodic damage (DoT ticks) into the tracker.
+        // Sum the damage portion of all PeriodicDamage / PeriodicDamagePercent
+        // effect entries — heals and other auras don't count as damage threat.
+        double dotDamage = 0;
+        foreach (var effect in spell.Effects)
+        {
+            if (effect.Effect == (uint)AuraType.PeriodicDamage ||
+                effect.Effect == (uint)AuraType.PeriodicDamagePercent)
+            {
+                dotDamage += effect.Amount;
+            }
+        }
+        if (dotDamage > 0)
+        {
+            GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, dotDamage);
+        }
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_ENERGIZE_LOG)]
@@ -1734,6 +1754,12 @@ public partial class WorldClient
 
         spell.SchoolMask = school;
         SendPacketToClient(spell);
+
+        // Threat translation: damage-shield reflects (Thorns, Retribution Aura,
+        // Lightning Shield) generate threat to the attacker who hit us. The
+        // CasterGUID here is whoever owns the shield (us or our pet), the
+        // VictimGUID is the attacker who got reflected on.
+        GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.VictimGUID, spell.Damage);
     }
 
     [PacketHandler(Opcode.SMSG_ENVIRONMENTAL_DAMAGE_LOG)]

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -915,6 +915,13 @@ public partial class WorldClient
         }
 
         SendPacketToClient(spell);
+
+        // JimsProxy threat translation: route Hunter / Pet / class abilities
+        // through the threat tracker so SMSG_THREAT_UPDATE reflects the cast.
+        // Done after SendPacketToClient so the SpellGo arrives first and any
+        // resulting THREAT_UPDATE follows it on the wire (matches the
+        // server-driven ordering the modern client expects).
+        GetSession().ThreatTracker.OnSpellCast(spell.Cast.CasterUnit, spell.Cast.SpellID, spell.Cast.HitTargets);
     }
 
     SpellCastData HandleSpellStartOrGo(WorldPacket packet, bool isSpellGo)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1514,6 +1514,15 @@ public partial class WorldClient
         });
 
         SendPacketToClient(spell);
+
+        // Threat translation: heal threat = 0.5 x effective heal, distributed
+        // across every mob in combat with the heal target. Overheal generates
+        // no threat — feed only the effective amount.
+        long effectiveHeal = (long)spell.HealAmount - (long)spell.OverHeal;
+        if (effectiveHeal > 0)
+        {
+            GetSession().ThreatTracker.OnHeal(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, effectiveHeal);
+        }
     }
 
     // Computes overhealing for a heal event by looking up the target's current HP
@@ -1673,8 +1682,9 @@ public partial class WorldClient
 
         // Threat translation: feed periodic damage (DoT ticks) into the tracker.
         // Sum the damage portion of all PeriodicDamage / PeriodicDamagePercent
-        // effect entries — heals and other auras don't count as damage threat.
+        // effect entries; heal ticks generate heal threat instead.
         double dotDamage = 0;
+        double hotHeal = 0;
         foreach (var effect in spell.Effects)
         {
             if (effect.Effect == (uint)AuraType.PeriodicDamage ||
@@ -1682,10 +1692,21 @@ public partial class WorldClient
             {
                 dotDamage += effect.Amount;
             }
+            else if (effect.Effect == (uint)AuraType.PeriodicHeal)
+            {
+                hotHeal += effect.Amount;
+            }
         }
         if (dotDamage > 0)
         {
             GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, dotDamage);
+        }
+        if (hotHeal > 0)
+        {
+            // HoT ticks don't carry overheal info on the wire, so we feed
+            // the raw amount. Slight overcount when the target is at max hp;
+            // acceptable at this stage.
+            GetSession().ThreatTracker.OnHeal(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, hotHeal);
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1312,7 +1312,9 @@ public partial class WorldClient
         SendPacketToClient(spell);
 
         // Threat translation: feed spell damage (direct hit) into the tracker.
-        GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, spell.Damage);
+        // Pass the spell id so the per-ability damage multiplier (Maul x1.75,
+        // Earth Shock x2, Holy Nova x0, etc.) can apply.
+        GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, spell.Damage);
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_EXECUTE_LOG)]
@@ -1683,7 +1685,7 @@ public partial class WorldClient
         }
         if (dotDamage > 0)
         {
-            GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, dotDamage);
+            GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, dotDamage);
         }
     }
 
@@ -1765,8 +1767,9 @@ public partial class WorldClient
         // Threat translation: damage-shield reflects (Thorns, Retribution Aura,
         // Lightning Shield) generate threat to the attacker who hit us. The
         // CasterGUID here is whoever owns the shield (us or our pet), the
-        // VictimGUID is the attacker who got reflected on.
-        GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.VictimGUID, spell.Damage);
+        // VictimGUID is the attacker who got reflected on. Pass the shield
+        // spell id so Holy Shield (x1.2) and friends pick up the right mult.
+        GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.VictimGUID, (int)spell.SpellID, spell.Damage);
     }
 
     [PacketHandler(Opcode.SMSG_ENVIRONMENTAL_DAMAGE_LOG)]

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -51,6 +51,13 @@ public partial class WorldClient
         UpdateObject updateObject = new UpdateObject(GetSession().GameState);
         updateObject.DestroyedGuids.Add(guid);
         SendPacketToClient(updateObject);
+
+        // Threat translation: when a unit despawns / dies / leaves the player's
+        // visibility, drop any threat list keyed off it (it was a mob we tracked)
+        // and any entries it held on other mobs (it was a player/pet who left
+        // the fight). The first call emits SMSG_THREAT_CLEAR; the loop emits
+        // per-mob updates so the modern client's threat APIs go quiet.
+        GetSession().ThreatTracker.OnUnitDestroyed(guid);
     }
 
     [PacketHandler(Opcode.SMSG_COMPRESSED_UPDATE_OBJECT)]

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -398,7 +398,7 @@ public partial class WorldSocket
         update.ThreatList.Add(new ThreatInfo
         {
             ThreaterGUID = playerGuid,
-            Threat = 1234500u,
+            Threat = 1234500L,
         });
         session.WorldClient.SendPacketToClient(update);
 
@@ -413,7 +413,7 @@ public partial class WorldSocket
         highest.ThreatList.Add(new ThreatInfo
         {
             ThreaterGUID = playerGuid,
-            Threat = 1234500u,
+            Threat = 1234500L,
         });
         session.WorldClient.SendPacketToClient(highest);
 

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Collections.Generic;
@@ -153,6 +154,29 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_CHAT_MESSAGE_INSTANCE_CHAT)]
     void HandleChatMessage(ChatMessage packet)
     {
+        // JimsProxy threat-translation Phase 1 smoke test. The 1.12 vanilla server
+        // does not broadcast threat data; we plan to calculate threat client-side
+        // (port of LibThreatClassic2) and synthesize SMSG_THREAT_UPDATE for the
+        // modern client. Before committing to the full engine port, prove the
+        // client accepts synthesized threat opcodes by firing a hardcoded threat
+        // value when the player /says one of these debug commands:
+        //   "jpthreattest"  -> emit SMSG_THREAT_UPDATE on current target
+        //   "jpthreatclear" -> emit SMSG_THREAT_CLEAR  on current target
+        // Doesn't forward the chat to the legacy server. Drop these handlers
+        // (and the SMSG packet writers stay) once the engine port lands.
+        string chatText = packet.Text ?? string.Empty;
+        string trimmed = chatText.Trim();
+        if (trimmed.Equals("jpthreattest", StringComparison.OrdinalIgnoreCase))
+        {
+            FireThreatSmokeTest(clear: false);
+            return;
+        }
+        if (trimmed.Equals("jpthreatclear", StringComparison.OrdinalIgnoreCase))
+        {
+            FireThreatSmokeTest(clear: true);
+            return;
+        }
+
         ChatMessageTypeModern type;
 
         switch (packet.GetUniversalOpcode())
@@ -189,7 +213,7 @@ public partial class WorldSocket
                 return;
         }
 
-        var toBeSentTextParts = ConvertTextMessageIntoMaxLengthParts(packet.Text);
+        var toBeSentTextParts = ConvertTextMessageIntoMaxLengthParts(chatText);
         foreach (string text in toBeSentTextParts)
         {
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
@@ -300,5 +324,107 @@ public partial class WorldSocket
         }
 
         return toBeSendTextParts;
+    }
+
+    private void FireThreatSmokeTest(bool clear)
+    {
+        var session = GetSession();
+        if (session?.WorldClient == null)
+        {
+            Log.Print(LogType.Warn, "jpthreat smoke test: no WorldClient yet");
+            return;
+        }
+
+        var gameState = session.GameState;
+        var playerGuid = gameState.CurrentPlayerGuid;
+        if (playerGuid.GetCounter() == 0)
+        {
+            SendDebugChat("jpthreat: no player GUID yet");
+            return;
+        }
+
+        // Resolve the player's current target via UNIT_FIELD_TARGET on the cached
+        // legacy fields. This is the entity the WoW client considers "target" — the
+        // mob the player has selected and is hopefully attacking.
+        var fields = gameState.GetCachedObjectFieldsLegacy(playerGuid);
+        if (fields == null)
+        {
+            SendDebugChat("jpthreat: no cached fields for player");
+            return;
+        }
+
+        int targetFieldIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_TARGET);
+        if (targetFieldIdx < 0)
+        {
+            SendDebugChat("jpthreat: UNIT_FIELD_TARGET not mapped");
+            return;
+        }
+
+        WowGuid64 targetGuid64 = fields.GetGuidValue(targetFieldIdx);
+        if (targetGuid64 == WowGuid64.Empty)
+        {
+            SendDebugChat("jpthreat: no target selected");
+            return;
+        }
+
+        WowGuid128 targetGuid128 = targetGuid64.To128(gameState);
+
+        Framework.Logging.Log.Event("threat.smoke_test", new
+        {
+            mode = clear ? "clear" : "update",
+            player_guid = playerGuid.ToString(),
+            target_guid = targetGuid128.ToString(),
+        });
+
+        if (clear)
+        {
+            var pkt = new ThreatClearPkt
+            {
+                UnitGUID = targetGuid128,
+            };
+            session.WorldClient.SendPacketToClient(pkt);
+            SendDebugChat($"jpthreat: sent SMSG_THREAT_CLEAR for {targetGuid128}");
+            return;
+        }
+
+        // Synthesize a threat list with just the player at 12345 raw threat.
+        // Modern wire format packs threat × 100, so emitting 1234500 should
+        // surface as 12345 in the addons that divide by 100. Useful sanity
+        // signal: the number 12345 is recognizable in TinyThreat / Skada.
+        var update = new ThreatUpdatePkt
+        {
+            UnitGUID = targetGuid128,
+        };
+        update.ThreatList.Add(new ThreatInfo
+        {
+            ThreaterGUID = playerGuid,
+            Threat = 1234500u,
+        });
+        session.WorldClient.SendPacketToClient(update);
+
+        // Also emit HIGHEST_THREAT_UPDATE so any addon that listens specifically
+        // for "you are top threat" sees it. The player is the only threater so
+        // they're necessarily highest.
+        var highest = new HighestThreatUpdatePkt
+        {
+            UnitGUID = targetGuid128,
+            HighestThreatGUID = playerGuid,
+        };
+        highest.ThreatList.Add(new ThreatInfo
+        {
+            ThreaterGUID = playerGuid,
+            Threat = 1234500u,
+        });
+        session.WorldClient.SendPacketToClient(highest);
+
+        SendDebugChat($"jpthreat: sent SMSG_THREAT_UPDATE + HIGHEST for {targetGuid128} (12345 raw / 1234500 wire)");
+    }
+
+    private void SendDebugChat(string text)
+    {
+        var session = GetSession();
+        if (session?.WorldClient == null) return;
+        var msg = new ChatPkt(session, ChatMessageTypeModern.System, text);
+        session.WorldClient.SendPacketToClient(msg);
     }
 }

--- a/HermesProxy/World/Server/Packets/CombatPackets.cs
+++ b/HermesProxy/World/Server/Packets/CombatPackets.cs
@@ -348,13 +348,24 @@ class PartyKillLog : ServerPacket, ISpanWritable
 // event) populate, which in turn drives addons like Details TinyThreat and
 // Threat Plates without any addon-side modification.
 //
-// Wire format follows TrinityCore/CypherCore convention. Note that the modern
-// protocol packs threat values × 100 (Classic Era addons divide by 100 on read),
-// so emitters must scale up before writing.
+// Wire format follows TrinityCore Classic 1.14 convention:
+//   PackedGuid128 unitGUID
+//   uint32 count
+//   foreach threater:
+//     PackedGuid128 threaterGUID
+//     int64 threat  <-- 8 BYTES, not 4. Modern protocol uses int64 even though
+//                       practical threat values fit in 32 bits; reading 4 here
+//                       causes the client to gobble the next entry's GUID-mask
+//                       bytes into the high dword and produce billions-scale
+//                       garbage values. Verified against TrinityCore master
+//                       and Frostshake/TrinityCoreClassic 1.14.0.40618.
+//
+// Note that the modern protocol packs threat values × 100 (Classic Era addons
+// divide by 100 on read), so emitters must scale up before writing.
 public class ThreatInfo
 {
     public WowGuid128 ThreaterGUID;
-    public uint Threat; // raw threat × 100
+    public long Threat; // raw threat × 100, on-wire int64
 }
 
 public class ThreatUpdatePkt : ServerPacket
@@ -368,7 +379,7 @@ public class ThreatUpdatePkt : ServerPacket
         foreach (var info in ThreatList)
         {
             _worldPacket.WritePackedGuid128(info.ThreaterGUID);
-            _worldPacket.WriteUInt32(info.Threat);
+            _worldPacket.WriteInt64(info.Threat);
         }
     }
 
@@ -388,7 +399,7 @@ public class HighestThreatUpdatePkt : ServerPacket
         foreach (var info in ThreatList)
         {
             _worldPacket.WritePackedGuid128(info.ThreaterGUID);
-            _worldPacket.WriteUInt32(info.Threat);
+            _worldPacket.WriteInt64(info.Threat);
         }
     }
 

--- a/HermesProxy/World/Server/Packets/CombatPackets.cs
+++ b/HermesProxy/World/Server/Packets/CombatPackets.cs
@@ -339,3 +339,86 @@ class PartyKillLog : ServerPacket, ISpanWritable
     public WowGuid128 Player;
     public WowGuid128 Victim;
 }
+
+// JimsProxy: synthesized threat opcodes. The 1.12 vanilla legacy server does not
+// broadcast threat data over the wire — threat tables are server-side internal
+// state. The proxy calculates threat client-side (port of LibThreatClassic2) and
+// emits these modern SMSG packets so the 1.14 client's native threat APIs
+// (UnitThreatSituation, UnitDetailedThreatSituation, UNIT_THREAT_LIST_UPDATE
+// event) populate, which in turn drives addons like Details TinyThreat and
+// Threat Plates without any addon-side modification.
+//
+// Wire format follows TrinityCore/CypherCore convention. Note that the modern
+// protocol packs threat values × 100 (Classic Era addons divide by 100 on read),
+// so emitters must scale up before writing.
+public class ThreatInfo
+{
+    public WowGuid128 ThreaterGUID;
+    public uint Threat; // raw threat × 100
+}
+
+public class ThreatUpdatePkt : ServerPacket
+{
+    public ThreatUpdatePkt() : base(Opcode.SMSG_THREAT_UPDATE) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(UnitGUID);
+        _worldPacket.WriteUInt32((uint)ThreatList.Count);
+        foreach (var info in ThreatList)
+        {
+            _worldPacket.WritePackedGuid128(info.ThreaterGUID);
+            _worldPacket.WriteUInt32(info.Threat);
+        }
+    }
+
+    public WowGuid128 UnitGUID;                    // the threatened entity (mob)
+    public List<ThreatInfo> ThreatList = new();    // threaters (players/pets) and their threat × 100
+}
+
+public class HighestThreatUpdatePkt : ServerPacket
+{
+    public HighestThreatUpdatePkt() : base(Opcode.SMSG_HIGHEST_THREAT_UPDATE) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(UnitGUID);
+        _worldPacket.WritePackedGuid128(HighestThreatGUID);
+        _worldPacket.WriteUInt32((uint)ThreatList.Count);
+        foreach (var info in ThreatList)
+        {
+            _worldPacket.WritePackedGuid128(info.ThreaterGUID);
+            _worldPacket.WriteUInt32(info.Threat);
+        }
+    }
+
+    public WowGuid128 UnitGUID;                    // the threatened entity (mob)
+    public WowGuid128 HighestThreatGUID;            // the new top threater
+    public List<ThreatInfo> ThreatList = new();
+}
+
+public class ThreatRemovePkt : ServerPacket
+{
+    public ThreatRemovePkt() : base(Opcode.SMSG_THREAT_REMOVE) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(UnitGUID);
+        _worldPacket.WritePackedGuid128(AboutGUID);
+    }
+
+    public WowGuid128 UnitGUID;     // the threatened entity (mob)
+    public WowGuid128 AboutGUID;    // the threater being removed from the mob's threat list
+}
+
+public class ThreatClearPkt : ServerPacket
+{
+    public ThreatClearPkt() : base(Opcode.SMSG_THREAT_CLEAR) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(UnitGUID);
+    }
+
+    public WowGuid128 UnitGUID;     // the entity whose threat list is being cleared
+}

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -34,7 +34,17 @@ internal static class ThreatModules
         WowGuid128 caster,
         IList<WowGuid128> hitTargets);
 
-    private static readonly Dictionary<int, ThreatHandler> Handlers = BuildHandlers();
+    // Built lazily via the static constructor so field initializers for the
+    // per-spell amount dictionaries (declared further down in the file) have
+    // already run by the time BuildHandlers reads them. Inline-initializing
+    // this field would run BuildHandlers FIRST (lexical order), which would
+    // NRE on the still-null amount dictionaries.
+    private static readonly Dictionary<int, ThreatHandler> Handlers;
+
+    static ThreatModules()
+    {
+        Handlers = BuildHandlers();
+    }
 
     public static bool TryHandle(
         ThreatTracker tracker,

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -230,6 +230,26 @@ internal static class ThreatModules
         [11303] = -600, [25302] = -800,
     };
 
+    // Warrior Demoralizing Shout — demoShoutFactor = 43/54.
+    private static readonly Dictionary<int, double> DemoralizingShoutAmount = new()
+    {
+        [1160]  = 43.0 / 54.0 * 14,
+        [6190]  = 43.0 / 54.0 * 24,
+        [11554] = 43.0 / 54.0 * 34,
+        [11555] = 43.0 / 54.0 * 44,
+        [11556] = 43,
+    };
+
+    // Druid Demoralizing Roar — flat per rank.
+    private static readonly Dictionary<int, double> DemoralizingRoarAmount = new()
+    {
+        [99]   = 9,
+        [1735] = 15,
+        [9490] = 20,
+        [9747] = 30,
+        [9898] = 39,
+    };
+
     // -----------------------------------------------------------------------
     // Generic helpers — parametrize the common shapes so each ability boils
     // down to one entry in the registry.
@@ -249,6 +269,29 @@ internal static class ThreatModules
             {
                 spell_id = spellId,
                 target_low = target.GetCounter(),
+                amount,
+            });
+        };
+
+    // For abilities that apply the same flat threat to every mob they hit
+    // (Demoralizing Shout, Demoralizing Roar, etc.). Lib treats these as
+    // MobDebuffHandlers — fires once per target when the debuff lands. Our
+    // approximation is to iterate the SMSG_SPELL_GO HitTargets list, which
+    // the legacy server populates only with mobs that didn't resist.
+    private static ThreatHandler PlayerMultiTargetFlat(string eventTag, Dictionary<int, double> amounts)
+        => (tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPlayerGuid) return;
+            if (hitTargets.Count == 0) return;
+            if (!amounts.TryGetValue(spellId, out double amount)) return;
+
+            foreach (var target in hitTargets)
+                tracker.AddModifiedThreat(target, caster, amount);
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                target_count = hitTargets.Count,
                 amount,
             });
         };
@@ -402,6 +445,14 @@ internal static class ThreatModules
 
         // Paladin
         map[4987] = PlayerAddToAllMobs("cleanse", 40);
+
+        // Warrior Demoralizing Shout — multi-target debuff threat.
+        var demoShout = PlayerMultiTargetFlat("demoralizing_shout", DemoralizingShoutAmount);
+        foreach (var id in DemoralizingShoutAmount.Keys) map[id] = demoShout;
+
+        // Druid Demoralizing Roar — multi-target debuff threat.
+        var demoRoar = PlayerMultiTargetFlat("demoralizing_roar", DemoralizingRoarAmount);
+        foreach (var id in DemoralizingRoarAmount.Keys) map[id] = demoRoar;
 
         return map;
     }

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -1,0 +1,193 @@
+using Framework.Logging;
+using HermesProxy.World.Objects;
+using System.Collections.Generic;
+
+namespace HermesProxy.World;
+
+// Phase 3 of the threat translation port. Registers per-spell threat behavior
+// for the local player and pet — Hunter and Pet abilities first, other classes
+// follow in later phases.
+//
+// LibThreatClassic2 (the upstream addon library this is ported from) hangs each
+// spell off a Lua module's CastSuccessHandlers / CastMissHandlers tables. We
+// flatten that into a single static dictionary keyed by spell id. All threat
+// numbers come straight from KTMClassic\Libs\LibThreatClassic2\ClassModules\
+// Classic\{Hunter,Pet}.lua so on-wire client behavior stays bug-for-bug
+// compatible with what an addon-driven setup would show.
+//
+// Caster gating: every handler re-checks that the caster is the local player
+// or pet before mutating threat. The OnDamage path already does the same check;
+// we duplicate it here because spell hits propagate via SMSG_SPELL_GO for any
+// caster in range, not just the local player's threaters.
+internal static class ThreatModules
+{
+    private delegate void ThreatHandler(
+        ThreatTracker tracker,
+        GlobalSessionData session,
+        int spellId,
+        WowGuid128 caster,
+        IList<WowGuid128> hitTargets);
+
+    private static readonly Dictionary<int, ThreatHandler> Handlers = new()
+    {
+        // Hunter — Distracting Shot (rank 1..6). Flat add; misses subtract but
+        // we don't see a CastMiss event server-side, so we only model success.
+        [20736] = HunterDistractingShot,
+        [14274] = HunterDistractingShot,
+        [15629] = HunterDistractingShot,
+        [15630] = HunterDistractingShot,
+        [15631] = HunterDistractingShot,
+        [15632] = HunterDistractingShot,
+
+        // Hunter — Disengage (rank 1..3). Flat negative threat against the
+        // current target. SMSG_SPELL_GO fires on success, so subtract directly.
+        [781]   = HunterDisengage,
+        [14272] = HunterDisengage,
+        [14273] = HunterDisengage,
+
+        // Hunter — Feign Death. ×0 multiplier across every mob the player has
+        // threat on. Vanilla addon code waits for ERR_FEIGN_DEATH_RESISTED to
+        // un-prime; on the proxy we apply unconditionally — the legacy server
+        // already cleared its threat on success, so a per-mob resist will just
+        // re-establish threat naturally as combat resumes.
+        [5384]  = HunterFeignDeath,
+
+        // Pet — Growl (rank 1..7). Flat threat add per rank. Vanilla addon
+        // additionally scales by pet AP; we ship base values now and revisit
+        // AP scaling in Phase 3.5 (needs UNIT_FIELD_ATTACK_POWER lookup +
+        // tester validation that pet field caching is current).
+        [2649]  = PetGrowl,
+        [14916] = PetGrowl,
+        [14917] = PetGrowl,
+        [14918] = PetGrowl,
+        [14919] = PetGrowl,
+        [14920] = PetGrowl,
+        [14921] = PetGrowl,
+
+        // Pet — Cower (rank 1..6). Flat negative threat on current target.
+        [1742]  = PetCower,
+        [1753]  = PetCower,
+        [1754]  = PetCower,
+        [1755]  = PetCower,
+        [1756]  = PetCower,
+        [16697] = PetCower,
+    };
+
+    private static readonly Dictionary<int, double> DistractingShotAmount = new()
+    {
+        [20736] = 120, [14274] = 200, [15629] = 300,
+        [15630] = 400, [15631] = 500, [15632] = 600,
+    };
+
+    private static readonly Dictionary<int, double> DisengageAmount = new()
+    {
+        [781] = -140, [14272] = -280, [14273] = -405,
+    };
+
+    private static readonly Dictionary<int, double> GrowlAmount = new()
+    {
+        [2649] = 50, [14916] = 65, [14917] = 110,
+        [14918] = 170, [14919] = 240, [14920] = 320, [14921] = 415,
+    };
+
+    private static readonly Dictionary<int, double> CowerAmount = new()
+    {
+        [1742] = -30, [1753] = -55, [1754] = -85,
+        [1755] = -125, [1756] = -175, [16697] = -225,
+    };
+
+    public static bool TryHandle(
+        ThreatTracker tracker,
+        GlobalSessionData session,
+        int spellId,
+        WowGuid128 caster,
+        IList<WowGuid128> hitTargets)
+    {
+        if (!Handlers.TryGetValue(spellId, out var handler))
+            return false;
+
+        handler(tracker, session, spellId, caster, hitTargets);
+        return true;
+    }
+
+    private static void HunterDistractingShot(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    {
+        if (caster != session.GameState.CurrentPlayerGuid) return;
+        if (hitTargets.Count == 0) return;
+        if (!DistractingShotAmount.TryGetValue(spellId, out double amount)) return;
+
+        var target = hitTargets[0];
+        tracker.AddThreat(target, caster, amount);
+
+        Log.Event("threat.spell.distracting_shot", new
+        {
+            spell_id = spellId,
+            target_low = target.GetCounter(),
+            amount,
+        });
+    }
+
+    private static void HunterDisengage(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    {
+        if (caster != session.GameState.CurrentPlayerGuid) return;
+        if (hitTargets.Count == 0) return;
+        if (!DisengageAmount.TryGetValue(spellId, out double amount)) return;
+
+        var target = hitTargets[0];
+        tracker.AddThreat(target, caster, amount);
+
+        Log.Event("threat.spell.disengage", new
+        {
+            spell_id = spellId,
+            target_low = target.GetCounter(),
+            amount,
+        });
+    }
+
+    private static void HunterFeignDeath(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    {
+        if (caster != session.GameState.CurrentPlayerGuid) return;
+
+        tracker.MultiplyThreat(caster, 0.0);
+
+        Log.Event("threat.spell.feign_death", new
+        {
+            spell_id = spellId,
+            caster_low = caster.GetCounter(),
+        });
+    }
+
+    private static void PetGrowl(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    {
+        if (caster != session.GameState.CurrentPetGuid) return;
+        if (hitTargets.Count == 0) return;
+        if (!GrowlAmount.TryGetValue(spellId, out double amount)) return;
+
+        var target = hitTargets[0];
+        tracker.AddThreat(target, caster, amount);
+
+        Log.Event("threat.spell.growl", new
+        {
+            spell_id = spellId,
+            target_low = target.GetCounter(),
+            amount,
+        });
+    }
+
+    private static void PetCower(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    {
+        if (caster != session.GameState.CurrentPetGuid) return;
+        if (hitTargets.Count == 0) return;
+        if (!CowerAmount.TryGetValue(spellId, out double amount)) return;
+
+        var target = hitTargets[0];
+        tracker.AddThreat(target, caster, amount);
+
+        Log.Event("threat.spell.cower", new
+        {
+            spell_id = spellId,
+            target_low = target.GetCounter(),
+            amount,
+        });
+    }
+}

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -4,21 +4,27 @@ using System.Collections.Generic;
 
 namespace HermesProxy.World;
 
-// Phase 3 of the threat translation port. Registers per-spell threat behavior
-// for the local player and pet — Hunter and Pet abilities first, other classes
-// follow in later phases.
+// Per-spell threat behavior for the local player and pet, ported from
+// LibThreatClassic2 (KTMClassic addon). Phases roll out incrementally:
+//   Phase 3: Hunter, Pet
+//   Phase 4: Warrior, Druid, Mage, Rogue, Paladin (cast-success flat threat,
+//            taunt-style set-to-top, zero-multiplier abilities, simple
+//            add-to-all-mobs casts)
 //
-// LibThreatClassic2 (the upstream addon library this is ported from) hangs each
-// spell off a Lua module's CastSuccessHandlers / CastMissHandlers tables. We
-// flatten that into a single static dictionary keyed by spell id. All threat
-// numbers come straight from KTMClassic\Libs\LibThreatClassic2\ClassModules\
-// Classic\{Hunter,Pet}.lua so on-wire client behavior stays bug-for-bug
-// compatible with what an addon-driven setup would show.
+// Out of scope here (deferred):
+//   - AbilityHandlers (per-damage spell-school multipliers, e.g. Maul x1.75,
+//     Earth Shock x2, Searing Pain x2). Needs the OnDamage path to know which
+//     spell school did the damage.
+//   - MobDebuffHandlers (Demoralizing Shout, Demoralizing Roar, Faerie Fire
+//     debuff stick). Needs SMSG_AURA_UPDATE observer.
+//   - Stance / form / Righteous Fury passive multipliers and class talents
+//     (Defiance, Feral Instinct, Subtlety, Shadow Affinity, Improved PWS).
+//   - Multi-target effects that read party/raid composition (Greater Blessings).
 //
 // Caster gating: every handler re-checks that the caster is the local player
-// or pet before mutating threat. The OnDamage path already does the same check;
-// we duplicate it here because spell hits propagate via SMSG_SPELL_GO for any
-// caster in range, not just the local player's threaters.
+// (or pet, where applicable) before mutating threat. The OnDamage path already
+// does the same check; we duplicate it here because spell hits propagate via
+// SMSG_SPELL_GO for any caster in range, not just the local player.
 internal static class ThreatModules
 {
     private delegate void ThreatHandler(
@@ -28,73 +34,7 @@ internal static class ThreatModules
         WowGuid128 caster,
         IList<WowGuid128> hitTargets);
 
-    private static readonly Dictionary<int, ThreatHandler> Handlers = new()
-    {
-        // Hunter — Distracting Shot (rank 1..6). Flat add; misses subtract but
-        // we don't see a CastMiss event server-side, so we only model success.
-        [20736] = HunterDistractingShot,
-        [14274] = HunterDistractingShot,
-        [15629] = HunterDistractingShot,
-        [15630] = HunterDistractingShot,
-        [15631] = HunterDistractingShot,
-        [15632] = HunterDistractingShot,
-
-        // Hunter — Disengage (rank 1..3). Flat negative threat against the
-        // current target. SMSG_SPELL_GO fires on success, so subtract directly.
-        [781]   = HunterDisengage,
-        [14272] = HunterDisengage,
-        [14273] = HunterDisengage,
-
-        // Hunter — Feign Death. ×0 multiplier across every mob the player has
-        // threat on. Vanilla addon code waits for ERR_FEIGN_DEATH_RESISTED to
-        // un-prime; on the proxy we apply unconditionally — the legacy server
-        // already cleared its threat on success, so a per-mob resist will just
-        // re-establish threat naturally as combat resumes.
-        [5384]  = HunterFeignDeath,
-
-        // Pet — Growl (rank 1..7). Flat threat add per rank. Vanilla addon
-        // additionally scales by pet AP; we ship base values now and revisit
-        // AP scaling in Phase 3.5 (needs UNIT_FIELD_ATTACK_POWER lookup +
-        // tester validation that pet field caching is current).
-        [2649]  = PetGrowl,
-        [14916] = PetGrowl,
-        [14917] = PetGrowl,
-        [14918] = PetGrowl,
-        [14919] = PetGrowl,
-        [14920] = PetGrowl,
-        [14921] = PetGrowl,
-
-        // Pet — Cower (rank 1..6). Flat negative threat on current target.
-        [1742]  = PetCower,
-        [1753]  = PetCower,
-        [1754]  = PetCower,
-        [1755]  = PetCower,
-        [1756]  = PetCower,
-        [16697] = PetCower,
-    };
-
-    private static readonly Dictionary<int, double> DistractingShotAmount = new()
-    {
-        [20736] = 120, [14274] = 200, [15629] = 300,
-        [15630] = 400, [15631] = 500, [15632] = 600,
-    };
-
-    private static readonly Dictionary<int, double> DisengageAmount = new()
-    {
-        [781] = -140, [14272] = -280, [14273] = -405,
-    };
-
-    private static readonly Dictionary<int, double> GrowlAmount = new()
-    {
-        [2649] = 50, [14916] = 65, [14917] = 110,
-        [14918] = 170, [14919] = 240, [14920] = 320, [14921] = 415,
-    };
-
-    private static readonly Dictionary<int, double> CowerAmount = new()
-    {
-        [1742] = -30, [1753] = -55, [1754] = -85,
-        [1755] = -125, [1756] = -175, [16697] = -225,
-    };
+    private static readonly Dictionary<int, ThreatHandler> Handlers = BuildHandlers();
 
     public static bool TryHandle(
         ThreatTracker tracker,
@@ -110,84 +50,299 @@ internal static class ThreatModules
         return true;
     }
 
-    private static void HunterDistractingShot(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    // -----------------------------------------------------------------------
+    // Per-spell threat tables (rank → amount). Numbers come straight from
+    // LibThreatClassic2 ClassModules/Classic/*.lua.
+    // -----------------------------------------------------------------------
+
+    // Hunter
+    private static readonly Dictionary<int, double> DistractingShotAmount = new()
     {
-        if (caster != session.GameState.CurrentPlayerGuid) return;
-        if (hitTargets.Count == 0) return;
-        if (!DistractingShotAmount.TryGetValue(spellId, out double amount)) return;
-
-        var target = hitTargets[0];
-        tracker.AddThreat(target, caster, amount);
-
-        Log.Event("threat.spell.distracting_shot", new
-        {
-            spell_id = spellId,
-            target_low = target.GetCounter(),
-            amount,
-        });
-    }
-
-    private static void HunterDisengage(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+        [20736] = 120, [14274] = 200, [15629] = 300,
+        [15630] = 400, [15631] = 500, [15632] = 600,
+    };
+    private static readonly Dictionary<int, double> DisengageAmount = new()
     {
-        if (caster != session.GameState.CurrentPlayerGuid) return;
-        if (hitTargets.Count == 0) return;
-        if (!DisengageAmount.TryGetValue(spellId, out double amount)) return;
+        [781] = -140, [14272] = -280, [14273] = -405,
+    };
 
-        var target = hitTargets[0];
-        tracker.AddThreat(target, caster, amount);
-
-        Log.Event("threat.spell.disengage", new
-        {
-            spell_id = spellId,
-            target_low = target.GetCounter(),
-            amount,
-        });
-    }
-
-    private static void HunterFeignDeath(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    // Pet
+    private static readonly Dictionary<int, double> GrowlAmount = new()
     {
-        if (caster != session.GameState.CurrentPlayerGuid) return;
-
-        tracker.MultiplyThreat(caster, 0.0);
-
-        Log.Event("threat.spell.feign_death", new
-        {
-            spell_id = spellId,
-            caster_low = caster.GetCounter(),
-        });
-    }
-
-    private static void PetGrowl(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+        [2649] = 50, [14916] = 65, [14917] = 110,
+        [14918] = 170, [14919] = 240, [14920] = 320, [14921] = 415,
+    };
+    private static readonly Dictionary<int, double> CowerPetAmount = new()
     {
-        if (caster != session.GameState.CurrentPetGuid) return;
-        if (hitTargets.Count == 0) return;
-        if (!GrowlAmount.TryGetValue(spellId, out double amount)) return;
+        [1742] = -30, [1753] = -55, [1754] = -85,
+        [1755] = -125, [1756] = -175, [16697] = -225,
+    };
 
-        var target = hitTargets[0];
-        tracker.AddThreat(target, caster, amount);
-
-        Log.Event("threat.spell.growl", new
-        {
-            spell_id = spellId,
-            target_low = target.GetCounter(),
-            amount,
-        });
-    }
-
-    private static void PetCower(ThreatTracker tracker, GlobalSessionData session, int spellId, WowGuid128 caster, IList<WowGuid128> hitTargets)
+    // Warrior — sunderFactor = 261/58, with R5 hardcoded to 261.
+    private static readonly Dictionary<int, double> SunderArmorAmount = new()
     {
-        if (caster != session.GameState.CurrentPetGuid) return;
-        if (hitTargets.Count == 0) return;
-        if (!CowerAmount.TryGetValue(spellId, out double amount)) return;
+        [7386]  = 261.0 / 58.0 * 10,
+        [7405]  = 261.0 / 58.0 * 22,
+        [8380]  = 261.0 / 58.0 * 34,
+        [11596] = 261.0 / 58.0 * 46,
+        [11597] = 261,
+    };
+    private static readonly Dictionary<int, double> HeroicStrikeAmount = new()
+    {
+        [78] = 20, [284] = 39, [285] = 59, [1608] = 78,
+        [11564] = 98, [11565] = 118, [11566] = 137,
+        [11567] = 145, [25286] = 175,
+    };
+    private static readonly Dictionary<int, double> CleaveAmount = new()
+    {
+        [845] = 10, [7369] = 40, [11608] = 60, [11609] = 70, [20569] = 100,
+    };
+    // Revenge — revengeFactor = 355/60. Vanilla hardcodes the top two ranks.
+    private static readonly Dictionary<int, double> RevengeAmount = new()
+    {
+        [6572]  = 355.0 / 60.0 * 14,
+        [6574]  = 355.0 / 60.0 * 24,
+        [7379]  = 355.0 / 60.0 * 34,
+        [11600] = 355.0 / 60.0 * 44,
+        [11601] = 315,
+        [25288] = 355,
+    };
+    // Hamstring — hamstringFactor = 145/54.
+    private static readonly Dictionary<int, double> HamstringAmount = new()
+    {
+        [1715] = 145.0 / 54.0 * 8,
+        [7372] = 145.0 / 54.0 * 32,
+        [7373] = 145,
+    };
+    // Shield Slam — shieldSlamFactor = 250/60.
+    private static readonly Dictionary<int, double> ShieldSlamAmount = new()
+    {
+        [23922] = 250.0 / 60.0 * 40,
+        [23923] = 250.0 / 60.0 * 48,
+        [23924] = 250.0 / 60.0 * 54,
+        [23925] = 250,
+    };
+    // Shield Bash — shieldBashFactor = 187/52.
+    private static readonly Dictionary<int, double> ShieldBashAmount = new()
+    {
+        [72]   = 187.0 / 52.0 * 12,
+        [1671] = 187.0 / 52.0 * 32,
+        [1672] = 187,
+    };
+    // Thunder Clap — thunderClapFactor = 130/58.
+    private static readonly Dictionary<int, double> ThunderClapAmount = new()
+    {
+        [6343]  = 130.0 / 58.0 * 6,
+        [8198]  = 130.0 / 58.0 * 18,
+        [8204]  = 130.0 / 58.0 * 28,
+        [8205]  = 130.0 / 58.0 * 38,
+        [11580] = 130.0 / 58.0 * 48,
+        [11581] = 130,
+    };
+    private static readonly Dictionary<int, double> DisarmAmount = new()
+    {
+        [676] = 104,
+    };
 
-        var target = hitTargets[0];
-        tracker.AddThreat(target, caster, amount);
+    // Druid
+    private static readonly Dictionary<int, double> FaerieFireAmount = new()
+    {
+        // caster faerie fire — factor 108/54
+        [770]   = 108.0 / 54.0 * 18,
+        [778]   = 108.0 / 54.0 * 30,
+        [9749]  = 108.0 / 54.0 * 42,
+        [9907]  = 108,
+        // feral
+        [16857] = 108.0 / 54.0 * 18,
+        [17390] = 108.0 / 54.0 * 30,
+        [17391] = 108.0 / 54.0 * 42,
+        [17392] = 108,
+    };
+    private static readonly Dictionary<int, double> CowerDruidAmount = new()
+    {
+        [8998] = -240, [9000] = -390, [9892] = -600,
+    };
 
-        Log.Event("threat.spell.cower", new
+    // Rogue — Feint scales NEGATIVE.
+    private static readonly Dictionary<int, double> FeintAmount = new()
+    {
+        [1966] = -150, [6768] = -240, [8637] = -390,
+        [11303] = -600, [25302] = -800,
+    };
+
+    // -----------------------------------------------------------------------
+    // Generic helpers — parametrize the common shapes so each ability boils
+    // down to one entry in the registry.
+    // -----------------------------------------------------------------------
+
+    private static ThreatHandler PlayerSingleTargetFlat(string eventTag, Dictionary<int, double> amounts)
+        => (tracker, session, spellId, caster, hitTargets) =>
         {
-            spell_id = spellId,
-            target_low = target.GetCounter(),
-            amount,
-        });
+            if (caster != session.GameState.CurrentPlayerGuid) return;
+            if (hitTargets.Count == 0) return;
+            if (!amounts.TryGetValue(spellId, out double amount)) return;
+
+            var target = hitTargets[0];
+            tracker.AddThreat(target, caster, amount);
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                target_low = target.GetCounter(),
+                amount,
+            });
+        };
+
+    private static ThreatHandler PetSingleTargetFlat(string eventTag, Dictionary<int, double> amounts)
+        => (tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPetGuid) return;
+            if (hitTargets.Count == 0) return;
+            if (!amounts.TryGetValue(spellId, out double amount)) return;
+
+            var target = hitTargets[0];
+            tracker.AddThreat(target, caster, amount);
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                target_low = target.GetCounter(),
+                amount,
+            });
+        };
+
+    private static ThreatHandler PlayerSetToTop(string eventTag)
+        => (tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPlayerGuid) return;
+            if (hitTargets.Count == 0) return;
+
+            var target = hitTargets[0];
+            tracker.SetToTop(target, caster);
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                target_low = target.GetCounter(),
+            });
+        };
+
+    private static ThreatHandler PlayerZeroAllMobs(string eventTag)
+        => (tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPlayerGuid) return;
+
+            tracker.MultiplyThreat(caster, 0.0);
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                caster_low = caster.GetCounter(),
+            });
+        };
+
+    private static ThreatHandler PlayerAddToAllMobs(string eventTag, double amount)
+        => (tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPlayerGuid) return;
+
+            tracker.AddThreatToAllMobs(caster, amount);
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                caster_low = caster.GetCounter(),
+                amount,
+            });
+        };
+
+    // -----------------------------------------------------------------------
+    // Registry — every spell ID we care about lands here. Adding a new ability
+    // is one entry plus (optionally) a per-rank amount table above.
+    // -----------------------------------------------------------------------
+
+    private static Dictionary<int, ThreatHandler> BuildHandlers()
+    {
+        var map = new Dictionary<int, ThreatHandler>();
+
+        // Hunter
+        var hunterDistractingShot = PlayerSingleTargetFlat("distracting_shot", DistractingShotAmount);
+        foreach (var id in DistractingShotAmount.Keys) map[id] = hunterDistractingShot;
+
+        var hunterDisengage = PlayerSingleTargetFlat("disengage", DisengageAmount);
+        foreach (var id in DisengageAmount.Keys) map[id] = hunterDisengage;
+
+        map[5384] = PlayerZeroAllMobs("feign_death");
+
+        // Pet
+        var petGrowl = PetSingleTargetFlat("growl", GrowlAmount);
+        foreach (var id in GrowlAmount.Keys) map[id] = petGrowl;
+
+        var petCower = PetSingleTargetFlat("cower_pet", CowerPetAmount);
+        foreach (var id in CowerPetAmount.Keys) map[id] = petCower;
+
+        // Warrior
+        var sunder = PlayerSingleTargetFlat("sunder_armor", SunderArmorAmount);
+        foreach (var id in SunderArmorAmount.Keys) map[id] = sunder;
+
+        var heroicStrike = PlayerSingleTargetFlat("heroic_strike", HeroicStrikeAmount);
+        foreach (var id in HeroicStrikeAmount.Keys) map[id] = heroicStrike;
+
+        var cleave = PlayerSingleTargetFlat("cleave", CleaveAmount);
+        foreach (var id in CleaveAmount.Keys) map[id] = cleave;
+
+        var revenge = PlayerSingleTargetFlat("revenge", RevengeAmount);
+        foreach (var id in RevengeAmount.Keys) map[id] = revenge;
+
+        var hamstring = PlayerSingleTargetFlat("hamstring", HamstringAmount);
+        foreach (var id in HamstringAmount.Keys) map[id] = hamstring;
+
+        var shieldSlam = PlayerSingleTargetFlat("shield_slam", ShieldSlamAmount);
+        foreach (var id in ShieldSlamAmount.Keys) map[id] = shieldSlam;
+
+        var shieldBash = PlayerSingleTargetFlat("shield_bash", ShieldBashAmount);
+        foreach (var id in ShieldBashAmount.Keys) map[id] = shieldBash;
+
+        var thunderClap = PlayerSingleTargetFlat("thunder_clap", ThunderClapAmount);
+        foreach (var id in ThunderClapAmount.Keys) map[id] = thunderClap;
+
+        var disarm = PlayerSingleTargetFlat("disarm", DisarmAmount);
+        foreach (var id in DisarmAmount.Keys) map[id] = disarm;
+
+        // Warrior — Taunt (set-to-top). Vanilla addon also gates on "is taunt
+        // immune?", but we apply unconditionally — the legacy server already
+        // resolved immunity before sending SMSG_SPELL_GO, so the cast having
+        // landed is itself the success signal.
+        map[355] = PlayerSetToTop("taunt");
+
+        // Warrior — Mocking Blow ranks 1..5, also taunt-style.
+        var mockingBlow = PlayerSetToTop("mocking_blow");
+        foreach (var id in new[] { 694, 7400, 7402, 20559, 20560 }) map[id] = mockingBlow;
+
+        // Druid
+        var faerieFire = PlayerSingleTargetFlat("faerie_fire", FaerieFireAmount);
+        foreach (var id in FaerieFireAmount.Keys) map[id] = faerieFire;
+
+        var cowerDruid = PlayerSingleTargetFlat("cower_druid", CowerDruidAmount);
+        foreach (var id in CowerDruidAmount.Keys) map[id] = cowerDruid;
+
+        // Druid Growl is a player taunt (bear form).
+        map[6795] = PlayerSetToTop("growl_druid");
+
+        // Mage
+        map[2139] = PlayerSingleTargetFlat("counterspell", new Dictionary<int, double> { [2139] = 300 });
+        map[475]  = PlayerAddToAllMobs("remove_lesser_curse", 14);
+
+        // Rogue
+        var feint = PlayerSingleTargetFlat("feint", FeintAmount);
+        foreach (var id in FeintAmount.Keys) map[id] = feint;
+
+        var vanish = PlayerZeroAllMobs("vanish");
+        foreach (var id in new[] { 1856, 1857 }) map[id] = vanish;
+
+        // Paladin
+        map[4987] = PlayerAddToAllMobs("cleanse", 40);
+
+        return map;
     }
 }

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -60,6 +60,56 @@ internal static class ThreatModules
         return true;
     }
 
+    // Phase 6 — per-spell damage threat multiplier. Looked up on every
+    // OnDamage event with a non-zero spell id. Values mirror
+    // LibThreatClassic2's AbilityHandlers entries; spells not in the table
+    // (and melee swings, which arrive with spellId=0) get the implicit 1.0×.
+    //
+    // Set-bonus modifiers (Mage Netherwind, Warlock Plagueheart/Nemesis,
+    // Rogue Bonescythe) and talent-based school multipliers are deferred —
+    // those need item-set / talent introspection from the proxy side.
+    private static readonly Dictionary<int, double> DamageMultipliers = new()
+    {
+        // Druid Maul (R1..7) — bear-form spike attack, double-threat per the lib
+        [6807] = 1.75, [6808] = 1.75, [6809] = 1.75,
+        [8972] = 1.75, [9745] = 1.75, [9880] = 1.75, [9881] = 1.75,
+
+        // Druid Swipe (R1..5)
+        [779]  = 1.75, [780]  = 1.75, [769]  = 1.75,
+        [9754] = 1.75, [9908] = 1.75,
+
+        // Warlock Searing Pain (R1..6) — high-threat dps spell by design
+        [5676] = 2.0, [17919] = 2.0, [17920] = 2.0,
+        [17921] = 2.0, [17922] = 2.0, [17923] = 2.0,
+
+        // Priest Mind Blast (R1..9)
+        [8092] = 2.0, [8102] = 2.0, [8103] = 2.0,
+        [8104] = 2.0, [8105] = 2.0, [8106] = 2.0,
+        [10945] = 2.0, [10946] = 2.0, [10947] = 2.0,
+
+        // Priest Holy Nova damage component (R1..6) — generates no threat
+        [15237] = 0.0, [15430] = 0.0, [15431] = 0.0,
+        [27799] = 0.0, [27800] = 0.0, [27801] = 0.0,
+
+        // Priest Shadowguard reflect (R1..6) — generates no threat
+        [18137] = 0.0, [19308] = 0.0, [19309] = 0.0,
+        [19310] = 0.0, [19311] = 0.0, [19312] = 0.0,
+
+        // Shaman Earth Shock (R1..7) — designed as the shaman tank-equivalent
+        // taunt, lib applies 2x to give it real teeth on a threat meter
+        [8042] = 2.0, [8044] = 2.0, [8045] = 2.0,
+        [8046] = 2.0, [10412] = 2.0, [10413] = 2.0, [10414] = 2.0,
+
+        // Paladin Holy Shield reflect damage (R1..3)
+        [20925] = 1.2, [20927] = 1.2, [20928] = 1.2,
+    };
+
+    public static double GetDamageMultiplier(int spellId)
+    {
+        if (spellId <= 0) return 1.0;
+        return DamageMultipliers.TryGetValue(spellId, out double mult) ? mult : 1.0;
+    }
+
     // -----------------------------------------------------------------------
     // Per-spell threat tables (rank → amount). Numbers come straight from
     // LibThreatClassic2 ClassModules/Classic/*.lua.

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -250,6 +250,47 @@ internal static class ThreatModules
         [9898] = 39,
     };
 
+    // Warrior Battle Shout — adds threat to all mobs in combat with caster
+    // when the buff goes out (per-rank flat).
+    private static readonly Dictionary<int, double> BattleShoutAmount = new()
+    {
+        [6673]  = 1,
+        [5242]  = 12,
+        [6192]  = 22,
+        [11549] = 32,
+        [11550] = 42,
+        [11551] = 52,
+        [25289] = 60,
+    };
+
+    // Paladin Lesser Blessings — small flat threat to every mob in combat
+    // each time the buff is cast (per-rank, per-blessing-type from the lib).
+    // Greater Blessings deferred — those scale by raid class headcount,
+    // which needs raid roster mirroring we don't have yet.
+    private static readonly Dictionary<int, double> LesserBlessingAmount = new()
+    {
+        // Kings
+        [20217] = 20,
+        // Light
+        [19977] = 40, [19978] = 50, [19979] = 60,
+        // Might
+        [19740] = 4, [19834] = 12, [19835] = 22, [19836] = 32,
+        [19837] = 42, [19838] = 52, [25291] = 60,
+        // Sanctuary
+        [20911] = 30, [20912] = 40, [20913] = 50, [20914] = 60,
+        // Salvation
+        [1038]  = 26,
+        // Wisdom
+        [19742] = 14, [19850] = 24, [19852] = 34, [19853] = 44,
+        [19854] = 54, [25290] = 60,
+        // Freedom
+        [1044]  = 18,
+        // Protection
+        [1022]  = 10, [5599]  = 24, [10278] = 38,
+        // Sacrifice
+        [6940]  = 46, [20729] = 54,
+    };
+
     // -----------------------------------------------------------------------
     // Generic helpers — parametrize the common shapes so each ability boils
     // down to one entry in the registry.
@@ -359,6 +400,24 @@ internal static class ThreatModules
             });
         };
 
+    // Per-rank variant for shouts and blessings — adds the rank's flat amount
+    // to every mob the caster currently has on a threat list.
+    private static ThreatHandler PlayerAddToAllMobsByRank(string eventTag, Dictionary<int, double> amounts)
+        => (tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPlayerGuid) return;
+            if (!amounts.TryGetValue(spellId, out double amount)) return;
+
+            tracker.AddThreatToAllMobs(caster, amount);
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                caster_low = caster.GetCounter(),
+                amount,
+            });
+        };
+
     // -----------------------------------------------------------------------
     // Registry — every spell ID we care about lands here. Adding a new ability
     // is one entry plus (optionally) a per-rank amount table above.
@@ -453,6 +512,14 @@ internal static class ThreatModules
         // Druid Demoralizing Roar — multi-target debuff threat.
         var demoRoar = PlayerMultiTargetFlat("demoralizing_roar", DemoralizingRoarAmount);
         foreach (var id in DemoralizingRoarAmount.Keys) map[id] = demoRoar;
+
+        // Warrior Battle Shout — flat add to every mob in combat with caster.
+        var battleShout = PlayerAddToAllMobsByRank("battle_shout", BattleShoutAmount);
+        foreach (var id in BattleShoutAmount.Keys) map[id] = battleShout;
+
+        // Paladin Lesser Blessings — flat add to every mob in combat.
+        var lesserBlessing = PlayerAddToAllMobsByRank("lesser_blessing", LesserBlessingAmount);
+        foreach (var id in LesserBlessingAmount.Keys) map[id] = lesserBlessing;
 
         return map;
     }

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -193,7 +193,7 @@ internal static class ThreatModules
             if (!amounts.TryGetValue(spellId, out double amount)) return;
 
             var target = hitTargets[0];
-            tracker.AddThreat(target, caster, amount);
+            tracker.AddModifiedThreat(target, caster, amount);
 
             Log.Event("threat.spell." + eventTag, new
             {
@@ -211,7 +211,7 @@ internal static class ThreatModules
             if (!amounts.TryGetValue(spellId, out double amount)) return;
 
             var target = hitTargets[0];
-            tracker.AddThreat(target, caster, amount);
+            tracker.AddModifiedThreat(target, caster, amount);
 
             Log.Event("threat.spell." + eventTag, new
             {

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -379,6 +379,63 @@ public sealed class ThreatTracker
         EmitDirty();
     }
 
+    // Phase 7 — heal threat. Vanilla heal threat is 0.5 × effective heal,
+    // distributed evenly across every mob currently in combat with the heal
+    // target (i.e., every mob whose threater list contains healTarget).
+    //
+    // Caveat: we only know about mobs WE have engaged. If a pure healer
+    // never deals damage, the mobs they're "supporting" never enter our
+    // threat list, so heal threat won't fire for them. Group-sync threat
+    // (a future phase) is the proper fix; until then, the limitation is
+    // identical to the rest of the system — heal threat works for tanks,
+    // off-healers who DPS, and self-heals while in combat.
+    public void OnHeal(WowGuid128 healer, WowGuid128 healTarget, int spellId, double effectiveHeal)
+    {
+        if (effectiveHeal <= 0) return;
+        if (!IsLocalThreater(healer)) return;
+        if (healTarget == default) return;
+
+        // Collect mobs whose threater list contains the heal target.
+        List<WowGuid128>? mobsThreateningTarget = null;
+        foreach (var (mob, list) in _threatLists)
+        {
+            if (list.ContainsKey(healTarget))
+            {
+                mobsThreateningTarget ??= new List<WowGuid128>();
+                mobsThreateningTarget.Add(mob);
+            }
+        }
+
+        if (mobsThreateningTarget == null || mobsThreateningTarget.Count == 0)
+        {
+            // Healed someone we don't know is in combat — drop. Avoids
+            // putting threat on every mob we've ever fought just because we
+            // healed a friendly out of nowhere.
+            return;
+        }
+
+        double passiveModifier = GetPassiveModifier(healer);
+        double totalThreat = effectiveHeal * 0.5 * passiveModifier;
+        double threatPerMob = totalThreat / mobsThreateningTarget.Count;
+
+        foreach (var mob in mobsThreateningTarget)
+            AddThreat(mob, healer, threatPerMob);
+
+        Log.Event("threat.heal_added", new
+        {
+            healer_low = healer.GetCounter(),
+            heal_target_low = healTarget.GetCounter(),
+            spell_id = spellId,
+            effective_heal = (long)effectiveHeal,
+            passive_mod = passiveModifier,
+            mobs_split = mobsThreateningTarget.Count,
+            threat_per_mob = (long)threatPerMob,
+            total_threat = (long)totalThreat,
+        });
+
+        EmitDirty();
+    }
+
     // Called from SMSG_SPELL_GO observer for any spell cast that may modify
     // threat (Distracting Shot, Disengage, Feign Death, Growl, Cower, ...).
     // Routes to ThreatModules' per-spell-id handler. Auto-flushes the dirty

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -1,0 +1,329 @@
+using Framework.Logging;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
+using System;
+using System.Collections.Generic;
+
+namespace HermesProxy.World;
+
+// JimsProxy threat translation: client-side threat calculation engine.
+//
+// Vanilla 1.12 servers don't broadcast threat over the wire; threat tables live
+// in server-side internal state. The modern 1.14 client expects SMSG_THREAT_UPDATE
+// (and friends) so its native APIs (UnitDetailedThreatSituation, UnitThreatSituation,
+// UNIT_THREAT_LIST_UPDATE event) populate. Without those packets the modern client
+// shows zero threat and downstream addons (Details TinyThreat, TidyPlates_ThreatPlates,
+// default UI target frame) get nothing to display.
+//
+// This class observes combat events forwarded from the legacy server, computes
+// threat per LibThreatClassic2 rules (port-in-progress, see ClassModules/), and
+// emits modern SMSG threat opcodes to the client.
+//
+// Phase 2 scope: track damage threat for the local player and their pet. Other
+// group members' threat is not yet shown (Phase 6 group sync). Class-specific
+// abilities (Distracting Shot, Feign Death, Sunder Armor flat threat, defensive
+// stance multipliers, etc.) ship in Phase 3+.
+//
+// Threading: methods are called from the WorldClient thread (which dispatches
+// SMSG packet handlers). Emission goes back via WorldClient.SendPacketToClient
+// so it stays on the same thread — no cross-thread state mutation.
+public sealed class ThreatTracker
+{
+    // Per-mob threat list. Outer key = threatened entity (mob). Inner dict
+    // maps threater (player/pet) -> raw threat value. We pack × 100 only at
+    // emit time so internal math can stay floating point.
+    private readonly Dictionary<WowGuid128, Dictionary<WowGuid128, double>> _threatLists = new();
+
+    // Mobs whose threat list has been mutated since the last emit. Flushed
+    // in EmitDirty(). Lets a single damage event that touches multiple mobs
+    // (e.g. Multi-Shot, Volley) batch into one round of SMSG emission.
+    private readonly HashSet<WowGuid128> _dirty = new();
+
+    // Last-emitted highest threater per mob — so we only emit
+    // SMSG_HIGHEST_THREAT_UPDATE when the top actually changes.
+    private readonly Dictionary<WowGuid128, WowGuid128> _lastHighest = new();
+
+    private readonly GlobalSessionData _session;
+
+    public ThreatTracker(GlobalSessionData session)
+    {
+        _session = session;
+    }
+
+    // Add (or subtract, if amount is negative) raw threat from a threater
+    // against a mob. Marks the mob dirty so the next EmitDirty pushes the
+    // updated threat list to the client.
+    public void AddThreat(WowGuid128 mob, WowGuid128 threater, double amount)
+    {
+        if (mob == default || threater == default || amount == 0)
+            return;
+
+        if (!_threatLists.TryGetValue(mob, out var list))
+        {
+            list = new Dictionary<WowGuid128, double>();
+            _threatLists[mob] = list;
+        }
+
+        list.TryGetValue(threater, out double existing);
+        double updated = existing + amount;
+        // Vanilla clamps threat at zero — negative threat is invisible to the
+        // server's pull aggro check. LibThreatClassic2 mirrors this.
+        if (updated < 0) updated = 0;
+        list[threater] = updated;
+
+        _dirty.Add(mob);
+    }
+
+    // Set a threater's threat on a mob to an absolute value. Used by Growl
+    // (which sets pet threat to current top + 1) in Phase 3.
+    public void SetThreat(WowGuid128 mob, WowGuid128 threater, double amount)
+    {
+        if (mob == default || threater == default)
+            return;
+
+        if (!_threatLists.TryGetValue(mob, out var list))
+        {
+            list = new Dictionary<WowGuid128, double>();
+            _threatLists[mob] = list;
+        }
+        if (amount < 0) amount = 0;
+        list[threater] = amount;
+        _dirty.Add(mob);
+    }
+
+    // Multiply a single threater's threat by a factor across ALL their mobs.
+    // Hunter Feign Death uses this (factor = 0). Returns to the caller via
+    // dirty-mark; emit happens on next flush.
+    public void MultiplyThreat(WowGuid128 threater, double factor)
+    {
+        if (threater == default) return;
+        foreach (var (mob, list) in _threatLists)
+        {
+            if (list.TryGetValue(threater, out double current))
+            {
+                double updated = current * factor;
+                if (updated < 0) updated = 0;
+                list[threater] = updated;
+                _dirty.Add(mob);
+            }
+        }
+    }
+
+    // Mob died, ran far away, evaded, etc. Remove its threat list entirely
+    // and emit SMSG_THREAT_CLEAR so the modern client knows to drop it from
+    // the threat APIs.
+    public void ClearMob(WowGuid128 mob)
+    {
+        if (mob == default) return;
+        if (!_threatLists.Remove(mob))
+            return;
+        _lastHighest.Remove(mob);
+        _dirty.Remove(mob);
+
+        var pkt = new ThreatClearPkt { UnitGUID = mob };
+        SendToClient(pkt);
+
+        Log.Event("threat.mob_cleared", new
+        {
+            mob_guid = mob.ToString(),
+        });
+    }
+
+    // A single threater (e.g. a player who left the group, died) drops off a
+    // mob's threat list. Vanilla also fires this on Vanish, etc. — Phase 3+.
+    public void RemoveThreater(WowGuid128 mob, WowGuid128 threater)
+    {
+        if (mob == default || threater == default) return;
+        if (!_threatLists.TryGetValue(mob, out var list)) return;
+        if (!list.Remove(threater)) return;
+
+        var pkt = new ThreatRemovePkt
+        {
+            UnitGUID = mob,
+            AboutGUID = threater,
+        };
+        SendToClient(pkt);
+
+        // The mob's remaining list may still need an update (since the top
+        // may have changed). Mark dirty so EmitDirty refreshes it.
+        if (list.Count > 0)
+        {
+            _dirty.Add(mob);
+        }
+        else
+        {
+            _threatLists.Remove(mob);
+            _lastHighest.Remove(mob);
+        }
+    }
+
+    // Flush all pending dirty mobs to the client. Call after a batch of damage
+    // events — typically once per WorldClient packet dispatch is fine since
+    // most encounters fire one combat event at a time.
+    public void EmitDirty()
+    {
+        if (_dirty.Count == 0) return;
+
+        // Snapshot then clear before emitting so any re-entrancy from the
+        // emit path doesn't see the same dirty mobs twice.
+        var toEmit = new List<WowGuid128>(_dirty);
+        _dirty.Clear();
+
+        foreach (var mob in toEmit)
+        {
+            if (!_threatLists.TryGetValue(mob, out var list) || list.Count == 0)
+                continue;
+
+            // Find the top threater. Ties broken arbitrarily — vanilla itself
+            // has tie-breaking quirks but they don't matter for display.
+            WowGuid128 newHighest = default;
+            double highestValue = -1;
+            foreach (var (threater, value) in list)
+            {
+                if (value > highestValue)
+                {
+                    highestValue = value;
+                    newHighest = threater;
+                }
+            }
+
+            var update = new ThreatUpdatePkt { UnitGUID = mob };
+            foreach (var (threater, value) in list)
+            {
+                update.ThreatList.Add(new ThreatInfo
+                {
+                    ThreaterGUID = threater,
+                    Threat = ToWireThreat(value),
+                });
+            }
+            SendToClient(update);
+
+            // Emit HIGHEST only when the top changes — saves churn but keeps
+            // tank-aggro indicators (red border, nameplate color) snappy.
+            _lastHighest.TryGetValue(mob, out var prevHighest);
+            if (prevHighest != newHighest)
+            {
+                _lastHighest[mob] = newHighest;
+                var highest = new HighestThreatUpdatePkt
+                {
+                    UnitGUID = mob,
+                    HighestThreatGUID = newHighest,
+                };
+                foreach (var (threater, value) in list)
+                {
+                    highest.ThreatList.Add(new ThreatInfo
+                    {
+                        ThreaterGUID = threater,
+                        Threat = ToWireThreat(value),
+                    });
+                }
+                SendToClient(highest);
+            }
+        }
+    }
+
+    // Wipe everything — used on session disconnect / character switch. Doesn't
+    // emit packets since the client connection is going away anyway.
+    public void Reset()
+    {
+        _threatLists.Clear();
+        _lastHighest.Clear();
+        _dirty.Clear();
+    }
+
+    // Called from the SMSG_DESTROY_OBJECT handler. Two cases to clean up:
+    //   1) The destroyed unit was a mob we tracked → ClearMob (emit SMSG_THREAT_CLEAR).
+    //   2) The destroyed unit was a threater (player who left, pet despawned) →
+    //      RemoveThreater across every mob that had them on its list.
+    public void OnUnitDestroyed(WowGuid128 guid)
+    {
+        if (guid == default) return;
+
+        // Case 1: this guid was a mob in our tracked set.
+        if (_threatLists.ContainsKey(guid))
+        {
+            ClearMob(guid);
+        }
+
+        // Case 2: this guid was a threater on some other mob's list. Scan all
+        // remaining lists. Vanilla group sizes keep this O(party) — cheap.
+        List<WowGuid128>? mobsToCleanup = null;
+        foreach (var (mob, list) in _threatLists)
+        {
+            if (list.ContainsKey(guid))
+            {
+                mobsToCleanup ??= new List<WowGuid128>();
+                mobsToCleanup.Add(mob);
+            }
+        }
+        if (mobsToCleanup != null)
+        {
+            foreach (var mob in mobsToCleanup)
+                RemoveThreater(mob, guid);
+            EmitDirty();
+        }
+    }
+
+    // Called by the SMSG combat-log observers in WorldClient handlers. Checks
+    // if the attacker is one of "my threaters" (the local player or their pet)
+    // and adds damage threat against the victim mob if so. Damage threat in
+    // vanilla is 1.0 × raw damage with no school multiplier (modifiers from
+    // class abilities like Defensive Stance ×1.45 ship in Phase 3+).
+    //
+    // Auto-flushes the dirty set so a single combat-log packet results in at
+    // most one SMSG_THREAT_UPDATE on the wire. Callers don't need to remember
+    // to call EmitDirty.
+    public void OnDamage(WowGuid128 attacker, WowGuid128 victim, double rawDamage)
+    {
+        if (rawDamage <= 0) return;
+        if (!IsLocalThreater(attacker)) return;
+        if (victim == default) return;
+
+        AddThreat(victim, attacker, rawDamage);
+        EmitDirty();
+    }
+
+    // True if the given GUID is the local player or a unit they currently own
+    // (pet, totem, guardian). Pet ownership is read from UNIT_FIELD_SUMMONEDBY
+    // on the unit's cached fields, which the legacy server populates and the
+    // proxy mirrors. We re-check on every event rather than caching because
+    // pets get swapped (Hunter Call Pet, Warlock summon swap) and the cost
+    // of one dictionary lookup per damage event is negligible.
+    private bool IsLocalThreater(WowGuid128 guid)
+    {
+        if (guid == default) return false;
+        var playerGuid = _session.GameState.CurrentPlayerGuid;
+        if (guid == playerGuid) return true;
+
+        var fields = _session.GameState.GetCachedObjectFieldsLegacy(guid);
+        if (fields == null) return false;
+
+        int summonedByIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY);
+        if (summonedByIdx < 0) return false;
+
+        WowGuid64 summonedBy64 = fields.GetGuidValue(summonedByIdx);
+        if (summonedBy64 == WowGuid64.Empty) return false;
+
+        WowGuid128 summonedBy128 = summonedBy64.To128(_session.GameState);
+        return summonedBy128 == playerGuid;
+    }
+
+    private static uint ToWireThreat(double rawThreat)
+    {
+        // Modern protocol packs threat × 100. Classic Era addons divide back
+        // down on read (verified in Details_TinyThreat.lua). Clamp to uint
+        // range to avoid wrap if some absurd encounter happens.
+        double scaled = rawThreat * 100.0;
+        if (scaled <= 0) return 0;
+        if (scaled >= uint.MaxValue) return uint.MaxValue;
+        return (uint)scaled;
+    }
+
+    private void SendToClient(ServerPacket packet)
+    {
+        var worldClient = _session.WorldClient;
+        if (worldClient == null) return;
+        worldClient.SendPacketToClient(packet);
+    }
+}

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -281,6 +281,21 @@ public sealed class ThreatTracker
         if (victim == default) return;
 
         AddThreat(victim, attacker, rawDamage);
+
+        if (_threatLists.TryGetValue(victim, out var list) &&
+            list.TryGetValue(attacker, out double newTotal))
+        {
+            Log.Event("threat.damage_added", new
+            {
+                attacker_low = attacker.GetCounter(),
+                attacker_is_player = attacker == _session.GameState.CurrentPlayerGuid,
+                victim_low = victim.GetCounter(),
+                damage = (long)rawDamage,
+                new_total = (long)newTotal,
+                threater_count = list.Count,
+            });
+        }
+
         EmitDirty();
     }
 

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -110,6 +110,52 @@ public sealed class ThreatTracker
         }
     }
 
+    // Bring threater up to the current top of mob's list (taunt semantics).
+    // Used by Warrior Taunt, Mocking Blow, Druid Growl. If the threater is
+    // already at or above the top, no-op. Marks dirty on success so the next
+    // EmitDirty pushes both the changed value and the new HIGHEST_THREAT_UPDATE.
+    public void SetToTop(WowGuid128 mob, WowGuid128 threater)
+    {
+        if (mob == default || threater == default) return;
+        if (!_threatLists.TryGetValue(mob, out var list))
+        {
+            list = new Dictionary<WowGuid128, double>();
+            _threatLists[mob] = list;
+        }
+
+        double topThreat = 0;
+        foreach (var v in list.Values)
+        {
+            if (v > topThreat) topThreat = v;
+        }
+
+        list.TryGetValue(threater, out double myThreat);
+        if (myThreat >= topThreat) return;
+
+        list[threater] = topThreat;
+        _dirty.Add(mob);
+    }
+
+    // Add (or subtract) flat threat across every mob the threater is currently
+    // tracked on. Used for buffs / utility casts that bump aggro on every mob
+    // already in combat with the player (Cleanse, Remove Lesser Curse, etc.).
+    // No-op for mobs the threater isn't already on — vanilla doesn't generate
+    // threat against unrelated mobs from these casts.
+    public void AddThreatToAllMobs(WowGuid128 threater, double amount)
+    {
+        if (threater == default || amount == 0) return;
+
+        foreach (var (mob, list) in _threatLists)
+        {
+            if (!list.TryGetValue(threater, out double existing))
+                continue;
+            double updated = existing + amount;
+            if (updated < 0) updated = 0;
+            list[threater] = updated;
+            _dirty.Add(mob);
+        }
+    }
+
     // Mob died, ran far away, evaded, etc. Remove its threat list entirely
     // and emit SMSG_THREAT_CLEAR so the modern client knows to drop it from
     // the threat APIs.

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -324,15 +324,16 @@ public sealed class ThreatTracker
         return summonedBy128 == playerGuid;
     }
 
-    private static uint ToWireThreat(double rawThreat)
+    private static long ToWireThreat(double rawThreat)
     {
-        // Modern protocol packs threat × 100. Classic Era addons divide back
-        // down on read (verified in Details_TinyThreat.lua). Clamp to uint
-        // range to avoid wrap if some absurd encounter happens.
+        // Modern protocol packs threat × 100 and writes int64 (8 bytes — see
+        // CombatPackets.cs comment). Classic Era addons divide by 100 on read
+        // (verified in Details_TinyThreat.lua). Clamp to long range; practical
+        // values are well within 32 bits but the wire field is 64.
         double scaled = rawThreat * 100.0;
         if (scaled <= 0) return 0;
-        if (scaled >= uint.MaxValue) return uint.MaxValue;
-        return (uint)scaled;
+        if (scaled >= long.MaxValue) return long.MaxValue;
+        return (long)scaled;
     }
 
     private void SendToClient(ServerPacket packet)

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -299,6 +299,20 @@ public sealed class ThreatTracker
         EmitDirty();
     }
 
+    // Called from SMSG_SPELL_GO observer for any spell cast that may modify
+    // threat (Distracting Shot, Disengage, Feign Death, Growl, Cower, ...).
+    // Routes to ThreatModules' per-spell-id handler. Auto-flushes the dirty
+    // set so the threat-update SMSG goes out alongside the SpellGo packet.
+    public void OnSpellCast(WowGuid128 caster, int spellId, IList<WowGuid128> hitTargets)
+    {
+        if (caster == default) return;
+
+        if (!ThreatModules.TryHandle(this, _session, spellId, caster, hitTargets))
+            return;
+
+        EmitDirty();
+    }
+
     // True if the given GUID is the local player or a unit they currently own
     // (pet, totem, guardian). Pet ownership is read from UNIT_FIELD_SUMMONEDBY
     // on the unit's cached fields, which the legacy server populates and the

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -46,9 +46,28 @@ public sealed class ThreatTracker
 
     private readonly GlobalSessionData _session;
 
+    // Passive threat multiplier cache. Recomputed on every threat operation
+    // (cheap) but the threat.passive_modifier event only emits on change,
+    // so testers can spot stance / form transitions without spamming logs.
+    private double _cachedPassiveModifier = 1.0;
+    private uint _cachedStanceFormAuraId = 0;
+
     public ThreatTracker(GlobalSessionData session)
     {
         _session = session;
+    }
+
+    // Adds threat with the local player's stance / form / class passive
+    // modifier applied. Use for ability-driven flat threat (Sunder, Distracting
+    // Shot, etc.) and damage threat. Set / multiply / set-to-top operations
+    // bypass this — those encode their own absolute values.
+    //
+    // Pet attacks always pass through unmodified (modifier = 1.0). Non-local
+    // threaters never reach here in the first place.
+    public void AddModifiedThreat(WowGuid128 mob, WowGuid128 threater, double rawAmount)
+    {
+        double modifier = GetPassiveModifier(threater);
+        AddThreat(mob, threater, rawAmount * modifier);
     }
 
     // Add (or subtract, if amount is negative) raw threat from a threater
@@ -141,15 +160,18 @@ public sealed class ThreatTracker
     // already in combat with the player (Cleanse, Remove Lesser Curse, etc.).
     // No-op for mobs the threater isn't already on — vanilla doesn't generate
     // threat against unrelated mobs from these casts.
-    public void AddThreatToAllMobs(WowGuid128 threater, double amount)
+    public void AddThreatToAllMobs(WowGuid128 threater, double rawAmount)
     {
-        if (threater == default || amount == 0) return;
+        if (threater == default || rawAmount == 0) return;
+
+        double modifier = GetPassiveModifier(threater);
+        double scaledAmount = rawAmount * modifier;
 
         foreach (var (mob, list) in _threatLists)
         {
             if (!list.TryGetValue(threater, out double existing))
                 continue;
-            double updated = existing + amount;
+            double updated = existing + scaledAmount;
             if (updated < 0) updated = 0;
             list[threater] = updated;
             _dirty.Add(mob);
@@ -326,7 +348,9 @@ public sealed class ThreatTracker
         if (!IsLocalThreater(attacker)) return;
         if (victim == default) return;
 
-        AddThreat(victim, attacker, rawDamage);
+        double modifier = GetPassiveModifier(attacker);
+        double scaledThreat = rawDamage * modifier;
+        AddThreat(victim, attacker, scaledThreat);
 
         if (_threatLists.TryGetValue(victim, out var list) &&
             list.TryGetValue(attacker, out double newTotal))
@@ -337,6 +361,8 @@ public sealed class ThreatTracker
                 attacker_is_player = attacker == _session.GameState.CurrentPlayerGuid,
                 victim_low = victim.GetCounter(),
                 damage = (long)rawDamage,
+                modifier,
+                threat_added = (long)scaledThreat,
                 new_total = (long)newTotal,
                 threater_count = list.Count,
             });
@@ -382,6 +408,137 @@ public sealed class ThreatTracker
 
         WowGuid128 summonedBy128 = summonedBy64.To128(_session.GameState);
         return summonedBy128 == playerGuid;
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 5 — passive threat multipliers from class + stance / form.
+    //
+    // Vanilla LibThreatClassic2 reads GetShapeshiftForm() and class talents to
+    // compute a `passiveThreatModifiers` value applied to every flat-add threat
+    // operation. We can't introspect talents from the proxy side (they live in
+    // the client), so we ship the no-talent baselines:
+    //
+    //   Warrior:
+    //     Defensive Stance (71)   → 1.30  (no Defiance)
+    //     Berserker Stance (2458) → 0.80
+    //     Battle Stance (2457) /
+    //       no stance             → 0.80  (matches the lib's quirk; lib treats
+    //                                      non-Defensive warriors as 0.8, see
+    //                                      ClassModules/Classic/Warrior.lua)
+    //
+    //   Druid:
+    //     Bear / Dire Bear Form
+    //       (5487 / 9634)         → 1.30  (no Feral Instinct)
+    //     Cat (768) /
+    //       Travel (783) /
+    //       Aquatic (1066)        → 0.71
+    //     Caster                  → 1.00
+    //
+    //   Rogue:                    → 0.71  (always; passive at ClassEnable)
+    //   All other classes:        → 1.00
+    //
+    // Future Phase 6+ will layer talent reads (Defiance, Feral Instinct,
+    // Subtlety, Shadow Affinity, Improved PWS) on top — those need the proxy
+    // to start mirroring talent state from CMSG_LEARN_TALENT and
+    // SMSG_INITIALIZE_FACTIONS-era talent data. Until then, these baselines
+    // run ~3-9% under the actual server-side numbers for talented characters.
+
+    // Stance / form spell IDs we watch on the player's aura table. HashSet so
+    // the per-event scan is O(slots) with O(1) per-slot membership check.
+    private static readonly HashSet<uint> StanceFormAuras = new()
+    {
+        71,    // Warrior — Defensive Stance
+        2457,  // Warrior — Battle Stance
+        2458,  // Warrior — Berserker Stance
+        5487,  // Druid — Bear Form
+        9634,  // Druid — Dire Bear Form
+        768,   // Druid — Cat Form
+        783,   // Druid — Travel Form
+        1066,  // Druid — Aquatic Form
+    };
+
+    // Returns the passive multiplier to apply to threater's flat-add threat.
+    // Pet (and other local threaters that aren't the player) always return 1.0
+    // since vanilla pets carry no stance / form / class modifier.
+    //
+    // Side effect: emits threat.passive_modifier on every value change so
+    // testers can correlate stance switches with threat shifts in the JSONL.
+    private double GetPassiveModifier(WowGuid128 threater)
+    {
+        if (threater != _session.GameState.CurrentPlayerGuid)
+            return 1.0;
+
+        uint formAura = ScanPlayerStanceFormAura();
+        var playerClass = (Class)_session.GameState.CurrentPlayerClass;
+        double modifier = ComputePassiveModifier(playerClass, formAura);
+
+        if (formAura != _cachedStanceFormAuraId || modifier != _cachedPassiveModifier)
+        {
+            Log.Event("threat.passive_modifier", new
+            {
+                player_class = (byte)playerClass,
+                stance_form_spell = formAura,
+                modifier,
+                previous_modifier = _cachedPassiveModifier,
+                previous_stance_form_spell = _cachedStanceFormAuraId,
+            });
+            _cachedStanceFormAuraId = formAura;
+            _cachedPassiveModifier = modifier;
+        }
+
+        return modifier;
+    }
+
+    private uint ScanPlayerStanceFormAura()
+    {
+        var fields = _session.GameState.GetCachedObjectFieldsLegacy(_session.GameState.CurrentPlayerGuid);
+        if (fields == null) return 0;
+
+        int unitFieldAura = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_AURA);
+        if (unitFieldAura < 0) return 0;
+
+        int slots = LegacyVersion.GetAuraSlotsCount();
+        for (int i = 0; i < slots; i++)
+        {
+            if (!fields.TryGetValue(unitFieldAura + i, out var field))
+                continue;
+            uint spellId = field.UInt32Value;
+            if (spellId != 0 && StanceFormAuras.Contains(spellId))
+                return spellId;
+        }
+        return 0;
+    }
+
+    private static double ComputePassiveModifier(Class playerClass, uint stanceFormAura)
+    {
+        switch (playerClass)
+        {
+            case Class.Rogue:
+                return 0.71;
+
+            case Class.Warrior:
+                return stanceFormAura switch
+                {
+                    71   => 1.30, // Defensive Stance
+                    2458 => 0.80, // Berserker Stance
+                    2457 => 0.80, // Battle Stance — matches lib's quirk
+                    _    => 0.80, // no stance — matches lib's else branch
+                };
+
+            case Class.Druid:
+                return stanceFormAura switch
+                {
+                    5487 => 1.30, // Bear Form
+                    9634 => 1.30, // Dire Bear Form
+                    768  => 0.71, // Cat Form
+                    783  => 0.71, // Travel Form
+                    1066 => 0.71, // Aquatic Form
+                    _    => 1.00, // caster form
+                };
+
+            default:
+                return 1.0;
+        }
     }
 
     private static long ToWireThreat(double rawThreat)

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -342,14 +342,20 @@ public sealed class ThreatTracker
     // Auto-flushes the dirty set so a single combat-log packet results in at
     // most one SMSG_THREAT_UPDATE on the wire. Callers don't need to remember
     // to call EmitDirty.
+    // Convenience overload for melee swings (no spell id) and other call
+    // sites that don't have spell context yet. Treats it as plain damage.
     public void OnDamage(WowGuid128 attacker, WowGuid128 victim, double rawDamage)
+        => OnDamage(attacker, victim, 0, rawDamage);
+
+    public void OnDamage(WowGuid128 attacker, WowGuid128 victim, int spellId, double rawDamage)
     {
         if (rawDamage <= 0) return;
         if (!IsLocalThreater(attacker)) return;
         if (victim == default) return;
 
-        double modifier = GetPassiveModifier(attacker);
-        double scaledThreat = rawDamage * modifier;
+        double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);
+        double passiveModifier = GetPassiveModifier(attacker);
+        double scaledThreat = rawDamage * abilityMultiplier * passiveModifier;
         AddThreat(victim, attacker, scaledThreat);
 
         if (_threatLists.TryGetValue(victim, out var list) &&
@@ -360,8 +366,10 @@ public sealed class ThreatTracker
                 attacker_low = attacker.GetCounter(),
                 attacker_is_player = attacker == _session.GameState.CurrentPlayerGuid,
                 victim_low = victim.GetCounter(),
+                spell_id = spellId,
                 damage = (long)rawDamage,
-                modifier,
+                ability_mult = abilityMultiplier,
+                passive_mod = passiveModifier,
                 threat_added = (long)scaledThreat,
                 new_total = (long)newTotal,
                 threater_count = list.Count,


### PR DESCRIPTION
 ## Summary

  - Vanilla 1.12 servers don't broadcast threat over the wire — threat tables live in
    server-side internal state. The modern 1.14 client expects `SMSG_THREAT_UPDATE` /
    `HIGHEST_THREAT_UPDATE` / `THREAT_REMOVE` / `THREAT_CLEAR` so its native APIs
    (`UnitDetailedThreatSituation`, `UNIT_THREAT_LIST_UPDATE`) populate. Without those
    packets every threat-aware addon (Details TinyThreat, TidyPlates_ThreatPlates,
    default UI target frame) reads zero.
  - This PR ports LibThreatClassic2 (the library KTMClassic uses) into the proxy.
    The proxy observes combat events forwarded from the legacy server, computes
    threat per the lib's rules, and emits the modern SMSG opcodes — modern threat
    addons now Just Work, no client mods needed.

  ## Architecture

  `HermesProxy/World/ThreatTracker.cs` owns the per-mob threat tables and the
  modern-opcode emit path. `HermesProxy/World/ThreatModules.cs` is a static
  registry mapping spell id → handler delegate, populated from
  `KTMClassic/Libs/LibThreatClassic2/ClassModules/Classic/*.lua`.

  SMSG_ATTACKER_STATE_UPDATE / SMSG_SPELL_NON_MELEE_DAMAGE_LOG ──┐
  SMSG_SPELL_PERIODIC_AURA_LOG (DoT ticks)                       ├──> OnDamage(spellId, raw)
  SMSG_SPELL_DAMAGE_SHIELD                                       ┘
  SMSG_SPELL_HEAL_LOG                                            ──> OnHeal(spellId, effective)
  SMSG_SPELL_PERIODIC_AURA_LOG (HoT ticks)                       ──> OnHeal(spellId, raw)
  SMSG_SPELL_GO  ──> OnSpellCast(spellId, hitTargets) ──> ThreatModules registry
  SMSG_PARTY_KILL_LOG / SMSG_DESTROY_OBJECT  ──> ClearMob / OnUnitDestroyed

  OnDamage  =  rawDamage × abilityMultiplier × passiveModifier  ──> AddThreat
  OnHeal    =  effectiveHeal × 0.5 × passiveModifier / |mobs threatening target|

  `EmitDirty()` batches per-mob updates so a single combat-log packet results in at
  most one `SMSG_THREAT_UPDATE` plus an optional `SMSG_HIGHEST_THREAT_UPDATE`
  (only when the top of the table actually changes).

  ## Phases

  | Phase | Scope |
  |---|---|
  | 1 | SMSG packet writers + `/say jpthreattest` smoke-test |
  | 2 | Damage threat for player and pet |
  | 2.5 | Clear mob threat on `SMSG_PARTY_KILL_LOG` |
  | 3 | Hunter + Pet abilities (Distracting Shot, Disengage, Feign Death, Growl, Cower) |
  | 4 | Warrior, Druid, Mage, Rogue, Paladin cast-success threat (incl. taunt-to-top, zero-multiplier abilities,
  add-to-all-mobs casts) |
  | 5 | Passive stance / form / class modifiers (Defensive Stance ×1.3, Cat Form ×0.71, Rogue ×0.71, etc.) |
  | 6 | Per-spell damage multipliers (Maul ×1.75, Earth Shock ×2, Mind Blast ×2, Holy Nova ×0, Holy Shield ×1.2) |
  | 7 | Heal threat — 0.5 × effective heal distributed across mobs threatening the heal target (direct heals + HoT
  ticks) |
  | 8 | Multi-target debuff threat (Demoralizing Shout, Demoralizing Roar) |
  | 9 | Multi-mob casts (Battle Shout, Paladin Lesser Blessings) |

  ## Validation

  End-to-end tested on Twinstar Kronos PTR with multiple JSONL bundles:

  - **Phase 2** — Hunter + pet damage stack correctly per damage event, pet appears
    as separate entry on the threat list.
  - **Phase 3** — Distracting Shot +600, Disengage -405, Feign Death zeroes player
    threat across all mobs. Pet Growl R6 +320 stacks. Math walks line-by-line.
  - **Phase 4** — Builds clean. Login regression caught and fixed mid-PR
    (`TypeInitializationException` → static constructor pattern).
  - **Phase 5** — Druid Cat Form transition: `threat.passive_modifier` event
    fires once on form switch, every subsequent damage scales by 0.71 exactly
    (246→174, 71→50, 82→58, 115→81, 153→108).
  - **Phase 6** — Priest Mind Blast: 608 raw × 2.0 ability_mult × 1.0 passive_mod
    → 1216 threat_added.
  - **Phase 7** — Priest heal threat: Renew (286→143), Holy Nova (7→3), Flash Heal
    (116→58, 221→110), Greater Heal (1362→681). All ÷2 math walks.
  - **Phase 8** — Warrior Demoralizing Shout R5: 3 events with `target_count: 3`,
    amount 43 to each of 3 mobs hit.
  - **Phase 9** — Warrior Battle Shout R2 (amount 12) + Paladin Lesser Blessing of
    Wisdom R5 (amount 54), per-rank lookup correct.

  ## Diagnostics

  Every event ships a `threat.*` `Log.Event` so testers can debug from JSONL
  without addon-side instrumentation:

  - `threat.damage_added` — every damage event, with `spell_id`, `ability_mult`,
    `passive_mod`, `threat_added`, `new_total`
  - `threat.heal_added` — heals, with split-distribution math
  - `threat.spell.{ability_name}` — every cast-success threat handler
  - `threat.passive_modifier` — fires on stance / form / class change only
  - `threat.mob_cleared` — mob death / despawn cleanup

  ## Out of Scope (deferred)

  - **Talent reads** (Defiance, Feral Instinct, Subtlety, Shadow Affinity,
    Improved PWS, Improved Righteous Fury). Multipliers run ~3-15% under the
    fully-talented numbers. Needs proxy-side talent mirror.
  - **School-based threat multipliers** (Mage fire/frost/arcane, Priest shadow,
    Paladin Holy under Righteous Fury).
  - **Item set bonuses** (Mage Netherwind, Warlock Plagueheart/Nemesis, Rogue
    Bonescythe, Warrior Might, Priest Vestments).
  - **Greater Blessings** — scales by raid class headcount; needs raid roster.
  - **Group sync** — other party members' threat from raid combat log; without
    this, heal threat is invisible to pure healers (only mobs the proxy-side
    player has personally engaged enter the threat list).

  These are additive layers — none of them require touching the existing
  ThreatTracker / ThreatModules architecture, just adding new state plus
  multiplier hooks. Ship as follow-up PRs.

  ## Test plan

  - [x] Phase 2 damage walk validated on hunter+pet
  - [x] Phase 3 Hunter abilities (Distracting Shot, Disengage, Feign Death) validated
  - [x] Phase 3 Pet Growl validated, pet attribution working
  - [x] Phase 4 build clean (warrior abilities untestable on PTR — questline-locked)
  - [x] Phase 5 Druid Cat Form modifier transition validated
  - [x] Phase 6 Priest Mind Blast 2.0× validated
  - [x] Phase 7 heal threat validated (Renew, Holy Nova, Flash Heal, Greater Heal)
  - [x] Phase 8 Demoralizing Shout R5 validated, target_count=3 multi-hit
  - [x] Phase 9 Battle Shout R2 + Lesser Blessing of Wisdom R5 validated