### PR TITLE
Taxi fix clean

### DIFF
--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -8,6 +8,7 @@
 
 Core.lua
 PetFix.lua
+TaxiFix.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua
 castbars/Data.lua

--- a/Addons/JimsPlus/TaxiFix.lua
+++ b/Addons/JimsPlus/TaxiFix.lua
@@ -1,0 +1,39 @@
+-- JimsPlus TaxiFix
+-- Hide the "Stop at next flight path" button on the 1.14 TaxiFrame.
+--
+-- Vanilla 1.12 servers have no concept of early landing — the server is
+-- committed to the full SplineTimeFull and ignores any opcode trying to cut
+-- a flight short. The proxy's HandleTaxiRequestEarlyLanding logs the click
+-- and otherwise no-ops; the original dismount Task fires on schedule so the
+-- player still lands cleanly at the original destination. Hiding the button
+-- avoids the confusing "I clicked it and nothing happened" user experience.
+
+local function HideEarlyLandingButton()
+    -- Button name varies across 1.14.x client versions and reskins; try the
+    -- known candidates and Hide whichever exists. Lookup via _G is safe even
+    -- when the button doesn't exist on the running client.
+    local names = {
+        "TaxiFrameStopButton",
+        "TaxiRequestEarlyLandingButton",
+    }
+    for _, n in ipairs(names) do
+        local btn = _G[n]
+        if btn then
+            if btn.Hide then btn:Hide() end
+            if btn.Disable then btn:Disable() end
+        end
+    end
+end
+
+local f = CreateFrame("Frame")
+-- TAXIMAP_OPENED fires every time the player talks to a flight master, AFTER
+-- TaxiFrame is shown — so the button (if it exists) has been parented and
+-- positioned. PLAYER_LOGIN covers the case where the frame was created at
+-- load time.
+f:RegisterEvent("PLAYER_LOGIN")
+f:RegisterEvent("TAXIMAP_OPENED")
+f:SetScript("OnEvent", function()
+    HideEarlyLandingButton()
+end)
+
+print("|cFF00FF00[JimsPlus]|r TaxiFix loaded (early-landing button hidden — vanilla servers don't support early landing)")

--- a/Addons/JimsPlus/TaxiFix.lua
+++ b/Addons/JimsPlus/TaxiFix.lua
@@ -1,39 +1,40 @@
 -- JimsPlus TaxiFix
--- Hide the "Stop at next flight path" button on the 1.14 TaxiFrame.
+-- Hide the in-flight "Leave Vehicle" button on the 1.14 Classic Era client.
 --
--- Vanilla 1.12 servers have no concept of early landing — the server is
--- committed to the full SplineTimeFull and ignores any opcode trying to cut
--- a flight short. The proxy's HandleTaxiRequestEarlyLanding logs the click
--- and otherwise no-ops; the original dismount Task fires on schedule so the
--- player still lands cleanly at the original destination. Hiding the button
--- avoids the confusing "I clicked it and nothing happened" user experience.
+-- The 1.14 modern client treats taxi flights as vehicles in its UI layer and
+-- reuses the generic MainMenuBarVehicleLeaveButton during flight. Clicking it
+-- sends CMSG_TAXI_REQUEST_EARLY_LANDING. Vanilla 1.12 servers have no concept
+-- of early landing -- the legacy server is committed to SplineTimeFull and
+-- ignores the opcode -- so the proxy logs and no-ops it. To avoid the
+-- "I clicked it and nothing happened" UX, hide the button entirely.
+--
+-- Vanilla 1.12 has no real vehicles either (TBC+ feature), so the button has
+-- no other reason to exist on this server. Permanent hide is safe.
+--
+-- Native vanilla mechanism for early landing remains: log out at the next
+-- flight master.
 
-local function HideEarlyLandingButton()
-    -- Button name varies across 1.14.x client versions and reskins; try the
-    -- known candidates and Hide whichever exists. Lookup via _G is safe even
-    -- when the button doesn't exist on the running client.
-    local names = {
-        "TaxiFrameStopButton",
-        "TaxiRequestEarlyLandingButton",
-    }
-    for _, n in ipairs(names) do
-        local btn = _G[n]
-        if btn then
-            if btn.Hide then btn:Hide() end
-            if btn.Disable then btn:Disable() end
-        end
-    end
+local function Apply(btn)
+    if not btn then return end
+    btn:Hide()
+    -- Prevent any other code (Blizzard FrameXML, Dominos, etc.) from showing
+    -- it back. Re-hide on every OnShow attempt.
+    btn:SetScript("OnShow", function(self) self:Hide() end)
 end
 
 local f = CreateFrame("Frame")
--- TAXIMAP_OPENED fires every time the player talks to a flight master, AFTER
--- TaxiFrame is shown — so the button (if it exists) has been parented and
--- positioned. PLAYER_LOGIN covers the case where the frame was created at
--- load time.
 f:RegisterEvent("PLAYER_LOGIN")
