### PR TITLE
Fix/spell failure misleading combat error

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1588,6 +1588,16 @@ public class GlobalSessionData
     public WorldSocket InstanceSocket = null!;
     public AuthClient AuthClient = null!;
     public WorldClient? WorldClient;
+    // JimsProxy: set true on SMSG_LOGOUT_COMPLETE so the next CMSG_PLAYER_LOGIN
+    // tears down and recreates WorldClient. Twinstar accepts a second
+    // CMSG_PLAYER_LOGIN on the same world TCP (the LOGIN_VERIFY_WORLD comes
+    // back fine) but then closes the connection a few seconds into the new
+    // character's session — leaving session.WorldClient null mid-game. We
+    // can't drop the WorldClient at LOGOUT_COMPLETE itself because char-select
+    // (CMSG_ENUM_CHARACTERS / CMSG_QUERY_PLAYER_NAME / etc.) is forwarded over
+    // the same WorldClient and needs it alive until the user picks a char.
+    // Cleared after the recreate succeeds.
+    public bool WorldClientNeedsRecreateOnNextLogin;
     public SniffFile ModernSniff = null!;
 
     public Dictionary<string, WowGuid128> GuildsByName = [];

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -370,32 +370,31 @@ public partial class WorldClient
         // the next character (or the same one re-logging in) starts clean.
         GetSession().ThreatTracker.Reset();
 
-        // JimsProxy (logout-wtf-flush follow-up): drop the session's reference
-        // to this WorldClient. The legacy server's world session for the
-        // outgoing character ends with SMSG_LOGOUT_COMPLETE; Twinstar closes
-        // its end of the world TCP shortly after. Because 861c9a5 keeps the
-        // BNet/InstanceSocket alive across logout, the next char-login arrives
-        // as CMSG_AUTH_CONTINUED_SESSION, which does NOT run the WorldClient-
-        // creation code in WorldSocket.HandleAuthSession. Without this nulling,
-        // HandlePlayerLogin's null-check would see the stale-but-not-yet-closed
-        // legacy connection, forward CMSG_PLAYER_LOGIN into a doomed socket,
-        // and either time out at "Enter World" with WOW51900309 or — worse —
-        // get the modern client into the world over the dying connection and
-        // NRE at ChatHandler.cs:227 the moment the player /says.
+        // JimsProxy (logout-wtf-flush follow-up): mark the session so the next
+        // CMSG_PLAYER_LOGIN tears down and recreates WorldClient. Twinstar
+        // accepts a second CMSG_PLAYER_LOGIN on the existing world TCP (the
+        // LOGIN_VERIFY_WORLD comes back fine) but then drops the connection
+        // a few seconds into the new character's session, leaving
+        // session.WorldClient null mid-game. The first observed symptom was
+        // an NRE at ChatHandler.cs:227 the moment the player /said; the
+        // second was WOW51900309 at "Enter World" if the legacy socket died
+        // before HandlePlayerLogin could forward CMSG_PLAYER_LOGIN.
         //
