### PR TITLE
Fix warlock pet over-scale; add diagnostics for spawn-cast glow triage

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1062,26 +1062,6 @@ public partial class WorldClient
             }
         }
 
-        // JimsProxy: emit structured spell.cast event so we can diagnose spell-ID
-        // and visual-kit lookup issues without parsing .pkt files. Particularly
-        // useful for comparing what different 1.12 servers (Kronos vs Ashen-wow)
-        // send for the same spell -- on Kronos PW:Shield doesn't render the
-        // bubble visual; on Ashen-wow it does. If spell_visual_id=0 here, the
-        // CSV lookup failed (either wrong spellId from server or missing row).
-        // Emitted for both SMSG_SPELL_START and SMSG_SPELL_GO (shared codepath).
-        Log.Event("spell.cast", new
-        {
-            direction = "s2c",
-            phase = isSpellGo ? "go" : "start",
-            spell_id = dbdata.SpellID,
-            spell_visual_id = dbdata.SpellXSpellVisualID,
-            visual_lookup_missing = dbdata.SpellXSpellVisualID == 0,
-            caster_guid = dbdata.CasterGUID.ToString(),
-            caster_is_player = dbdata.CasterGUID == GetSession().GameState.CurrentPlayerGuid,
-            casterCounter = dbdata.CasterUnit.GetCounter(), //MIRASU - lets us correlate with spell.failed_other.routed
-            castIdCounter = dbdata.CastID.GetCounter(),     //MIRASU - this is the CastID the modern client tracks
-        });
-
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180) && LegacyVersion.RemovedInVersion(ClientVersionBuild.V3_0_2_9056) && !isSpellGo)
             packet.ReadUInt8(); // cast count
 
@@ -1101,6 +1081,31 @@ public partial class WorldClient
         // client's TIME_SYNC offset can convert it to local time.
         if (isSpellGo && dbdata.CastTime == 0)
             dbdata.CastTime = Time.GetMSTime();
+
+        // JimsProxy: emit structured spell.cast event so we can diagnose spell-ID
+        // and visual-kit lookup issues without parsing .pkt files. Particularly
+        // useful for comparing what different 1.12 servers (Kronos vs Ashen-wow)
+        // send for the same spell -- on Kronos PW:Shield doesn't render the
+        // bubble visual; on Ashen-wow it does. If spell_visual_id=0 here, the
+        // CSV lookup failed (either wrong spellId from server or missing row).
+        // Emitted for both SMSG_SPELL_START and SMSG_SPELL_GO (shared codepath).
+        // Logged after CastFlags + CastTime are parsed so the bundle can grep
+        // pet-only instant-cast SPELL_STARTs (warlock-pet spawn glow triage).
+        Log.Event("spell.cast", new
+        {
+            direction = "s2c",
+            phase = isSpellGo ? "go" : "start",
+            spell_id = dbdata.SpellID,
+            spell_visual_id = dbdata.SpellXSpellVisualID,
+            visual_lookup_missing = dbdata.SpellXSpellVisualID == 0,
+            caster_guid = dbdata.CasterGUID.ToString(),
+            caster_is_player = dbdata.CasterGUID == GetSession().GameState.CurrentPlayerGuid,
+            caster_is_pet = dbdata.CasterUnit == GetSession().GameState.CurrentPetGuid,
+            cast_time = dbdata.CastTime,
+            cast_flags = dbdata.CastFlags,
+            casterCounter = dbdata.CasterUnit.GetCounter(), //MIRASU - lets us correlate with spell.failed_other.routed
+            castIdCounter = dbdata.CastID.GetCounter(),     //MIRASU - this is the CastID the modern client tracks
+        });
 
         if (isSpellGo)
         {

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -10,6 +10,7 @@ using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Collections;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,6 +18,21 @@ namespace HermesProxy.World.Client;
 
 public partial class WorldClient
 {
+    // JimsProxy (warlock-pet-scale): inverse-CMS pet-scale fix from PR #117 over-bumped
+    // every warlock pet by ~2x at K=1.5 (tester screenshots 2026-05-06: Imp/Felhunter/
+    // Voidwalker/Succubus all uniformly oversized vs 1.12). Halving K for the warlock
+    // family lands them at 1.12 size without disturbing hunter-pet behavior. Detection
+    // is by DisplayID — vanilla warlock pet roster is fixed and small.
+    private static readonly FrozenSet<int> WarlockPetDisplayIds = new[]
+    {
+        4449,   // Imp
+        850,    // Felhunter
+        1132,   // Voidwalker
+        4162,   // Succubus
+        1813,   // Felsteed
+        18223,  // Dreadsteed
+    }.ToFrozenSet();
+
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_DESTROY_OBJECT)]
     void HandleDestroyObject(WorldPacket packet)