+f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:RegisterEvent("TAXIMAP_OPENED")
+f:RegisterEvent("UPDATE_BONUS_ACTIONBAR")  -- fires when the vehicle bar transitions in
 f:SetScript("OnEvent", function()
-    HideEarlyLandingButton()
+    -- Primary target: the in-flight leave-vehicle button (per /framestack on
+    -- 1.14.2 Classic Era).
+    Apply(_G["MainMenuBarVehicleLeaveButton"])
+    -- Defensive: also catch alternate names that may exist on other client
+    -- variants or addon-overridden bars (e.g. Dominos wraps but does not
+    -- replace the named button, so the primary hide above still works).
+    Apply(_G["TaxiFrameStopButton"])
+    Apply(_G["TaxiRequestEarlyLandingButton"])
 end)
 
-print("|cFF00FF00[JimsPlus]|r TaxiFix loaded (early-landing button hidden — vanilla servers don't support early landing)")

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -55,8 +55,21 @@ public sealed class GameSessionData
     public bool ChannelDisplayList;
     public bool ShowPlayedTime;
     public bool IsInFarSight;
+    // JimsProxy (taxi-flight-robustness): IsInTaxiFlight is read on the dismount Task's
+    // ThreadPool thread and written on the packet-handler thread. Always access via
+    // Volatile.Read/Write so weak-memory-model reorderings can't deliver stale state to
+    // the dismount logic (e.g. seeing true after handler set it false).
     public bool IsInTaxiFlight;
     public bool IsWaitingForTaxiStart;
+    // JimsProxy (taxi-flight-robustness): when set, signals a pending taxi-dismount Task
+    // scheduled to fire at TaxiDismountFiresAtTickMs. The CTS is cancelled+disposed on
+    // (a) clean session disconnect, (b) early landing CMSG, (c) a fresh taxi spline
+    // arriving before the prior dismount fired (multi-segment chained flights). Without
+    // cancellation the Task captured a now-dead session and either NRE'd inside
+    // SendPacketToClient or fired control-grant packets at a session that had moved on.
+    public CancellationTokenSource? TaxiDismountCts;
+    public long TaxiDismountFiresAtTickMs;
+    public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;
     public bool IsFirstEnterWorld;
@@ -1237,6 +1250,32 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy (taxi-flight-robustness): cancel any pending taxi-dismount Task and clear
+    /// the in-flight bookkeeping. Idempotent — safe to call when no flight is active.
+    /// Called on (a) clean session disconnect, (b) early-landing CMSG, (c) a fresh taxi
+    /// spline arriving for the same player (multi-segment chained flights re-issue rather
+    /// than queuing). Without cancellation the captured Task fires SendPacketToClient
+    /// against a session that may have already been torn down or replaced.
+    /// </summary>
+    public void CancelTaxiDismount(string reason)
+    {
+        var cts = Interlocked.Exchange(ref TaxiDismountCts, null);
+        var attemptId = TaxiAttemptId;
+        if (cts != null)
+        {
+            try { cts.Cancel(); } catch { /* CTS may already be disposed */ }
+            cts.Dispose();
+            Framework.Logging.Log.Event("taxi.flight.dismount_cancelled", new
+            {
+                attempt_id = attemptId,
+                reason = reason,
+            });
+        }
+        TaxiDismountFiresAtTickMs = 0;
+        TaxiAttemptId = null;
+    }
+
+    /// <summary>
     /// Test-only: peek at the currently-held cast without consuming it. Returns null when none held.
     /// </summary>
     internal ClientCastRequest? PeekHeldGcdCast()
@@ -2150,6 +2189,12 @@ public class GlobalSessionData
         // JimsProxy (issue #43): cancel any held GCD cast and dispose its timer so it can't
         // fire after InstanceSocket has been torn down.
         GameState?.CancelGcdHold();
