### PR TITLE
 Fix WTF wipe on logout + recreate WorldClient on relog

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1588,6 +1588,16 @@ public class GlobalSessionData
     public WorldSocket InstanceSocket = null!;
     public AuthClient AuthClient = null!;
     public WorldClient? WorldClient;
+    // JimsProxy: set true on SMSG_LOGOUT_COMPLETE so the next CMSG_PLAYER_LOGIN
+    // tears down and recreates WorldClient. Twinstar accepts a second
+    // CMSG_PLAYER_LOGIN on the same world TCP (the LOGIN_VERIFY_WORLD comes
+    // back fine) but then closes the connection a few seconds into the new
+    // character's session — leaving session.WorldClient null mid-game. We
+    // can't drop the WorldClient at LOGOUT_COMPLETE itself because char-select
+    // (CMSG_ENUM_CHARACTERS / CMSG_QUERY_PLAYER_NAME / etc.) is forwarded over
+    // the same WorldClient and needs it alive until the user picks a char.
+    // Cleared after the recreate succeeds.
+    public bool WorldClientNeedsRecreateOnNextLogin;
     public SniffFile ModernSniff = null!;
 
     public Dictionary<string, WowGuid128> GuildsByName = [];

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -370,32 +370,31 @@ public partial class WorldClient
         // the next character (or the same one re-logging in) starts clean.
         GetSession().ThreatTracker.Reset();
 
-        // JimsProxy (logout-wtf-flush follow-up): drop the session's reference
-        // to this WorldClient. The legacy server's world session for the
-        // outgoing character ends with SMSG_LOGOUT_COMPLETE; Twinstar closes
-        // its end of the world TCP shortly after. Because 861c9a5 keeps the
-        // BNet/InstanceSocket alive across logout, the next char-login arrives
-        // as CMSG_AUTH_CONTINUED_SESSION, which does NOT run the WorldClient-
-        // creation code in WorldSocket.HandleAuthSession. Without this nulling,
-        // HandlePlayerLogin's null-check would see the stale-but-not-yet-closed
-        // legacy connection, forward CMSG_PLAYER_LOGIN into a doomed socket,
-        // and either time out at "Enter World" with WOW51900309 or — worse —
-        // get the modern client into the world over the dying connection and
-        // NRE at ChatHandler.cs:227 the moment the player /says.
+        // JimsProxy (logout-wtf-flush follow-up): mark the session so the next
+        // CMSG_PLAYER_LOGIN tears down and recreates WorldClient. Twinstar
+        // accepts a second CMSG_PLAYER_LOGIN on the existing world TCP (the
+        // LOGIN_VERIFY_WORLD comes back fine) but then drops the connection
+        // a few seconds into the new character's session, leaving
+        // session.WorldClient null mid-game. The first observed symptom was
+        // an NRE at ChatHandler.cs:227 the moment the player /said; the
+        // second was WOW51900309 at "Enter World" if the legacy socket died
+        // before HandlePlayerLogin could forward CMSG_PLAYER_LOGIN.
         //
-        // We deliberately do NOT call Disconnect() here: this handler is
-        // running on the receive thread we'd be tearing down, which races the
-        // loop's own exit-via-disconnect path. Letting Twinstar close on its
-        // end is safer; the receive loop drains via the existing
-        // session.ondisconnect.suppressed path with was_active_world_client=false
-        // (we already nulled the slot, so its CompareExchange no-ops).
-        var droppedWorldClient = GetSession().WorldClient;
-        GetSession().WorldClient = null;
-        Log.Event("session.logout_complete.worldclient_dropped", new
+        // We do NOT null WorldClient here: the modern client transitions to
+        // char-select during the InstanceSocket hold below, and char-select
+        // forwards CMSG_ENUM_CHARACTERS / CMSG_QUERY_PLAYER_NAME / etc.
+        // through the same WorldClient. Nulling here means those queries
+        // get silently dropped, the modern client never receives
+        // SMSG_ENUM_CHARACTERS_RESULT, and after ~12s of waiting it sends
+        // CMSG_LOG_DISCONNECT and quits to the login screen. Bundle
+        // 20260505-130649 reproduced exactly that regression. The flag is
+        // cleared in WorldSocket.HandlePlayerLogin after the recreate.
+        GetSession().WorldClientNeedsRecreateOnNextLogin = true;
+        Log.Event("session.logout_complete.worldclient_recreate_marked", new
         {
-            had_world_client = droppedWorldClient != null,
-            was_connected = droppedWorldClient?.IsConnected() ?? false,
-            was_authenticated = droppedWorldClient?.IsAuthenticated() ?? false,
+            had_world_client = GetSession().WorldClient != null,
+            was_connected = GetSession().WorldClient?.IsConnected() ?? false,
+            was_authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
         });
 
         // JimsProxy WTF-flush fix: capture the InstanceSocket reference and

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -333,6 +333,21 @@ public partial class WorldClient
         SendPacketToClient(logout);
     }
 