-        // We deliberately do NOT call Disconnect() here: this handler is
-        // running on the receive thread we'd be tearing down, which races the
-        // loop's own exit-via-disconnect path. Letting Twinstar close on its
-        // end is safer; the receive loop drains via the existing
-        // session.ondisconnect.suppressed path with was_active_world_client=false
-        // (we already nulled the slot, so its CompareExchange no-ops).
-        var droppedWorldClient = GetSession().WorldClient;
-        GetSession().WorldClient = null;
-        Log.Event("session.logout_complete.worldclient_dropped", new
+        // We do NOT null WorldClient here: the modern client transitions to
+        // char-select during the InstanceSocket hold below, and char-select
+        // forwards CMSG_ENUM_CHARACTERS / CMSG_QUERY_PLAYER_NAME / etc.
+        // through the same WorldClient. Nulling here means those queries
+        // get silently dropped, the modern client never receives
+        // SMSG_ENUM_CHARACTERS_RESULT, and after ~12s of waiting it sends
+        // CMSG_LOG_DISCONNECT and quits to the login screen. Bundle
+        // 20260505-130649 reproduced exactly that regression. The flag is
+        // cleared in WorldSocket.HandlePlayerLogin after the recreate.
+        GetSession().WorldClientNeedsRecreateOnNextLogin = true;
+        Log.Event("session.logout_complete.worldclient_recreate_marked", new
         {
-            had_world_client = droppedWorldClient != null,
-            was_connected = droppedWorldClient?.IsConnected() ?? false,
-            was_authenticated = droppedWorldClient?.IsAuthenticated() ?? false,
+            had_world_client = GetSession().WorldClient != null,
+            was_connected = GetSession().WorldClient?.IsConnected() ?? false,
+            was_authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
         });
 
         // JimsProxy WTF-flush fix: capture the InstanceSocket reference and

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -333,6 +333,21 @@ public partial class WorldClient
         SendPacketToClient(logout);
     }
 
