### PR TITLE
Fix realm switch: stale character file + AuthClient gate

### DIFF
--- a/HermesProxy/BnetServer/Services/Services/GameUtilities.cs
+++ b/HermesProxy/BnetServer/Services/Services/GameUtilities.cs
@@ -129,7 +129,10 @@ public partial class BnetServices
 
         var realm = GetSession().RealmManager.GetRealms().FirstOrDefault(r => r.Name == lastPlayedChar.realmName && !r.Flags.HasFlag(RealmFlags.Offline));
         if (realm == null)
-            return BattlenetRpcErrorCode.UtilServerFailedToSerializeResponse;
+        {
+            GetSession().AccountMetaDataMgr.InvalidateLastSelectedCharacter();
+            return BattlenetRpcErrorCode.Ok;
+        }
 
         byte[] compressedRealmEntry = GetSession().RealmManager.GetCompressdRealmEntryJSON(realm, GetSession().Build);
         if (compressedRealmEntry.Length == 0)

--- a/HermesProxy/BnetServer/Services/Services/GameUtilities.cs
+++ b/HermesProxy/BnetServer/Services/Services/GameUtilities.cs
@@ -151,7 +151,7 @@ public partial class BnetServices
         if (GetSession().GameAccountInfo == null)
             return BattlenetRpcErrorCode.UserServerBadWowAccount;
 
-        if (!GetSession().AuthClient.IsConnected())
+        if (!GetSession().AuthClient.IsConnected() && !GetSession().RealmManager.GetRealms().Any())
             return BattlenetRpcErrorCode.UtilServerMissingRealmList;
 
         string subRegionId = "";


### PR DESCRIPTION
## Summary
- **Stale last_character.txt** — When the saved realm name doesn't match any available realm (e.g., Kronos renamed to "Kronos Legacy"), `GetLastCharPlayed` returned an error but never cleared the file. Every login attempt looped on the same stale data. Now invalidates the file and returns Ok so the client shows the full realm list.
- **AuthClient gate on realm switch** — Kronos closes the realmd socket after the initial auth handshake. `GetRealmList` gated on `AuthClient.IsConnected()`, so clicking "Change Realm" at character select always failed even though the realms were already cached. Now only fails if AuthClient is disconnected AND no realms are cached.

## Files changed
- `HermesProxy/BnetServer/Services/Services/GameUtilities.cs` — both fixes in `GetLastCharPlayed()` and `GetRealmList()`

## Test plan
- [ ] Login with stale last_character.txt pointing to a renamed/removed realm → should show realm list instead of error loop
- [ ] Connect to Kronos V → click Change Realm → should show realm list with PTR available
- [ ] Normal login flow unchanged — last character auto-select still works when realm name matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)