### PR TITLE
Fix /dance staying active through movement: synthesize stop emote on …

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -69,6 +69,14 @@ public sealed class GameSessionData
     // SendPacketToClient or fired control-grant packets at a session that had moved on.
     public CancellationTokenSource? TaxiDismountCts;
     public long TaxiDismountFiresAtTickMs;
+    // JimsProxy (dance-stuck-on-movement 2026-05-07): the modern Classic 1.14 client treats
+    // certain ONESHOT emote IDs (notably EMOTE_ONESHOT_DANCE = 10) as looping animations
+    // client-side and only stops them on a new SMSG_EMOTE arriving. Vanilla 1.12 servers
+    // (Kronos / Twinstar) don't broadcast a stop emote when the player moves, so the dance
+    // loops indefinitely. Track the last looping emote so HandlePlayerMove can synthesize
+    // a stop SMSG_EMOTE on the first movement-start packet.
+    public uint LastLoopingEmoteId; // 0 means no active loop
+    public long LastLoopingEmoteTickMs;
     public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -527,7 +527,44 @@ public partial class WorldClient
         EmoteMessage emote = new EmoteMessage();
         emote.EmoteID = packet.ReadUInt32();
         emote.Guid = packet.ReadGuid().To128(GetSession().GameState);
+        // JimsProxy (emote-state-diag 2026-05-07): capture emote broadcasts so we can pair them
+        // with subsequent emote.state.update events when triaging stuck-dance bugs.
+        Framework.Logging.Log.Event("emote.broadcast", new
+        {
+            emote_id = emote.EmoteID,
+            target_low = emote.Guid.GetCounter(),
+            is_player_target = emote.Guid == GetSession().GameState.CurrentPlayerGuid,
+        });
+        // JimsProxy (dance-stuck-on-movement 2026-05-07): track the player's last looping
+        // emote. EMOTE_ONESHOT_DANCE (10) is the known case — Classic 1.14 client loops it
+        // until another SMSG_EMOTE arrives, and Kronos/Twinstar don't broadcast one on move.
+        // Any new SMSG_EMOTE for the player overrides/clears the tracker (matches the actual
+        // client-side behavior — a new emote replaces the active loop).
+        if (emote.Guid == GetSession().GameState.CurrentPlayerGuid)
+        {
+            if (IsClientLoopingEmote(emote.EmoteID))
+            {
+                GetSession().GameState.LastLoopingEmoteId = emote.EmoteID;
+                GetSession().GameState.LastLoopingEmoteTickMs = Environment.TickCount64;
+            }
+            else
+            {
+                // Non-looping emote breaks any active loop on the client side; mirror that.
+                GetSession().GameState.LastLoopingEmoteId = 0;
+            }
+        }
         SendPacketToClient(emote);
