### PR TITLE
Auctionator fix

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -133,6 +133,23 @@ public sealed class GameSessionData
     public uint CurrentGuildNumAccounts;
     public WowGuid128 CurrentInteractedWithNPC;
     public WowGuid128 CurrentInteractedWithGO;
+    // JimsProxy: Auctionator-style Full Scan synthesis state. CMSG_AUCTION_REPLICATE_ITEMS
+    // has no legacy 1.12 equivalent; the proxy walks pages internally via
+    // CMSG_AUCTION_LIST_ITEMS at the canonical 6s cooldown and assembles rows
+    // into one SMSG_AUCTION_REPLICATE_RESPONSE. Default Browse-UI Search uses
+    // CMSG_AUCTION_LIST_ITEMS (different opcode), so every REPLICATE_ITEMS is
+    // by definition a full-AH scan request — no side-channel needed to
+    // differentiate. Lock guards every read/write: accumulator is appended
+    // from the WorldClient SMSG thread and read from the WorldSocket CMSG thread.
+    public bool AuctionReplicateInProgress;
+    public int AuctionReplicatePage;
+    public WowGuid128 AuctionReplicateAuctioneer = WowGuid128.Empty;
+    public uint AuctionReplicateChangeNumberGlobal;
+    public uint AuctionReplicateChangeNumberCursor;
+    public uint AuctionReplicateChangeNumberTombstone;
+    public List<World.Server.Packets.AuctionItem> AuctionReplicateAccumulator = new();
+    public readonly Lock AuctionReplicateLock = new();
+    public DateTime AuctionReplicateStartTime;
     public uint LastWhoRequestId;
     public WowGuid128 CurrentPetGuid;
     public WowGuid64 CurrentAttackTarget;        // active CMSG_ATTACK_SWING victim, cleared on ATTACK_STOP/CANCEL_COMBAT

--- a/HermesProxy/World/Client/PacketHandlers/AuctionHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/AuctionHandler.cs
@@ -5,11 +5,17 @@ using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace HermesProxy.World.Client;
 
 public partial class WorldClient
 {
+    // JimsProxy: gap between proxy-internal CMSG_AUCTION_LIST_ITEMS during a Full
+    // Scan walk. 200ms slack above the canonical 6s vanilla cooldown so we never
+    // graze Kronos's per-session anti-flood drop (documented in Kronos AH cooldown
+    // memory: rapid AH queries silently drop and risk a session kick).
+    private const int AuctionReplicatePageGapMs = 6200;
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.MSG_AUCTION_HELLO)]
     void HandleAuctionHello(WorldPacket packet)
@@ -121,6 +127,23 @@ public partial class WorldClient
         if (auction.DesiredDelay < MinDesiredDelayMs)
             auction.DesiredDelay = MinDesiredDelayMs;
 
+        // JimsProxy: while a Full Scan / GetAll is in progress the proxy is the
+        // one driving the per-page CMSG_AUCTION_LIST_ITEMS — the modern client
+        // never sent these and must not see them. Accumulate instead, then
+        // either schedule the next page (if the page came back full) or
+        // finalize into one SMSG_AUCTION_REPLICATE_RESPONSE.
+        var gameState = GetSession().GameState;
+        bool replicating;
+        lock (gameState.AuctionReplicateLock)
+        {
+            replicating = gameState.AuctionReplicateInProgress;
+        }
+        if (replicating)
+        {
+            HandleReplicatePageResult(auction);
+            return;
+        }
+
         Log.Event("auction.list.result", new
         {
             items_returned = auction.Items.Count,
@@ -129,6 +152,149 @@ public partial class WorldClient
         });
 
         SendPacketToClient(auction);
