### PR TITLE
Fix Kronos auth ban after logout: remove double realmd auth, add logout flag

### DIFF
--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -71,7 +71,7 @@ public static class Settings
         StructuredLog = config.GetBoolean("StructuredLog", true);
         VerboseLog = config.GetBoolean("VerboseLog", false);
         SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
-        EnableUnplannedReconnect = config.GetBoolean("EnableUnplannedReconnect", true);
+        EnableUnplannedReconnect = config.GetBoolean("EnableUnplannedReconnect", false);
         UnplannedReconnectTimeoutMs = Math.Clamp(config.GetInt("UnplannedReconnectTimeoutMs", 5000), 1000, 30000);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1830,6 +1830,29 @@ public class GlobalSessionData
     // 0 = idle, 1 = attempt in flight. Compare-and-swapped at entry; reset in finally.
     private int _reconnectInProgress;
 
+    // Intentional-logout/disconnect flag. Set when the player initiates logout
+    // (CMSG_LOGOUT_REQUEST forwarded) or the modern client sends CMSG_LOG_DISCONNECT.
+    // Cleared on SMSG_LOGOUT_CANCEL_ACK and CMSG_PLAYER_LOGIN (fresh session).
+    // Cross-thread: RealmSocket thread writes (CMSG_LOG_DISCONNECT),
+    // WorldClient ReceiveLoop thread reads (HandleDisconnect).
+    // Accessed via Volatile.Write/Read for memory ordering.
+    private int _logoutOrDisconnectIntentional;
+
+    public void SetLogoutIntentional()
+    {
+        Volatile.Write(ref _logoutOrDisconnectIntentional, 1);
+    }
+
+    public void ClearLogoutIntentional()
+    {
+        Volatile.Write(ref _logoutOrDisconnectIntentional, 0);
+    }
+
+    public bool IsLogoutIntentional()
+    {
+        return Volatile.Read(ref _logoutOrDisconnectIntentional) != 0;
+    }
+
     public void TryUnplannedReconnectAndPropagate(
         World.Client.WorldClient deadClient,
         string? originalExceptionType = null,

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -358,6 +358,7 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_LOGOUT_CANCEL_ACK)]
     void HandleLogoutCancelAck(WorldPacket packet)
     {
+        GetSession().ClearLogoutIntentional();
         LogoutCancelAck logout = new LogoutCancelAck();
         SendPacketToClient(logout);
     }

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -260,16 +260,23 @@ public partial class WorldClient
                 ms_since_last_opcode = _lastInboundOpcodeTick == 0 ? -1 : Environment.TickCount - _lastInboundOpcodeTick,
                 was_active_world_client = wasActiveWorldClient,
             });
-            // JimsProxy (unplanned-dc-auto-reconnect): when this is a genuinely
-            // unplanned DC (we were the active client, no realm swap is replacing us),
-            // try one cached-key reconnect. If that fails, propagate cleanly to the
-            // modern client. Realm-swap path (wasActiveWorldClient == false) skips this
-            // — the new WorldClient is already in flight and will handle continuity.
-            // No exception to forward here — this path is hit on a clean read failure
-            // (zero bytes / FIN), not an exception. The reason string ("header"/"payload")
-            // is already in `session.ondisconnect.suppressed` as `disconnect_reason`.
             if (wasActiveWorldClient)
-                session!.TryUnplannedReconnectAndPropagate(this);
+            {
+                if (session!.IsLogoutIntentional())
+                {
+                    Log.Event("session.unplanned_reconnect.skipped_intentional_logout", new
+                    {
+                        disconnect_reason = reason,
+                    });
+                    session.PropagateUnplannedDcToModern(
+                        Guid.NewGuid().ToString("N")[..8],
+                        "intentional_logout");
+                }
+                else
+                {
+                    session.TryUnplannedReconnectAndPropagate(this);
+                }
+            }
         }
     }
 
@@ -340,17 +347,24 @@ public partial class WorldClient
                     ms_since_last_opcode = _lastInboundOpcodeTick == 0 ? -1 : Environment.TickCount - _lastInboundOpcodeTick,
                     was_active_world_client = wasActiveWorldClient,
                 });
