### PR TITLE
Clear cast-time hold on SPELL_FAILURE dequeue

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -521,6 +521,8 @@ public partial class WorldClient
             failed.Reason = reason;
             failed.CastID = pendingNormal.ServerGUID;
             SendPacketToClient(failed);
+
+            GetSession().GameState.ClearHeldCastTimeCast();
         }
         else if (GetSession().GameState.CurrentPetGuid == casterUnit &&
                  GetSession().GameState.TryDequeuePendingPetCast(spellId, out var pendingPet))


### PR DESCRIPTION
## Summary

One-liner interaction fix for #137 + #136. HandleSpellFailure dequeues the active cast when Kronos skips CAST_FAILED, but didn't clear the `_heldCastTimeCast` slot. If the player pressed during the cast bar (held via #136), the stale held cast would fire spuriously on the next SPELL_GO.

## Test plan

- [ ] Cast Frostbolt, press Frostbolt during cast, target dies mid-cast (SPELL_FAILURE) — next cast on new target fires cleanly, no double-cast

🤖 Generated with [Claude Code](https://claude.com/claude-code)