+    }
+
+    private void HandleReplicatePageResult(AuctionListItemsResult page)
+    {
+        var gameState = GetSession().GameState;
+        int currentPage;
+        int totalSoFar;
+        WowGuid128 auctioneer;
+        bool isLastPage;
+
+        lock (gameState.AuctionReplicateLock)
+        {
+            // The session may have been aborted (logout / disconnect) while the
+            // legacy result was in flight — drop on the floor in that case.
+            if (!gameState.AuctionReplicateInProgress)
+                return;
+
+            gameState.AuctionReplicateAccumulator.AddRange(page.Items);
+            currentPage = gameState.AuctionReplicatePage;
+            totalSoFar = gameState.AuctionReplicateAccumulator.Count;
+            auctioneer = gameState.AuctionReplicateAuctioneer;
+
+            // Short page = server says "no more rows".
+            isLastPage = page.Items.Count < Server.WorldSocket.AuctionLegacyPageSize;
+
+            if (!isLastPage)
+                gameState.AuctionReplicatePage = currentPage + 1;
+        }
+
+        Log.Event("auction.replicate.page_received", new
+        {
+            page = currentPage,
+            items_in_page = page.Items.Count,
+            items_total = totalSoFar,
+            is_last = isLastPage,
+        });
+
+        if (isLastPage)
+        {
+            FinalizeReplicate();
+        }
+        else
+        {
+            // Periodic progress update — every 5 pages ≈ 30s on the 6s cooldown.
+            if ((currentPage + 1) % 5 == 0)
+            {
+                ChatPkt progress = new ChatPkt(GetSession(), ChatMessageTypeModern.System,
+                    $"Full Scan: page {currentPage + 1}...");
+                SendPacketToClient(progress);
+            }
+            ScheduleNextReplicatePage(auctioneer, (uint)(currentPage + 1));
+        }
+    }
+
+    private void ScheduleNextReplicatePage(WowGuid128 auctioneer, uint nextPage)
+    {
+        Task.Delay(AuctionReplicatePageGapMs).ContinueWith(_ =>
+        {
+            try
+            {
+                var gameState = GetSession().GameState;
+                lock (gameState.AuctionReplicateLock)
+                {
+                    if (!gameState.AuctionReplicateInProgress)
+                        return;
+                }
+                var worldClient = GetSession().WorldClient;
+                if (worldClient == null || !worldClient.IsConnected())
+                {
+                    Log.Event("auction.replicate.aborted", new { reason = "world_client_disconnected" });
+                    AbortReplicate();
+                    return;
+                }
+                var socket = GetSession().InstanceSocket;
+                if (socket == null)
+                {
+                    Log.Event("auction.replicate.aborted", new { reason = "no_instance_socket" });
+                    AbortReplicate();
+                    return;
+                }
+                socket.SendReplicatePageQuery(auctioneer, nextPage);
+            }
+            catch (Exception ex)
+            {
+                Log.Event("auction.replicate.aborted", new { reason = "exception", message = ex.Message });
+                AbortReplicate();
+            }
+        });
+    }
+
+    private void FinalizeReplicate()
+    {
+        var gameState = GetSession().GameState;
+        AuctionReplicateResponse resp;
+        int finalCount;
+        int finalPage;
+        TimeSpan elapsed;
+
+        lock (gameState.AuctionReplicateLock)
+        {
+            if (!gameState.AuctionReplicateInProgress)
+                return;
+
+            resp = new AuctionReplicateResponse
+            {
+                Result = 0,
+                DesiredDelay = 6000,
+                ChangeNumberGlobal = gameState.AuctionReplicateChangeNumberGlobal,
+                ChangeNumberCursor = gameState.AuctionReplicateChangeNumberCursor,
+                ChangeNumberTombstone = gameState.AuctionReplicateChangeNumberTombstone,
+                Items = new List<AuctionItem>(gameState.AuctionReplicateAccumulator),
+            };
+            finalCount = resp.Items.Count;
+            finalPage = gameState.AuctionReplicatePage;
+            elapsed = DateTime.UtcNow - gameState.AuctionReplicateStartTime;
+            gameState.AuctionReplicateInProgress = false;
+            gameState.AuctionReplicateAccumulator.Clear();
+        }
+
+        SendPacketToClient(resp);
+
+        ChatPkt done = new ChatPkt(GetSession(), ChatMessageTypeModern.System,
+            $"Full Scan complete: {finalPage + 1} pages in {(long)elapsed.TotalSeconds}s.");
+        SendPacketToClient(done);
+
+        Log.Event("auction.replicate.complete", new
+        {
+            items = finalCount,
+            pages = finalPage + 1,
+            elapsed_seconds = (long)elapsed.TotalSeconds,
+        });
+    }
+
+    private void AbortReplicate()
+    {
+        var gameState = GetSession().GameState;
+        lock (gameState.AuctionReplicateLock)
+        {
+            if (!gameState.AuctionReplicateInProgress)
+                return;
+            gameState.AuctionReplicateInProgress = false;
+            gameState.AuctionReplicateAccumulator.Clear();
+        }
     }
 
     [PacketHandler(Opcode.SMSG_AUCTION_COMMAND_RESULT)]

