### PR TITLE
Spell handler resilience: catch parse failures and synth SPELL_START for auto-shot

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -341,6 +341,16 @@ public sealed class GameSessionData
     // is merged against state the client no longer has, and the previous
     // buff bar lingers stale until reload.
     public HashSet<WowGuid128> NeedsFullAuraRefresh = [];
+    // JimsProxy (synth-spell-start-for-autoshot): timestamp of the most recent
+    // natural SMSG_SPELL_START forwarded for the local player's ranged auto
+    // attack (Auto Shot 75 / Shoot 5019). The 1.12 server only emits SPELL_START
+    // at toggle/retarget — every subsequent auto-repeat tick arrives as a bare
+    // SPELL_GO. Modern Classic 1.14 servers emit SPELL_START per tick, so any
+    // CAST_START-driven swing-timer addon (e.g. Kaedin's swing timer) only
+    // fires once per series via the proxy. HandleSpellGo synthesizes a
+    // SPELL_START before the GO when no natural one was forwarded recently
+    // (window: AutoShotSynthSpellStartGapMs).
+    public Dictionary<uint, long> LastNaturalAutoShotSpellStartMs = [];
     public TradeSession? CurrentTrade = null;
     public HashSet<uint> RequestedItemHotfixes = [];
     public HashSet<uint> RequestedItemSparseHotfixes = [];

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -744,6 +744,7 @@ public partial class WorldClient
             // bubble up through ReceiveLoop and DC the user. See HandleSpellGo
             // for the in-the-wild repro and rationale.
             LogSpellStartGoParseFailure(packet, e, isSpellGo: false);
+            DrainOrphanedStartedNormalCastsOnParseFailure(isSpellGo: false);
             return;
         }
 
@@ -826,6 +827,11 @@ public partial class WorldClient
                 caster_is_player = casterIsLocalPlayer,
                 caster_is_pet = casterIsLocalPet,
             });
+            // Track the natural SPELL_START so HandleSpellGo can decide
+            // whether to synthesize one for subsequent auto-repeat ticks
+            // that arrive without a preceding START.
+            if (casterIsLocalPlayer)
+                GetSession().GameState.LastNaturalAutoShotSpellStartMs[(uint)spell.Cast.SpellID] = Time.GetMSTime();
         }
         if (isChanneled && (casterIsLocalPlayer || casterIsLocalPet) && spell.Cast.CastTime == 0)
         {
@@ -873,7 +879,38 @@ public partial class WorldClient
             // DCs the entire WorldClient session. Log full packet
             // contents so the next hit gives us bytes to fix the parser.
             LogSpellStartGoParseFailure(packet, e, isSpellGo: true);
+            DrainOrphanedStartedNormalCastsOnParseFailure(isSpellGo: true);
             return;
+        }
+
+        // JimsProxy (synth-spell-start-for-autoshot): the 1.12 server only
+        // emits SMSG_SPELL_START at toggle/retarget for ranged auto attacks
+        // (Auto Shot 75, Shoot 5019). Every auto-repeat tick is a bare
+        // SPELL_GO. Modern Classic 1.14 servers emit SPELL_START per tick,
+        // so addons that listen for COMBAT_LOG_EVENT SPELL_CAST_START
+        // (Kaedin's swing timer, Quartz, etc.) only fire once per series
+        // through the proxy. Synthesize a SPELL_START before the GO when
+        // no natural one was forwarded within AutoShotSynthSpellStartGapMs.
+        bool isRangedAutoAttack = spell.Cast.SpellID == 75 || spell.Cast.SpellID == 5019;
+        if (isRangedAutoAttack &&
+            spell.Cast.CasterUnit == GetSession().GameState.CurrentPlayerGuid)
+        {
+            long now = Time.GetMSTime();
+            long lastNaturalMs = GetSession().GameState.LastNaturalAutoShotSpellStartMs
+                .GetValueOrDefault((uint)spell.Cast.SpellID, 0);
+            long gapMs = now - lastNaturalMs;
+            const long AutoShotSynthSpellStartGapMs = 1000;
+            if (gapMs > AutoShotSynthSpellStartGapMs)
+            {
+                SpellStart synthStart = new SpellStart();
+                synthStart.Cast = spell.Cast;
+                SendPacketToClient(synthStart);
+                Log.Event("spell.start.synth_for_autoshot", new
+                {
+                    spell_id = spell.Cast.SpellID,
+                    gap_ms = gapMs,
+                });
+            }
         }
 
         // Dequeue completed cast (queue-based, FIFO order)
