### PR TITLE
Refresh aura state when target leaves render distance

### DIFF
--- a/HermesProxy.Tests/World/AuraRefreshAfterFarObjectsTests.cs
+++ b/HermesProxy.Tests/World/AuraRefreshAfterFarObjectsTests.cs
@@ -1,0 +1,68 @@
+using HermesProxy;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class AuraRefreshAfterFarObjectsTests
+{
+    static AuraRefreshAfterFarObjectsTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    private static WowGuid128 Creature(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 12345, counter);
+
+    [Fact]
+    public void NeedsFullAuraRefresh_FreshState_Empty()
+    {
+        var state = GameSessionData.CreateForTesting();
+        Assert.Empty(state.NeedsFullAuraRefresh);
+    }
+
+    [Fact]
+    public void NeedsFullAuraRefresh_AddThenRemove_TrueOnFirstRemove()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Creature(1);
+        state.NeedsFullAuraRefresh.Add(guid);
+
+        Assert.True(state.NeedsFullAuraRefresh.Remove(guid));
+        Assert.False(state.NeedsFullAuraRefresh.Remove(guid));
+    }
+
+    [Fact]
+    public void NeedsFullAuraRefresh_RemoveUnknownGuid_False()
+    {
+        var state = GameSessionData.CreateForTesting();
+        Assert.False(state.NeedsFullAuraRefresh.Remove(Creature(99)));
+    }
+
+    [Fact]
+    public void NeedsFullAuraRefresh_AddTwice_DedupedToOne()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Creature(1);
+        state.NeedsFullAuraRefresh.Add(guid);
+        state.NeedsFullAuraRefresh.Add(guid);
+
+        Assert.Single(state.NeedsFullAuraRefresh);
+    }
+
+    [Fact]
+    public void NeedsFullAuraRefresh_SeparateGuids_TrackedIndependently()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var a = Creature(1);
+        var b = Creature(2);
+        state.NeedsFullAuraRefresh.Add(a);
+
+        Assert.True(state.NeedsFullAuraRefresh.Remove(a));
+        Assert.False(state.NeedsFullAuraRefresh.Remove(b));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -333,6 +333,14 @@ public sealed class GameSessionData
     public Dictionary<byte, Dictionary<byte, int>> FlatSpellMods = [];
     public Dictionary<byte, Dictionary<byte, int>> PctSpellMods = [];
     public Dictionary<WowGuid128, Dictionary<uint, WowGuid128>> LastAuraCasterOnTarget = [];
+    // JimsProxy (aura-refresh-after-far-objects): GUIDs the legacy server
+    // just told us to remove via FarObjects. The modern client drops the
+    // unit's aura state on OutOfRangeGuids, so the next Values update for
+    // any of these units must arrive as AuraUpdate(UpdateAll=true) to
+    // reseed the buff/debuff bar from scratch — otherwise the next delta
+    // is merged against state the client no longer has, and the previous
+    // buff bar lingers stale until reload.
+    public HashSet<WowGuid128> NeedsFullAuraRefresh = [];
     public TradeSession? CurrentTrade = null;
     public HashSet<uint> RequestedItemHotfixes = [];
     public HashSet<uint> RequestedItemSparseHotfixes = [];

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -111,7 +111,14 @@ public partial class WorldClient
                     PrintString($"Guid = {guid.ToString()}", i);
 
                     ObjectUpdate updateData = new ObjectUpdate(guid, UpdateTypeModern.Values, GetSession());
-                    AuraUpdate auraUpdate = new AuraUpdate(guid, false);
+                    // JimsProxy (aura-refresh-after-far-objects): if this unit
+                    // was just FarObjects-evicted, the modern client dropped
+                    // the unit's aura state on OutOfRangeGuids — a delta
+                    // AuraUpdate has nothing to merge against and the buff
+                    // bar lingers stale. Promote this AuraUpdate to a full
+                    // refresh so the modern client reseeds from scratch.
+                    bool needsFullAuraRefresh = GetSession().GameState.NeedsFullAuraRefresh.Remove(guid);
+                    AuraUpdate auraUpdate = new AuraUpdate(guid, needsFullAuraRefresh);
                     PowerUpdate powerUpdate = new PowerUpdate(guid);
                     ReadValuesUpdateBlock(packet, guid, updateData, auraUpdate, powerUpdate, i);
 