+
+        // JimsProxy (taxi-flight-robustness): same reasoning for the taxi-dismount Task —
+        // a pending flight Task captures session/InstanceSocket references and would NRE
+        // (or worse, send packets to a recreated session post-reconnect) if it fired after
+        // teardown.
+        GameState?.CancelTaxiDismount("session_disconnect");
 
         //MIRASU - capture quest item running totals before GameState is recreated so an unexpected
         //MIRASU   network disconnect followed by reconnect-to-same-character preserves the toast

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -144,14 +144,18 @@ public partial class WorldClient
     {
         WowGuid128 guid = packet.ReadPackedGuid().To128(GetSession().GameState);
 
-        if (GetSession().GameState.IsInTaxiFlight &&
+        if (System.Threading.Volatile.Read(ref GetSession().GameState.IsInTaxiFlight) &&
             GetSession().GameState.CurrentPlayerGuid == guid)
         {
             ControlUpdate control = new ControlUpdate();
             control.Guid = guid;
             control.HasControl = true;
             SendPacketToClient(control);
-            GetSession().GameState.IsInTaxiFlight = false;
+            System.Threading.Volatile.Write(ref GetSession().GameState.IsInTaxiFlight, false);
+            // JimsProxy (taxi-flight-robustness): teleport-ack ended the flight (zone change,
+            // early-arrival sync, etc.) — cancel the pending dismount Task so it doesn't fire
+            // duplicate control/gravity packets after the player has already regained control.
+            GetSession().GameState.CancelTaxiDismount("teleport_ack_during_flight");
         }
 
         MoveTeleport teleport = new MoveTeleport();
@@ -703,43 +707,118 @@ public partial class WorldClient
 
         if (isTaxiFlight)
         {
-            if (GetSession().GameState.IsWaitingForTaxiStart)
+            var session = GetSession();
+            var gameState = session.GameState;
+
+            if (gameState.IsWaitingForTaxiStart)
             {
                 ActivateTaxiReplyPkt taxi = new();
                 taxi.Reply = ActivateTaxiReply.Ok;
                 SendPacketToClient(taxi);
-                GetSession().GameState.IsWaitingForTaxiStart = false;
+                gameState.IsWaitingForTaxiStart = false;
             }
-            GetSession().GameState.IsInTaxiFlight = true;
+            System.Threading.Volatile.Write(ref gameState.IsInTaxiFlight, true);
 
-            // Restore player control after the flight spline completes — without this,
-            // the modern client stays in the "flying" state (no gravity, no movement).
-            uint flightDuration = moveSpline.SplineTimeFull;
-            WowGuid128 playerGuid = guid;
-            System.Threading.Tasks.Task.Run(async () =>
+            // JimsProxy (taxi-flight-robustness): a fresh taxi spline supersedes any pending
+            // dismount Task — multi-segment chained flights re-enter this branch per leg and
+            // we must not let an earlier leg's timer fire mid-next-leg. CancelTaxiDismount is
+            // idempotent and a no-op when nothing is pending.
+            gameState.CancelTaxiDismount("new_taxi_spline");
+
+            // Clamp the server-reported spline duration to a sane upper bound. Longest vanilla
+            // flight is well under 10 minutes; anything larger is a malformed/buggy server packet.
+            // Without the clamp, a corrupt SplineTimeFull near uint.MaxValue would either wrap
+            // negative on the (int) cast (Task.Delay throws ArgumentOutOfRange — silently swallowed
+            // by the unawaited Task, dismount never fires) or stall the Task for weeks.
+            const uint TAXI_FLIGHT_MAX_MS = 600_000;
+            uint flightDuration = Math.Min(moveSpline.SplineTimeFull, TAXI_FLIGHT_MAX_MS);
+            int delayMs = (int)flightDuration + 250;
+
+            var attemptId = Guid.NewGuid().ToString("N").Substring(0, 8);
+            var cts = new System.Threading.CancellationTokenSource();
+            gameState.TaxiDismountCts = cts;
+            gameState.TaxiDismountFiresAtTickMs = Environment.TickCount64 + delayMs;
+            gameState.TaxiAttemptId = attemptId;
+
+            Framework.Logging.Log.Event("taxi.flight.scheduled", new
             {
-                await System.Threading.Tasks.Task.Delay((int)flightDuration + 250);
-                if (GetSession()?.GameState?.IsInTaxiFlight != true)
+                attempt_id = attemptId,
+                player_guid = guid.ToString(),
+                spline_time_full_ms = moveSpline.SplineTimeFull,
+                clamped = moveSpline.SplineTimeFull > TAXI_FLIGHT_MAX_MS,
+                delay_ms = delayMs,
+            });
+
+            // Capture session/playerGuid by value so the Task does not re-resolve GetSession()
+            // on a possibly-replaced session post-reconnect (PR #119 spawns a new WorldClient
+            // on unplanned DC). The CTS guards against firing after legitimate cancellation.
+            WowGuid128 playerGuid = guid;
+            var capturedSession = session;
+            var capturedClient = this; // for SendPacketToClient — use captured-WorldClient routing
+            var token = cts.Token;
+            _ = System.Threading.Tasks.Task.Run(async () =>
+            {
+                try
+                {
+                    await System.Threading.Tasks.Task.Delay(delayMs, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // CancelTaxiDismount logged the cancellation event already.
                     return;
+                }
+
+                // Defense in depth: if the in-flight bool was cleared by another path
+                // (MoveTeleportAck on line ~154, manual debug, etc.) skip the dismount.
+                if (!System.Threading.Volatile.Read(ref capturedSession.GameState.IsInTaxiFlight))
+                {
+                    Framework.Logging.Log.Event("taxi.flight.dismount_skipped", new
+                    {
+                        attempt_id = attemptId,
+                        reason = "not_in_taxi_flight",
+                    });
+                    return;
+                }
+                if (capturedSession.InstanceSocket == null)
+                {
+                    Framework.Logging.Log.Event("taxi.flight.dismount_skipped", new
+                    {
+                        attempt_id = attemptId,
+                        reason = "no_instance_socket",
+                    });
+                    return;
+                }
 
                 ControlUpdate control = new ControlUpdate();
                 control.Guid = playerGuid;
                 control.HasControl = true;
-                SendPacketToClient(control);
+                capturedClient.SendPacketToClient(control);
 
                 MoveSetFlag enableGravity = new MoveSetFlag(Opcode.SMSG_MOVE_ENABLE_GRAVITY);
                 enableGravity.MoverGUID = playerGuid;
-                SendPacketToClient(enableGravity);
+                capturedClient.SendPacketToClient(enableGravity);
 
                 MoveSetFlag unsetFly = new MoveSetFlag(Opcode.SMSG_MOVE_UNSET_CAN_FLY);
                 unsetFly.MoverGUID = playerGuid;
-                SendPacketToClient(unsetFly);
+                capturedClient.SendPacketToClient(unsetFly);
 
                 MoveSetFlag unroot = new MoveSetFlag(Opcode.SMSG_MOVE_UNROOT);
                 unroot.MoverGUID = playerGuid;
-                SendPacketToClient(unroot);
+                capturedClient.SendPacketToClient(unroot);
 
-                GetSession().GameState.IsInTaxiFlight = false;
+                System.Threading.Volatile.Write(ref capturedSession.GameState.IsInTaxiFlight, false);
+                long firedAt = Environment.TickCount64;
+                Framework.Logging.Log.Event("taxi.flight.dismount_fired", new
+                {
+                    attempt_id = attemptId,
+                    player_guid = playerGuid.ToString(),
+                    late_by_ms = firedAt - capturedSession.GameState.TaxiDismountFiresAtTickMs,
+                });
+                // Clear bookkeeping AFTER firing so the diagnostic above can include `late_by_ms`.
+                // CancelTaxiDismount would also clear it but logs a `cancelled` event we don't want here.
+                capturedSession.GameState.TaxiDismountCts = null;
+                capturedSession.GameState.TaxiDismountFiresAtTickMs = 0;
+                capturedSession.GameState.TaxiAttemptId = null;
             });
         }
     }

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -660,36 +660,59 @@ public partial class WorldClient
             }
         }
 
+        // JimsProxy (taxi-flight-robustness): explicit leg-2+ detection. The rejoin
+        // window (1000ms after CurrentPlayerCreateTime) only happens to fire on a leg
+        // transition because the legacy server bumps the player CREATE timestamp. Treat
+        // an active taxi flight as authoritative — every taxi-flagged spline that arrives
+        // while IsInTaxiFlight is true is a leg of the same flight. Avoids the case
+        // where leg-2's rejoin window misses by >1000ms and the spline gets handled as
+        // a non-taxi move (would leave the player ungoverned mid-air).
+        bool isAlreadyInTaxiFlight = System.Threading.Volatile.Read(ref GetSession().GameState.IsInTaxiFlight);
         bool isTaxiFlight = (hasTaxiFlightFlags &&
                             (GetSession().GameState.IsWaitingForTaxiStart ||
+                             isAlreadyInTaxiFlight ||
                              Math.Abs(packet.GetReceivedTime() - GetSession().GameState.CurrentPlayerCreateTime) <= 1000) &&
                              GetSession().GameState.CurrentPlayerGuid == guid);
+        bool isFirstLegOfFlight = isTaxiFlight && !isAlreadyInTaxiFlight;
 
         if (isTaxiFlight)
         {
-            // Exact sequence of packets from sniff.
-            // Client instantly teleports to destination if anything is left out.
+            if (isFirstLegOfFlight)
+            {
+                // Exact sequence of packets from sniff. Required to transition the
+                // modern client from grounded → flying-on-taxi state. Client instantly
+                // teleports to destination if anything is left out.
+                //
+                // JimsProxy (taxi-flight-robustness): only emit on the FIRST leg of a
+                // multi-hop flight. On leg 2+, the modern client is already in flying-
+                // on-taxi state — sending stop-spline + control-loss tells it to snap-
+                // stop at leg 2's start position, which is the visible "gryphon warp"
+                // bundle 20260504-035621 captured during the second leg of an express
+                // flight. Subsequent legs just get a clean MonsterMove for smooth
+                // spline-to-spline transition.
+                ServerSideMovement stopSpline = new();
+                stopSpline.StartPosition = moveSpline.StartPosition;
+                stopSpline.SplineId = moveSpline.SplineId - 2;
+                MonsterMove moveStop = new MonsterMove(guid, stopSpline);
+                SendPacketToClient(moveStop);
 
-            ServerSideMovement stopSpline = new();
-            stopSpline.StartPosition = moveSpline.StartPosition;
-            stopSpline.SplineId = moveSpline.SplineId - 2;
-            MonsterMove moveStop = new MonsterMove(guid, stopSpline);
-            SendPacketToClient(moveStop);
+                ControlUpdate update = new();
+                update.Guid = guid;
+                update.HasControl = false;
+                SendPacketToClient(update);
 
-            ControlUpdate update = new();
-            update.Guid = guid;
-            update.HasControl = false;
-            SendPacketToClient(update);
+                stopSpline.SplineId = moveSpline.SplineId - 1;
+                moveStop = new MonsterMove(guid, stopSpline);
+                SendPacketToClient(moveStop);
 
-            stopSpline.SplineId = moveSpline.SplineId - 1;
-            moveStop = new MonsterMove(guid, stopSpline);
-            SendPacketToClient(moveStop);
+                update = new();
+                update.Guid = guid;
+                update.HasControl = false;
+                SendPacketToClient(update);
+            }
 
-            update = new();
-            update.Guid = guid;
-            update.HasControl = false;
-            SendPacketToClient(update);
-
+            // Spline flags + catmull-rom endpoint apply to every taxi spline (first leg
+            // and follow-ons alike) so the client renders continuous flight movement.
             moveSpline.SplineFlags = SplineFlagModern.Flying |
                                      SplineFlagModern.CatmullRom |
                                      SplineFlagModern.CanSwim |
@@ -736,8 +759,13 @@ public partial class WorldClient
 
             var attemptId = Guid.NewGuid().ToString("N").Substring(0, 8);
             var cts = new System.Threading.CancellationTokenSource();
+            // Capture the scheduled fire-time in the closure so `late_by_ms` stays correct
+            // for THIS attempt even if a subsequent leg overwrites GameState.TaxiDismountFiresAtTickMs.
+            // (Bundle 20260504-035621 showed late_by_ms=-3968 because leg 2 overwrote leg 1's
+            // schedule before leg 1 fired.)
+            long firesAtTickMs = Environment.TickCount64 + delayMs;
             gameState.TaxiDismountCts = cts;
-            gameState.TaxiDismountFiresAtTickMs = Environment.TickCount64 + delayMs;
+            gameState.TaxiDismountFiresAtTickMs = firesAtTickMs;
             gameState.TaxiAttemptId = attemptId;
 
             Framework.Logging.Log.Event("taxi.flight.scheduled", new
@@ -747,6 +775,7 @@ public partial class WorldClient
                 spline_time_full_ms = moveSpline.SplineTimeFull,
                 clamped = moveSpline.SplineTimeFull > TAXI_FLIGHT_MAX_MS,
                 delay_ms = delayMs,
+                is_first_leg = isFirstLegOfFlight,
             });
 
             // Capture session/playerGuid by value so the Task does not re-resolve GetSession()
@@ -764,61 +793,84 @@ public partial class WorldClient
                 }
                 catch (OperationCanceledException)
                 {
-                    // CancelTaxiDismount logged the cancellation event already.
+                    // CancelTaxiDismount logged the cancellation event and disposed cts.
                     return;
                 }
 
