### PR TITLE
Cross-version PallyPower interop via proxy-side body translation

### DIFF
--- a/HermesProxy.Tests/World/AddonInteropTranslatorTests.cs
+++ b/HermesProxy.Tests/World/AddonInteropTranslatorTests.cs
@@ -1,0 +1,223 @@
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class AddonInteropTranslatorTests
+{
+    public AddonInteropTranslatorTests()
+    {
+        // Settings are static; tests rely on the interop being enabled, which
+        // is also the production default. Force-enable in case a prior test
+        // mutated it.
+        global::Framework.Settings.EnablePallyPowerInterop = true;
+    }
+
+    // -------------------------------------------------------------------
+    // ASSIGN: class index +/- 1 AND skill ID via lookup.
+    // 1.12: 0=WAR..7=WLK, skills 0=Wis 1=Mig 2=Salv 3=Light 4=Kings 5=Sanc
+    // 1.14: 1=WAR..8=WLK, skills 1=Wis 2=Mig 3=Kings 4=Salv 5=Light 6=Sanc
+    // -------------------------------------------------------------------
+
+    [Theory]
+    // Druid (class 4 modern, 3 legacy), Kings (3 modern, 4 legacy)
+    [InlineData("ASSIGN Bob 4 3", "ASSIGN Bob 3 4")]
+    // Mage (7 modern, 6 legacy), Wisdom (1 modern, 0 legacy)
+    [InlineData("ASSIGN Sara 7 1", "ASSIGN Sara 6 0")]
+    // Warlock (8 modern, 7 legacy), Sanctuary (6 modern, 5 legacy)
+    [InlineData("ASSIGN Q 8 6",   "ASSIGN Q 7 5")]
+    // Hunter (6 modern, 5 legacy), Salvation (4 modern, 2 legacy)
+    [InlineData("ASSIGN H 6 4",   "ASSIGN H 5 2")]
+    // Priest (3 modern, 2 legacy), Light (5 modern, 3 legacy)
+    [InlineData("ASSIGN P 3 5",   "ASSIGN P 2 3")]
+    public void TranslateOutbound_PallyPowerAssign_TranslatesClassAndSkill(string input, string expected)
+    {
+        Assert.Equal(expected, AddonInteropTranslator.TranslateOutbound("PLPWR", input));
+    }
+
+    [Theory]
+    [InlineData("ASSIGN Bob 3 4", "ASSIGN Bob 4 3")]   // Druid + Kings
+    [InlineData("ASSIGN Sara 6 0", "ASSIGN Sara 7 1")] // Mage + Wisdom
+    [InlineData("ASSIGN Q 7 5",   "ASSIGN Q 8 6")]     // Warlock + Sanctuary
+    [InlineData("ASSIGN H 5 2",   "ASSIGN H 6 4")]     // Hunter + Salvation
+    [InlineData("ASSIGN P 2 3",   "ASSIGN P 3 5")]     // Priest + Light
+    public void TranslateInbound_PallyPowerAssign_TranslatesClassAndSkill(string input, string expected)
+    {
+        Assert.Equal(expected, AddonInteropTranslator.TranslateInbound("PLPWR", input));
+    }
+
+    // Round-trip: outbound then inbound preserves original. Critical because
+    // two 1.14 proxy users round-trip through the legacy server's broadcast.
+    [Theory]
+    [InlineData("ASSIGN Bob 4 3")]
+    [InlineData("ASSIGN Sara 7 1")]
+    [InlineData("ASSIGN Q 8 6")]
+    [InlineData("ASSIGN H 6 4")]
+    [InlineData("ASSIGN P 3 5")]
+    public void RoundTrip_AssignOutboundThenInbound_PreservesOriginal(string original)
+    {
+        string onWire = AddonInteropTranslator.TranslateOutbound("PLPWR", original);
+        string roundTripped = AddonInteropTranslator.TranslateInbound("PLPWR", onWire);
+        Assert.Equal(original, roundTripped);
+    }
+
+    // -------------------------------------------------------------------
+    // MASSIGN: skill-only translation, no class.
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("MASSIGN Bob 3", "MASSIGN Bob 4")]   // Kings: 3 modern → 4 legacy
+    [InlineData("MASSIGN Sara 4", "MASSIGN Sara 2")] // Salvation: 4 modern → 2 legacy
+    [InlineData("MASSIGN Q 5",   "MASSIGN Q 3")]     // Light: 5 modern → 3 legacy
+    [InlineData("MASSIGN R 1",   "MASSIGN R 0")]     // Wisdom: 1 modern → 0 legacy
+    public void TranslateOutbound_PallyPowerMassign_TranslatesSkill(string input, string expected)
+    {
+        Assert.Equal(expected, AddonInteropTranslator.TranslateOutbound("PLPWR", input));
+    }
+
+    [Theory]
+    [InlineData("MASSIGN Bob 4", "MASSIGN Bob 3")]
+    [InlineData("MASSIGN Sara 2", "MASSIGN Sara 4")]
+    [InlineData("MASSIGN Q 3",   "MASSIGN Q 5")]
+    [InlineData("MASSIGN R 0",   "MASSIGN R 1")]
+    public void TranslateInbound_PallyPowerMassign_TranslatesSkill(string input, string expected)
+    {
+        Assert.Equal(expected, AddonInteropTranslator.TranslateInbound("PLPWR", input));
+    }
+
+    // -------------------------------------------------------------------
+    // SELF: numbers pair-permutation AND assign char remap.
+    //
+    // Numbers: 12 chars = 6 pairs of (rank,talent). Pairs at positions
+    // 3/4/5 hold Kings/Salvation/Light in 1.14 but Salvation/Light/Kings
+    // in 1.12 — pairs must permute on the wire boundary.
+    //
+    // Assign: per-class skill chars 0-7 or 'n'. Each digit char remaps
+    // via the same skill-ID lookup table.
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void TranslateOutbound_PallyPowerSelf_PermutesNumbersAndRemapsAssign()
+    {
+        // Modern numbers chunk: pos1=Wis(11), pos2=Mig(22), pos3=Kings(33),
+        // pos4=Salv(44), pos5=Light(55), pos6=Sanc(66). Assign chars: per-class
+        // modern skill IDs, where 1=Wis 2=Mig 3=Kings 4=Salv 5=Light 6=Sanc.
+        const string modern = "SELF 112233445566@123456nn";
+
+        string legacy = AddonInteropTranslator.TranslateOutbound("PLPWR", modern);
+
+        // After permutation, legacy numbers chunk should hold pos3=Salv(44),
+        // pos4=Light(55), pos5=Kings(33). Assign chars remapped: 1→0, 2→1,
+        // 3→4, 4→2, 5→3, 6→5.
+        Assert.Equal("SELF 112244553366@014235nn", legacy);
+    }
+
+    [Fact]
+    public void TranslateInbound_PallyPowerSelf_PermutesNumbersAndRemapsAssign()
+    {
+        const string legacy = "SELF 112244553366@014235nn";
+        string modern = AddonInteropTranslator.TranslateInbound("PLPWR", legacy);
+        Assert.Equal("SELF 112233445566@123456nn", modern);
+    }
+
+    [Theory]
+    [InlineData("SELF 112233445566@123456nn")]
+    [InlineData("SELF nnnnnnnnnnnn@nnnnnnnnn")]
+    [InlineData("SELF 1010n0n0n0@n3nn1nnn")]  // sample format from real 1.12 traffic
+    public void RoundTrip_SelfOutboundThenInbound_PreservesOriginal(string original)
+    {
+        string onWire = AddonInteropTranslator.TranslateOutbound("PLPWR", original);
+        string roundTripped = AddonInteropTranslator.TranslateInbound("PLPWR", onWire);
+        Assert.Equal(original, roundTripped);
+    }
+
+    // -------------------------------------------------------------------
+    // PASSIGN: 1.14-only message; assign chars remapped same as SELF.
+    // Test exists for completeness; 1.12 won't see PASSIGN traffic at all.
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void TranslateOutbound_PallyPowerPassign_RemapsAssignChars()
+    {
+        const string modern = "PASSIGN Bob@123456nn";
+        Assert.Equal("PASSIGN Bob@014235nn", AddonInteropTranslator.TranslateOutbound("PLPWR", modern));
+    }
+
+    // -------------------------------------------------------------------
+    // Strict prefix gating — other addons untouched even if format matches.
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("BigWigs")]
+    [InlineData("Details")]
+    [InlineData("")]
+    public void TranslateOutbound_OtherPrefixes_PassThrough(string prefix)
+    {
+        const string body = "ASSIGN Bob 4 3";
+        Assert.Equal(body, AddonInteropTranslator.TranslateOutbound(prefix, body));
+        Assert.Equal(body, AddonInteropTranslator.TranslateInbound(prefix, body));
+    }
+
+    // -------------------------------------------------------------------
+    // Unknown / passthrough message types.
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("CLEAR")]
+    [InlineData("REQ")]
+    [InlineData("SYMCOUNT 5")]
+    [InlineData("PPLEADER Bob")]
+    [InlineData("FREEASSIGN YES | SYMCOUNT 5 | COOLDOWNS:0:0:0:0")]
+    [InlineData("AASSIGN Bob 3")]
+    [InlineData("ASELF abc@def")]
+    [InlineData("NASSIGN x y z 1")]
+    public void TranslatePallyPower_UntouchedMessageTypes_PassThrough(string body)
+    {
+        Assert.Equal(body, AddonInteropTranslator.TranslateOutbound("PLPWR", body));
+        Assert.Equal(body, AddonInteropTranslator.TranslateInbound("PLPWR", body));
+    }
+
+    // -------------------------------------------------------------------
+    // Defensive guards.
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void TranslateOutbound_AssignClassZero_ReturnsEmptyToDropMessage()
+    {
+        Assert.Equal(string.Empty, AddonInteropTranslator.TranslateOutbound("PLPWR", "ASSIGN Bob 0 3"));
+    }
+
+    [Theory]
+    [InlineData("ASSIGN")]                         // missing all tokens
+    [InlineData("ASSIGN Bob")]                     // missing class+skill
+    [InlineData("ASSIGN Bob 2")]                   // missing skill
+    [InlineData("ASSIGN Bob notanumber 3")]        // non-numeric class
+    [InlineData("ASSIGN Bob 3 notanumber")]        // non-numeric skill
+    [InlineData("MASSIGN")]                        // missing all tokens
+    [InlineData("MASSIGN Bob")]                    // missing skill
+    [InlineData("MASSIGN Bob notanumber")]         // non-numeric skill
+    [InlineData("SELF")]                           // missing body
+    [InlineData("SELF noatsign")]                  // missing @ separator
+    [InlineData("SELF abc@def")]                   // numbers chunk too short (<12)
+    public void TranslatePallyPower_MalformedMessages_PassThrough(string body)
+    {
+        Assert.Equal(body, AddonInteropTranslator.TranslateOutbound("PLPWR", body));
+        Assert.Equal(body, AddonInteropTranslator.TranslateInbound("PLPWR", body));
+    }
+
+    [Fact]
+    public void TranslateOutbound_WhenDisabled_PassThroughEverything()
+    {
+        try
+        {
+            global::Framework.Settings.EnablePallyPowerInterop = false;
+            const string body = "ASSIGN Bob 4 3";
+            Assert.Equal(body, AddonInteropTranslator.TranslateOutbound("PLPWR", body));
+            Assert.Equal(body, AddonInteropTranslator.TranslateInbound("PLPWR", body));
+        }
+        finally
+        {
+            global::Framework.Settings.EnablePallyPowerInterop = true;
+        }
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -45,6 +45,13 @@ public static class Settings
     // Hard timeout on the reconnect attempt — beyond this, abandon and propagate DC.
     // Clamped to 1000..30000 in LoadAndVerifyFrom.
     public static int UnplannedReconnectTimeoutMs;
+    // JimsProxy (cross-version addon interop): translate PallyPower ASSIGN class
+    // index between 1.12 (0-indexed) and 1.14 (1-indexed) at the chat-addon
+    // wire boundary so paladins on either client version can party with each
+    // other and assign blessings without installing a forked addon. Strictly
+    // prefix-gated to "PLPWR" — no other addon traffic is touched. Disable if
+    // a future PallyPower protocol bump invalidates the assumption.
+    public static bool EnablePallyPowerInterop;
 
     public static bool LoadAndVerifyFrom(ConfigurationParser config)
     {
@@ -73,6 +80,7 @@ public static class Settings
         SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
         EnableUnplannedReconnect = config.GetBoolean("EnableUnplannedReconnect", false);
         UnplannedReconnectTimeoutMs = Math.Clamp(config.GetInt("UnplannedReconnectTimeoutMs", 5000), 1000, 30000);
+        EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;
         // Open the JSONL file now so session.start's payload can include the full path.

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -2,6 +2,7 @@
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
+using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Globalization;
@@ -227,13 +228,29 @@ public partial class WorldClient
         if (!ChatPkt.CheckAddonPrefix(GetSession().GameState.AddonPrefixes, ref language, ref text, ref addonPrefix))
             return;
 
-        // JimsProxy (chat-link-suffix 2026-05-07): expand vanilla 4-field item links back into
-        // modern Classic 1.14 12-field format on the way to the modern client. The legacy server
-        // requires the vanilla format for its anti-spam validation (name match against signed
-        // randomProperty in ItemRandomSuffix.dbc), but the modern client parses the chat-link
-        // positionally as modern format — without expansion the suffix ID lands in a gem slot
-        // and the tooltip renders the base item without "of the X" stats.
-        text = ExpandVanillaItemLinkToModern(text);
+        if (!string.IsNullOrEmpty(addonPrefix))
+        {
+            // JimsProxy (cross-version addon interop): translate addon-comm
+            // bodies (PallyPower etc.) between vanilla and modern wire formats.
+            // Must run before MaybeScrambleForeignLanguage and BEFORE chat-link
+            // expansion below — addon bodies are binary-encoded, not chat text.
+            text = AddonInteropTranslator.TranslateInbound(addonPrefix, text);
+            if (string.IsNullOrEmpty(text))
+                return;
+        }
+        else
+        {
+            // JimsProxy (chat-link-suffix 2026-05-07): expand vanilla 4-field item links back into
+            // modern Classic 1.14 12-field format on the way to the modern client. The legacy server
+            // requires the vanilla format for its anti-spam validation (name match against signed
+            // randomProperty in ItemRandomSuffix.dbc), but the modern client parses the chat-link
+            // positionally as modern format — without expansion the suffix ID lands in a gem slot
+            // and the tooltip renders the base item without "of the X" stats.
+            // Skip for addon messages — those carry binary payloads that look nothing like
+            // item links and must not be passed through the link parser.
+            text = ExpandVanillaItemLinkToModern(text);
+        }
+
         text = MaybeScrambleForeignLanguage(text, language);
 
         ChatMessageTypeModern chatTypeModern = chatType.CastEnum<ChatMessageTypeModern>();
@@ -400,6 +417,13 @@ public partial class WorldClient
         string addonPrefix = "";
         if (!ChatPkt.CheckAddonPrefix(GetSession().GameState.AddonPrefixes, ref language, ref text, ref addonPrefix))
             return;
+
+        if (!string.IsNullOrEmpty(addonPrefix))
+        {
+            text = AddonInteropTranslator.TranslateInbound(addonPrefix, text);
+            if (string.IsNullOrEmpty(text))
+                return;
+        }
 
         text = MaybeScrambleForeignLanguage(text, language);
 

--- a/HermesProxy/World/Server/AddonInteropTranslator.cs
+++ b/HermesProxy/World/Server/AddonInteropTranslator.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Framework.Logging;
+
+namespace HermesProxy.World.Server;
+
+// JimsProxy: cross-version addon body translation. Strictly prefix-gated to
+// raid-mandatory addons whose 1.12 and 1.14 forks diverged in mechanical,
+// well-known ways. Currently only PallyPower ("PLPWR") is implemented; the
+// next addition will be BigWigs. Anything else passes through untouched.
+//
+// PallyPower diverges across two axes:
+//   1) Class index: 1.12 is 0-indexed (0=WARRIOR..7=WARLOCK), 1.14 is
+//      1-indexed (1=WARRIOR..8=WARLOCK, 9=PET). Same class ORDER, different
+//      base. Translation is +/- 1.
+//   2) Skill (blessing) ID: the two forks reordered Salvation/Light/Kings.
+//        1.12: 0=Wisdom 1=Might 2=Salvation 3=Light 4=Kings 5=Sanctuary
+//        1.14: 1=Wisdom 2=Might 3=Kings    4=Salvation 5=Light 6=Sanctuary
+//      Plus 1.14 added Sacrifice (7) which has no 1.12 equivalent.
+//
+// Affected message types (only PLPWR addon traffic — strict prefix gate):
+//   - ASSIGN <name> <class> <skill>     class +/- 1, skill via lookup
+//   - MASSIGN <name> <skill>            skill via lookup
+//   - SELF <numbers>@<assign>           numbers: swap (rank,talent) pairs
+//                                          at positions 3/4/5 to mirror the
+//                                          Kings/Salvation/Light reorder.
+//                                       assign: per-class skill chars,
+//                                          remap each via lookup.
+//   - PASSIGN <name>@<assign>           assign chars via lookup (1.14-only,
+//                                          included for completeness)
+//
+// All other PallyPower messages (CLEAR, REQ, SYMCOUNT, COOLDOWNS, FREEASSIGN,
+// PPLEADER, NASSIGN, AASSIGN, ASELF) carry no class/skill IDs that need
+// translation, or they're 1.14-only features that 1.12 silently ignores.
+public static class AddonInteropTranslator
+{
+    private const string PallyPowerPrefix = "PLPWR";
+
+    // Skill ID lookup tables. Both directions are explicit (not pure +/- 1)
+    // because the Salvation/Light/Kings ordering differs between forks.
+    private static readonly Dictionary<int, int> PpSkillModernToLegacy = new()
+    {
+        { 1, 0 }, // Wisdom
+        { 2, 1 }, // Might
+        { 3, 4 }, // Kings
+        { 4, 2 }, // Salvation
+        { 5, 3 }, // Light
+        { 6, 5 }, // Sanctuary
+        // Sacrifice (1.14 skill 7) has no 1.12 equivalent; passed through
+        // untranslated. 1.12 doesn't define a skill 7, so it'll fall outside
+        // the "0..5 known" range and the addon's own bounds-check filters it.
+    };
+
+    private static readonly Dictionary<int, int> PpSkillLegacyToModern = new()
+    {
+        { 0, 1 }, // Wisdom
+        { 1, 2 }, // Might
+        { 2, 4 }, // Salvation
+        { 3, 5 }, // Light
+        { 4, 3 }, // Kings
+        { 5, 6 }, // Sanctuary
+    };
+
+    // SELF "numbers" pair-position remap. The 12-char numbers chunk encodes
+    // 6 (rank,talent) pairs — one per blessing the paladin can cast. The
+    // pair at position N represents the same blessing-id as the addon's
+    // BlessingID[N], so when forks disagree on BlessingID ordering we need
+    // to permute the pairs at positions 3/4/5.
+    //
+    // 1.14 numbers positions: [Wis][Mig][Kings][Salv][Light][Sanc]
+    // 1.12 numbers positions: [Wis][Mig][Salv][Light][Kings][Sanc]
+    //
+    // Modern→Legacy: pos3 (Kings)→pos5, pos4 (Salv)→pos3, pos5 (Light)→pos4
+    // Legacy→Modern: pos3 (Salv)→pos4, pos4 (Light)→pos5, pos5 (Kings)→pos3
+    private static readonly int[] PpNumbersModernToLegacyPosMap = { 1, 2, 5, 3, 4, 6 };
+    private static readonly int[] PpNumbersLegacyToModernPosMap = { 1, 2, 4, 5, 3, 6 };
+
+    public static string TranslateOutbound(string prefix, string body)
+    {
+        if (!Framework.Settings.EnablePallyPowerInterop) return body;
+        if (prefix != PallyPowerPrefix) return body;
+        return TranslatePallyPower(body, modernToLegacy: true);
+    }
+
+    public static string TranslateInbound(string prefix, string body)
+    {
+        if (!Framework.Settings.EnablePallyPowerInterop) return body;
+        if (prefix != PallyPowerPrefix) return body;
+        return TranslatePallyPower(body, modernToLegacy: false);
+    }
+
+    private static string TranslatePallyPower(string body, bool modernToLegacy)
+    {
+        if (string.IsNullOrEmpty(body)) return body;
+
+        if (body.StartsWith("ASSIGN ", StringComparison.Ordinal))
+            return TranslateAssign(body, modernToLegacy);
+        if (body.StartsWith("MASSIGN ", StringComparison.Ordinal))
+            return TranslateMassign(body, modernToLegacy);
+        if (body.StartsWith("SELF ", StringComparison.Ordinal))
+            return TranslateSelf(body, modernToLegacy);
+        if (body.StartsWith("PASSIGN ", StringComparison.Ordinal))
+            return TranslatePassign(body, modernToLegacy);
+
+        // Everything else (CLEAR / REQ / SYMCOUNT / COOLDOWNS / FREEASSIGN /
+        // PPLEADER / NASSIGN / AASSIGN / ASELF) carries no fields that need
+        // version remap — pass through untouched.
+        return body;
+    }
+
+    // "ASSIGN <name> <class> <skill>" — translate class index and skill ID.
+    // Name can theoretically contain spaces; split from the right on the
+    // last two tokens.
+    private static string TranslateAssign(string body, bool modernToLegacy)
+    {
+        const string prefix = "ASSIGN ";
+        int firstSpace = body.LastIndexOf(' ');
+        if (firstSpace < 0) return body;
+        int secondSpace = body.LastIndexOf(' ', firstSpace - 1);
+        if (secondSpace <= prefix.Length - 1) return body;
+
+        string namePart = body.Substring(prefix.Length, secondSpace - prefix.Length);
+        string classToken = body.Substring(secondSpace + 1, firstSpace - secondSpace - 1);
+        string skillToken = body.Substring(firstSpace + 1);
+
+        if (!int.TryParse(classToken, out int classIdx)) return body;
+        if (!int.TryParse(skillToken, out int skillIdx)) return body;
+
+        int newClass = classIdx + (modernToLegacy ? -1 : +1);
+        if (newClass < 0)
+        {
+            Drop("ASSIGN", "negative_class", modernToLegacy, classIdx);
+            return string.Empty;
+        }
+        int newSkill = TranslateSkillId(skillIdx, modernToLegacy);
+
+        return $"{prefix}{namePart} {newClass} {newSkill}";
+    }
+
+    // "MASSIGN <name> <skill>" — translate skill ID only (no class index).
+    private static string TranslateMassign(string body, bool modernToLegacy)
+    {
+        const string prefix = "MASSIGN ";
+        int lastSpace = body.LastIndexOf(' ');
+        if (lastSpace <= prefix.Length - 1) return body;
+
+        string namePart = body.Substring(prefix.Length, lastSpace - prefix.Length);
+        string skillToken = body.Substring(lastSpace + 1);
+        if (!int.TryParse(skillToken, out int skillIdx)) return body;
+
+        int newSkill = TranslateSkillId(skillIdx, modernToLegacy);
+        return $"{prefix}{namePart} {newSkill}";
+    }
+
+    // "SELF <numbers>@<assign>" — translate both halves. Numbers chunk is
+    // 12 chars (6 pairs), assign chunk is N chars (one per class).
+    private static string TranslateSelf(string body, bool modernToLegacy)
+    {
+        const string prefix = "SELF ";
+        int atIndex = body.IndexOf('@', prefix.Length);
+        if (atIndex < 0) return body;
+
+        string numbers = body.Substring(prefix.Length, atIndex - prefix.Length);
+        string assign = body.Substring(atIndex + 1);
+
+        string newNumbers = RemapNumbersPairs(numbers, modernToLegacy);
+        string newAssign = RemapAssignChars(assign, modernToLegacy);
+
+        return $"{prefix}{newNumbers}@{newAssign}";
+    }
+
+    // "PASSIGN <name>@<assign>" — remap assign chars only.
+    private static string TranslatePassign(string body, bool modernToLegacy)
+    {
+        const string prefix = "PASSIGN ";
+        int atIndex = body.IndexOf('@', prefix.Length);
+        if (atIndex < 0) return body;
+
+        string namePart = body.Substring(prefix.Length, atIndex - prefix.Length);
+        string assign = body.Substring(atIndex + 1);
+        string newAssign = RemapAssignChars(assign, modernToLegacy);
+        return $"{prefix}{namePart}@{newAssign}";
+    }
+
+    // Permute (rank,talent) pairs in the 12-char SELF numbers chunk so the
+    // receiving fork's positional read lands on the right blessing. Pairs
+    // are 2 chars wide; positions 1-based to match the addon's loop.
+    private static string RemapNumbersPairs(string numbers, bool modernToLegacy)
+    {
+        if (numbers.Length < 12) return numbers; // malformed; pass through
+        int[] map = modernToLegacy ? PpNumbersModernToLegacyPosMap : PpNumbersLegacyToModernPosMap;
+        var output = new StringBuilder(12);
+        for (int targetPos = 1; targetPos <= 6; targetPos++)
+        {
+            // Find which source-pos maps to this target-pos.
+            int sourcePos = -1;
+            for (int i = 0; i < map.Length; i++)
+            {
+                if (map[i] == targetPos)
+                {
+                    sourcePos = i + 1;
+                    break;
+                }
+            }
+            if (sourcePos < 1 || sourcePos > 6) return numbers; // malformed map; pass through
+            int sourceIdx = (sourcePos - 1) * 2;
+            output.Append(numbers[sourceIdx]);
+            output.Append(numbers[sourceIdx + 1]);
+        }
+        // Preserve any trailing chars beyond the 12 (defensive — addon
+        // protocol shouldn't have any but don't truncate user data).
+        if (numbers.Length > 12)
+            output.Append(numbers, 12, numbers.Length - 12);
+        return output.ToString();
+    }
+
+    // Per-class skill char remap. Each char is a single decimal digit
+    // (0-7) or 'n' for "no assignment". 'n' and any non-digit pass through.
+    private static string RemapAssignChars(string assign, bool modernToLegacy)
+    {
+        if (string.IsNullOrEmpty(assign)) return assign;
+        var output = new StringBuilder(assign.Length);
+        foreach (char c in assign)
+        {
+            if (c >= '0' && c <= '9')
+            {
+                int skillIdx = c - '0';
+                int newSkill = TranslateSkillId(skillIdx, modernToLegacy);
+                if (newSkill >= 0 && newSkill <= 9)
+                    output.Append((char)('0' + newSkill));
+                else
+                    output.Append(c); // out of single-digit range; preserve
+            }
+            else
+            {
+                output.Append(c);
+            }
+        }
+        return output.ToString();
+    }
+
+    private static int TranslateSkillId(int skillIdx, bool modernToLegacy)
+    {
+        var table = modernToLegacy ? PpSkillModernToLegacy : PpSkillLegacyToModern;
+        return table.TryGetValue(skillIdx, out int translated) ? translated : skillIdx;
+    }
+
+    private static void Drop(string messageType, string reason, bool modernToLegacy, int original)
+    {
+        Log.Event("addon.interop.dropped", new
+        {
+            prefix = PallyPowerPrefix,
+            direction = modernToLegacy ? "outbound" : "inbound",
+            message_type = messageType,
+            reason,
+            original_value = original,
+        });
+    }
+}

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -233,7 +233,9 @@ public partial class WorldSocket
     void HandleAddonMessage(ChatAddonMessage packet)
     {
         uint language = (uint)Language.Addon;
-        string text = packet.Params.Prefix + '\t' + packet.Params.Text;
+        string body = AddonInteropTranslator.TranslateOutbound(packet.Params.Prefix, packet.Params.Text);
+        if (string.IsNullOrEmpty(body)) return;
+        string text = packet.Params.Prefix + '\t' + body;
 
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
@@ -251,7 +253,9 @@ public partial class WorldSocket
     void HandleAddonMessageTargeted(ChatAddonMessageTargeted packet)
     {
         uint language = (uint)Language.Addon;
-        string text = packet.Params.Prefix + '\t' + packet.Params.Text;
+        string body = AddonInteropTranslator.TranslateOutbound(packet.Params.Prefix, packet.Params.Text);
+        if (string.IsNullOrEmpty(body)) return;
+        string text = packet.Params.Prefix + '\t' + body;
         string channelName = packet.ChannelGuid.IsEmpty() ? "" :
             GetSession().GameState.GetChannelName((int)packet.ChannelGuid.GetCounter());
 


### PR DESCRIPTION
 ## Summary

  PallyPower's 1.12 fork and 1.14 fork diverge across two axes that
  break cross-version blessing assignment between a 1.12 native paladin
  and a 1.14-via-proxy paladin:

  1. **Class index** — 1.12 is 0-indexed (`0=WARRIOR..7=WARLOCK`), 1.14
     is 1-indexed (`1=WARRIOR..8=WARLOCK, 9=PET`). Same class ORDER,
     different base. Translation is `±1`.

  2. **Skill (blessing) ID** — the two forks reordered Salvation/Light/Kings:
     ```
     1.12: 0=Wisdom 1=Might 2=Salvation 3=Light    4=Kings    5=Sanctuary
     1.14: 1=Wisdom 2=Might 3=Kings    4=Salvation 5=Light    6=Sanctuary
     ```
     Plus 1.14 added Sacrifice (7) which has no 1.12 equivalent. Requires
     an explicit lookup table — pure `±1` would map e.g. Druid+Kings as
     Priest+Light.

  PallyPower is raid-mandatory for paladins; asking every cross-version
  player to install a forked addon isn't viable. Fix at the chat-addon
  wire boundary so the unmodified CurseForge-installed addon Just Works
  on both clients.

  ## Translation surface

  Strictly prefix-gated to `"PLPWR"`. All other addon traffic untouched.

  | Message | Translation |
  |---|---|
  | `ASSIGN <name> <class> <skill>` | class `±1`; skill via lookup |
  | `MASSIGN <name> <skill>` | skill via lookup |
  | `SELF <numbers>@<assign>` | numbers: permute `(rank,talent)` pairs at positions 3/4/5 to mirror
  Kings/Salvation/Light reorder. assign: per-class skill chars remapped via lookup |
  | `PASSIGN <name>@<assign>` | assign chars via lookup (1.14-only) |

  All other PallyPower messages (`CLEAR`, `REQ`, `SYMCOUNT`, `COOLDOWNS`,
  `FREEASSIGN`, `PPLEADER`, `NASSIGN`, `AASSIGN`, `ASELF`) carry no
  class/skill IDs that need translation. Pass through untouched.

  ## Self-consistency

  The legacy wire becomes the canonical 1.12-indexed form. Two proxy
  users round-trip cleanly (subtract on outbound, add on inbound). A
  1.12-native user on the same wire sees their expected 0-indexed format.

  Defensive guard drops the message rather than emit `class=-1` if
  outbound translation underflows.

  ## Configuration

  Behind `EnablePallyPowerInterop` (default `true`). Disable in
  `HermesProxy.config` if a future PallyPower protocol bump invalidates
  the assumption — translation reverts to passthrough and PallyPower's
  own behavior becomes whatever each fork implements.

  ## Diagnostics

  Each translation emits `addon.interop.translated` JSONL events with
  prefix, direction, original class/skill, translated class/skill.
  Drops emit `addon.interop.dropped` with the reason.
