### PR TITLE
Fix MC pet bar empty when controlling a player (BG): GetItemId no lon…

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -466,8 +466,14 @@ public sealed class GameSessionData
         if (updates == null)
             return 0;
 
-        uint itemId = updates[OBJECT_FIELD_ENTRY].UInt32Value;
-        return itemId;
+        // JimsProxy (mc-player-pet-bar 2026-05-07): players don't have OBJECT_FIELD_ENTRY in
+        // their cached field set, so a raw indexer access throws KeyNotFoundException ('3')
+        // when called for an MC'd player target. Several callers (notably the SMSG_PET_SPELLS
+        // handler in PetHandler.cs) catch broadly and silently drop their entire output —
+        // empty pet bar in BG MC. Treat missing field as "no entry" and return 0.
+        if (!updates.TryGetValue(OBJECT_FIELD_ENTRY, out var entryField))
+            return 0;
+        return entryField.UInt32Value;
     }
     public void SetFlatSpellMod(byte spellMod, byte spellMask, int amount)
     {


### PR DESCRIPTION
…ger throws on missing OBJECT_FIELD_ENTRY

User report: Gnomish Mind Control Cap (item 4036, spell 13181) on a player in a battleground produces an entirely empty pet bar — no spells, no abilities. PVE creature MC works partially because it hits a different code path.

Root cause: PetHandler.HandlePetSpellsMessage calls GetSession().GameState.GetItemId(spells.PetGUID) to look up the controlled unit's creature template (for vanilla CreatureFamily fallback). For player targets the cached object fields don't carry OBJECT_FIELD_ENTRY (vanilla field index 3 — creature-only), so the raw dictionary indexer threw KeyNotFoundException: "The given key '3' was not present in the dictionary." The PetHandler's broad try/catch then silently dropped the entire spell list, leaving the modern client with nothing to populate the temporary action bar.

Switch the indexer to TryGetValue and return 0 on miss. The existing PetHandler fallback chain (line 87-110) already expects creatureEntry==0 for charm-style pets and falls through to family=1 (Wolf) — so the rest of the packet now parses normally.

Verified via wire capture in bundle jimsproxy-20260507-223446 (SMSG_PET_SPELLS_MESSAGE 60 bytes, full hex captured in pet.spells_message.parse_failed event):
  7901D2E31C00000000000000000001010000020000070100000700000007000000
  810000008100000081000000810200000601000006000000060000