+    // JimsProxy: how long to leave the InstanceSocket open after sending
+    // SMSG_LOGOUT_COMPLETE before the proxy force-closes it as a safety net.
+    // The 1.14 client flushes WTF (keybinds / macros / account / cache) as
+    // part of its char-select transition; if we slam the TCP socket within
+    // microseconds of LOGOUT_COMPLETE the client takes an error-disconnect
+    // code path that skips the flush, wiping settings. Symptom is most
+    // common on instant-logout flows (Exit Game, in-town logout) where
+    // there's no 20s countdown to widen the window. A direct 1.12 client
+    // ↔ 1.12 server connection never sees this because the legacy server
+    // doesn't proactively kill the client socket on logout-complete; we
+    // mirror that and let WoW close its end first. The safety-net timer
+    // bounds how long a buggy / never-closing client can leak the socket.
+    private const int LogoutCompleteSocketHoldMs = 3_000;
+    private const int LogoutCompletePollIntervalMs = 100;
+
     [PacketHandler(Opcode.SMSG_LOGOUT_COMPLETE)]
     void HandleLogoutComplete(WorldPacket packet)
     {
@@ -354,8 +369,70 @@ public partial class WorldClient
         // Threat lists were keyed off the outgoing character's GUIDs; wipe so
         // the next character (or the same one re-logging in) starts clean.
         GetSession().ThreatTracker.Reset();
-        GetSession().InstanceSocket.CloseSocket();
+
+        // JimsProxy WTF-flush fix: capture the InstanceSocket reference and
+        // hand it to a delayed safety-net close. Drop the session's reference
+        // immediately so any subsequent send-on-this-socket path nulls out
+        // cleanly via the existing send-on-closed handling. Do NOT call
+        // CloseSocket() synchronously -- the modern client's WTF flush is
+        // gated on a clean socket lifetime through the char-select transition.
+        var lingeringSocket = GetSession().InstanceSocket;
         GetSession().InstanceSocket = null!;
+        var holdStart = DateTime.UtcNow;
+        Log.Event("session.logout_complete.socket_hold_started", new
+        {
+            hold_ms = LogoutCompleteSocketHoldMs,
+            poll_interval_ms = LogoutCompletePollIntervalMs,
+        });
+        // Poll the socket so the JSONL captures *when* the client closed
+        // its end (the WTF flush gate). On fast paths (Exit Game / in-town
+        // instant logout) we expect this to land well under 3s; on the
+        // 20s-countdown path the client may already have closed by the
+        // time LOGOUT_COMPLETE arrives. If 3s elapses without the client
+        // closing, the safety net fires and the same elapsed_ms tells us
+        // the buffer was actually load-bearing this session.
+        System.Threading.Tasks.Task.Run(async () =>
+        {
+            try
+            {
+                while ((DateTime.UtcNow - holdStart).TotalMilliseconds < LogoutCompleteSocketHoldMs)
+                {
+                    if (lingeringSocket == null || !lingeringSocket.IsOpen())
+                    {
+                        var elapsed = (long)(DateTime.UtcNow - holdStart).TotalMilliseconds;
+                        Log.Event("session.logout_complete.client_closed_first", new
+                        {
+                            elapsed_ms = elapsed,
+                        });
+                        return;
+                    }
+                    await System.Threading.Tasks.Task.Delay(LogoutCompletePollIntervalMs);
+                }
+                // 3s elapsed and the client still hasn't closed -- safety net.
+                if (lingeringSocket != null && lingeringSocket.IsOpen())
+                {
+                    lingeringSocket.CloseSocket();
+                    Log.Event("session.logout_complete.safety_net_closed", new
+                    {
+                        elapsed_ms = LogoutCompleteSocketHoldMs,
+                    });
+                }
+                else
+                {
+                    // Tight race: client closed between the last poll and the
+                    // window expiring. Treat as client-closed-first.
+                    Log.Event("session.logout_complete.client_closed_first", new
+                    {
+                        elapsed_ms = LogoutCompleteSocketHoldMs,
+                        late_race = true,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Event("session.logout_complete.safety_net_error", new { message = ex.Message });
+            }
+        });
     }
 
     [PacketHandler(Opcode.SMSG_LOGOUT_CANCEL_ACK)]

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -370,6 +370,34 @@ public partial class WorldClient
         // the next character (or the same one re-logging in) starts clean.
         GetSession().ThreatTracker.Reset();
 
+        // JimsProxy (logout-wtf-flush follow-up): drop the session's reference
+        // to this WorldClient. The legacy server's world session for the
+        // outgoing character ends with SMSG_LOGOUT_COMPLETE; Twinstar closes
+        // its end of the world TCP shortly after. Because 861c9a5 keeps the
+        // BNet/InstanceSocket alive across logout, the next char-login arrives
+        // as CMSG_AUTH_CONTINUED_SESSION, which does NOT run the WorldClient-
+        // creation code in WorldSocket.HandleAuthSession. Without this nulling,
+        // HandlePlayerLogin's null-check would see the stale-but-not-yet-closed
+        // legacy connection, forward CMSG_PLAYER_LOGIN into a doomed socket,
+        // and either time out at "Enter World" with WOW51900309 or — worse —
+        // get the modern client into the world over the dying connection and
+        // NRE at ChatHandler.cs:227 the moment the player /says.
+        //
+        // We deliberately do NOT call Disconnect() here: this handler is
+        // running on the receive thread we'd be tearing down, which races the
+        // loop's own exit-via-disconnect path. Letting Twinstar close on its
+        // end is safer; the receive loop drains via the existing
+        // session.ondisconnect.suppressed path with was_active_world_client=false
+        // (we already nulled the slot, so its CompareExchange no-ops).
+        var droppedWorldClient = GetSession().WorldClient;
+        GetSession().WorldClient = null;
+        Log.Event("session.logout_complete.worldclient_dropped", new
+        {
+            had_world_client = droppedWorldClient != null,
+            was_connected = droppedWorldClient?.IsConnected() ?? false,
+            was_authenticated = droppedWorldClient?.IsAuthenticated() ?? false,
+        });
+
         // JimsProxy WTF-flush fix: capture the InstanceSocket reference and
         // hand it to a delayed safety-net close. Drop the session's reference
         // immediately so any subsequent send-on-this-socket path nulls out

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -186,11 +186,72 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_PLAYER_LOGIN)]
     void HandlePlayerLogin(PlayerLogin playerLogin)
     {
+        // JimsProxy (logout-wtf-flush follow-up): on every char-login after
+        // the first one in a session — including same-char relogs — the
+        // session's WorldClient slot is null (SMSG_LOGOUT_COMPLETE drops it,
+        // see World/Client/PacketHandlers/CharacterHandler.cs::HandleLogoutComplete).
+        // Re-establish a fresh legacy world session here. Mirrors a direct
+        // 1.12 client ↔ 1.12 server connection, which opens a new world TCP
+        // per character. The first login of a session falls through this
+        // block — WorldClient is already set up by WorldSocket.HandleAuthSession.
         if (GetSession().WorldClient == null || !GetSession().WorldClient!.IsConnected())
         {
-            Log.Print(LogType.Error, "WorldClient is disconnected, cannot enter world.");
-            AbortLogin(LoginFailureReason.NoWorld);
-            return;
+            Log.Event("session.relogin.worldclient_recreate_attempt", new
+            {
+                had_world_client = GetSession().WorldClient != null,
+                was_connected = GetSession().WorldClient?.IsConnected() ?? false,
+                was_authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
+                target_guid_low = playerLogin.Guid.GetCounter(),
+            });
+
+            var reloginRealm = GetSession().RealmManager.GetRealm(GetSession().RealmId);
+            if (reloginRealm == null)
+            {
+                Log.Print(LogType.Error, $"HandlePlayerLogin: cannot recreate WorldClient — unknown realm id {GetSession().RealmId}");
+                Log.Event("session.relogin.worldclient_recreate_failed", new
+                {
+                    reason = "unknown_realm",
+                    realm_id_index = (int)GetSession().RealmId.Index,
+                });
+                AbortLogin(LoginFailureReason.NoWorld);
+                return;
+            }
+
+            // Tear down a stale-but-not-yet-disconnected leftover before
+            // overwriting the slot, so its receive-loop exit path doesn't
+            // race the new client onto session.WorldClient. Disconnect()
+            // is idempotent on already-closed sockets.
+            var staleWorldClient = GetSession().WorldClient;
+            if (staleWorldClient != null)
+            {
+                try { staleWorldClient.Disconnect(); }
+                catch (Exception ex)
+                {
+                    Log.Event("session.relogin.stale_worldclient_disconnect_error", new
+                    {
+                        exception_type = ex.GetType().Name,
+                        message = ex.Message,
+                    });
+                }
+            }
+
+            var reconnectStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            GetSession().WorldClient = new World.Client.WorldClient();
+            bool reloginConnected = GetSession().WorldClient!.ConnectToWorldServer(reloginRealm, GetSession());
+            Log.Event("session.relogin.worldclient_recreated", new
+            {
+                realm_name = reloginRealm.Name,
+                connected = reloginConnected,
+                authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
+                elapsed_ms = reconnectStopwatch.ElapsedMilliseconds,
+            });
+            if (!reloginConnected)
+            {
+                Log.Print(LogType.Error, "HandlePlayerLogin: failed to recreate WorldClient on re-login.");
+                GetSession().WorldClient = null;
+                AbortLogin(LoginFailureReason.NoWorld);
+                return;
+            }
         }
 
         if (!GetSession().GameState.CachedPlayers.TryGetValue(playerLogin.Guid, out var selectedChar))

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -186,21 +186,29 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_PLAYER_LOGIN)]
     void HandlePlayerLogin(PlayerLogin playerLogin)
     {
-        // JimsProxy (logout-wtf-flush follow-up): on every char-login after
-        // the first one in a session — including same-char relogs — the
-        // session's WorldClient slot is null (SMSG_LOGOUT_COMPLETE drops it,
-        // see World/Client/PacketHandlers/CharacterHandler.cs::HandleLogoutComplete).
-        // Re-establish a fresh legacy world session here. Mirrors a direct
-        // 1.12 client ↔ 1.12 server connection, which opens a new world TCP
-        // per character. The first login of a session falls through this
-        // block — WorldClient is already set up by WorldSocket.HandleAuthSession.
-        if (GetSession().WorldClient == null || !GetSession().WorldClient!.IsConnected())
+        // JimsProxy (logout-wtf-flush follow-up): recreate WorldClient if
+        //   (a) it's null/disconnected (defensive), OR
+        //   (b) the prior character's logout marked the session for a fresh
+        //       world TCP (WorldClientNeedsRecreateOnNextLogin).
+        // Twinstar accepts a second CMSG_PLAYER_LOGIN on the existing world
+        // TCP -- the LOGIN_VERIFY_WORLD comes back fine -- but then drops
+        // the connection a few seconds into the new character's session,
+        // leaving session.WorldClient null mid-game and NRE'ing the next
+        // /say at ChatHandler.cs:227. Mirror direct 1.12 client ↔ 1.12
+        // server (one world TCP per character). The first login of a
+        // session takes neither branch: WorldClient is alive from
+        // WorldSocket.HandleAuthSession and the recreate flag isn't set.
+        bool needsRecreate = GetSession().WorldClient == null
+            || !GetSession().WorldClient!.IsConnected()
+            || GetSession().WorldClientNeedsRecreateOnNextLogin;
+        if (needsRecreate)
         {
             Log.Event("session.relogin.worldclient_recreate_attempt", new
             {
                 had_world_client = GetSession().WorldClient != null,
                 was_connected = GetSession().WorldClient?.IsConnected() ?? false,
                 was_authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
+                marked_by_logout = GetSession().WorldClientNeedsRecreateOnNextLogin,
                 target_guid_low = playerLogin.Guid.GetCounter(),
             });
 
@@ -217,7 +225,7 @@ public partial class WorldSocket
                 return;
             }
 
-            // Tear down a stale-but-not-yet-disconnected leftover before
+            // Tear down the existing client (alive or stale) before
             // overwriting the slot, so its receive-loop exit path doesn't
             // race the new client onto session.WorldClient. Disconnect()
             // is idempotent on already-closed sockets.
@@ -252,6 +260,7 @@ public partial class WorldSocket
                 AbortLogin(LoginFailureReason.NoWorld);
                 return;
             }