@@ -1114,6 +1151,52 @@ public partial class WorldClient
             error = e.Message,
             stack = e.StackTrace,
         });
+    }
+
+    // JimsProxy (synth-spell-start-for-autoshot follow-up): when a SPELL_START
+    // or SPELL_GO packet fails to parse, the matching pending-cast queue entry
+    // is orphaned — no normal completion path dequeues it. For HasStarted=true
+    // entries this is bad: HasStartedNormalCast() permanently returns true and
+    // blocks subsequent cast-time spells. Emit a synthetic CastFailed(DontReport)
+    // for each orphaned entry so the modern client's cast bar dismisses
+    // silently and the queue self-heals. We can't tell from a failed parse
+    // whether the packet was for the local player or a foreign caster; on
+    // average there's at most one HasStarted=true entry (the GCD gate ensures
+    // serial cast-time spells), so worst-case spurious cleanup is bounded to
+    // one cast — a small price to avoid the permanent lock.
+    private void DrainOrphanedStartedNormalCastsOnParseFailure(bool isSpellGo)
+    {
+        var queue = GetSession().GameState.PendingNormalCasts;
+        var keep = new List<ClientCastRequest>();
+        int orphaned = 0;
+        while (queue.TryDequeue(out var cast))
+        {
+            if (cast.HasStarted)
+            {
+                CastFailed failed = new();
+                failed.SpellID = cast.SpellId;
+                failed.SpellXSpellVisualID = cast.SpellXSpellVisualId;
+                failed.Reason = (uint)SpellCastResultClassic.DontReport;
+                failed.CastID = cast.ServerGUID;
+                SendPacketToClient(failed);
+                orphaned++;
+            }
+            else
+            {
+                keep.Add(cast);
+            }
+        }
+        foreach (var c in keep)
+            queue.Enqueue(c);
+
+        if (orphaned > 0)
+        {
+            Log.Event("spell.parse_failed.queue_drained", new
+            {
+                phase = isSpellGo ? "go" : "start",
+                orphaned_count = orphaned,
+            });
+        }
     }
 
     SpellCastData HandleSpellStartOrGo(WorldPacket packet, bool isSpellGo)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -734,7 +734,18 @@ public partial class WorldClient
             return;
 
         SpellStart spell = new SpellStart();
-        spell.Cast = HandleSpellStartOrGo(packet, false);
+        try
+        {
+            spell.Cast = HandleSpellStartOrGo(packet, false);
+        }
+        catch (Exception e)
+        {
+            // Log + skip the cast instead of letting the parse exception
+            // bubble up through ReceiveLoop and DC the user. See HandleSpellGo
+            // for the in-the-wild repro and rationale.
+            LogSpellStartGoParseFailure(packet, e, isSpellGo: false);
+            return;
+        }
 
         bool casterIsLocalPlayer = GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit;
         bool casterIsLocalPet    = GetSession().GameState.CurrentPetGuid    == spell.Cast.CasterUnit;
@@ -849,7 +860,21 @@ public partial class WorldClient
             return;
 
         SpellGo spell = new SpellGo();
-        spell.Cast = HandleSpellStartOrGo(packet, true);
+        try
+        {
+            spell.Cast = HandleSpellStartOrGo(packet, true);
+        }
+        catch (Exception e)
+        {
+            // Some legacy servers emit a SMSG_SPELL_GO that the parser
+            // misreads — most often around channeled-spell ticks (Drain
+            // Soul on Kronos PTR was the original repro). Without this
+            // guard the exception bubbles up through ReceiveLoop and
+            // DCs the entire WorldClient session. Log full packet
+            // contents so the next hit gives us bytes to fix the parser.
+            LogSpellStartGoParseFailure(packet, e, isSpellGo: true);
+            return;
+        }
 
         // Dequeue completed cast (queue-based, FIFO order)
         if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