+    // JimsProxy: how long to leave the InstanceSocket open after sending
+    // SMSG_LOGOUT_COMPLETE before the proxy force-closes it as a safety net.
+    // The 1.14 client flushes WTF (keybinds / macros / account / cache) as
+    // part of its char-select transition; if we slam the TCP socket within
+    // microseconds of LOGOUT_COMPLETE the client takes an error-disconnect
+    // code path that skips the flush, wiping settings. Symptom is most
+    // common on instant-logout flows (Exit Game, in-town logout) where
+    // there's no 20s countdown to widen the window. A direct 1.12 client
+    // ↔ 1.12 server connection never sees this because the legacy server
+    // doesn't proactively kill the client socket on logout-complete; we
+    // mirror that and let WoW close its end first. The safety-net timer
+    // bounds how long a buggy / never-closing client can leak the socket.
+    private const int LogoutCompleteSocketHoldMs = 3_000;
+    private const int LogoutCompletePollIntervalMs = 100;
+
     [PacketHandler(Opcode.SMSG_LOGOUT_COMPLETE)]
     void HandleLogoutComplete(WorldPacket packet)
     {
@@ -354,8 +369,70 @@ public partial class WorldClient
         // Threat lists were keyed off the outgoing character's GUIDs; wipe so
         // the next character (or the same one re-logging in) starts clean.
         GetSession().ThreatTracker.Reset();
-        GetSession().InstanceSocket.CloseSocket();
+
+        // JimsProxy WTF-flush fix: capture the InstanceSocket reference and
+        // hand it to a delayed safety-net close. Drop the session's reference
+        // immediately so any subsequent send-on-this-socket path nulls out
+        // cleanly via the existing send-on-closed handling. Do NOT call
+        // CloseSocket() synchronously -- the modern client's WTF flush is
+        // gated on a clean socket lifetime through the char-select transition.
+        var lingeringSocket = GetSession().InstanceSocket;
         GetSession().InstanceSocket = null!;
+        var holdStart = DateTime.UtcNow;
+        Log.Event("session.logout_complete.socket_hold_started", new
+        {
+            hold_ms = LogoutCompleteSocketHoldMs,
+            poll_interval_ms = LogoutCompletePollIntervalMs,
+        });
+        // Poll the socket so the JSONL captures *when* the client closed
+        // its end (the WTF flush gate). On fast paths (Exit Game / in-town
+        // instant logout) we expect this to land well under 3s; on the
+        // 20s-countdown path the client may already have closed by the
+        // time LOGOUT_COMPLETE arrives. If 3s elapses without the client
+        // closing, the safety net fires and the same elapsed_ms tells us
+        // the buffer was actually load-bearing this session.
+        System.Threading.Tasks.Task.Run(async () =>
+        {
+            try
+            {
+                while ((DateTime.UtcNow - holdStart).TotalMilliseconds < LogoutCompleteSocketHoldMs)
+                {
+                    if (lingeringSocket == null || !lingeringSocket.IsOpen())
+                    {
+                        var elapsed = (long)(DateTime.UtcNow - holdStart).TotalMilliseconds;
+                        Log.Event("session.logout_complete.client_closed_first", new
+                        {
+                            elapsed_ms = elapsed,
+                        });
+                        return;
+                    }
+                    await System.Threading.Tasks.Task.Delay(LogoutCompletePollIntervalMs);
+                }
+                // 3s elapsed and the client still hasn't closed -- safety net.
+                if (lingeringSocket != null && lingeringSocket.IsOpen())
+                {
+                    lingeringSocket.CloseSocket();
+                    Log.Event("session.logout_complete.safety_net_closed", new
+                    {
+                        elapsed_ms = LogoutCompleteSocketHoldMs,
+                    });
+                }
+                else
+                {
+                    // Tight race: client closed between the last poll and the
+                    // window expiring. Treat as client-closed-first.
+                    Log.Event("session.logout_complete.client_closed_first", new
+                    {
+                        elapsed_ms = LogoutCompleteSocketHoldMs,
+                        late_race = true,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Event("session.logout_complete.safety_net_error", new { message = ex.Message });
+            }
+        });
     }
 
     [PacketHandler(Opcode.SMSG_LOGOUT_CANCEL_ACK)]

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -370,6 +370,34 @@ public partial class WorldClient
         // the next character (or the same one re-logging in) starts clean.
         GetSession().ThreatTracker.Reset();
 
+        // JimsProxy (logout-wtf-flush follow-up): drop the session's reference
+        // to this WorldClient. The legacy server's world session for the
+        // outgoing character ends with SMSG_LOGOUT_COMPLETE; Twinstar closes
+        // its end of the world TCP shortly after. Because 861c9a5 keeps the
+        // BNet/InstanceSocket alive across logout, the next char-login arrives
+        // as CMSG_AUTH_CONTINUED_SESSION, which does NOT run the WorldClient-
+        // creation code in WorldSocket.HandleAuthSession. Without this nulling,
+        // HandlePlayerLogin's null-check would see the stale-but-not-yet-closed
+        // legacy connection, forward CMSG_PLAYER_LOGIN into a doomed socket,
+        // and either time out at "Enter World" with WOW51900309 or — worse —
+        // get the modern client into the world over the dying connection and
+        // NRE at ChatHandler.cs:227 the moment the player /says.
+        //
+        // We deliberately do NOT call Disconnect() here: this handler is
+        // running on the receive thread we'd be tearing down, which races the
+        // loop's own exit-via-disconnect path. Letting Twinstar close on its
+        // end is safer; the receive loop drains via the existing
+        // session.ondisconnect.suppressed path with was_active_world_client=false
+        // (we already nulled the slot, so its CompareExchange no-ops).
+        var droppedWorldClient = GetSession().WorldClient;
+        GetSession().WorldClient = null;
+        Log.Event("session.logout_complete.worldclient_dropped", new
+        {
+            had_world_client = droppedWorldClient != null,
+            was_connected = droppedWorldClient?.IsConnected() ?? false,
+            was_authenticated = droppedWorldClient?.IsAuthenticated() ?? false,
+        });
+
         // JimsProxy WTF-flush fix: capture the InstanceSocket reference and
         // hand it to a delayed safety-net close. Drop the session's reference
         // immediately so any subsequent send-on-this-socket path nulls out

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -492,6 +492,26 @@ public partial class WorldClient
         bool dequeued = false;
         bool wasStarted = false;
         bool foundActiveCastId = false;
+
+        // JimsProxy: Twinstar's Spell::SendInterrupted hardcodes the wire reason
+        // byte to vanilla 0 (= classic AffectingCombat=1 after translation). For
+        // local-player/pet casts the real reason arrives ~1ms later in
+        // SMSG_CAST_FAILED, but the misleading "You are in combat" popup from
+        // SMSG_SPELL_FAILURE has already shown. Bundle 20260505-191020 caught
+        // this on a Mage casting Remove Lesser Curse with no curse to remove
+        // (real reason: AlreadyAtFullHealth). Override the broadcast reason to
+        // DontReport (classic 30) for local casts so the cast-bar / bow-draw
+        // dismiss still happens but no error popup fires; CastFailed (from
+        // either this path's inline send or HandleCastFailed) carries the real
+        // reason and renders the correct popup.
+        bool overrideReasonForLocalBroadcast = false;
+        bool skipBroadcastFailure = false;
+        // 1.14 needs SMSG_SPELL_FAILURE to retract the bow-draw / wand-aim visual
+        // for ranged auto-attacks (Auto Shot 75, Shoot 5019); CastFailed +
+        // CANCEL_AUTO_REPEAT alone leaves the bow stuck drawn. Other instants
+        // can drop the broadcast entirely -- there's no animation to cancel.
+        bool isRangedAutoAttack = spellId == 75 || spellId == 5019;
+
         // Local player: DEQUEUE and send CastFailed immediately. Kronos doesn't
         // always follow SMSG_SPELL_FAILURE with SMSG_CAST_FAILED (e.g. target dies
         // mid-cast). Previously this only peeked, relying on HandleCastFailed to
@@ -523,6 +543,15 @@ public partial class WorldClient
             SendPacketToClient(failed);
 
             GetSession().GameState.ClearHeldCastTimeCast();
+
+            // Instant cast that wasn't a ranged auto-attack: SPELL_START was
+            // never forwarded, so there's no cast bar to dismiss. CastFailed
+            // already cancelled GCD anticipation. Skip the misleading
+            // SpellFailure broadcast entirely.
+            if (!pendingNormal.HasStarted && !isRangedAutoAttack)
+                skipBroadcastFailure = true;
+            else
+                overrideReasonForLocalBroadcast = true;
         }
         else if (GetSession().GameState.CurrentPetGuid == casterUnit &&
                  GetSession().GameState.TryDequeuePendingPetCast(spellId, out var pendingPet))
@@ -539,6 +568,14 @@ public partial class WorldClient
             petFailed.Reason = reason;
             petFailed.CastID = pendingPet.ServerGUID;
             SendPacketToClient(petFailed);
+
+            // Pet path: PetCastFailed handles the pet UI. Suppress the broadcast
+            // SpellFailure for instants (no cast bar); for cast-time pet spells
+            // forward with DontReport so the bar dismisses without popup spam.
+            if (!pendingPet.HasStarted)
+                skipBroadcastFailure = true;
+            else
+                overrideReasonForLocalBroadcast = true;
         }
         else
         {
@@ -559,13 +596,17 @@ public partial class WorldClient
             spellVisual = GameData.GetSpellVisual(spellId);
         }
 
-        SpellFailure spell = new SpellFailure();
-        spell.CasterUnit = casterUnit;
-        spell.CastID = castId;
-        spell.SpellID = spellId;
-        spell.SpellXSpellVisualID = spellVisual;
-        spell.Reason = reason;
-        SendPacketToClient(spell);
+        byte broadcastReason = overrideReasonForLocalBroadcast ? (byte)SpellCastResultClassic.DontReport : reason;
+        if (!skipBroadcastFailure)
+        {
+            SpellFailure spell = new SpellFailure();
+            spell.CasterUnit = casterUnit;
+            spell.CastID = castId;
+            spell.SpellID = spellId;
+            spell.SpellXSpellVisualID = spellVisual;
+            spell.Reason = broadcastReason;
+            SendPacketToClient(spell);
+        }
 
         //MIRASU - Mirror the FAILED_OTHER interrupt synthesis for the broadcasted FAILURE path.
         //MIRASU   PvP scenario: you Counterspell an enemy player -> Kronos broadcasts
@@ -603,6 +644,10 @@ public partial class WorldClient
         {
             spellId,
             reason,
+            broadcast_reason = broadcastReason,
+            broadcast_skipped = skipBroadcastFailure,
+            broadcast_reason_overridden = overrideReasonForLocalBroadcast,
+            is_ranged_auto_attack = isRangedAutoAttack,
             isCaster = GetSession().GameState.CurrentPlayerGuid == casterUnit,
             isPetCaster = GetSession().GameState.CurrentPetGuid == casterUnit,
             dequeued,

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -38,6 +38,20 @@ public partial class WorldClient
     uint _keepAlivePingSerial;
     const int KeepAliveIntervalMs = 30_000;
 
+    // JimsProxy silent-stall watchdog: if the legacy server stops delivering
+    // s2c traffic for this long while we're still sending keepalive pings,
+    // declare the WorldClient stale and trigger the unplanned-reconnect path.
+    // Bundle 20260505-131650 caught Twinstar going silent for 150s under
+    // Stormwind crowd load -- no FIN, no RST, just no data flowing -- which
+    // froze spell casts (waiting on SMSG_SPELL_GO that never came) while
+    // movement still worked client-side via extrapolation. The unplanned-
+    // reconnect path was wired but only fires on TCP RST/FIN; without a
+    // disconnect signal it never triggered, leaving the user in a ghost
+    // world until WoW itself crashed. 60s = 2 keepalive intervals + buffer;
+    // anything shorter risks false positives on transient hiccups, anything
+    // longer leaves the user staring at a frozen UI.
+    const int SilentStallThresholdMs = 60_000;
+
     // JimsProxy: last-inbound-opcode tracking for disconnect diagnostics. When
     // the legacy connection dies unexpectedly (zombie state, AFK DC), capturing
     // the most recent server-to-proxy opcode + its arrival tick narrows down
@@ -800,6 +814,72 @@ public partial class WorldClient
 
     private void SendKeepAlivePing(object? state)
     {
+        // Race guard: the timer's queued callback can still execute briefly
+        // after Disconnect() / StopKeepAliveTimer() races with it. Bail
+        // before we try to ping or trip the watchdog on a corpse.
+        if (!IsConnected() || _isSuccessful == false)
+            return;
+
+        // JimsProxy silent-stall watchdog: before sending the next keepalive
+        // ping, check whether the legacy server has gone silent on us. The
+        // existing reconnect path (HandleDisconnect / receive-loop catch)
+        // only fires on TCP RST/FIN; if Twinstar just stops sending data
+        // without closing, no disconnect ever fires and the player sits in
+        // a frozen ghost world. We piggyback on the keepalive timer rather
+        // than a dedicated watchdog timer to avoid extra timer churn -- if
+        // pings are firing, we're alive enough to check.
+        //
+        // Skip when _lastInboundOpcodeTick is still 0 (no s2c packets ever
+        // received -- mid-handshake, treat as alive).
+        if (_lastInboundOpcodeTick != 0)
+        {
+            int elapsedMs = Environment.TickCount - _lastInboundOpcodeTick;
+            if (elapsedMs > SilentStallThresholdMs)
+            {
+                Log.Event("session.worldclient.silent_stall_detected", new
+                {
+                    ms_since_last_inbound = elapsedMs,
+                    threshold_ms = SilentStallThresholdMs,
+                    last_opcode = _lastInboundOpcode.ToString(),
+                    last_opcode_raw = _lastInboundOpcodeRaw,
+                    keepalive_serial = _keepAlivePingSerial,
+                });
+
+                // Mirror the receive-loop disconnect path: take the slot if
+                // we still own it, then trigger the existing reconnect logic.
+                // CompareExchange so a racing HandleDisconnect on a real
+                // FIN arriving in the same window can't double-fire the
+                // reconnect (TryUnplannedReconnectAndPropagate also has its
+                // own CAS guard, but defense in depth is cheap).
+                var session = GetSession();
+                bool wasActiveWorldClient = false;
+                if (session != null)
+                {
+                    var prior = Interlocked.CompareExchange(ref session.WorldClient, null, this);
+                    wasActiveWorldClient = ReferenceEquals(prior, this);
+                }
+                try { Disconnect(); }
+                catch (Exception ex)
+                {
+                    Log.Event("session.worldclient.silent_stall_disconnect_error", new
+                    {
+                        exception_type = ex.GetType().Name,
+                        message = ex.Message,
+                    });
+                }
+                StopKeepAliveTimer();
+                if (wasActiveWorldClient && session != null)
+                {
+                    session.TryUnplannedReconnectAndPropagate(
+                        this,
+                        originalExceptionType: "SilentStall",
+                        originalExceptionMessage: $"No s2c packets for {elapsedMs}ms (threshold {SilentStallThresholdMs}ms)",
+                        originalSocketErrorCode: null);
+                }
+                return;
+            }
+        }
+
         uint serial = Interlocked.Increment(ref _keepAlivePingSerial);
         SendPing(serial | 0x80000000, 0);
     }

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -186,11 +186,72 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_PLAYER_LOGIN)]
     void HandlePlayerLogin(PlayerLogin playerLogin)
     {
+        // JimsProxy (logout-wtf-flush follow-up): on every char-login after
+        // the first one in a session — including same-char relogs — the
+        // session's WorldClient slot is null (SMSG_LOGOUT_COMPLETE drops it,
+        // see World/Client/PacketHandlers/CharacterHandler.cs::HandleLogoutComplete).
+        // Re-establish a fresh legacy world session here. Mirrors a direct
+        // 1.12 client ↔ 1.12 server connection, which opens a new world TCP
+        // per character. The first login of a session falls through this
+        // block — WorldClient is already set up by WorldSocket.HandleAuthSession.
         if (GetSession().WorldClient == null || !GetSession().WorldClient!.IsConnected())
         {
-            Log.Print(LogType.Error, "WorldClient is disconnected, cannot enter world.");
-            AbortLogin(LoginFailureReason.NoWorld);
-            return;
+            Log.Event("session.relogin.worldclient_recreate_attempt", new
+            {
+                had_world_client = GetSession().WorldClient != null,
+                was_connected = GetSession().WorldClient?.IsConnected() ?? false,
+                was_authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
+                target_guid_low = playerLogin.Guid.GetCounter(),
+            });
+
+            var reloginRealm = GetSession().RealmManager.GetRealm(GetSession().RealmId);
+            if (reloginRealm == null)
+            {
+                Log.Print(LogType.Error, $"HandlePlayerLogin: cannot recreate WorldClient — unknown realm id {GetSession().RealmId}");
+                Log.Event("session.relogin.worldclient_recreate_failed", new
+                {
+                    reason = "unknown_realm",
+                    realm_id_index = (int)GetSession().RealmId.Index,
+                });
+                AbortLogin(LoginFailureReason.NoWorld);
+                return;
+            }
+
+            // Tear down a stale-but-not-yet-disconnected leftover before
+            // overwriting the slot, so its receive-loop exit path doesn't
+            // race the new client onto session.WorldClient. Disconnect()
+            // is idempotent on already-closed sockets.
+            var staleWorldClient = GetSession().WorldClient;
+            if (staleWorldClient != null)
+            {
+                try { staleWorldClient.Disconnect(); }
+                catch (Exception ex)
+                {
+                    Log.Event("session.relogin.stale_worldclient_disconnect_error", new
+                    {
+                        exception_type = ex.GetType().Name,
+                        message = ex.Message,
+                    });
+                }
+            }
+
+            var reconnectStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            GetSession().WorldClient = new World.Client.WorldClient();
+            bool reloginConnected = GetSession().WorldClient!.ConnectToWorldServer(reloginRealm, GetSession());
+            Log.Event("session.relogin.worldclient_recreated", new
+            {
+                realm_name = reloginRealm.Name,
+                connected = reloginConnected,
+                authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
+                elapsed_ms = reconnectStopwatch.ElapsedMilliseconds,
+            });
+            if (!reloginConnected)
+            {
+                Log.Print(LogType.Error, "HandlePlayerLogin: failed to recreate WorldClient on re-login.");
+                GetSession().WorldClient = null;
+                AbortLogin(LoginFailureReason.NoWorld);
+                return;
+            }
         }
 
         if (!GetSession().GameState.CachedPlayers.TryGetValue(playerLogin.Guid, out var selectedChar))

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -186,21 +186,29 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_PLAYER_LOGIN)]
     void HandlePlayerLogin(PlayerLogin playerLogin)
     {
-        // JimsProxy (logout-wtf-flush follow-up): on every char-login after
-        // the first one in a session — including same-char relogs — the
-        // session's WorldClient slot is null (SMSG_LOGOUT_COMPLETE drops it,
-        // see World/Client/PacketHandlers/CharacterHandler.cs::HandleLogoutComplete).
-        // Re-establish a fresh legacy world session here. Mirrors a direct
-        // 1.12 client ↔ 1.12 server connection, which opens a new world TCP
-        // per character. The first login of a session falls through this
-        // block — WorldClient is already set up by WorldSocket.HandleAuthSession.
-        if (GetSession().WorldClient == null || !GetSession().WorldClient!.IsConnected())
+        // JimsProxy (logout-wtf-flush follow-up): recreate WorldClient if
+        //   (a) it's null/disconnected (defensive), OR
+        //   (b) the prior character's logout marked the session for a fresh
+        //       world TCP (WorldClientNeedsRecreateOnNextLogin).
+        // Twinstar accepts a second CMSG_PLAYER_LOGIN on the existing world
+        // TCP -- the LOGIN_VERIFY_WORLD comes back fine -- but then drops
+        // the connection a few seconds into the new character's session,
+        // leaving session.WorldClient null mid-game and NRE'ing the next
+        // /say at ChatHandler.cs:227. Mirror direct 1.12 client ↔ 1.12
+        // server (one world TCP per character). The first login of a
+        // session takes neither branch: WorldClient is alive from
+        // WorldSocket.HandleAuthSession and the recreate flag isn't set.
+        bool needsRecreate = GetSession().WorldClient == null
+            || !GetSession().WorldClient!.IsConnected()
+            || GetSession().WorldClientNeedsRecreateOnNextLogin;
+        if (needsRecreate)
         {
             Log.Event("session.relogin.worldclient_recreate_attempt", new
             {
                 had_world_client = GetSession().WorldClient != null,
                 was_connected = GetSession().WorldClient?.IsConnected() ?? false,
                 was_authenticated = GetSession().WorldClient?.IsAuthenticated() ?? false,
+                marked_by_logout = GetSession().WorldClientNeedsRecreateOnNextLogin,
                 target_guid_low = playerLogin.Guid.GetCounter(),
             });
 
@@ -217,7 +225,7 @@ public partial class WorldSocket
                 return;
             }
 
-            // Tear down a stale-but-not-yet-disconnected leftover before
+            // Tear down the existing client (alive or stale) before
             // overwriting the slot, so its receive-loop exit path doesn't
             // race the new client onto session.WorldClient. Disconnect()
             // is idempotent on already-closed sockets.
@@ -252,6 +260,7 @@ public partial class WorldSocket
                 AbortLogin(LoginFailureReason.NoWorld);
                 return;
             }
