### PR TITLE
Fix/reconnect state cleanup

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1109,6 +1109,40 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy reconnect-state-cleanup: drop all in-flight cast bookkeeping
+    /// after an unplanned disconnect+reconnect. The legacy server forgets
+    /// everything we had in flight when it cuts the socket; if we don't drop
+    /// our local mirror, the next press of any spell that was pending at DC
+    /// time gets silently rejected by HasNonStartedPendingCastForSpell —
+    /// user-visible symptom is "spell stuck, spamming key does nothing, no
+    /// error message" (e.g. rogue's R-key Sinister Strike not firing). Same
+    /// story for OtherCasterActiveCastIds (mob/other-player CastIDs minted
+    /// pre-DC won't match anything the new server-side state knows about).
+    /// Returns the count of entries cleared so the reconnect log can show
+    /// whether the gap was actually significant.
+    /// </summary>
+    public (int normalCasts, int petCasts, int otherCasterIds) ResetInFlightCastState()
+    {
+        int normalCount;
+        lock (PendingCastsLock)
+        {
+            normalCount = PendingNormalCasts.Count;
+            while (PendingNormalCasts.TryDequeue(out _)) { }
+        }
+        int petCount = PendingPetCasts.Count;
+        while (PendingPetCasts.TryDequeue(out _)) { }
+        int otherCount = OtherCasterActiveCastIds.Count;
+        OtherCasterActiveCastIds.Clear();
+        // Single-slot trackers for melee + auto-repeat (Auto Shot, Shoot Wand)
+        // — same lifecycle as PendingNormalCasts; if a tracker was set when
+        // the DC fired, it never gets cleared by the SPELL_GO/CAST_FAILED
+        // path that normally nulls it.
+        CurrentClientNextMeleeCast = null;
+        CurrentClientAutoRepeatCast = null;
+        return (normalCount, petCount, otherCount);
+    }
+
+    /// <summary>
     /// Check if there's a pet cast that has already started (is in progress).
     /// Used to reject new casts without forwarding to server.
     /// </summary>
@@ -2113,6 +2147,23 @@ public class GlobalSessionData
                         PropagateUnplannedDcToModern(attemptId, "auth_failed");
                         return;
                     }
+
+                    // JimsProxy reconnect-state-cleanup: drop in-flight cast bookkeeping that
+                    // the legacy server forgot when it cut the socket. Without this, the next
+                    // press of any spell that was pending at DC time gets silently rejected
+                    // (HasNonStartedPendingCastForSpell), and the user sees "stuck spell, no
+                    // error". Done BEFORE registering the new WorldClient so that any CMSG
+                    // arriving in the tiny race window between WorldClient assignment and
+                    // PLAYER_LOGIN-completion sees a clean slate. See ResetInFlightCastState
+                    // doc for the full rationale.
+                    var clearedCounts = GameState!.ResetInFlightCastState();
+                    Framework.Logging.Log.Event("session.unplanned_reconnect.state_cleared", new
+                    {
+                        attempt_id = attemptId,
+                        normal_casts_cleared = clearedCounts.normalCasts,
+                        pet_casts_cleared = clearedCounts.petCasts,
+                        other_caster_ids_cleared = clearedCounts.otherCasterIds,
+                    });
 
                     // CRITICAL: register the new client with the session BEFORE sending CMSG_PLAYER_LOGIN.
                     // Modern→legacy CMSGs route via session.WorldClient (set null when the dead client

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -778,7 +778,20 @@ public partial class WorldClient
             }
             _isSuccessful = true;
             StartKeepAliveTimer();
