### PR TITLE
Limit late same-spell drops to active GCD

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1179,7 +1179,9 @@ public sealed class GameSessionData
     {
         lock (_gcdLock)
         {
-            return _gcdTimerHasFired && _lastFiredSpellId == spellId;
+            return _gcdTimerHasFired &&
+                   _lastFiredSpellId == spellId &&
+                   _gcdExpireTimestampMs > Environment.TickCount64;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a client-side spell lockup that could happen when repeatedly spamming the same instant spell during the vanilla GCD queue window, observed with Sinister Strike on Kronos.

## Problem

The proxy has a `ShouldDropLateSameSpell()` guard used after the GCD hold timer has already fired a held spell. Its goal is to prevent forwarding a duplicate same-spell press during the tiny remaining GCD window, because the server would reject it as not ready anyway.

However, the guard only checked:

```csharp
_gcdTimerHasFired && _lastFiredSpellId == spellId
This meant the condition could remain true even after the actual GCD had fully expired. In practice, after Sinister Strike was released by the GCD timer, every later Sinister Strike press could still be classified as a late duplicate and dropped locally with DontReport.

The server never received those later casts, and the client could appear stuck: the spell icon remained usable, but pressing it did nothing meaningful.

Fix
ShouldDropLateSameSpell() now also verifies that the GCD hold window is still active:

_gcdExpireTimestampMs > Environment.TickCount64
So duplicate same-spell drops are only allowed during the real leftover GCD window. Once the GCD has expired, the next same-spell press is forwarded normally to the server.

Validation
Built successfully with dotnet build HermesProxy/HermesProxy.csproj -c Release.
Tested in-game by repeatedly spamming Sinister Strike while killing around 20 mobs.
The spell no longer became stuck after the fix.