+            GetSession().WorldClientNeedsRecreateOnNextLogin = false;
         }
 
         if (!GetSession().GameState.CachedPlayers.TryGetValue(playerLogin.Guid, out var selectedChar))


### PR DESCRIPTION
 ## Summary

  Bundle `20260505-191020`: a Mage casting Remove Lesser Curse (475) with no curse to remove sees **"You are in
  combat"** — but the player isn't in combat, and Remove Lesser Curse isn't combat-restricted anyway. Same misleading
  popup hits any local cast that fails on Twinstar/vmangos.

  ## Root cause

  `vmangos / Twinstar's Spell::SendInterrupted` hardcodes the `SMSG_SPELL_FAILURE` wire reason byte to vanilla `0`
  (`AffectingCombat`), using it as a generic "interrupted" signal — the **real** failure reason arrives ~1ms later in
  `SMSG_CAST_FAILED`. The proxy correctly translates vanilla 0 → classic 1 (`AffectingCombat`) via
  `ConvertSpellCastResult`, but classic 1 still means `AffectingCombat` — the 1.14 client renders the misleading popup
  before `CastFailed` (with the real reason, e.g. `AlreadyAtFullHealth`) lands.

  JSONL packet sequence (Remove Lesser Curse, no curse on target):
  | t (ms) | direction | event |
  |---|---|---|
  | 0 | c2s | `CMSG_CAST_SPELL spell=475` |
  | +58 | s2c | `SMSG_SPELL_FAILURE` (Twinstar's hardcoded reason 0) |
  | +58 | proxy | `spell.failure.routed { reason: 1 }` ← popup fires here |
  | +59 | s2c | `SMSG_CAST_FAILED` (real reason, too late) |

  ## Fix

  For local-player and pet casts in `HandleSpellFailure`:
  - **Instant cast (`HasStarted=false`) + non-auto-attack:** skip the broadcast `SpellFailure` entirely. SPELL_START was
   never forwarded, so there's no cast bar or animation to dismiss; `CastFailed` already cancels GCD anticipation.
  - **Cast-time spell (`HasStarted=true`) OR ranged auto-attack (75 / 5019):** forward `SpellFailure` so the cast bar /
  bow-draw dismisses, but override the reason to `DontReport` (classic 30) so no popup fires. `CastFailed` (sent inline
  and/or by `HandleCastFailed` for the `SMSG_CAST_FAILED` that follows) carries the real reason and renders the correct
  popup.

  Non-local casters (PvP enemy, mob casts) are unchanged: the existing interrupt-log + cancel-visual synthesis at
  `reason==61` still fires because that gate runs against the original `reason`, not the overridden `broadcastReason`.

  ## Diagnostics

  `spell.failure.routed` gains:
  - `broadcast_reason` — what was actually sent on the wire
  - `broadcast_skipped` — true when the broadcast was suppressed entirely
  - `broadcast_reason_overridden` — true when reason was changed to DontReport
  - `is_ranged_auto_attack` — true for spells 75 / 5019

  ## Dependencies

  Stacked on `Mongrul:fix/worldclient-silent-stall-watchdog`, which is stacked on `Mongrul:logout-wtf-flush` (PR #144).
  **Merge order: #144 → watchdog PR → this PR.** Once the predecessors merge, this branch rebases to a clean 1-commit
  diff vs `beta`.

  ## Test plan

  - [ ] Cast Remove Lesser Curse with no curse: no "in combat" popup, get `AlreadyAtFullHealth` error in chat
  - [ ] Cast Polymorph on a Magic Immune target: cast bar dismisses, get correct error (no spurious "in combat")
  - [ ] Cast Hearthstone in combat: still gets correct "in combat" error from the *real* CastFailed
  - [ ] Hunter Auto Shot out of range: bow draw cancels (no stuck-drawn regression), no spurious popup
  - [ ] PvP Counterspell on enemy player: target-frame cast bar still dismisses (interrupt-log path still fires)
  - [ ] JSONL bundle shows `spell.failure.routed { broadcast_skipped: true }` for instant casts and `{
  broadcast_reason_overridden: true }` for cast-time spells / auto-attacks