@@ -3877,7 +3893,12 @@ public partial class WorldClient
         // Only fires when SCALE_X is present in this update (Scale != null) — a delta
         // values update without SCALE_X leaves the already-normalized scale sticky on the
         // client and avoids compounding multiplications across updates.
-        const float PetScaleK = 1.5f;
+        // K_hunter validated against Dire Wolf side-by-side vs 1.12 (commit 17a08c7).
+        // K_warlock = K_hunter / 2 — tester screenshots 2026-05-06 showed every warlock
+        // pet (Imp/Felhunter/Voidwalker/Succubus) rendering ~2x oversized at K=1.5
+        // uniformly across CMS values; halving the constant lands them at 1.12 size.
+        const float K_hunter  = 1.5f;
+        const float K_warlock = 0.75f;
         if (LegacyVersion.ExpansionVersion == 1
             && updateData.ObjectData.Scale != null
             && (objectType == ObjectType.Unit || objectType == ObjectType.Player || objectType == ObjectType.ActivePlayer))
@@ -3907,12 +3928,15 @@ public partial class WorldClient
                 if (displayId > 0)
                     cms = GameData.GetDisplayInfo((uint)displayId).DisplayScale;
 
+                bool isWarlockPet = WarlockPetDisplayIds.Contains(displayId);
+                float k = isWarlockPet ? K_warlock : K_hunter;
+
                 // Skip normalization if CMS data is missing/invalid — fall back to a flat
                 // K multiply so the pet still gets a size bump rather than passing through
                 // un-modified (and rendering small).
                 float emit = (cms > 0)
-                    ? (rawScale / cms) * PetScaleK
-                    : rawScale * PetScaleK;
+                    ? (rawScale / cms) * k
+                    : rawScale * k;
 
                 updateData.ObjectData.Scale = emit;
 
@@ -3921,7 +3945,8 @@ public partial class WorldClient
                     guid = guid.ToString(),
                     display_id = displayId,
                     creature_model_scale = cms,
-                    k = PetScaleK,
+                    k = k,
+                    family = isWarlockPet ? "warlock" : "hunter",
                     raw_scale = rawScale,
                     emitted_scale = emit,
                     matched_via = (currentPetGuid != default && guid == currentPetGuid) ? "current_pet_guid" : "summoned_by",


### PR DESCRIPTION
Tester screenshots 2026-05-06 showed the inverse-CMS pet-scale fix from PR #117 over-bumped every warlock pet by ~2x at K=1.5 (Imp, Felhunter, Voidwalker, Succubus all uniformly oversized vs 1.12). Hunter pets (Dire Wolf side-by-side) match 1.12 correctly.

UpdateHandler.cs:
- Add WarlockPetDisplayIds FrozenSet (Imp 4449, Felhunter 850, Voidwalker 1132, Succubus 4162, Felsteed 1813, Dreadsteed 18223).
- Split PetScaleK into K_hunter (1.5, unchanged) and K_warlock (0.75, half of K_hunter). Branch by family after DisplayID resolution.
- Add `family` field to unit.pet_scale.applied JSONL event so a bundle shows which branch fired without cross-referencing the display ID.

SpellHandler.cs:
- Relocate existing spell.cast Log.Event to fire AFTER CastFlags + CastTime are parsed from the wire — they were previously logged as zeros because the event ran before the parse.
- Add caster_is_pet, cast_time, cast_flags fields. Needed to triage a separate bug where Imp/Felhunter/Succubus emit a casting visual + sound on spawn but Voidwalker doesn't — suspected SMSG_SPELL_START forward of pet passive auras (Phase Shift, Tainted Blood, etc.) that the modern client treats as in-progress casts. With the new fields a tester JSONL can be filtered to `caster_is_pet=true && phase=start && cast_time=0` to read off the exact spell IDs to suppress in a follow-up. No behavior change in this commit; diagnostic-only.