+            GetSession().WorldClientNeedsRecreateOnNextLogin = false;
         }
 
         if (!GetSession().GameState.CachedPlayers.TryGetValue(playerLogin.Guid, out var selectedChar))


### PR DESCRIPTION
## Summary

  Two related fixes for the logout → char-select → relog flow.

  ### Commit 1 (861c9a5) — hold InstanceSocket open through char-select

  **Bug:** SMSG_LOGOUT_COMPLETE handler was calling `InstanceSocket.CloseSocket()` synchronously after forwarding the
  packet to the modern client. The 1.14 client flushes WTF (keybinds, macros, account/config caches, SavedVariables) as
  part of its char-select transition triggered by LOGOUT_COMPLETE, and that transition takes ~1s on observed runs.
  Slamming the TCP socket microseconds after the packet pushed the client into an error-disconnect code path that
  skipped the flush — wiping the user's keybindings, macros, and account settings.

  Symptom was rare and elusive because the 20s open-world logout countdown gave WoW wide margin to finish flushing
  before whatever it was racing landed; the bug almost always reproduced on instant-logout flows (Exit Game, in-town
  logout) where there's no countdown.

  **Fix:** capture the InstanceSocket reference, null the session pointer immediately so subsequent send paths handle it
   cleanly via existing send-on-closed logic, and hand the socket to a 3s polling task that closes only if the client
  hasn't done so itself. A direct 1.12 client ↔ 1.12 server connection never sees this — the legacy server doesn't
  proactively kill the client on logout-complete; we now mirror that.

  **Diagnostics:** `session.logout_complete.*` JSONL events
  - `socket_hold_started` (`hold_ms`, `poll_interval_ms`)
  - `client_closed_first` (`elapsed_ms`) — normal path
  - `safety_net_closed` (`elapsed_ms`) — 3s expired, proxy closed
  - `safety_net_error` (`message`)

  **Validated bundle 20260505-051822:** `client_closed_first elapsed_ms=1080`, i.e. WoW needed 1.08s to finish flushing
  — under the old code the socket died within microseconds of LOGOUT_COMPLETE, well over a full second before WoW was
  done. 3s buffer leaves ~1.9s headroom.

  ### Commit 2 (04ccdf1) — recreate WorldClient on relog

  861c9a5 keeps BNet/InstanceSocket alive across logout. Side effect: the next char-login arrives as
  `CMSG_AUTH_CONTINUED_SESSION` instead of `CMSG_AUTH_SESSION`, and `HandleAuthContinuedSession` does not run the
  WorldClient-creation code that `HandleAuthSession` does. Twinstar closes the legacy world TCP shortly after each
  logout completes server-side, so by the time `CMSG_PLAYER_LOGIN` for the next char arrives the proxy's `WorldClient`
  is dead or about to be.

  **Two failure modes observed in user bundles after only commit 1:**
  - **WOW51900309** at "Enter World" — `CMSG_PLAYER_LOGIN` forwarded into a closed legacy socket; no
  `SMSG_LOGIN_VERIFY_WORLD` ever returns, modern client times out on the realm/instance handshake.
  - **NullReferenceException** at `ChatHandler.cs:227` — relog landed in world via a still-alive-but-doomed connection
  that died ~3s later, `GetSession().WorldClient` went null, the first `/say` deref'd it (the `!`-suppression doesn't
  help at runtime).

  **Fix:** mirror direct 1.12 client ↔ 1.12 server, which opens a new world TCP per character.
  - `SMSG_LOGOUT_COMPLETE` drops `session.WorldClient` (no proactive `Disconnect()` — we're on the receive thread; let
  Twinstar close on its end).
  - `HandlePlayerLogin`'s null-check now recreates `WorldClient` via `ConnectToWorldServer` instead of bailing with
  `NoWorld`. `AuthClient` is disconnected post-first-login but its session key survives (snapshot in `WorldClient.cs:90`
   already handles that case).

  **Diagnostics:**
  - `session.logout_complete.worldclient_dropped`
  - `session.relogin.worldclient_recreate_attempt`
  - `session.relogin.worldclient_recreated` (with `elapsed_ms`)
  - `session.relogin.worldclient_recreate_failed` (e.g. unknown realm)
  - `session.relogin.stale_worldclient_disconnect_error`

  **Repro bundle 20260505-120057:** char A logout at t=696s, char B login at t=706s via `CMSG_AUTH_CONTINUED_SESSION`
  (no `HandleAuthSession` path), `session.ondisconnect.suppressed` at t=709s nulled `WorldClient`, then NRE at t=758s on
   `/say`.

  ## Test plan

  - [ ] Open-world `/logout` (20s countdown): WTF preserved, relog into different char succeeds, chat works
  - [ ] In-town `/logout` (instant): WTF preserved, relog succeeds, chat works
  - [ ] Exit Game button: WTF preserved
  - [ ] Rapid relog within 3s: socket-hold doesn't interfere
  - [ ] Log-out → pick same character → enter world: chat works (no NRE)
  - [ ] Log-out → pick different character → enter world: chat works, no WOW51900309
  - [ ] JSONL bundle shows `session.relogin.worldclient_recreated { connected: true }` on every relog