### PR TITLE
Add mob-channel cleanup packet content diagnostics

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -378,6 +378,14 @@ public partial class WorldClient
         bool sentInterruptLog = false;
         bool sentCancelVisual = false;
         uint resolvedSpellVisualId = 0;
+        // JimsProxy (mob-channel-cleanup-diag 2026-05-07): capture the actual GUIDs and
+        // BackfireSpellID we stamp on the synthesized packets so a bug bundle can prove
+        // whether either is being filled with the wrong value (e.g. player GUID instead
+        // of mob GUID, or BackfireSpellID=0). Default 0 = packet was not synthesized.
+        ulong interruptLogCasterLow = 0;
+        ulong interruptLogVictimLow = 0;
+        int interruptLogBackfireSpellId = 0;
+        ulong cancelVisualSourceLow = 0;
         if (reason == 61 /* Interrupted */ && !casterIsPlayer && !casterIsPet)
         {
             SpellInterruptLog interruptLog = new SpellInterruptLog();
@@ -392,6 +400,9 @@ public partial class WorldClient
             interruptLog.BackfireSpellID = (int)spellId;
             SendPacketToClient(interruptLog);
             sentInterruptLog = true;
+            interruptLogCasterLow = interruptLog.Caster.GetCounter();
+            interruptLogVictimLow = interruptLog.Victim.GetCounter();
+            interruptLogBackfireSpellId = interruptLog.BackfireSpellID;
 
             resolvedSpellVisualId = GameData.GetSpellVisualIdFromXSpellVisual(spellVisual);
             if (resolvedSpellVisualId != 0)
@@ -401,6 +412,7 @@ public partial class WorldClient
                 cancelVisual.SpellVisualID = (int)resolvedSpellVisualId;
                 SendPacketToClient(cancelVisual);
                 sentCancelVisual = true;
+                cancelVisualSourceLow = cancelVisual.Source.GetCounter();
             }
         }
 
@@ -416,6 +428,7 @@ public partial class WorldClient
                 cancelVisual.SpellVisualID = (int)resolvedSpellVisualId;
                 SendPacketToClient(cancelVisual);
                 sentCancelVisual = true;
+                cancelVisualSourceLow = cancelVisual.Source.GetCounter();
             }
         }
 
@@ -431,6 +444,12 @@ public partial class WorldClient
             sentInterruptLog,
             sentCancelVisual,
             resolvedSpellVisualId,
+            // Diagnostic: actual content of synthesized cleanup packets
+            interruptLogCasterLow,
+            interruptLogVictimLow,
+            interruptLogBackfireSpellId,
+            cancelVisualSourceLow,
+            playerGuidLow = GetSession().GameState.CurrentPlayerGuid.GetCounter(),
         });
     }
 
@@ -634,6 +653,11 @@ public partial class WorldClient
         bool sentInterruptLog = false;
         bool sentCancelVisual = false;
         uint resolvedSpellVisualId = 0;
+        // JimsProxy (mob-channel-cleanup-diag 2026-05-07): see HandleSpellFailedOther for rationale.
+        ulong interruptLogCasterLow = 0;
+        ulong interruptLogVictimLow = 0;
+        int interruptLogBackfireSpellId = 0;
+        ulong cancelVisualSourceLow = 0;
         if (reason == 61 /* Interrupted */ && foundActiveCastId && !casterIsPlayer && !casterIsPet)
         {
             SpellInterruptLog interruptLog = new SpellInterruptLog();
@@ -643,6 +667,9 @@ public partial class WorldClient
             interruptLog.BackfireSpellID = (int)spellId;
             SendPacketToClient(interruptLog);
             sentInterruptLog = true;
+            interruptLogCasterLow = interruptLog.Caster.GetCounter();
+            interruptLogVictimLow = interruptLog.Victim.GetCounter();
+            interruptLogBackfireSpellId = interruptLog.BackfireSpellID;
 
             resolvedSpellVisualId = GameData.GetSpellVisualIdFromXSpellVisual(spellVisual);
             if (resolvedSpellVisualId != 0)
@@ -652,6 +679,7 @@ public partial class WorldClient
                 cancelVisual.SpellVisualID = (int)resolvedSpellVisualId;
                 SendPacketToClient(cancelVisual);
                 sentCancelVisual = true;
+                cancelVisualSourceLow = cancelVisual.Source.GetCounter();
             }
         }
 
@@ -669,6 +697,7 @@ public partial class WorldClient
                 cancelVisual.SpellVisualID = (int)resolvedSpellVisualId;
                 SendPacketToClient(cancelVisual);
                 sentCancelVisual = true;
+                cancelVisualSourceLow = cancelVisual.Source.GetCounter();
             }
         }
 
@@ -688,6 +717,13 @@ public partial class WorldClient
             sentInterruptLog,
             sentCancelVisual,
             resolvedSpellVisualId,
+            // Diagnostic: actual content of synthesized cleanup packets
+            interruptLogCasterLow,
+            interruptLogVictimLow,
+            interruptLogBackfireSpellId,
+            cancelVisualSourceLow,
+            casterUnitLow = casterUnit.GetCounter(),
+            playerGuidLow = GetSession().GameState.CurrentPlayerGuid.GetCounter(),
         });
     }
 


### PR DESCRIPTION
 ## Why

  User report (2026-05-07): a mob was channeling Arcane mid-fight, player killed
  it during the channel, and both the cast animation and looping sound queue
  transferred to the player's own character indefinitely until ESC was pressed.

  Existing diagnostics (`spell.failed_other.routed`, `spell.failure.routed`)
  report whether the synthesized cleanup packets fired (`sentInterruptLog`,
  `sentCancelVisual`) but **not** what was stamped inside them. From a tester
  bundle (`jimsproxy-20260507-194406`) we can see the cleanup chain ran on a
  mid-cast mob interrupt (spell 15493, mob caster Low=92700) — but we can't
  verify whether:

  - `SMSG_CANCEL_SPELL_VISUAL.Source` was stamped with the player's GUID by
    mistake (would explain the "visual on me" symptom)
  - `SMSG_SPELL_INTERRUPT_LOG.BackfireSpellID` was stamped with 0 (per
    `project_mob_cast_bar_dismiss.md` the modern client gates dismiss on
    this being non-zero — 0 leaves the visual lingering)
  - some other GUID/spell-id mix-up entirely

  ## Change

  Pure additive — extends the two existing `Log.Event` payloads in
  `HandleSpellFailedOther` and `HandleSpellFailure`. Adds:

  - `interruptLogCasterLow` — the GUID we stamped on `SpellInterruptLog.Caster`
  - `interruptLogVictimLow` — the GUID we stamped on `SpellInterruptLog.Victim`
  - `interruptLogBackfireSpellId` — the value we put in `BackfireSpellID`
  - `cancelVisualSourceLow` — the GUID we stamped on `CancelSpellVisual.Source`
  - `playerGuidLow` (and `casterUnitLow` on the failure event) for cross-reference

  Default 0 means the corresponding packet was not synthesized. No new firing
  sites — same number of events, payload grows by ~80 bytes per existing
  event line.

  ## How testers help

  If a tester reproduces the "visual transferred to me after killing a
  channeler" symptom on this build, the bundle will pinpoint which packet's
  GUID is wrong (or whether it's a third path entirely — e.g.
  `SMSG_PLAY_SPELL_VISUAL` from the server itself). Then the actual fix is
  small.

  ## Risk

  None. Diagnostic-only — no behavior change.