-            SendRttProbes();
+            // JimsProxy m_OverSpeedPings antiflood fix:
+            // Replaced 3-pings-at-login burst with a single immediate ping. vmangos-
+            // family servers (Twinstar, Kronos) flag any ping arriving <27s after the
+            // prior one as an "over-speed ping" via m_OverSpeedPings counter. The
+            // original 3 probes 1s apart added 2 over-speed strikes per session,
+            // accumulating toward the kick threshold across hours. Stacked with the
+            // doubled-forward bug (also fixed in this PR — see WorldSocket.cs
+            // CMSG_PING handler) this is what was triggering "Socket Closed By
+            // GameWorldServer (header)" 1-2 hours into a session. One immediate
+            // probe still seeds RTT 30s ahead of the first keepalive (preserves
+            // issue #43 adaptive-fire-offset convergence) without tripping the
+            // counter — this single probe is the first ping on the connection so
+            // there's no prior to be over-speed against.
+            SendKeepAlivePing(null);
         }
         else if (result == AuthResult.AUTH_WAIT_QUEUE)
         {

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -297,12 +297,24 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             case Opcode.CMSG_PING:
                 Ping ping = new(packet);
                 ping.Read();
-                if (_connectType == ConnectionType.Realm && GetSession().WorldClient != null && GetSession().WorldClient!.IsConnected() && GetSession().WorldClient!.IsAuthenticated())
-                {
-                    GetSession().WorldClient!.SendPing(ping.Serial, ping.Latency);
-                }
-                else
-                    HandlePing(ping);
+                // JimsProxy m_OverSpeedPings antiflood fix:
+                // Previously when _connectType==Realm we ALSO forwarded the modern client's
+                // ping to the legacy server (in addition to responding locally). Combined
+                // with WorldClient's own _keepAliveTimer (KeepAliveIntervalMs=30s) this
+                // delivered TWO CMSG_PING per ~30s cycle to the legacy server, both anchored
+                // to ~connect time so they arrived within milliseconds of each other. Vanilla
+                // mangos-derived servers (Twinstar, Kronos) track over-speed pings via a
+                // counter (vmangos m_OverSpeedPings — confirmed by Kronos dev) and kick when
+                // it exceeds threshold; the kick presents as "Socket Closed By GameWorldServer
+                // (header)" some minutes into a session and is one of the three delayed-kick
+                // sources Kronos dev called out (the other two: malformed packet, Warden 90s).
+                // Modern client pings two TCP sockets (Realm + Instance) ~every 30s; both
+                // arrive here within 1ms of each other (visible as paired path:inline events
+                // in JSONL bundles). The proxy's own keepalive timer suffices to keep the
+                // legacy connection alive — never forward client pings to legacy. We sacrifice
+                // forwarding the client's measured-latency value to legacy (purely cosmetic
+                // for the friends-list latency icon) and gain a kick-free session.
+                HandlePing(ping);
                 break;
             case Opcode.CMSG_AUTH_SESSION:
                 AuthSession authSession = new(packet);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -431,12 +431,57 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
         }
     }
 
+    // JimsProxy: counters for c2s packets dropped while WorldClient is disconnected.
+    // The modern client keeps spamming movement (60+ Hz) during the dead window
+    // between TCP close and the reconnect's WorldClient reassignment. Each drop
+    // used to log a separate Log.Print line — under a 7-second DC window with a
+    // moving player that's hundreds of lines of noise drowning the actual
+    // disconnect cause in JSONL bundles. We now suppress per-packet logs after
+    // the first few and emit a single structured summary, then reset on next
+    // successful c2s send.
+    private int _disconnectedDropCount;
+    private long _disconnectedFirstDropMs;
+    private const int DropLogVerboseLimit = 3;
+
     private void SendPacketToServer(WorldPacket packet, Opcode delayUntilOpcode = Opcode.MSG_NULL_ACTION)
     {
         if (GetSession().WorldClient != null)
+        {
+            // Reset the drop-window counter on first successful send after a DC,
+            // emit a final summary so the JSONL shows the size of the gap.
+            if (_disconnectedDropCount > 0)
+            {
+                int finalCount = _disconnectedDropCount;
+                long firstMs = _disconnectedFirstDropMs;
+                _disconnectedDropCount = 0;
+                _disconnectedFirstDropMs = 0;
+                Log.Event("c2s.dropped_during_disconnect.summary", new
+                {
+                    total_dropped = finalCount,
+                    window_ms = firstMs == 0 ? 0 : Environment.TickCount64 - firstMs,
+                });
+            }
             GetSession().WorldClient!.SendPacketToServer(packet, delayUntilOpcode);
-        else
-            Log.Print(LogType.Error, $"Attempt to send opcode {packet.GetUniversalOpcode(false)} ({packet.GetOpcode()}) while WorldClient is disconnected!");
+            return;
+        }
+
+        // WorldClient is null: drop the packet. Log verbose for the first few
+        // (still useful diagnostics for one-off issues) then go quiet, but keep
+        // structured-event accounting so a DC investigation can see the rate.
+        int dropIdx = Interlocked.Increment(ref _disconnectedDropCount);
+        if (dropIdx == 1)
+            _disconnectedFirstDropMs = Environment.TickCount64;
+        var opcode = packet.GetUniversalOpcode(false);
+        Log.Event("c2s.dropped_during_disconnect", new
+        {
+            opcode = opcode.ToString(),
+            opcode_raw = packet.GetOpcode(),
+            drop_index = dropIdx,
+        });
+        if (dropIdx <= DropLogVerboseLimit)
+            Log.Print(LogType.Error, $"Attempt to send opcode {opcode} ({packet.GetOpcode()}) while WorldClient is disconnected!");
+        else if (dropIdx == DropLogVerboseLimit + 1)
+            Log.Print(LogType.Error, $"... further per-packet drop logs suppressed (see c2s.dropped_during_disconnect events for full count)");
     }
 
     public PacketHandler? GetHandler(Opcode opcode)