-                // JimsProxy (unplanned-dc-auto-reconnect): same logic as HandleDisconnect.
-                // Bundle 20260503-195159 showed Kronos PTR forcibly closing the proxy's
-                // TCP socket mid-combat (TCP RST, last_opcode SMSG_ON_MONSTER_MOVE), then
-                // 37s of frozen ghost world before the player gave up and logged out.
-                // Now: try one reconnect, fall back to clean DC. Forward the exception
-                // type/message and SocketError code so a JSONL bundle shows *why* the
-                // server cut us off (Warden mid-session vs network reset vs server crash).
                 if (wasActiveWorldClient)
                 {
-                    int? socketErrorCode = (e is SocketException se) ? (int)se.SocketErrorCode : null;
-                    session!.TryUnplannedReconnectAndPropagate(this, e.GetType().Name, e.Message, socketErrorCode);
+                    if (session!.IsLogoutIntentional())
+                    {
+                        Log.Event("session.unplanned_reconnect.skipped_intentional_logout", new
+                        {
+                            exception_type = e.GetType().Name,
+                            exception_message = e.Message,
+                        });
+                        session.PropagateUnplannedDcToModern(
+                            Guid.NewGuid().ToString("N")[..8],
+                            "intentional_logout");
+                    }
+                    else
+                    {
+                        int? socketErrorCode = (e is SocketException se) ? (int)se.SocketErrorCode : null;
+                        session.TryUnplannedReconnectAndPropagate(this, e.GetType().Name, e.Message, socketErrorCode);
+                    }
                 }
             }
         }

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -214,6 +214,7 @@ public partial class WorldSocket
         SendConnectToInstance(ConnectToSerial.WorldAttempt1);
         GetSession().GameState.IsConnectedToInstance = true;
         GetSession().GameState.IsFirstEnterWorld = true;
+        GetSession().ClearLogoutIntentional();
         GetSession().GameState.CurrentPlayerGuid = playerLogin.Guid;
         GetSession().GameState.CurrentPlayerInfo = GetSession().GameState.OwnCharacters.Single(x => x.CharacterGuid == playerLogin.Guid);
         GetSession().GameState.CurrentPlayerStorage.LoadCurrentPlayer();
@@ -235,6 +236,7 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_LOGOUT_REQUEST)]
     void HandleLogoutRequest(LogoutRequest logoutRequest)
     {
+        GetSession().SetLogoutIntentional();
         WorldPacket packet = new WorldPacket(Opcode.CMSG_LOGOUT_REQUEST);
         SendPacketToServer(packet);
     }

--- a/HermesProxy/World/Server/PacketHandlers/SessionHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SessionHandler.cs
@@ -12,7 +12,6 @@ using Framework.Web;
 using Google.Protobuf;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Server.Packets;
-using AuthResult = HermesProxy.Auth.AuthResult;
 
 namespace HermesProxy.World.Server;
 
@@ -24,51 +23,17 @@ public partial class WorldSocket
         ChangeRealmTicketResponse response = new();
         response.Token = request.Token;
 