-                // Defense in depth: if the in-flight bool was cleared by another path
-                // (MoveTeleportAck on line ~154, manual debug, etc.) skip the dismount.
-                if (!System.Threading.Volatile.Read(ref capturedSession.GameState.IsInTaxiFlight))
+                // JimsProxy (taxi-flight-robustness): atomic claim of the right to fire.
+                // CompareExchange(slot, null, cts) succeeds only if `slot` still references
+                // OUR cts; on success it nulls the slot in the same operation. If a newer
+                // leg already replaced the slot (multi-leg flight) or CancelTaxiDismount
+                // ran between Task.Delay completing and reaching here, we lose the swap and
+                // skip — eliminates the TOCTOU race that on long flights would otherwise
+                // fire mid-flight dismount packets right as the next leg started.
+                var prior = System.Threading.Interlocked.CompareExchange(
+                    ref capturedSession.GameState.TaxiDismountCts, null, cts);
+                if (!ReferenceEquals(prior, cts))
                 {
                     Framework.Logging.Log.Event("taxi.flight.dismount_skipped", new
                     {
                         attempt_id = attemptId,
-                        reason = "not_in_taxi_flight",
+                        reason = "superseded",
                     });
                     return;
                 }
-                if (capturedSession.InstanceSocket == null)
+
+                // We own the dismount; cleanup of cts/bookkeeping is now our responsibility.
+                try
                 {
-                    Framework.Logging.Log.Event("taxi.flight.dismount_skipped", new
+                    if (!System.Threading.Volatile.Read(ref capturedSession.GameState.IsInTaxiFlight))
+                    {
+                        Framework.Logging.Log.Event("taxi.flight.dismount_skipped", new
+                        {
+                            attempt_id = attemptId,
+                            reason = "not_in_taxi_flight",
+                        });
+                        return;
+                    }
+                    if (capturedSession.InstanceSocket == null)
+                    {
+                        Framework.Logging.Log.Event("taxi.flight.dismount_skipped", new
+                        {
+                            attempt_id = attemptId,
+                            reason = "no_instance_socket",
+                        });
+                        return;
+                    }
+
+                    ControlUpdate control = new ControlUpdate();
+                    control.Guid = playerGuid;
+                    control.HasControl = true;
+                    capturedClient.SendPacketToClient(control);
+
+                    MoveSetFlag enableGravity = new MoveSetFlag(Opcode.SMSG_MOVE_ENABLE_GRAVITY);
+                    enableGravity.MoverGUID = playerGuid;
+                    capturedClient.SendPacketToClient(enableGravity);
+
+                    MoveSetFlag unsetFly = new MoveSetFlag(Opcode.SMSG_MOVE_UNSET_CAN_FLY);
+                    unsetFly.MoverGUID = playerGuid;
+                    capturedClient.SendPacketToClient(unsetFly);
+
+                    MoveSetFlag unroot = new MoveSetFlag(Opcode.SMSG_MOVE_UNROOT);
+                    unroot.MoverGUID = playerGuid;
+                    capturedClient.SendPacketToClient(unroot);
+
+                    System.Threading.Volatile.Write(ref capturedSession.GameState.IsInTaxiFlight, false);
+                    long firedAt = Environment.TickCount64;
+                    Framework.Logging.Log.Event("taxi.flight.dismount_fired", new
                     {
                         attempt_id = attemptId,
-                        reason = "no_instance_socket",
+                        player_guid = playerGuid.ToString(),
+                        late_by_ms = firedAt - firesAtTickMs,
                     });
-                    return;
                 }
-
-                ControlUpdate control = new ControlUpdate();
-                control.Guid = playerGuid;
-                control.HasControl = true;
-                capturedClient.SendPacketToClient(control);
-
-                MoveSetFlag enableGravity = new MoveSetFlag(Opcode.SMSG_MOVE_ENABLE_GRAVITY);
-                enableGravity.MoverGUID = playerGuid;
-                capturedClient.SendPacketToClient(enableGravity);
-
-                MoveSetFlag unsetFly = new MoveSetFlag(Opcode.SMSG_MOVE_UNSET_CAN_FLY);
-                unsetFly.MoverGUID = playerGuid;
-                capturedClient.SendPacketToClient(unsetFly);
-
-                MoveSetFlag unroot = new MoveSetFlag(Opcode.SMSG_MOVE_UNROOT);
-                unroot.MoverGUID = playerGuid;
-                capturedClient.SendPacketToClient(unroot);
-
-                System.Threading.Volatile.Write(ref capturedSession.GameState.IsInTaxiFlight, false);
-                long firedAt = Environment.TickCount64;
-                Framework.Logging.Log.Event("taxi.flight.dismount_fired", new
+                finally
                 {
-                    attempt_id = attemptId,
-                    player_guid = playerGuid.ToString(),
-                    late_by_ms = firedAt - capturedSession.GameState.TaxiDismountFiresAtTickMs,
-                });
-                // Clear bookkeeping AFTER firing so the diagnostic above can include `late_by_ms`.
-                // CancelTaxiDismount would also clear it but logs a `cancelled` event we don't want here.
-                capturedSession.GameState.TaxiDismountCts = null;
-                capturedSession.GameState.TaxiDismountFiresAtTickMs = 0;
-                capturedSession.GameState.TaxiAttemptId = null;
+                    // CompareExchange already nulled TaxiDismountCts; clear the rest.
+                    capturedSession.GameState.TaxiDismountFiresAtTickMs = 0;
+                    capturedSession.GameState.TaxiAttemptId = null;
+                    cts.Dispose();
+                }
             });
         }
     }