### PR DESCRIPTION
 ## Summary

  Three independent fixes targeting reconnect resilience and antiflood behavior on vanilla-mangos-family servers
  (Twinstar, Kronos).

  ## 1. Stuck-spell after reconnect

  Most reproducible on rogue Sinister Strike key spam after the proxy auto-reconnects from an unplanned DC. Pressing the
   bound key does nothing, no error message appears.

  Root cause: `TryUnplannedReconnectAndPropagate` reused the existing `GameState` across the dead-and-fresh
  `WorldClient` swap. Any cast in flight at DC time stayed in `PendingNormalCasts` forever. The next press hit
  `HasNonStartedPendingCastForSpell` → silent `SendCastFailedWithoutPrepare` drop. `ClearPendingNormalCasts()` already
  existed in `GlobalSessionData` but had **zero callers in source**.

  Fix: `GameState.ResetInFlightCastState()` drops `PendingNormalCasts`, `PendingPetCasts`, `OtherCasterActiveCastIds`,
  and the single-slot melee/auto-repeat trackers. Called immediately before `WorldClient = newClient` assignment in the
  reconnect path. Emits `session.unplanned_reconnect.state_cleared` JSONL event with per-bucket counts.

  ## 2. m_OverSpeedPings antiflood (the "Socket Closed By GameWorldServer (header)" 1-2hr kick)

  Vanilla mangos-family servers track an `m_OverSpeedPings` counter that increments any time a `CMSG_PING` arrives <27
  seconds after the previous one. When the counter exceeds threshold the server closes the socket with a "header"
  disconnect — one of three delayed-kick sources Kronos dev confirmed (other two: malformed packet, Warden 90s).

  Two stacked proxy bugs were both hitting it:

  **A. CMSG_PING forwarding** — `WorldSocket.cs:297-306` forwarded the modern client's Realm-connection ping to the
  legacy server (in addition to local Pong response). Combined with WorldClient's own 30s `_keepAliveTimer` this
  delivered TWO CMSG_PING per ~30s cycle to legacy, both anchored to ~connect time so they arrived within milliseconds
  of each other. JSONL bundles show the doubled-ping anomaly clearly. Now responds locally only — proxy's own keepalive
  timer suffices to keep legacy socket alive; we lose the cosmetic latency-icon value.

  **B. RTT-probe burst at login** — `SendRttProbes()` fired 3 pings 1s apart to seed RTT quickly. With the <27s
  over-speed threshold, probes 2 and 3 each added an over-speed strike — 2 strikes per session accumulated across hours.
   Replaced with a single immediate ping; RTT seeds 30s ahead of the first regular keepalive (preserves issue-#43
  adaptive-fire-offset convergence) and the single probe is the first ping on the connection so it can't be over-speed
  against itself.

  ## 3. Disconnect drop-log noise reduction

  `Attempt to send opcode while WorldClient is disconnected!` was drowning DC investigations — modern client sends 60+
  Hz of movement during the dead window, so a 7-second DC produces ~400 lines of identical errors hiding the real signal
   in JSONL bundles.

  Now logs verbose for the first 3 drops, then suppresses console output and emits structured
  `c2s.dropped_during_disconnect` events for accounting. On first successful c2s send post-reconnect, emits
  `c2s.dropped_during_disconnect.summary` with total count + window duration so the gap is visible at a glance.

  ## Test plan

  - [x] Build clean, 320/320 tests pass
  - [ ] Run uninterrupted for 1-2 hours — confirms no `Socket Closed By GameWorldServer (header)` kick
  - [ ] Forced reconnect (stop+start proxy mid-session) — rogue Sinister Strike fires immediately after, no stuck-spell