@@ -161,6 +168,10 @@ public partial class WorldClient
 
                     ObjectUpdate updateData = new ObjectUpdate(guid, UpdateTypeModern.CreateObject1, GetSession());
                     AuraUpdate auraUpdate = new AuraUpdate(guid, true);
+                    // CREATE already uses UpdateAll=true; just clear the
+                    // FarObjects bookkeeping so a later Values update for
+                    // this guid doesn't double-promote.
+                    GetSession().GameState.NeedsFullAuraRefresh.Remove(guid);
                     ReadCreateObjectBlock(packet, guid, updateData, auraUpdate, i);
 
                     if (updateData.Guid == GetSession().GameState.CurrentPlayerGuid)
@@ -196,6 +207,7 @@ public partial class WorldClient
 
                     ObjectUpdate updateData = new ObjectUpdate(guid, UpdateTypeModern.CreateObject2, GetSession());
                     AuraUpdate auraUpdate = new AuraUpdate(guid, true);
+                    GetSession().GameState.NeedsFullAuraRefresh.Remove(guid);
                     ReadCreateObjectBlock(packet, guid, updateData, auraUpdate, i);
 
                     if (guid.IsItem() && updateData.ObjectData.EntryID != null &&
@@ -376,6 +388,31 @@ public partial class WorldClient
                 GetSession().GameState.ObjectCacheModern.Remove(guid);
             }
             GetSession().GameState.LastAuraCasterOnTarget.Remove(guid);
+            // JimsProxy (aura-refresh-after-far-objects): aura state only
+            // applies to units (players, creatures, pets, vehicles). Skip
+            // gameobjects, items, dynamic objects, corpses, etc. — sending
+            // an AuraUpdate for those is at best ignored and at worst
+            // malformed traffic the client logs as an error.
+            bool guidIsUnit = guid.IsPlayer() || guid.IsCreature();
+            if (guidIsUnit)
+            {
+                // JimsProxy (aura-refresh-after-far-objects): mark this guid so
+                // the next Values OBJECT_UPDATE for it arrives as
+                // AuraUpdate(UpdateAll=true). The modern client just dropped the
+                // unit's aura state on OutOfRangeGuids; without the promotion,
+                // a later delta merges against nothing and the buff bar lingers
+                // stale until the user reloads the UI.
+                GetSession().GameState.NeedsFullAuraRefresh.Add(guid);
+                // Proactively wipe the modern client's buff/debuff bar for this
+                // unit. The target frame keeps showing the last-known auras
+                // after the unit leaves render — sending an empty AuraUpdate
+                // with UpdateAll=true wipes them immediately so PvPers don't
+                // see stale debuff icons (e.g. Detect Magic) hanging on a
+                // target that ran out of range. Re-entry via CreateObject1/2
+                // carries the full aura state from the legacy server, so the
+                // bar repopulates correctly when the unit returns.
+                SendPacketToClient(new AuraUpdate(guid, true));
+            }
 
             // If the pet is too far away, sends a SMSG_UPDATE_OBJECT protocol
             if (GetSession().GameState.CurrentPetGuid == guid)


### PR DESCRIPTION
Two related symptoms with the same root cause: the modern client's target frame doesn't drop a unit's aura state when the legacy server issues OutOfRangeGuids for that unit. Fixed by:

1. Proactive wipe at FarObjects: send AuraUpdate(guid, UpdateAll=true) with an empty aura list so the modern client immediately clears the buff/debuff bar for the unit. PvPers were seeing stale debuff icons (e.g. Detect Magic) hanging on hostile targets that had run out of range.

2. Promotion of the next Values AuraUpdate to UpdateAll=true via a GameSessionData.NeedsFullAuraRefresh HashSet (set on the FarObjects emit, drained on the next CreateObject1/2 or Values for that GUID). Covers the rarer case where the legacy server pushes a Values delta for a unit that just left and re-entered render — the delta would otherwise merge against state the client no longer has.

Repro:
- Cast a buff on a unit, walk far enough that it gets OOR-evicted, walk back. Buff bar matches current server state.
- Same flow but the buff *expires* while target is OOR. Buff bar empty on return.
- Same flow but a debuff is *added* while OOR. Debuff appears on return.
- Cast Detect Magic on a hostile target, walk away until OOR. The debuff icon clears off the target frame instead of lingering.