### PR TITLE
Add cast-time spell queue: hold last press during cast, fire on SPELL_GO

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -164,6 +164,47 @@ public sealed class GameSessionData
     private uint _lastFiredSpellId;                     // spell ID forwarded by the timer; used to drop same-spell late presses
     public Action<ClientCastRequest>? OnGcdHeldCastFire; // set by WorldSocket at attach time; invoked on a ThreadPool thread at GCD expiry
 
+    // JimsProxy: cast-time spell queue. While a cast-time spell is in progress
+    // (HasStartedNormalCast), presses are held here instead of dropped. Fired
+    // on SPELL_GO when the cast completes. Most-recent-press-wins, one slot.
+    private ClientCastRequest? _heldCastTimeCast;
+
+    public ClientCastRequest? HoldCastDuringCastTime(ClientCastRequest cast)
+    {
+        lock (_gcdLock)
+        {
+            var displaced = _heldCastTimeCast;
+            _heldCastTimeCast = cast;
+            return displaced;
+        }
+    }
+
+    public ClientCastRequest? TakeHeldCastTimeCast()
+    {
+        lock (_gcdLock)
+        {
+            var cast = _heldCastTimeCast;
+            _heldCastTimeCast = null;
+            return cast;
+        }
+    }
+
+    public void ClearHeldCastTimeCast()
+    {
+        lock (_gcdLock) { _heldCastTimeCast = null; }
+    }
+
+    public bool HasNonStartedPendingCastForSpell(uint spellId)
+    {
+        foreach (var item in PendingNormalCasts)
+        {
+            if (!item.HasStarted &&
+                (item.SpellId == spellId || (item.LegacySpellId != 0 && item.LegacySpellId == spellId)))
+                return true;
+        }
+        return false;
+    }
+
     // JimsProxy: proxy→server RTT measurement for adaptive GCD fire offset.
     private readonly object _rttLock = new();
     private long _lastPingSendTickMs;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -211,6 +211,7 @@ public partial class WorldClient
             SendPacketToClient(failed);
 
             var gameState = GetSession().GameState;
+            gameState.ClearHeldCastTimeCast();
             if (!gameState.IsGcdHoldActive() && !gameState.HasForwardedPendingCast())
             {
                 var heldCast = gameState.TakeHeldCastIfReady();
@@ -822,6 +823,17 @@ public partial class WorldClient
                     });
                     gameStateAfter.OnGcdHeldCastFire?.Invoke(heldCast);
                 }
+            }
+
+            var heldCastTime = gameStateAfter.TakeHeldCastTimeCast();
+            if (heldCastTime != null)
+            {
+                Log.Event("cast.held_fire_on_cast_complete", new
+                {
+                    completed_spell_id = spell.Cast.SpellID,
+                    held_spell_id = heldCastTime.SpellId,
+                });
+                gameStateAfter.OnGcdHeldCastFire?.Invoke(heldCastTime);
             }
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -251,20 +251,35 @@ public partial class WorldSocket
             // 1.12 client would fire these mid-cast-bar and mid-GCD, so we match that.
             if (!isOffGcd)
             {
-                // Drop duplicate presses while a cast is started or in-flight.
-                // Send SpellPrepare + CastFailed(DontReport) to resolve the client's
-                // per-press pending button state without visible error toasts.
-                bool gateStarted = GetSession().GameState.HasStartedNormalCast();
-                bool gateInFlight = GetSession().GameState.HasInFlightNormalCastForSpell((uint)cast.Cast.SpellID);
-                if (gateStarted || gateInFlight)
+                // Guard: RTT-window duplicate — same spell forwarded but not yet started
+                if (GetSession().GameState.HasNonStartedPendingCastForSpell((uint)cast.Cast.SpellID))
                 {
                     Log.Event("cast.dropped.duplicate", new
                     {
                         spell_id = cast.Cast.SpellID,
-                        reason = gateInFlight ? "in_flight_same_spell_cast_spell" : "another_cast_started",
+                        reason = "in_flight_same_spell",
                         client_cast_id = cast.Cast.CastID.ToString(),
                         queue_depth = GetSession().GameState.PendingNormalCasts.Count,
                     });
+                    SendCastFailedWithoutPrepare(castRequest);
+                    return;
+                }
+
+                // Guard: cast-time spell in progress — hold (most-recent-wins, hidden queue)
+                if (GetSession().GameState.HasStartedNormalCast())
+                {
+                    WorldPacket heldPacket = BuildCastSpellPacket(cast);
+                    castRequest.HeldPacketForReplay = heldPacket;
+                    castRequest.HeldAtTickMs = Environment.TickCount64;
+                    var displaced = GetSession().GameState.HoldCastDuringCastTime(castRequest);
+                    Log.Event("cast.held_during_cast", new
+                    {
+                        spell_id = cast.Cast.SpellID,
+                        displaced_spell_id = displaced?.SpellId ?? 0,
+                        client_cast_id = castRequest.ClientGUID.ToString(),
+                    });
+                    if (displaced != null)
+                        SendCastFailedWithoutPrepare(displaced);
                     SendCastFailedWithoutPrepare(castRequest);
                     return;
                 }


### PR DESCRIPTION
## Summary

- Cast-time spells (Frostbolt, heals, Shadowbolt) had no spell queue — `HasStartedNormalCast()` dropped all presses during an active cast bar. For spells with cast time > GCD, the GCD hold couldn't help. Players had to wait for the cast to fully complete before pressing, adding a visible gap.
- Adds a `_heldCastTimeCast` hold slot (same pattern as GCD hold). Most-recent-press-wins, fired on SPELL_GO.
- Splits the combined `HasStartedNormalCast`/`HasInFlightNormalCastForSpell` guard into two: non-started in-flight duplicates are still dropped (RTT-window guard), but started casts now HOLD instead of drop.
- `HasInFlightNormalCastForSpell` narrowed to `HasNonStartedPendingCastForSpell` so same-spell queuing (Frostbolt during Frostbolt) works.
- Hidden queue pattern (no SpellPrepare for held cast, matching GCD hold).

## Test plan

- [x] Chain 5+ Frostbolts spam-pressing during cast — smooth, JSONL shows `cast.held_during_cast` + `cast.held_fire_on_cast_complete`
- [x] Instant-cast spam (Arcane Explosion) — unaffected, uses GCD hold path
- [x] Cancel mid-cast (movement) — held cast discarded via HandleCastFailed clear
- [x] Target dies mid-cast — next cast on new target works immediately
- [x] Mount double-tap — second press held, fired, server rejects harmlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)