-        // JimsProxy: realm-swap diagnostics. CHANGE_REALM_TICKET is the modern client's
-        // signal that it intends to (re)select a realm — fires both on initial pick from
-        // the realm list and on any subsequent swap (e.g. PTR↔Live). The Reconnect()
-        // below only runs if AuthClient is currently disconnected; if it's still alive
-        // the ticket reuses the existing SRP-derived session key. The session key prefix
-        // before/after lets us see whether a fresh SRP key was actually derived, since
-        // the new realm will reject reuse of the prior realm's key.
-        bool authWasConnected = GetSession().AuthClient != null && GetSession().AuthClient.IsConnected();
-        string keyBefore = SafeAuthKeyPrefix(GetSession().AuthClient);
-        bool reconnectAttempted = false;
-        string? reconnectResult = null;
-
-        if (GetSession().AuthClient != null && !GetSession().AuthClient.IsConnected())
-        {
-            reconnectAttempted = true;
-            var rc = GetSession().AuthClient.Reconnect();
-            reconnectResult = rc.ToString();
-            if (rc != AuthResult.SUCCESS)
-            {
-                Log.Event("realm.swap.change_ticket", new
-                {
-                    phase = "reconnect_failed",
-                    auth_was_connected = authWasConnected,
-                    reconnect_attempted = reconnectAttempted,
-                    reconnect_result = reconnectResult,
-                    auth_key_prefix_before = keyBefore,
-                });
-                Log.Print(LogType.Error, "Failed to reconnect to auth server.");
-                response.Allow = false;
-                SendPacket(response);
-                return;
-            }
-        }
-        // GetSession().AuthClient.SendRealmListUpdateRequest();
-
-        string keyAfter = SafeAuthKeyPrefix(GetSession().AuthClient);
+        // JimsProxy: removed AuthClient.Reconnect() that previously fired here when
+        // the realmd socket was closed. Kronos closes the realmd TCP after sending the
+        // realmlist, so Reconnect() fired on EVERY realm select — doing a full SRP6
+        // LOGON_CHALLENGE that doubled the auth count per login and tripped Kronos's
+        // rate limiter after a few login cycles. The session key from the initial
+        // ConnectToAuthServer persists in the realmd DB until the next login, so the
+        // world server's CMSG_AUTH_SESSION validation still works without re-authing.
         Log.Event("realm.swap.change_ticket", new
         {
             phase = "ok",
-            auth_was_connected = authWasConnected,
-            reconnect_attempted = reconnectAttempted,
-            reconnect_result = reconnectResult,
-            auth_key_prefix_before = keyBefore,
-            auth_key_prefix_after = keyAfter,
-            auth_key_changed = keyBefore != keyAfter,
+            auth_connected = GetSession().AuthClient != null && GetSession().AuthClient.IsConnected(),
         });
 
         _bnetRpc.SetClientSecret(request.Secret);
@@ -77,25 +42,6 @@ public partial class WorldSocket
         response.Ticket = new ByteBuffer(new byte[1]);
 
         SendPacket(response);
-    }
-
-    // JimsProxy: 4-byte hex prefix of the SRP-derived session key. Safe against null
-    // AuthClient and empty key arrays. Used by realm.swap.* events so we can correlate
-    // whether the key actually rotated between phases without leaking the full secret.
-    private static string SafeAuthKeyPrefix(HermesProxy.Auth.AuthClient? authClient)
-    {
-        if (authClient == null) return "<null>";
-        try
-        {
-            var key = authClient.GetSessionKey();
-            if (key == null || key.Length == 0) return "<empty>";
-            int n = Math.Min(4, key.Length);
-            return Convert.ToHexString(key, 0, n);
-        }
-        catch
-        {
-            return "<error>";
-        }
     }
 
     [PacketHandler(Opcode.CMSG_BATTLENET_REQUEST)]

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -321,6 +321,7 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 Log.Print(LogType.Server, $"Client disconnected with reason {reason}.");
                 if (_connectType == ConnectionType.Realm)
                 {
+                    GetSession().SetLogoutIntentional();
                     if (GetSession().AuthClient != null)
                         GetSession().AuthClient.Disconnect();
                     if (GetSession().WorldClient != null)
@@ -691,6 +692,7 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 previous_was_authenticated = previousWorldClient.IsAuthenticated(),
                 new_realm_index = (uint)_realmId.Index,
             });
+            previousWorldClient.Disconnect();
         }
 
         GetSession().WorldClient = new Client.WorldClient();


### PR DESCRIPTION
Cherry-pick of the auth ban fix onto clean master (the original #132 merge accidentally pulled all beta history).

## Summary
- Remove double realmd auth that tripped Kronos rate limiter after 3 login cycles
- Add intentional-logout flag to suppress reconnect during logout countdown
- Disconnect orphaned WorldClients during realm swap
- Default EnableUnplannedReconnect to false