+    }
+
+    /// <summary>
+    /// JimsProxy: returns true if the given EMOTE_ONESHOT_* ID is one that the modern
+    /// Classic 1.14 client treats as a looping animation client-side (continues until a
+    /// new SMSG_EMOTE arrives). Currently just EMOTE_ONESHOT_DANCE (10). Add others here
+    /// if reports surface for /sleep, /kneel, etc.
+    /// </summary>
+    private static bool IsClientLoopingEmote(uint emoteId)
+    {
+        return emoteId == 10; // EMOTE_ONESHOT_DANCE
     }
 
     [PacketHandler(Opcode.SMSG_TEXT_EMOTE)]

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2326,6 +2326,17 @@ public partial class WorldClient
             if (UNIT_NPC_EMOTESTATE >= 0 && updateMaskArray[UNIT_NPC_EMOTESTATE])
             {
                 updateData.UnitData.EmoteState = updates[UNIT_NPC_EMOTESTATE].Int32Value;
+                // JimsProxy (emote-state-diag 2026-05-07): user reports /dance staying active
+                // through movement on Kronos. Capture every EMOTESTATE update so we can see
+                // whether the server sends EMOTESTATE=0 on move (proxy is dropping it) or never
+                // sends it at all (server-side bug, fix via proxy synthesis on movement).
+                Framework.Logging.Log.Event("emote.state.update", new
+                {
+                    target_low = guid.GetCounter(),
+                    is_player_target = guid == GetSession().GameState.CurrentPlayerGuid,
+                    new_emote_state = updateData.UnitData.EmoteState,
+                    is_create = isCreate,
+                });
             }
             int UNIT_TRAINING_POINTS = LegacyVersion.GetUpdateField(UnitField.UNIT_TRAINING_POINTS);
             if (UNIT_TRAINING_POINTS >= 0 && updateMaskArray[UNIT_TRAINING_POINTS])

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -45,6 +45,25 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_MOVE_DOUBLE_JUMP)]
     void HandlePlayerMove(ClientPlayerMovement movement)
     {
+        // JimsProxy (dance-stuck-on-movement 2026-05-07): if the player has an active
+        // client-looping emote (e.g. /dance) and just initiated movement, synthesize a stop
+        // SMSG_EMOTE to break the loop. Kronos/Twinstar never broadcast one for movement, so
+        // without this the dance loops forever until another emote is used.
+        if (GetSession().GameState.LastLoopingEmoteId != 0 && IsMovementStartOpcode(movement.GetUniversalOpcode()))
+        {
+            EmoteMessage stopEmote = new EmoteMessage();
+            stopEmote.EmoteID = 0; // EMOTE_ONESHOT_NONE — clears the looping animation
+            stopEmote.Guid = GetSession().GameState.CurrentPlayerGuid;
+            SendPacket(stopEmote);
+            Framework.Logging.Log.Event("emote.loop.broken_by_move", new
+            {
+                last_emote_id = GetSession().GameState.LastLoopingEmoteId,
+                age_ms = Environment.TickCount64 - GetSession().GameState.LastLoopingEmoteTickMs,
+                trigger_opcode = movement.GetUniversalOpcode().ToString(),
+            });
+            GetSession().GameState.LastLoopingEmoteId = 0;
+        }
+
         string opcodeName = movement.GetUniversalOpcode().ToString();
         opcodeName = opcodeName.Replace("CMSG", "MSG");
         uint opcode = Opcodes.GetOpcodeValueForVersion(opcodeName, Framework.Settings.ServerBuild);
@@ -56,6 +75,30 @@ public partial class WorldSocket
             packet.WritePackedGuid(movement.Guid.To64());
         movement.MoveInfo.WriteMovementInfoLegacy(packet);
         SendPacketToServer(packet);
+    }
+
+    /// <summary>
+    /// JimsProxy: true for movement-start CMSG opcodes that should break a client-side
+    /// looping emote. Excludes heartbeats (just position updates), stops, and turn/facing
+    /// changes (turning in place shouldn't break /dance).
+    /// </summary>
+    private static bool IsMovementStartOpcode(Opcode opcode)
+    {
+        switch (opcode)
+        {
+            case Opcode.CMSG_MOVE_START_FORWARD:
+            case Opcode.CMSG_MOVE_START_BACKWARD:
+            case Opcode.CMSG_MOVE_START_STRAFE_LEFT:
+            case Opcode.CMSG_MOVE_START_STRAFE_RIGHT:
+            case Opcode.CMSG_MOVE_START_SWIM:
+            case Opcode.CMSG_MOVE_START_ASCEND:
+            case Opcode.CMSG_MOVE_START_DESCEND:
+            case Opcode.CMSG_MOVE_JUMP:
+            case Opcode.CMSG_MOVE_DOUBLE_JUMP:
+                return true;
+            default:
+                return false;
+        }
     }
 
     [PacketHandler(Opcode.CMSG_MOVE_TELEPORT_ACK)]


### PR DESCRIPTION
…move-start

The modern Classic 1.14 client treats EMOTE_ONESHOT_DANCE (10) as a looping animation client-side, continuing until another SMSG_EMOTE arrives. Vanilla 1.12 servers (Kronos / Twinstar) never broadcast a stop emote on player movement, so /dance loops indefinitely until the player triggers another emote (/laugh, /wave, etc.).

Confirmed via diagnostic capture: zero UNIT_NPC_EMOTESTATE field updates flow through OBJECT_UPDATE for /dance — the loop is purely client-side.

Track the player's last looping emote in GlobalSessionData. When the modern client sends a movement-start CMSG (FORWARD/BACKWARD/STRAFE/SWIM/ASCEND/JUMP — excluding heartbeats, stops, and turn/facing), synthesize an SMSG_EMOTE with emote_id=0 to break the loop. Any new SMSG_EMOTE for the player also clears the tracker (mirrors the client's actual replace-loop behavior).

Diagnostic events:
- emote.broadcast — every SMSG_EMOTE forwarded with emote_id and target
- emote.state.update — every UNIT_NPC_EMOTESTATE field change (kept for future triage of stuck-state bugs on other emotes)
- emote.loop.broken_by_move — fires when the synthesized stop is sent