--- a/HermesProxy/World/Client/PacketHandlers/TaxiHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/TaxiHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Framework;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -25,6 +26,7 @@ public partial class WorldClient
         uint playerFlags = GetSession().GameState.GetLegacyFieldValueUInt32(GetSession().GameState.CurrentPlayerGuid, PlayerField.PLAYER_FLAGS);
         if (playerFlags.HasAnyFlag(PlayerFlags.GM))
         {
+            Log.Event("taxi.show_nodes_blocked", new { reason = "gm_mode" });
             ChatPkt chat = new ChatPkt(GetSession(), ChatMessageTypeModern.System, "Disable GM mode before talking to taxi master or your game will freeze.");
             SendPacketToClient(chat);
             return;
@@ -45,11 +47,18 @@ public partial class WorldClient
             taxi.CanUseNodes.Add(nodesMask);
         }
         GetSession().GameState.UsableTaxiNodes = taxi.CanUseNodes; // save for CMSG_ACTIVATE_TAXI_EXPRESS
+        Log.Event("taxi.show_nodes", new
+        {
+            current_node = GetSession().GameState.CurrentTaxiNode,
+            usable_node_bytes = taxi.CanUseNodes.Count,
+            has_window_info = hasWindowInfo,
+        });
         SendPacketToClient(taxi);
     }
     [PacketHandler(Opcode.SMSG_NEW_TAXI_PATH)]
     void HandleNewTaxiPath(WorldPacket packet)
     {
+        Log.Event("taxi.new_path", new { player_guid = GetSession().GameState.CurrentPlayerGuid.ToString() });
         NewTaxiPath taxi = new();
         SendPacketToClient(taxi);
     }
