### PR TITLE
Fix/cheap shot aura duration pr

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2523,6 +2523,16 @@ public partial class WorldClient
                             else
                             {
                                 GetSession().GameState.GetAuraDuration(guid, i, out durationLeft, out durationFull);
+                                // JimsProxy (Cheap-Shot-aura-duration 2026-05-07): mirror the
+                                // SpellHandler refresh path's CSV fallback. On a cold cache (fresh
+                                // enemy debuff via OBJECT_UPDATE before any SMSG_AURA_UPDATE fires)
+                                // GetAuraDuration returns 0 for both values, leaving the modern
+                                // client with no duration → UnitAura returns 0/0 → stun-watch
+                                // addons (TidyPlates, CCC, ElvUI) show no countdown. Spell 1833
+                                // (Cheap Shot, flat 4 s) is the primary case; any other spell with
+                                // an AuraDurations CSV row also benefits.
+                                if (durationFull <= 0)
+                                    durationFull = GameData.GetAuraSpellDuration((uint)aura.AuraData.SpellID);
                             }
 
                             if (durationLeft > 0 && durationFull > 0)


### PR DESCRIPTION
 ## Problem

  Cheap Shot (spell 1833) showed no countdown timer in UnitAura-based stun
  addons (TidyPlates, default buff frames). The CSV row exists
  (`AuraDurations1.csv: 1833,4000`) but wasn't consulted on a fresh
  aura-apply.

  ## Root cause

  `UpdateHandler.cs` aura-discovery path (cold cache) had no CSV fallback when
  `GetAuraDuration` returned 0 — sending Duration=0 to the client, which made
  UnitAura return 0/0.

  The sibling refresh path in `Client/SpellHandler.cs SendAuraRefreshUpdate`
  already had the right fallback (`GameData.GetAuraSpellDuration`); the cold
  path just didn't mirror it.

  ## Fix

  Add the CSV fallback in `UpdateHandler.cs` after `GetAuraDuration` returns 0,
  mirroring the refresh path. Any CSV-backed spell (200+ entries) now gets a
  correct first-paint duration. CP-scaling finishers continue to take the
  snapshot path; Gouge/Blind continue to work via their existing CSV rows.

  ## Testing

  Bundle `jimsproxy-20260507-180159.jsonl` — Cheap Shot now ships
  `duration_full:4000` (was 0). Kidney Shot snapshot path verified working
  correctly: 3 CP → 4000ms, 1 CP → 2000ms.

  ## Note

  CCC and ElvUI read CPs via the CombatLog at `SPELL_AURA_APPLIED` time, not
  UnitAura. Vanilla servers consume CPs before that event fires, so those
  addons fall back to a 1-CP default. That's a separate proxy-side issue
  (deferring the CP=0 OBJECT_UPDATE) — out of scope for this PR.