### PR TITLE
Preserve realm-scoped player caches across logout-relogin

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -349,10 +349,23 @@ public sealed class GameSessionData
 
     }
 
-    public static GameSessionData CreateNewGameSessionData(GlobalSessionData globalSession)
+    public static GameSessionData CreateNewGameSessionData(GlobalSessionData globalSession, GameSessionData? previous = null)
     {
         var self = new GameSessionData();
         self.CurrentPlayerStorage = new CurrentPlayerStorage(globalSession);
+
+        // Realm-scoped caches survive a /camp on a native 1.12 client (NameCache, ignore
+        // list, guild membership of other players are all per-realm files, not per-character).
+        // Wiping them on logout caused SMSG_INSPECT_RESULT to silently bail at the
+        // CachedPlayers lookup whenever the modern client's own persistent name cache
+        // satisfied the unit-frame name without issuing a fresh CMSG_QUERY_PLAYER_NAME —
+        // the proxy then had no entry to fill the inspect Name/Class/Race/Sex fields.
+        if (previous != null)
+        {
+            self.CachedPlayers = previous.CachedPlayers;
+            self.PlayerGuildIds = previous.PlayerGuildIds;
+            self.IgnoredPlayers = previous.IgnoredPlayers;
+        }
         return self;
     }
 
@@ -2335,7 +2348,7 @@ public class GlobalSessionData
             InstanceSocket = null!;
         }
 
-        GameState = GameSessionData.CreateNewGameSessionData(this);
+        GameState = GameSessionData.CreateNewGameSessionData(this, GameState);
         // Threat lists are tied to the previous character's mob/unit GUIDs;
         // wipe so the new login starts clean.
         ThreatTracker.Reset();

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -365,7 +365,7 @@ public partial class WorldClient
         //MIRASU   off the outgoing GameState.
         GetSession().SnapshotQuestItemProgressForRestore();
         GetSession().FlushQuestItemProgressToDisk();
-        GetSession().GameState = GameSessionData.CreateNewGameSessionData(GetSession());
+        GetSession().GameState = GameSessionData.CreateNewGameSessionData(GetSession(), GetSession().GameState);
         // Threat lists were keyed off the outgoing character's GUIDs; wipe so
         // the next character (or the same one re-logging in) starts clean.
         GetSession().ThreatTracker.Reset();


### PR DESCRIPTION
 ## Summary

  After /camp → char-select → log in a different toon on the same realm,
  target unit frames render "Unknown" and inspect silently fails. Repro
  is 100% — confirmed in a 1.12-native + 1.14-via-proxy 2-box test.

  ## Root cause

  `SMSG_LOGOUT_COMPLETE` and `OnDisconnect` both replace `GameSessionData`
  wholesale via `CreateNewGameSessionData`, wiping `CachedPlayers`,
  `PlayerGuildIds`, and `IgnoredPlayers` along with everything else.

  Those three are realm-scoped, not character-scoped — a native 1.12
  client persists them across /camp because the underlying NameCache,
  ignore list, and seen-guild data are per-realm files. The proxy was
  breaking that parity.

  The user-visible failure is `HandleInspectResult` at
  `CharacterHandler.cs:551-552`:

  ```csharp
  if (!GetSession().GameState.CachedPlayers.TryGetValue(inspect.DisplayInfo.GUID, out cache) || cache == null)
      return;

  Post-relogin the modern client's own persistent name cache satisfies
  unit-frame names, so it doesn't bother issuing CMSG_QUERY_PLAYER_NAME
  to repopulate the proxy's CachedPlayers. When SMSG_INSPECT_RESULT
  arrives, the cache lookup misses and the handler returns silently —
  the inspect window never opens.

  Diagnostic fingerprint

  SMSG_INSPECT_RESULT translation duration in jimsproxy JSONL bundles:

  ┌──────────────────────────────────┬────────────────────┬──────────┐
  │              Phase               │      Pre-fix       │ Post-fix │
  ├──────────────────────────────────┼────────────────────┼──────────┤
  │ Pre-relogin (toon A)             │ 3825μs             │ 3842μs   │
  ├──────────────────────────────────┼────────────────────┼──────────┤
  │ Post-relogin inspect #1 (toon B) │ 10μs (silent bail) │ 128μs    │
  ├──────────────────────────────────┼────────────────────┼──────────┤
  │ Post-relogin inspect #2 (toon B) │ 9μs (silent bail)  │ 290μs    │
  └──────────────────────────────────┴────────────────────┴──────────┘

  The single-digit-μs signature is the early return at
  CharacterHandler.cs:552 running with no work. Post-fix the cache
  lookup hits and the full handler executes; durations after the
  character's OBJECT_UPDATE fully re-propagates climb back to ~3800μs
  matching the pre-relogin baseline.

  Fix

  CreateNewGameSessionData now optionally accepts the previous
  GameSessionData and carries forward only the realm-scoped caches:
  CachedPlayers, PlayerGuildIds, IgnoredPlayers. Both reset sites
  (SMSG_LOGOUT_COMPLETE graceful path, OnDisconnect reconnect path)
  pass the outgoing state through.

  Everything else CreateNewGameSessionData resets remains reset:
  CurrentPlayerGuid, ObjectCacheLegacy/Modern, aura caches, combo
  points, pending casts, ItemGems, BattleField*, CurrentTrade,
  AddonPrefixes, etc. — all character-scoped and rightly cleared.

  SMSG_INVALIDATE_PLAYER already removes stale entries from
  CachedPlayers on rename (MiscHandler.cs:275), so the carry-forward
  doesn't strand renamed-player rows.

  Test plan

  - dotnet build clean
  - dotnet test 320/320 passing
  - 2-box repro (1.12-native observer + 1.14-via-proxy) on Kronos:
    - Pre-relogin: target other player → name shows, inspect → gear
    - /camp toon A, log in toon B without restarting client
    - Target other player → name shows correctly (was "Unknown")
    - Inspect → window opens with name/class/race; gear populates as
  OBJECT_UPDATE re-propagates
    - Party frames render names correctly when grouped post-relogin

  Risk

  - Stale entry if a player renames mid-session — already handled by
  SMSG_INVALIDATE_PLAYER removal at MiscHandler.cs:275
  - Memory growth — PlayerCache is ~6 fields per entry, realm-bounded
  population, not a concern
  - Realm-scope correctness — CachedPlayers/PlayerGuildIds/
  IgnoredPlayers are realm-keyed by definition; on actual realm swap
  the RealmManager.JoinRealm path takes over and the user goes
  through a fresh BNet rejoin where the proxy starts cleanly.