--- a/HermesProxy/World/Server/PacketHandlers/AuctionHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/AuctionHandler.cs
@@ -76,6 +76,35 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_AUCTION_LIST_ITEMS)]
     void HandleAuctionListItems(AuctionListItems auction)
     {
+        // JimsProxy: while a Full Scan is in progress, the proxy is internally
+        // paginating CMSG_AUCTION_LIST_ITEMS at the 6s cooldown. A user search
+        // click during that window would race for the same Kronos query slot
+        // and trip its anti-flood drop, kicking us. Reject with a chat-system
+        // line so the player knows scan is running.
+        var replicateState = GetSession().GameState;
+        bool replicateActive;
+        int replicatePage;
+        int replicateAccum;
+        lock (replicateState.AuctionReplicateLock)
+        {
+            replicateActive = replicateState.AuctionReplicateInProgress;
+            replicatePage = replicateState.AuctionReplicatePage;
+            replicateAccum = replicateState.AuctionReplicateAccumulator.Count;
+        }
+        if (replicateActive)
+        {
+            Log.Event("auction.list.rejected_replicate_in_progress", new
+            {
+                replicate_page = replicatePage,
+                replicate_items_so_far = replicateAccum,
+                name = auction.Name,
+            });
+            ChatPkt notice = new ChatPkt(GetSession(), ChatMessageTypeModern.System,
+                $"Full Scan in progress (page {replicatePage}, {replicateAccum} items). Please wait for it to finish before searching.");
+            GetSession().WorldClient!.SendPacketToClient(notice);
+            return;
+        }
+
         var now = DateTime.UtcNow;
         var elapsedMs = (now - _lastSearchTime).TotalMilliseconds;
         var cooldownMs = AuctionSearchCooldownSeconds * 1000.0;
@@ -769,6 +798,111 @@ public partial class WorldSocket
         packet.WriteGuid(auction.Auctioneer.To64());
         packet.WriteUInt32(auction.AuctionID);
         SendPacketToServer(packet);
+    }
+
+    // JimsProxy: legacy 1.12 vanilla page size for SMSG_AUCTION_LIST_ITEMS_RESULT.
+    // Mirrors Auctionator.Constants.MaxResultsPerPage; a returned page shorter than
+    // this is the last page and ends the replicate walk.
+    internal const int AuctionLegacyPageSize = 50;
+
+    [PacketHandler(Opcode.CMSG_AUCTION_REPLICATE_ITEMS)]
+    void HandleAuctionReplicateItems(AuctionReplicateItems req)
+    {
+        // CMSG_AUCTION_REPLICATE_ITEMS is the modern Full Scan opcode. Default
+        // Browse-UI Search uses CMSG_AUCTION_LIST_ITEMS (different opcode,
+        // different handler), so any REPLICATE_ITEMS arriving here came from an
+        // addon (Auctionator / Auctioneer / etc.) explicitly calling
+        // C_AuctionHouse.ReplicateItems(). Always walk the full AH.
+        var gameState = GetSession().GameState;
+        bool alreadyRunning = false;
+        lock (gameState.AuctionReplicateLock)
+        {
+            if (gameState.AuctionReplicateInProgress)
+            {
+                alreadyRunning = true;
+            }
+            else
+            {
+                gameState.AuctionReplicateInProgress = true;
+                gameState.AuctionReplicatePage = 0;
+                gameState.AuctionReplicateAuctioneer = req.Auctioneer;
+                gameState.AuctionReplicateChangeNumberGlobal = req.ChangeNumberGlobal;
+                gameState.AuctionReplicateChangeNumberCursor = req.ChangeNumberCursor;
+                gameState.AuctionReplicateChangeNumberTombstone = req.ChangeNumberTombstone;
+                gameState.AuctionReplicateAccumulator.Clear();
+                gameState.AuctionReplicateStartTime = DateTime.UtcNow;
+            }
+        }
+
+        if (alreadyRunning)
+        {
+            Log.Event("auction.replicate.rejected_already_running", new
+            {
+                auctioneer = req.Auctioneer.ToString(),
+            });
+            // Send an empty (Result=0, 0 items) response so the modern client's
+            // Full Scan frame doesn't hang waiting on AUCTION_ITEM_LIST_UPDATE.
+            SendEmptyAuctionReplicateResponse(req);
+            return;
+        }
+
+        Log.Event("auction.replicate.started", new
+        {
+            auctioneer = req.Auctioneer.ToString(),
+            change_global = req.ChangeNumberGlobal,
+            change_cursor = req.ChangeNumberCursor,
+            change_tombstone = req.ChangeNumberTombstone,
+            wire_tainted = req.TaintedBy != null,
+            wire_tainted_by = req.TaintedBy?.Name ?? "",
+        });
+
+        // Stamp our cooldown so the very next user CMSG (if any slips through
+        // before the first SMSG result re-asserts the in-progress flag in the
+        // common path) won't double up.
+        _lastSearchTime = DateTime.UtcNow;
+        SendReplicatePageQuery(req.Auctioneer, page: 0);
+    }
+
+    internal void SendReplicatePageQuery(WowGuid128 auctioneer, uint page)
+    {
+        // The legacy server's CMSG_AUCTION_LIST_ITEMS offset field is an *item*
+        // offset (rows-to-skip), not a page index. Confirmed against a 109-item
+        // PTR AH: sending raw page index produced 50 near-identical rows per
+        // "page" because the server window slid by 1 item instead of 50 (every
+        // SMSG was 3210 bytes: 50 items × ~64 bytes, just shifted). Multiply by
+        // the legacy 50-row page size so each query advances a full window.
+        uint itemOffset = page * (uint)AuctionLegacyPageSize;
+        WorldPacket packet = new WorldPacket(Opcode.CMSG_AUCTION_LIST_ITEMS);
+        packet.WriteGuid(auctioneer.To64());
+        packet.WriteUInt32(itemOffset);
+        packet.WriteCString("");
+        packet.WriteUInt8(0);  // minLevel
+        packet.WriteUInt8(0);  // maxLevel
+        packet.WriteInt32(-1); // inventorySlot — any
+        packet.WriteInt32(-1); // mainCategory
+        packet.WriteInt32(-1); // subCategory
+        packet.WriteInt32(-1); // quality — any
+        packet.WriteBool(false); // onlyUsable
+        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
+        {
+            packet.WriteBool(false); // exactMatch
+            packet.WriteUInt8(0);    // sortCount
+        }
+        SendPacketToServer(packet);
+        Log.Event("auction.replicate.page_query_sent", new { page, item_offset = itemOffset });
+    }
+
+    private void SendEmptyAuctionReplicateResponse(AuctionReplicateItems req)
+    {
+        AuctionReplicateResponse resp = new AuctionReplicateResponse
+        {
+            Result = 0,
+            DesiredDelay = 6000,
+            ChangeNumberGlobal = req.ChangeNumberGlobal,
+            ChangeNumberCursor = req.ChangeNumberCursor,
+            ChangeNumberTombstone = req.ChangeNumberTombstone,
+        };
+        GetSession().WorldClient!.SendPacketToClient(resp);
     }
 
     [PacketHandler(Opcode.CMSG_AUCTION_PLACE_BID)]