@@ -57,6 +66,11 @@ public partial class WorldClient
     void HandleActivateTaxiReply(WorldPacket packet)
     {
         ActivateTaxiReply reply = (ActivateTaxiReply)packet.ReadUInt32();
+        Log.Event("taxi.activate_reply", new
+        {
+            reply = reply.ToString(),
+            attempt_id = GetSession().GameState.TaxiAttemptId,
+        });
         // Ok status needs to be sent after the monster move packet.
         if (reply != ActivateTaxiReply.Ok)
         {
@@ -64,6 +78,10 @@ public partial class WorldClient
             taxi.Reply = reply;
             SendPacketToClient(taxi);
             GetSession().GameState.IsWaitingForTaxiStart = false;
+            // JimsProxy (taxi-flight-robustness): non-Ok reply = server rejected the activation,
+            // no spline incoming. If a stale dismount Task somehow exists (shouldn't but defensive),
+            // cancel it so it can't fire after the rejection.
+            GetSession().GameState.CancelTaxiDismount("activate_reply_not_ok");
         }
     }
 }

--- a/HermesProxy/World/Server/PacketHandlers/TaxiHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/TaxiHandler.cs
@@ -88,22 +88,32 @@ public partial class WorldSocket
         GetSession().GameState.IsWaitingForTaxiStart = true;
     }
 