@@ -1065,6 +1090,30 @@ public partial class WorldClient
         // resulting THREAT_UPDATE follows it on the wire (matches the
         // server-driven ordering the modern client expects).
         GetSession().ThreatTracker.OnSpellCast(spell.Cast.CasterUnit, spell.Cast.SpellID, spell.Cast.HitTargets);
+    }
+
+    private static void LogSpellStartGoParseFailure(WorldPacket packet, Exception e, bool isSpellGo)
+    {
+        // Capture full packet bytes (capped) as a hex string so the next time
+        // this fires we have exact bytes to trace the parse divergence.
+        const int maxBytes = 512;
+        byte[] data = packet.GetData();
+        int dumpLen = data.Length < maxBytes ? data.Length : maxBytes;
+        var sb = new System.Text.StringBuilder(dumpLen * 2);
+        for (int i = 0; i < dumpLen; i++)
+            sb.Append(data[i].ToString("x2"));
+
+        Log.PrintNet(LogType.Error, LogNetDir.S2P,
+            $"SMSG_SPELL_{(isSpellGo ? "GO" : "START")} parse failed (suppressed DC): {e.Message}");
+        Log.Event("spell.parse_failed", new
+        {
+            phase = isSpellGo ? "go" : "start",
+            packet_size = data.Length,
+            dumped_bytes = dumpLen,
+            packet_hex = sb.ToString(),
+            error = e.Message,
+            stack = e.StackTrace,
+        });
     }
 
     SpellCastData HandleSpellStartOrGo(WorldPacket packet, bool isSpellGo)


### PR DESCRIPTION
 ## Commits

  ### 1. Don't DC the user when SMSG_SPELL_START / SPELL_GO fails to parse
  - Wraps each `HandleSpellStartOrGo` call in `HandleSpellStart` / `HandleSpellGo` with try/catch.
  - On parse failure, drops the cast and emits a structured `spell.parse_failed` event with a hex dump of the full raw
  packet — instead of letting the exception bubble through `ReceiveLoop` and tear down the entire WorldClient session.
  - In-the-wild repro: warlock channeling Drain Soul on Kronos PTR — proxy hits `ReadUInt64()` past end of buffer
  mid-channel-end and the user gets booted to character select.

  ### 2. Synthesize SMSG_SPELL_START for ranged auto-shot ticks
  - Vanilla 1.12 servers only emit `SMSG_SPELL_START` at toggle/retarget for ranged auto attacks (Auto Shot 75, Shoot
  5019). Auto-repeat ticks arrive as bare `SMSG_SPELL_GO`. Modern Classic 1.14 servers emit `SPELL_START` per tick.
  - Result: swing-timer addons that listen on `COMBAT_LOG_EVENT_UNFILTERED` with subevent `SPELL_CAST_START` (Kaedin's
  Classic Swing Timer, Quartz ranged module, etc.) only fire once per series through the proxy.
  - When `HandleSpellGo` receives a ranged auto-attack from the local player and no natural `SPELL_START` was forwarded
  for that spell within the last 1000ms, synthesize a `SpellStart` mirroring the GO's `Cast` data.
  - `LastNaturalAutoShotSpellStartMs` on `GameSessionData` tracks the last natural forward; the 1s window suppresses the
   synth on the immediately-following GO so toggle doesn't double-fire CAST_START.

  ## Test plan
  - [ ] Regular spellcasting unaffected — no `spell.parse_failed` or unwarranted `spell.start.synth_for_autoshot` events
   on a clean session.
  - [ ] Hunter Auto Shot on a target dummy: bar resets every shot in Kaedin's swing timer / Quartz ranged.
  - [ ] Toggle auto-shot off and on rapidly: no double cast-bar visual on the first shot of a series.
  - [ ] Shoot (Wand, spell 5019) on caster classes: per-tick reset behavior.
  - [ ] If the Drain Soul-on-Kronos-PTR DC repro lands, session stays connected and JSONL contains a
  `spell.parse_failed` event with `phase: "go"`, packet size, and hex dump.