--- a/HermesProxy/World/Server/Packets/AuctionPackets.cs
+++ b/HermesProxy/World/Server/Packets/AuctionPackets.cs
@@ -385,6 +385,62 @@ public class ItemEnchantData
     public byte Slot;
 }
 
+// JimsProxy: modern client's "Full Scan" / GetAll request. Legacy 1.12 servers
+// have no equivalent — we synthesize the response by paginating internal
+// CMSG_AUCTION_LIST_ITEMS queries at the canonical 6s cooldown and assembling
+// the rows into one SMSG_AUCTION_REPLICATE_RESPONSE. See WorldSocket auction
+// handler for the orchestration and the auction.replicate.* JSONL events.
+class AuctionReplicateItems : ClientPacket
+{
+    public AuctionReplicateItems(WorldPacket packet) : base(packet) { }
+
+    public override void Read()
+    {
+        Auctioneer = _worldPacket.ReadPackedGuid128();
+        ChangeNumberGlobal = _worldPacket.ReadUInt32();
+        ChangeNumberCursor = _worldPacket.ReadUInt32();
+        ChangeNumberTombstone = _worldPacket.ReadUInt32();
+        Count = _worldPacket.ReadUInt32();
+        if (_worldPacket.HasBit())
+            TaintedBy = new();
+
+        if (TaintedBy != null)
+            TaintedBy.Read(_worldPacket);
+    }
+
+    public WowGuid128 Auctioneer;
+    public uint ChangeNumberGlobal;
+    public uint ChangeNumberCursor;
+    public uint ChangeNumberTombstone;
+    public uint Count;
+    public AddOnInfo TaintedBy = null!;
+}
+
+public class AuctionReplicateResponse : ServerPacket
+{
+    public AuctionReplicateResponse() : base(Opcode.SMSG_AUCTION_REPLICATE_RESPONSE) { }
+
+    public override void Write()
+    {
+        _worldPacket.WriteUInt32(Result);
+        _worldPacket.WriteUInt32(DesiredDelay);
+        _worldPacket.WriteUInt32(ChangeNumberGlobal);
+        _worldPacket.WriteUInt32(ChangeNumberCursor);
+        _worldPacket.WriteUInt32(ChangeNumberTombstone);
+        _worldPacket.WriteInt32(Items.Count);
+
+        foreach (AuctionItem item in Items)
+            item.Write(_worldPacket);
+    }
+
+    public uint Result;
+    public uint DesiredDelay = 6000;
+    public uint ChangeNumberGlobal;
+    public uint ChangeNumberCursor;
+    public uint ChangeNumberTombstone;
+    public List<AuctionItem> Items = new();
+}
+
 class AuctionSellItem : ClientPacket
 {
     public AuctionSellItem(WorldPacket packet) : base(packet) { }


### PR DESCRIPTION
## Summary
  - 1.14 client's `CMSG_AUCTION_REPLICATE_ITEMS` (Auctionator/Auc Full Scan, `C_AuctionHouse.ReplicateItems()`) had no
  handler; legacy 1.12 servers don't speak this opcode. Proxy now synthesizes the response by paginating internal
  `CMSG_AUCTION_LIST_ITEMS` queries and assembling rows into one `SMSG_AUCTION_REPLICATE_RESPONSE`.
  - Pacing: 6.2s between pages (200ms slack above Kronos's 6s anti-flood), terminates on short page. User-side
  `LIST_ITEMS` arriving mid-walk is rejected with a chat-system notice rather than racing the Kronos query slot and
  risking a kick.
  - Default Blizzard Browse UI uses `CMSG_AUCTION_LIST_ITEMS` (different opcode) and is untouched — so every
  `REPLICATE_ITEMS` arriving here is by definition a full scan, no addon side-channel or differentiation needed.
  - Liberal `auction.replicate.*` JSONL events (`started`, `page_query_sent`, `page_received`, `complete`,
  `rejected_already_running`, `aborted`).

  ## Files
  - `HermesProxy/GlobalSessionData.cs` — replicate-walk state (page, accumulator, ChangeNumber set, lock)
  - `HermesProxy/World/Server/PacketHandlers/AuctionHandler.cs` — `HandleAuctionReplicateItems`,
  `SendReplicatePageQuery` (offset = page × 50, item-offset not page index), mid-walk `LIST_ITEMS` rejection
  - `HermesProxy/World/Client/PacketHandlers/AuctionHandler.cs` — page accumulator, gap-scheduled next-page send,
  finalize, abort
  - `HermesProxy/World/Server/Packets/AuctionPackets.cs` — `AuctionReplicateItems` / `AuctionReplicateResponse`
  definitions

  ## Test plan
  - [ ] Kronos live: Auctionator Full Scan completes — verified, 726 items / 15 pages / 89s, zero kicks
  - [ ] PTR (sparse AH): verify short-page termination on first or second page
  - [ ] Default 1.14 AH Browse search: still uses `LIST_ITEMS` path, response unchanged
  - [ ] Aux + Auc-Advanced sell-side suite (PR #127 regressions): post / cancel / batch — untouched code path
  - [ ] Mid-scan: click default Browse Search during a Full Scan → "Full Scan in progress" chat notice, no Kronos kick
  - [ ] Concurrent replicate: second `REPLICATE_ITEMS` while one is running → empty response, no walker collision
  - [ ] Logout / disconnect mid-walk: no exception in scheduled `Task.Delay` continuation, walk aborts cleanly