-    // JimsProxy (taxi-flight-robustness): pass through the early-landing CMSG so the
-    // legacy server tears down the spline server-side, AND cancel our local dismount
-    // Task — without this, the Task fires `delay_ms` later and re-issues control/gravity
-    // packets after the player has already landed and regained control normally,
-    // potentially desyncing the modern client.
+    // JimsProxy (taxi-flight-robustness): vanilla 1.12 has no early-landing concept —
+    // the server is committed to the full SplineTimeFull and ignores any opcode trying
+    // to cut a flight short. The modern 1.14 client still surfaces the "Stop at next
+    // flight path" button regardless and sends this CMSG when clicked. Bundle
+    // 20260504-032731 (attempt_id dc1050b5) showed: server kept flying the original
+    // 56s spline to completion regardless of the early-landing CMSG.
+    //
+    // Therefore: don't forward (server can't honor it, no legacy mapping anyway), and
+    // don't cancel the dismount Task — cancelling left the player stuck in flight pose
+    // at the natural end of the spline because no one fired the control/gravity/unfly/
+    // unroot packets. The fix: log it for visibility, and let the dismount Task fire on
+    // its original schedule. Player lands cleanly at the original end destination; the
+    // button is purely cosmetic on vanilla.
+    //
+    // True early-landing emulation is a separate (substantial) follow-up — would need
+    // to compute the next taxi waypoint from the spline, force-teleport client+server
+    // there, and reconcile zone/instance/cost state. Tracked separately if needed.
     [PacketHandler(Opcode.CMSG_TAXI_REQUEST_EARLY_LANDING)]
     void HandleTaxiRequestEarlyLanding(EmptyClientPacket packet)
     {
-        Log.Event("taxi.early_landing_requested", new
+        Log.Event("taxi.early_landing_requested_ignored", new
         {
             attempt_id = GetSession().GameState.TaxiAttemptId,
             had_pending_dismount = GetSession().GameState.TaxiDismountCts != null,
+            reason = "vanilla_server_no_early_landing_support",
         });
-        GetSession().GameState.CancelTaxiDismount("early_landing_requested");
-        WorldPacket fwd = new WorldPacket(Opcode.CMSG_TAXI_REQUEST_EARLY_LANDING);
-        SendPacketToServer(fwd);
     }
     bool TaxiPathExist(uint from, uint to)
     {

--- a/HermesProxy/World/Server/PacketHandlers/TaxiHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/TaxiHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Framework.Constants;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
@@ -32,20 +33,41 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_ACTIVATE_TAXI)]
     void HandleActivateTaxi(ActivateTaxi taxi)
     {
+        uint fromNode = GetSession().GameState.CurrentTaxiNode;
+        bool direct = TaxiPathExist(fromNode, taxi.Node);
+
         // direct path exist
-        if (TaxiPathExist(GetSession().GameState.CurrentTaxiNode, taxi.Node))
+        if (direct)
         {
             WorldPacket packet = new WorldPacket(Opcode.CMSG_ACTIVATE_TAXI);
             packet.WriteGuid(taxi.FlightMaster.To64());
-            packet.WriteUInt32(GetSession().GameState.CurrentTaxiNode);
+            packet.WriteUInt32(fromNode);
             packet.WriteUInt32(taxi.Node);
             SendPacketToServer(packet);
+            Log.Event("taxi.activate_requested", new
+            {
+                flight_master = taxi.FlightMaster.ToString(),
+                from_node = fromNode,
+                to_node = taxi.Node,
+                routing = "direct",
+                hop_count = 2,
+            });
         }
         else // find shortest path
         {
-            HashSet<uint> path = GetTaxiPath(GetSession().GameState.CurrentTaxiNode, taxi.Node, GetSession().GameState.UsableTaxiNodes);
+            HashSet<uint> path = GetTaxiPath(fromNode, taxi.Node, GetSession().GameState.UsableTaxiNodes);
             if (path.Count <= 1) // no nodes found
+            {
+                Log.Event("taxi.activate_requested", new
+                {
+                    flight_master = taxi.FlightMaster.ToString(),
+                    from_node = fromNode,
+                    to_node = taxi.Node,
+                    routing = "no_path",
+                    hop_count = path.Count,
+                });
                 return;
+            }
 
             WorldPacket packet = new WorldPacket(Opcode.CMSG_ACTIVATE_TAXI_EXPRESS);
             packet.WriteGuid(taxi.FlightMaster.To64());
@@ -54,8 +76,34 @@ public partial class WorldSocket
             foreach (uint itr in path)
                 packet.WriteUInt32(itr);
             SendPacketToServer(packet);
+            Log.Event("taxi.activate_requested", new
+            {
+                flight_master = taxi.FlightMaster.ToString(),
+                from_node = fromNode,
+                to_node = taxi.Node,
+                routing = "express",
+                hop_count = path.Count,
+            });
         }
         GetSession().GameState.IsWaitingForTaxiStart = true;
+    }
+
+    // JimsProxy (taxi-flight-robustness): pass through the early-landing CMSG so the
+    // legacy server tears down the spline server-side, AND cancel our local dismount
+    // Task — without this, the Task fires `delay_ms` later and re-issues control/gravity
+    // packets after the player has already landed and regained control normally,
+    // potentially desyncing the modern client.
+    [PacketHandler(Opcode.CMSG_TAXI_REQUEST_EARLY_LANDING)]
+    void HandleTaxiRequestEarlyLanding(EmptyClientPacket packet)
+    {
+        Log.Event("taxi.early_landing_requested", new
+        {
+            attempt_id = GetSession().GameState.TaxiAttemptId,
+            had_pending_dismount = GetSession().GameState.TaxiDismountCts != null,
+        });
+        GetSession().GameState.CancelTaxiDismount("early_landing_requested");
+        WorldPacket fwd = new WorldPacket(Opcode.CMSG_TAXI_REQUEST_EARLY_LANDING);
+        SendPacketToServer(fwd);
     }
     bool TaxiPathExist(uint from, uint to)
     {


### PR DESCRIPTION
 ## Summary
  - Replaces #126 — same 3 commits (`38486a8`, `f4e33f8`, `9e50917`) cherry-picked onto current `beta` so the diff is
  taxi-only. The original branch was based on a pre-#127/#133 beta and therefore showed a ~2,000-line "deletion" of
  unrelated work that's already merged. Net diff here: +343/-50 across 6 files, all taxi-related.
  - Cancellable taxi-dismount Task: CTS + atomic CompareExchange swap, captured-by-value session/client to survive
  reconnects, idempotent CancelTaxiDismount wired into OnDisconnect, MoveTeleportAck mid-flight, and incoming taxi
  spline (multi-leg).
  - SplineTimeFull clamp to 600s before `(int)` cast — prevents Task.Delay ArgumentOutOfRange on corrupt spline
  durations leaving the player stuck mounted.
  - Multi-leg flights: stop-sequence + control-loss only fires on the *first* leg (gated by explicit
  `isAlreadyInTaxiFlight` Volatile.Read); leg 2+ gets a clean MonsterMove for smooth catmull-rom spline-to-spline
  transitions, fixing visible warps on hops.
  - Early-landing button: vanilla 1.12 has no early-landing semantics, so the server handler now logs and ignores
  `CMSG_TAXI_REQUEST_EARLY_LANDING` (forwarding it cancelled the dismount Task and left the player stuck), and JimsPlus
  `TaxiFix.lua` hides the button so the click-and-nothing-happens UX goes away.
  - Liberal `taxi.*` JSONL diagnostics: `show_nodes`, `activate_requested`, `activate_reply`, `new_path`,
  `flight.scheduled` (with `is_first_leg`), `flight.dismount_fired` (with `late_by_ms` from per-attempt closure),
  `flight.dismount_cancelled` (reason taxonomy), `flight.dismount_skipped`, `early_landing_requested_ignored`.

  ## Files
  - `Addons/JimsPlus/JimsPlus.toc` — register TaxiFix.lua
  - `Addons/JimsPlus/TaxiFix.lua` — defensive `_G` lookup of `TaxiFrameStopButton` / `TaxiRequestEarlyLandingButton`,
  hide on `PLAYER_LOGIN` and `TAXIMAP_OPENED`
  - `HermesProxy/GlobalSessionData.cs` — `TaxiDismountCts`, `TaxiDismountFiresAtTickMs`, `TaxiAttemptId`,
  `CancelTaxiDismount(reason)`
  - `HermesProxy/World/Client/PacketHandlers/MovementHandler.cs` — cancellable dismount Task, duration clamp, multi-leg
  gating, Volatile flag access, dismount cancellation on teleport / new-spline
  - `HermesProxy/World/Client/PacketHandlers/TaxiHandler.cs` — diagnostics
  - `HermesProxy/World/Server/PacketHandlers/TaxiHandler.cs` — `CMSG_TAXI_REQUEST_EARLY_LANDING` log-and-ignore,
  OnDisconnect wiring

  ## Test plan
  - [x] Validated on bundle 20260504-042238: 4-hop express flight, 6.5 min total, 3 spline legs, dismount fired
  `late_by_ms=-4` (4ms before schedule), every leg transition logged via `dismount_cancelled` → `dismount_fired` chain
  - [ ] Single-leg flight: dismount fires on schedule, control/gravity/unfly/unroot all sent
  - [ ] Multi-leg flight: no visible warp at leg transitions, dismount fires only at end destination
  - [ ] Disconnect mid-flight: no NRE in scheduled Task continuation, clean cancel via OnDisconnect
  - [ ] Click "Stop at next flight path" button (if visible on any client version where the addon hide doesn't catch
  it): logs `early_landing_requested_ignored`, original spline completes, player lands cleanly
  - [ ] Reconnect mid-flight (PR #119 path): Task closure routes packets through original-attempt client, no double-send
   to new client