### PR TITLE
Fix/dance stuck on movement

### DIFF
--- a/HermesProxy.Tests/World/WatchdogEvictionTests.cs
+++ b/HermesProxy.Tests/World/WatchdogEvictionTests.cs
@@ -240,4 +240,95 @@ public class WatchdogEvictionTests
 
         Assert.False(session.HasStartedNormalCast());
     }
+
+    // ---- Movement preemption tests ----
+
+    private static ClientCastRequest MakeCastTimeCast(uint spellId, uint castTimeMs, bool hasStarted)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            HasStarted = hasStarted,
+            StartedCastTimeMs = castTimeMs,
+        };
+    }
+
+    [Fact]
+    public void MarkStartedCastsMovementCancelled_StartedCastTime_Marked()
+    {
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        // 2.5s Frostbolt currently casting
+        session.PendingNormalCasts.Enqueue(MakeCastTimeCast(116, castTimeMs: 2500, hasStarted: true));
+
+        int marked = session.MarkStartedCastsMovementCancelled(now + 2500);
+
+        Assert.Equal(1, marked);
+        var entry = session.PendingNormalCasts.ToArray()[0];
+        Assert.True(entry.MovementCancelled);
+        Assert.Equal(now + 2500, entry.WatchdogDeadlineMs);
+    }
+
+    [Fact]
+    public void MarkStartedCastsMovementCancelled_Instant_NotMarked()
+    {
+        // Instants don't get cancelled by movement in vanilla.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCastTimeCast(1953, castTimeMs: 0, hasStarted: true));
+
+        int marked = session.MarkStartedCastsMovementCancelled(Environment.TickCount64 + 2500);
+
+        Assert.Equal(0, marked);
+        Assert.False(session.PendingNormalCasts.ToArray()[0].MovementCancelled);
+    }
+
+    [Fact]
+    public void MarkStartedCastsMovementCancelled_NotStarted_NotMarked()
+    {
+        // Cast hasn't started yet (in-flight to server, awaiting SMSG_SPELL_START).
+        // Movement at this stage doesn't apply because nothing's actually casting.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCastTimeCast(116, castTimeMs: 2500, hasStarted: false));
+
+        int marked = session.MarkStartedCastsMovementCancelled(Environment.TickCount64 + 2500);
+
+        Assert.Equal(0, marked);
+        Assert.False(session.PendingNormalCasts.ToArray()[0].MovementCancelled);
+    }
+
+    [Fact]
+    public void MarkStartedCastsMovementCancelled_PreservesExistingWatchdog()
+    {
+        // If a watchdog deadline was already set (e.g., from a prior peek),
+        // movement marking shouldn't shorten it. We only fill in the gap.
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        var cast = MakeCastTimeCast(116, castTimeMs: 2500, hasStarted: true);
+        cast.WatchdogDeadlineMs = now + 1000; // earlier deadline already armed
+        session.PendingNormalCasts.Enqueue(cast);
+
+        session.MarkStartedCastsMovementCancelled(now + 5000);
+
+        var entry = session.PendingNormalCasts.ToArray()[0];
+        Assert.True(entry.MovementCancelled);
+        Assert.Equal(now + 1000, entry.WatchdogDeadlineMs);
+    }
+
+    [Fact]
+    public void MarkStartedCastsMovementCancelled_MultipleEntries_OnlyStartedCastTimeMarked()
+    {
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCastTimeCast(116, castTimeMs: 2500, hasStarted: true));   // marked
+        session.PendingNormalCasts.Enqueue(MakeCastTimeCast(1953, castTimeMs: 0, hasStarted: true));    // instant — skip
+        session.PendingNormalCasts.Enqueue(MakeCastTimeCast(133, castTimeMs: 2500, hasStarted: false)); // not started — skip
+
+        int marked = session.MarkStartedCastsMovementCancelled(Environment.TickCount64 + 2500);
+
+        Assert.Equal(1, marked);
+        var arr = session.PendingNormalCasts.ToArray();
+        Assert.True(arr[0].MovementCancelled);
+        Assert.False(arr[1].MovementCancelled);
+        Assert.False(arr[2].MovementCancelled);
+    }
 }

--- a/HermesProxy.Tests/World/WatchdogEvictionTests.cs
+++ b/HermesProxy.Tests/World/WatchdogEvictionTests.cs
@@ -1,0 +1,139 @@
+using System;
+using HermesProxy;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (PR #161 follow-up): tests for DrainExpiredWatchdogCasts. Pure data
+// operation — verifies that expired peeks get dequeued without affecting other
+// pending casts or the unrelated pet queue.
+public class WatchdogEvictionTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static ClientCastRequest MakeCast(uint spellId, long watchdogDeadlineMs = 0, bool hasStarted = false)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            WatchdogDeadlineMs = watchdogDeadlineMs,
+            HasStarted = hasStarted,
+        };
+    }
+
+    [Fact]
+    public void EmptyQueues_ReturnsEmptyEvictedLists()
+    {
+        var session = NewSession();
+        session.DrainExpiredWatchdogCasts(Environment.TickCount64,
+            out var normal, out var pet);
+        Assert.Empty(normal);
+        Assert.Empty(pet);
+    }
+
+    [Fact]
+    public void DeadlineZero_NeverEvicted()
+    {
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(1234, watchdogDeadlineMs: 0));
+        session.DrainExpiredWatchdogCasts(Environment.TickCount64,
+            out var normal, out var _);
+        Assert.Empty(normal);
+        Assert.Single(session.PendingNormalCasts);
+    }
+
+    [Fact]
+    public void DeadlineInFuture_NotEvicted()
+    {
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        session.PendingNormalCasts.Enqueue(MakeCast(1234, watchdogDeadlineMs: now + 5000));
+        session.DrainExpiredWatchdogCasts(now,
+            out var normal, out var _);
+        Assert.Empty(normal);
+        Assert.Single(session.PendingNormalCasts);
+    }
+
+    [Fact]
+    public void DeadlineInPast_Evicted()
+    {
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        session.PendingNormalCasts.Enqueue(MakeCast(1234, watchdogDeadlineMs: now - 1000, hasStarted: true));
+        session.DrainExpiredWatchdogCasts(now,
+            out var normal, out var _);
+        Assert.Single(normal);
+        Assert.Equal(1234u, normal[0].SpellId);
+        Assert.True(normal[0].HasStarted);
+        Assert.Empty(session.PendingNormalCasts);
+    }
+
+    [Fact]
+    public void MixedQueue_OnlyExpiredEvicted_OthersKept()
+    {
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        session.PendingNormalCasts.Enqueue(MakeCast(100, watchdogDeadlineMs: now - 500));   // expired
+        session.PendingNormalCasts.Enqueue(MakeCast(200, watchdogDeadlineMs: 0));            // no watchdog
+        session.PendingNormalCasts.Enqueue(MakeCast(300, watchdogDeadlineMs: now + 1000));   // future
+        session.PendingNormalCasts.Enqueue(MakeCast(400, watchdogDeadlineMs: now - 100));    // expired
+
+        session.DrainExpiredWatchdogCasts(now, out var normal, out var _);
+
+        Assert.Equal(2, normal.Count);
+        Assert.Contains(normal, c => c.SpellId == 100);
+        Assert.Contains(normal, c => c.SpellId == 400);
+
+        Assert.Equal(2, session.PendingNormalCasts.Count);
+    }
+
+    [Fact]
+    public void PetQueue_DrainedSeparately()
+    {
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        session.PendingNormalCasts.Enqueue(MakeCast(100, watchdogDeadlineMs: now - 500));
+        session.PendingPetCasts.Enqueue(MakeCast(200, watchdogDeadlineMs: now - 500));
+
+        session.DrainExpiredWatchdogCasts(now, out var normal, out var pet);
+
+        Assert.Single(normal);
+        Assert.Single(pet);
+        Assert.Equal(100u, normal[0].SpellId);
+        Assert.Equal(200u, pet[0].SpellId);
+    }
+
+    [Fact]
+    public void HasStartedNormalCast_FalseAfterEvictingTheLeakedEntry()
+    {
+        // The actual symptom Jim flagged — leaked HasStarted=true entry blocks
+        // HasStartedNormalCast() from returning false. After eviction it should
+        // return false again, unblocking subsequent casts.
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        session.PendingNormalCasts.Enqueue(MakeCast(1234, watchdogDeadlineMs: now - 1000, hasStarted: true));
+
+        Assert.True(session.HasStartedNormalCast());
+
+        session.DrainExpiredWatchdogCasts(now, out var _, out var _);
+
+        Assert.False(session.HasStartedNormalCast());
+    }
+
+    [Fact]
+    public void DeadlineExactlyNow_NotEvicted()
+    {
+        // Strict <, not <=. A cast that just hit its deadline this same tick is
+        // considered borderline — the natural CAST_FAILED may still arrive in the
+        // same packet batch. Wait one more tick before evicting.
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        session.PendingNormalCasts.Enqueue(MakeCast(100, watchdogDeadlineMs: now));
+
+        session.DrainExpiredWatchdogCasts(now, out var normal, out var _);
+
+        Assert.Empty(normal);
+        Assert.Single(session.PendingNormalCasts);
+    }
+}

--- a/HermesProxy.Tests/World/WatchdogEvictionTests.cs
+++ b/HermesProxy.Tests/World/WatchdogEvictionTests.cs
@@ -1,5 +1,9 @@
 using System;
 using HermesProxy;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
 using Xunit;
 
 namespace HermesProxy.Tests.World;
@@ -135,5 +139,105 @@ public class WatchdogEvictionTests
 
         Assert.Empty(normal);
         Assert.Single(session.PendingNormalCasts);
+    }
+
+    // ---- Destroy-hook fast path tests ----
+
+    private static WowGuid128 Creature(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 12345, counter);
+
+    private static ClientCastRequest MakeCastWithTarget(uint spellId, WowGuid128 targetGuid, bool hasStarted = false)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            TargetGuid = targetGuid,
+            HasStarted = hasStarted,
+        };
+    }
+
+    [Fact]
+    public void DrainPendingCastsForDestroyedTarget_NoMatch_KeepsAll()
+    {
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, Creature(1)));
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(200, Creature(2)));
+
+        session.DrainPendingCastsForDestroyedTarget(Creature(99),
+            out var normal, out var pet);
+
+        Assert.Empty(normal);
+        Assert.Empty(pet);
+        Assert.Equal(2, session.PendingNormalCasts.Count);
+    }
+
+    [Fact]
+    public void DrainPendingCastsForDestroyedTarget_Match_EvictsOnly()
+    {
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, Creature(1), hasStarted: true));
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(200, Creature(2)));
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(300, Creature(1))); // also targets evicted unit
+
+        session.DrainPendingCastsForDestroyedTarget(Creature(1),
+            out var normal, out var pet);
+
+        Assert.Equal(2, normal.Count);
+        Assert.Contains(normal, c => c.SpellId == 100);
+        Assert.Contains(normal, c => c.SpellId == 300);
+        Assert.Single(session.PendingNormalCasts);
+        Assert.Empty(pet);
+    }
+
+    [Fact]
+    public void DrainPendingCastsForDestroyedTarget_EmptyTargetGuids_Ignored()
+    {
+        // AoE / self-cast spells have empty TargetGuid. Destroy hook should
+        // not match them by accident even if the destroyed GUID is also empty.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, default));
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(200, Creature(5)));
+
+        session.DrainPendingCastsForDestroyedTarget(default,
+            out var normal, out var _);
+
+        Assert.Empty(normal);
+        Assert.Equal(2, session.PendingNormalCasts.Count);
+    }
+
+    [Fact]
+    public void DrainPendingCastsForDestroyedTarget_PetQueue_DrainedSeparately()
+    {
+        var session = NewSession();
+        var dyingMob = Creature(1);
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, dyingMob));
+        session.PendingPetCasts.Enqueue(MakeCastWithTarget(200, dyingMob));
+
+        session.DrainPendingCastsForDestroyedTarget(dyingMob,
+            out var normal, out var pet);
+
+        Assert.Single(normal);
+        Assert.Single(pet);
+        Assert.Equal(100u, normal[0].SpellId);
+        Assert.Equal(200u, pet[0].SpellId);
+    }
+
+    [Fact]
+    public void DrainPendingCastsForDestroyedTarget_HasStartedNormalCast_FalseAfterEviction()
+    {
+        // The end-to-end symptom: cast-time spell on a target, target dies, server
+        // sends only SMSG_SPELL_FAILURE (no trailing CAST_FAILED on Kronos). Without
+        // the destroy hook the entry leaks. With the hook, SMSG_DESTROY_OBJECT for
+        // the target evicts it immediately and HasStartedNormalCast returns false.
+        var session = NewSession();
+        var dyingMob = Creature(1);
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, dyingMob, hasStarted: true));
+
+        Assert.True(session.HasStartedNormalCast());
+
+        session.DrainPendingCastsForDestroyedTarget(dyingMob, out var _, out var _);
+
+        Assert.False(session.HasStartedNormalCast());
     }
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -69,6 +69,14 @@ public sealed class GameSessionData
     // SendPacketToClient or fired control-grant packets at a session that had moved on.
     public CancellationTokenSource? TaxiDismountCts;
     public long TaxiDismountFiresAtTickMs;
+    // JimsProxy (dance-stuck-on-movement 2026-05-07): the modern Classic 1.14 client treats
+    // certain ONESHOT emote IDs (notably EMOTE_ONESHOT_DANCE = 10) as looping animations
+    // client-side and only stops them on a new SMSG_EMOTE arriving. Vanilla 1.12 servers
+    // (Kronos / Twinstar) don't broadcast a stop emote when the player moves, so the dance
+    // loops indefinitely. Track the last looping emote so HandlePlayerMove can synthesize
+    // a stop SMSG_EMOTE on the first movement-start packet.
+    public uint LastLoopingEmoteId; // 0 means no active loop
+    public long LastLoopingEmoteTickMs;
     public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -924,6 +924,46 @@ public sealed class GameSessionData
     /// .RunWatchdogEviction) emits the synthetic packets via InstanceSocket.
     /// Pure data operation — no socket dependency, easy to unit-test.
     /// </summary>
+    /// <summary>
+    /// JimsProxy (PR #161 follow-up — destroy-hook fast path): walks pending
+    /// queues and dequeues any cast whose TargetGuid matches the destroyed
+    /// unit. Returns evicted entries for the caller to emit synthetic
+    /// CastFailed packets with a more accurate reason (BadTargets) than the
+    /// watchdog's DontReport, since we know exactly why the cast can't
+    /// proceed: the target was destroyed.
+    /// </summary>
+    public void DrainPendingCastsForDestroyedTarget(WowGuid128 destroyedGuid,
+        out List<ClientCastRequest> normalEvicted,
+        out List<ClientCastRequest> petEvicted)
+    {
+        normalEvicted = new List<ClientCastRequest>();
+        petEvicted = new List<ClientCastRequest>();
+        if (destroyedGuid.IsEmpty())
+            return;
+
+        var keepNormal = new List<ClientCastRequest>();
+        while (PendingNormalCasts.TryDequeue(out var cast))
+        {
+            if (!cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+                normalEvicted.Add(cast);
+            else
+                keepNormal.Add(cast);
+        }
+        foreach (var c in keepNormal)
+            PendingNormalCasts.Enqueue(c);
+
+        var keepPet = new List<ClientCastRequest>();
+        while (PendingPetCasts.TryDequeue(out var cast))
+        {
+            if (!cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+                petEvicted.Add(cast);
+            else
+                keepPet.Add(cast);
+        }
+        foreach (var c in keepPet)
+            PendingPetCasts.Enqueue(c);
+    }
+
     public void DrainExpiredWatchdogCasts(long nowMs,
         out List<ClientCastRequest> normalEvicted,
         out List<ClientCastRequest> petEvicted)
@@ -1685,6 +1725,15 @@ public class ClientCastRequest
     // button-lit state instead of leaking a HasStarted=true entry that
     // permanently blocks HasStartedNormalCast(). 0 = no watchdog active.
     public long WatchdogDeadlineMs;
+
+    // JimsProxy (PR #161 follow-up — destroy-hook fast path): captured from
+    // CastSpell.Cast.Target.Unit at enqueue time. When HandleDestroyObject
+    // sees this GUID, the proxy can immediately evict any pending casts that
+    // were aimed at it (target died / despawned) and emit a synthetic
+    // CastFailed(BadTargets) — much faster than waiting up to 2.5s for the
+    // watchdog. Empty/default GUID = self-cast or no unit target (e.g. AoE
+    // ground-target spells), which the destroy hook ignores.
+    public WowGuid128 TargetGuid;
 }
 public class ArenaTeamData
 {
@@ -1771,6 +1820,66 @@ public class GlobalSessionData
         GameState = GameSessionData.CreateNewGameSessionData(this);
         AuthClient = new AuthClient(this);
         ThreatTracker = new ThreatTracker(this);
+    }
+
+    /// <summary>
+    /// JimsProxy (PR #161 follow-up — destroy-hook fast path): when
+    /// SMSG_DESTROY_OBJECT arrives for a unit, evict any pending casts aimed
+    /// at it. Reason=BadTargets because we know exactly why the cast can't
+    /// proceed (target was destroyed) and the modern client renders the
+    /// correct popup ("Invalid target"). Faster than the 2.5s watchdog —
+    /// fires within ~RTT of the destroy packet.
+    /// </summary>
+    public void EvictPendingCastsForDestroyedTarget(WowGuid128 destroyedGuid)
+    {
+        if (InstanceSocket == null) return;
+        if (destroyedGuid.IsEmpty()) return;
+
+        GameState.DrainPendingCastsForDestroyedTarget(destroyedGuid,
+            out var normalEvicted,
+            out var petEvicted);
+
+        foreach (var cast in normalEvicted)
+        {
+            Log.Event("cast.destroy_evicted", new
+            {
+                queue = "normal",
+                spell_id = cast.SpellId,
+                client_cast_id = cast.ClientGUID.ToString(),
+                target_low = cast.TargetGuid.GetCounter(),
+                had_started = cast.HasStarted,
+            });
+            if (!cast.HasStarted)
+            {
+                SpellPrepare prepare = new();
+                prepare.ClientCastID = cast.ClientGUID;
+                prepare.ServerCastID = cast.ServerGUID;
+                InstanceSocket.SendPacket(prepare);
+            }
+            CastFailed failed = new();
+            failed.SpellID = cast.SpellId;
+            failed.SpellXSpellVisualID = cast.SpellXSpellVisualId;
+            failed.Reason = (byte)SpellCastResultClassic.BadTargets;
+            failed.CastID = cast.ServerGUID;
+            InstanceSocket.SendPacket(failed);
+        }
+
+        foreach (var cast in petEvicted)
+        {
+            Log.Event("cast.destroy_evicted", new
+            {
+                queue = "pet",
+                spell_id = cast.SpellId,
+                client_cast_id = cast.ClientGUID.ToString(),
+                target_low = cast.TargetGuid.GetCounter(),
+                had_started = cast.HasStarted,
+            });
+            PetCastFailed failed = new();
+            failed.SpellID = cast.SpellId;
+            failed.Reason = (uint)SpellCastResultClassic.BadTargets;
+            failed.CastID = cast.ServerGUID;
+            InstanceSocket.SendPacket(failed);
+        }
     }
 
     /// <summary>

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -918,6 +918,43 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy (PR #161 follow-up): walks PendingNormalCasts and PendingPetCasts,
+    /// dequeues any entry whose WatchdogDeadlineMs has expired, and returns the
+    /// evicted entries via the out parameters. Caller (GlobalSessionData
+    /// .RunWatchdogEviction) emits the synthetic packets via InstanceSocket.
+    /// Pure data operation — no socket dependency, easy to unit-test.
+    /// </summary>
+    public void DrainExpiredWatchdogCasts(long nowMs,
+        out List<ClientCastRequest> normalEvicted,
+        out List<ClientCastRequest> petEvicted)
+    {
+        normalEvicted = new List<ClientCastRequest>();
+        petEvicted = new List<ClientCastRequest>();
+
+        var keepNormal = new List<ClientCastRequest>();
+        while (PendingNormalCasts.TryDequeue(out var cast))
+        {
+            if (cast.WatchdogDeadlineMs > 0 && cast.WatchdogDeadlineMs < nowMs)
+                normalEvicted.Add(cast);
+            else
+                keepNormal.Add(cast);
+        }
+        foreach (var c in keepNormal)
+            PendingNormalCasts.Enqueue(c);
+
+        var keepPet = new List<ClientCastRequest>();
+        while (PendingPetCasts.TryDequeue(out var cast))
+        {
+            if (cast.WatchdogDeadlineMs > 0 && cast.WatchdogDeadlineMs < nowMs)
+                petEvicted.Add(cast);
+            else
+                keepPet.Add(cast);
+        }
+        foreach (var c in keepPet)
+            PendingPetCasts.Enqueue(c);
+    }
+
+    /// <summary>
     /// JimsProxy (Mount-Button-Stuck-Lit): returns true if any pending normal cast — started OR
     /// merely in flight to the legacy server — matches the given SpellId (or its LegacySpellId
     /// for SoM-renumbered USE_ITEMs).
@@ -1638,6 +1675,16 @@ public class ClientCastRequest
     // The GCD hold gate in HandleSpellGo uses this instead of HasStarted so Kronos-flavored
     // instants still trigger BeginGcd. See JimsProxy issue #43 follow-up.
     public uint StartedCastTimeMs;
+
+    // JimsProxy (PR #161 follow-up): when HandleSpellFailure peeks this entry
+    // (instead of dequeuing) so the trailing SMSG_CAST_FAILED can deliver the
+    // real reason, set this to TickCount64 + 2500ms. If HandleCastFailed
+    // doesn't dequeue within the window (Kronos can drop the trailing CAST_FAILED
+    // on cast-time + target-dies), EvictExpiredWatchdogCasts force-dequeues
+    // and emits a synthetic SpellPrepare + CastFailed(DontReport) to clear
+    // button-lit state instead of leaking a HasStarted=true entry that
+    // permanently blocks HasStartedNormalCast(). 0 = no watchdog active.
+    public long WatchdogDeadlineMs;
 }
 public class ArenaTeamData
 {
@@ -1724,6 +1771,68 @@ public class GlobalSessionData
         GameState = GameSessionData.CreateNewGameSessionData(this);
         AuthClient = new AuthClient(this);
         ThreatTracker = new ThreatTracker(this);
+    }
+
+    /// <summary>
+    /// JimsProxy (PR #161 follow-up): drain any expired watchdog peeks from the
+    /// pending-cast queues and emit synthetic SpellPrepare + CastFailed(DontReport)
+    /// (or PetCastFailed) for each so the modern client's button-lit / cast-bar
+    /// state clears. Called from the top of every spell-event handler so a leak
+    /// from "no trailing CAST_FAILED arrived" is at most one cast event old.
+    /// Reason=DontReport because the trailing CAST_FAILED that would have carried
+    /// the real reason never arrived — we don't know which to show.
+    /// </summary>
+    public void RunWatchdogEviction()
+    {
+        if (InstanceSocket == null)
+            return;
+
+        long nowMs = Environment.TickCount64;
+        GameState.DrainExpiredWatchdogCasts(nowMs,
+            out var normalEvicted,
+            out var petEvicted);
+
+        foreach (var cast in normalEvicted)
+        {
+            Log.Event("cast.watchdog_evicted", new
+            {
+                queue = "normal",
+                spell_id = cast.SpellId,
+                client_cast_id = cast.ClientGUID.ToString(),
+                had_started = cast.HasStarted,
+                ms_overdue = nowMs - cast.WatchdogDeadlineMs,
+            });
+            if (!cast.HasStarted)
+            {
+                SpellPrepare prepare = new();
+                prepare.ClientCastID = cast.ClientGUID;
+                prepare.ServerCastID = cast.ServerGUID;
+                InstanceSocket.SendPacket(prepare);
+            }
+            CastFailed failed = new();
+            failed.SpellID = cast.SpellId;
+            failed.SpellXSpellVisualID = cast.SpellXSpellVisualId;
+            failed.Reason = (byte)SpellCastResultClassic.DontReport;
+            failed.CastID = cast.ServerGUID;
+            InstanceSocket.SendPacket(failed);
+        }
+
+        foreach (var cast in petEvicted)
+        {
+            Log.Event("cast.watchdog_evicted", new
+            {
+                queue = "pet",
+                spell_id = cast.SpellId,
+                client_cast_id = cast.ClientGUID.ToString(),
+                had_started = cast.HasStarted,
+                ms_overdue = nowMs - cast.WatchdogDeadlineMs,
+            });
+            PetCastFailed failed = new();
+            failed.SpellID = cast.SpellId;
+            failed.Reason = (uint)SpellCastResultClassic.DontReport;
+            failed.CastID = cast.ServerGUID;
+            InstanceSocket.SendPacket(failed);
+        }
     }
 
     public void StoreGuildRankNames(uint guildId, List<string> ranks)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -925,6 +925,33 @@ public sealed class GameSessionData
     /// Pure data operation — no socket dependency, easy to unit-test.
     /// </summary>
     /// <summary>
+    /// JimsProxy (PR #161 follow-up — movement preemption): walks
+    /// PendingNormalCasts and marks every HasStarted=true cast-time spell
+    /// (StartedCastTimeMs>0) as MovementCancelled. Trailing SMSG_SPELL_FAILURE
+    /// / SMSG_CAST_FAILED for these casts are suppressed (modern client
+    /// already cancelled its own cast bar via client-side movement prediction).
+    /// Also arms the watchdog so even if the legacy server never sends the
+    /// trailing failure, the leak heals at the next cast event. Returns the
+    /// number of casts marked, for diagnostics. Instants and not-yet-started
+    /// casts are ignored (movement doesn't cancel them in vanilla).
+    /// </summary>
+    public int MarkStartedCastsMovementCancelled(long watchdogDeadlineMs)
+    {
+        int marked = 0;
+        foreach (var cast in PendingNormalCasts)
+        {
+            if (cast.HasStarted && cast.StartedCastTimeMs > 0)
+            {
+                cast.MovementCancelled = true;
+                if (cast.WatchdogDeadlineMs == 0)
+                    cast.WatchdogDeadlineMs = watchdogDeadlineMs;
+                marked++;
+            }
+        }
+        return marked;
+    }
+
+    /// <summary>
     /// JimsProxy (PR #161 follow-up — destroy-hook fast path): walks pending
     /// queues and dequeues any cast whose TargetGuid matches the destroyed
     /// unit. Returns evicted entries for the caller to emit synthetic
@@ -1734,6 +1761,16 @@ public class ClientCastRequest
     // watchdog. Empty/default GUID = self-cast or no unit target (e.g. AoE
     // ground-target spells), which the destroy hook ignores.
     public WowGuid128 TargetGuid;
+
+    // JimsProxy (PR #161 follow-up — movement preemption): set true when the
+    // proxy detects a CMSG_MOVE_START_* opcode while this cast-time spell is
+    // in progress (HasStarted=true && StartedCastTimeMs>0). Vanilla cancels
+    // any cast-time spell on movement, and the modern 1.14 client predicts
+    // this client-side — so when this flag is set the trailing
+    // SMSG_SPELL_FAILURE suppresses its broadcast (no misleading "in combat"
+    // popup) and the trailing SMSG_CAST_FAILED forwards as DontReport so the
+    // client gets its CMSG_CANCEL_CAST ack without a popup.
+    public bool MovementCancelled;
 }
 public class ArenaTeamData
 {

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -614,7 +614,44 @@ public partial class WorldClient
         EmoteMessage emote = new EmoteMessage();
         emote.EmoteID = packet.ReadUInt32();
         emote.Guid = packet.ReadGuid().To128(GetSession().GameState);
+        // JimsProxy (emote-state-diag 2026-05-07): capture emote broadcasts so we can pair them
+        // with subsequent emote.state.update events when triaging stuck-dance bugs.
+        Framework.Logging.Log.Event("emote.broadcast", new
+        {
+            emote_id = emote.EmoteID,
+            target_low = emote.Guid.GetCounter(),
+            is_player_target = emote.Guid == GetSession().GameState.CurrentPlayerGuid,
+        });
+        // JimsProxy (dance-stuck-on-movement 2026-05-07): track the player's last looping
+        // emote. EMOTE_ONESHOT_DANCE (10) is the known case — Classic 1.14 client loops it
+        // until another SMSG_EMOTE arrives, and Kronos/Twinstar don't broadcast one on move.
+        // Any new SMSG_EMOTE for the player overrides/clears the tracker (matches the actual
+        // client-side behavior — a new emote replaces the active loop).
+        if (emote.Guid == GetSession().GameState.CurrentPlayerGuid)
+        {
+            if (IsClientLoopingEmote(emote.EmoteID))
+            {
+                GetSession().GameState.LastLoopingEmoteId = emote.EmoteID;
+                GetSession().GameState.LastLoopingEmoteTickMs = Environment.TickCount64;
+            }
+            else
+            {
+                // Non-looping emote breaks any active loop on the client side; mirror that.
+                GetSession().GameState.LastLoopingEmoteId = 0;
+            }
+        }
         SendPacketToClient(emote);
+    }
+
+    /// <summary>
+    /// JimsProxy: returns true if the given EMOTE_ONESHOT_* ID is one that the modern
+    /// Classic 1.14 client treats as a looping animation client-side (continues until a
+    /// new SMSG_EMOTE arrives). Currently just EMOTE_ONESHOT_DANCE (10). Add others here
+    /// if reports surface for /sleep, /kneel, etc.
+    /// </summary>
+    private static bool IsClientLoopingEmote(uint emoteId)
+    {
+        return emoteId == 10; // EMOTE_ONESHOT_DANCE
     }
 
     [PacketHandler(Opcode.SMSG_TEXT_EMOTE)]

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -546,62 +546,51 @@ public partial class WorldClient
         // can drop the broadcast entirely -- there's no animation to cancel.
         bool isRangedAutoAttack = spellId == 75 || spellId == 5019;
 
-        // Local player: DEQUEUE and send CastFailed immediately. Kronos doesn't
-        // always follow SMSG_SPELL_FAILURE with SMSG_CAST_FAILED (e.g. target dies
-        // mid-cast). Previously this only peeked, relying on HandleCastFailed to
-        // dequeue — but when CAST_FAILED never arrived, the entry leaked with
-        // HasStarted=true, permanently blocking all non-off-GCD casts.
+        // JimsProxy: PEEK (don't dequeue) so the trailing SMSG_CAST_FAILED — which
+        // carries the real failure reason on vmangos/Twinstar after Spell::SendInterrupted
+        // hardcodes the SpellFailure wire reason to 0 (= AffectingCombat after translation)
+        // — can be matched by HandleCastFailed via TryDequeuePendingNormalCast and
+        // delivered to the client. Sending an inline CastFailed here would (a) consume
+        // the queue entry HandleCastFailed needs, leaving its dequeue empty, and (b)
+        // ship the misleading hardcoded reason to the client, which the 1.14 popup +
+        // button-state renderer reads regardless of whether the broadcast SpellFailure
+        // was suppressed. Trade-off: on Kronos, where the trailing SMSG_CAST_FAILED can
+        // be dropped (e.g. target dies mid-cast on cast-time spells), the cast can leak
+        // in the queue. For the SendInterrupted hardcoded-zero path that triggers this
+        // suppression — overwhelmingly instants on vmangos/Twinstar — the trailing
+        // CAST_FAILED reliably arrives. ClearHeldCastTimeCast still fires to release
+        // any cast-time-held press attached to a now-failed cast bar.
         if (GetSession().GameState.CurrentPlayerGuid == casterUnit &&
-            GetSession().GameState.TryDequeuePendingNormalCast(spellId, out var pendingNormal))
+            GetSession().GameState.PendingNormalCasts.FirstOrDefault(c => c.SpellId == spellId || (c.LegacySpellId != 0 && c.LegacySpellId == spellId)) is { } pendingNormal)
         {
-            castId = pendingNormal!.ServerGUID;
+            castId = pendingNormal.ServerGUID;
             spellVisual = pendingNormal.SpellXSpellVisualId;
             if (pendingNormal.LegacySpellId != 0)
                 spellId = pendingNormal.SpellId;
             wasStarted = pendingNormal.HasStarted;
-            dequeued = true;
-
-            if (!pendingNormal.HasStarted)
-            {
-                SpellPrepare prepare = new();
-                prepare.ClientCastID = pendingNormal.ClientGUID;
-                prepare.ServerCastID = pendingNormal.ServerGUID;
-                SendPacketToClient(prepare);
-            }
-
-            CastFailed failed = new();
-            failed.SpellID = pendingNormal.SpellId;
-            failed.SpellXSpellVisualID = pendingNormal.SpellXSpellVisualId;
-            failed.Reason = reason;
-            failed.CastID = pendingNormal.ServerGUID;
-            SendPacketToClient(failed);
+            dequeued = false; // peeked — HandleCastFailed dequeues on the trailing SMSG_CAST_FAILED
 
             GetSession().GameState.ClearHeldCastTimeCast();
 
             // Instant cast that wasn't a ranged auto-attack: SPELL_START was
-            // never forwarded, so there's no cast bar to dismiss. CastFailed
-            // already cancelled GCD anticipation. Skip the misleading
-            // SpellFailure broadcast entirely.
+            // never forwarded, so there's no cast bar to dismiss. Skip the misleading
+            // broadcast SpellFailure entirely. The trailing SMSG_CAST_FAILED via
+            // HandleCastFailed sends SpellPrepare + CastFailed with the real reason,
+            // which clears button-lit state and shows the correct popup.
             if (!pendingNormal.HasStarted && !isRangedAutoAttack)
                 skipBroadcastFailure = true;
             else
                 overrideReasonForLocalBroadcast = true;
         }
         else if (GetSession().GameState.CurrentPetGuid == casterUnit &&
-                 GetSession().GameState.TryDequeuePendingPetCast(spellId, out var pendingPet))
+                 GetSession().GameState.PendingPetCasts.FirstOrDefault(c => c.SpellId == spellId || (c.LegacySpellId != 0 && c.LegacySpellId == spellId)) is { } pendingPet)
         {
-            castId = pendingPet!.ServerGUID;
+            castId = pendingPet.ServerGUID;
             spellVisual = pendingPet.SpellXSpellVisualId;
             if (pendingPet.LegacySpellId != 0)
                 spellId = pendingPet.SpellId;
             wasStarted = pendingPet.HasStarted;
-            dequeued = true;
-
-            PetCastFailed petFailed = new();
-            petFailed.SpellID = pendingPet.SpellId;
-            petFailed.Reason = reason;
-            petFailed.CastID = pendingPet.ServerGUID;
-            SendPacketToClient(petFailed);
+            dequeued = false; // peeked — HandlePetCastFailed dequeues on the trailing SMSG_PET_CAST_FAILED
 
             // Pet path: PetCastFailed handles the pet UI. Suppress the broadcast
             // SpellFailure for instants (no cast bar); for cast-time pet spells

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -12,6 +12,14 @@ namespace HermesProxy.World.Client;
 
 public partial class WorldClient
 {
+    // JimsProxy (PR #161 follow-up): how long after HandleSpellFailure peeks a
+    // pending cast we wait for the trailing SMSG_CAST_FAILED before assuming
+    // the legacy server isn't sending one. 2.5s is comfortably longer than
+    // any observed CAST_FAILED arrival on vmangos/Twinstar (~1ms after FAILURE)
+    // and shorter than feels-laggy to the user when the pathological Kronos
+    // case kicks in (target-dies-mid-cast, no trailing CAST_FAILED).
+    private const long WatchdogWindowMs = 2500;
+
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_SEND_KNOWN_SPELLS)]
     void HandleSendKnownSpells(WorldPacket packet)
@@ -137,6 +145,11 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_CAST_FAILED)]
     void HandleCastFailed(WorldPacket packet)
     {
+        // JimsProxy (PR #161 follow-up): clean up any prior peek that didn't
+        // get its own trailing CAST_FAILED — happens occasionally on Kronos
+        // for cast-time + target-dies. Self-healing on every cast event.
+        GetSession().RunWatchdogEviction();
+
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
             packet.ReadUInt8(); // cast count
 
@@ -468,6 +481,11 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_SPELL_FAILURE)]
     void HandleSpellFailure(WorldPacket packet)
     {
+        // JimsProxy (PR #161 follow-up): clean up any prior peek that didn't
+        // get a trailing CAST_FAILED within the watchdog window. Runs before
+        // we set up a new watchdog so leaks can't accumulate across failures.
+        GetSession().RunWatchdogEviction();
+
         WowGuid128 casterUnit;
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
             casterUnit = packet.ReadPackedGuid().To128(GetSession().GameState);
@@ -569,6 +587,13 @@ public partial class WorldClient
                 spellId = pendingNormal.SpellId;
             wasStarted = pendingNormal.HasStarted;
             dequeued = false; // peeked — HandleCastFailed dequeues on the trailing SMSG_CAST_FAILED
+            // JimsProxy (PR #161 follow-up): arm the watchdog. If the trailing
+            // SMSG_CAST_FAILED arrives within 2.5s, HandleCastFailed dequeues
+            // normally (deadline becomes irrelevant). If not (Kronos-style
+            // target-dies-mid-cast drop), the next event runs RunWatchdogEviction
+            // and force-dequeues with synthetic SpellPrepare + CastFailed(DontReport)
+            // so HasStartedNormalCast doesn't permanently block subsequent casts.
+            pendingNormal.WatchdogDeadlineMs = Environment.TickCount64 + WatchdogWindowMs;
 
             GetSession().GameState.ClearHeldCastTimeCast();
 
@@ -591,6 +616,7 @@ public partial class WorldClient
                 spellId = pendingPet.SpellId;
             wasStarted = pendingPet.HasStarted;
             dequeued = false; // peeked — HandlePetCastFailed dequeues on the trailing SMSG_PET_CAST_FAILED
+            pendingPet.WatchdogDeadlineMs = Environment.TickCount64 + WatchdogWindowMs;
 
             // Pet path: PetCastFailed handles the pet UI. Suppress the broadcast
             // SpellFailure for instants (no cast bar); for cast-time pet spells

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -206,7 +206,28 @@ public partial class WorldClient
         // Look up pending normal cast by SpellId (queue-based, FIFO order)
         else if (GetSession().GameState.TryDequeuePendingNormalCast(spellId, out var pendingCast))
         {
-            if (!pendingCast!.HasStarted)
+            // JimsProxy (PR #161 follow-up — movement preemption): if this
+            // cast was marked when the user started moving, the modern client
+            // sent CMSG_CANCEL_CAST and is waiting for SMSG_CAST_FAILED to
+            // confirm. Suppressing CastFailed entirely makes the bar linger
+            // for the legacy round-trip (~150-200ms — observed as a "small
+            // delay" by testers). Emit CastFailed with DontReport so the
+            // client gets its ack instantly with no popup or error sound.
+            // Skip the SpellPrepare (no point prepping a cast we're failing).
+            bool movementSuppressed = pendingCast!.MovementCancelled;
+            uint effectiveReason = movementSuppressed
+                ? (uint)SpellCastResultClassic.DontReport
+                : LegacyVersion.ConvertSpellCastResult(reason);
+            if (movementSuppressed)
+            {
+                Log.Event("cast.movement_cancel_suppressed", new
+                {
+                    queue = "normal",
+                    spell_id = pendingCast.SpellId,
+                    client_cast_id = pendingCast.ClientGUID.ToString(),
+                });
+            }
+            else if (!pendingCast.HasStarted)
             {
                 SpellPrepare prepare2 = new SpellPrepare();
                 prepare2.ClientCastID = pendingCast.ClientGUID;
@@ -217,7 +238,7 @@ public partial class WorldClient
             CastFailed failed = new();
             failed.SpellID = pendingCast.SpellId;
             failed.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
-            failed.Reason = LegacyVersion.ConvertSpellCastResult(reason);
+            failed.Reason = effectiveReason;
             failed.CastID = pendingCast.ServerGUID;
             failed.FailedArg1 = arg1;
             failed.FailedArg2 = arg2;
@@ -597,12 +618,20 @@ public partial class WorldClient
 
             GetSession().GameState.ClearHeldCastTimeCast();
 
+            // JimsProxy (PR #161 follow-up — movement preemption): if the user
+            // started moving while this cast-time spell was in progress, the
+            // modern client already cancelled its own cast bar via client-side
+            // prediction. Suppress the broadcast SpellFailure entirely —
+            // emitting it would surface a misleading "You are in combat" popup
+            // (Spell::SendInterrupted hardcodes the wire reason to 0).
+            if (pendingNormal.MovementCancelled)
+                skipBroadcastFailure = true;
             // Instant cast that wasn't a ranged auto-attack: SPELL_START was
             // never forwarded, so there's no cast bar to dismiss. Skip the misleading
             // broadcast SpellFailure entirely. The trailing SMSG_CAST_FAILED via
             // HandleCastFailed sends SpellPrepare + CastFailed with the real reason,
             // which clears button-lit state and shows the correct popup.
-            if (!pendingNormal.HasStarted && !isRangedAutoAttack)
+            else if (!pendingNormal.HasStarted && !isRangedAutoAttack)
                 skipBroadcastFailure = true;
             else
                 overrideReasonForLocalBroadcast = true;

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -64,6 +64,15 @@ public partial class WorldClient
         }
         GetSession().GameState.LastAuraCasterOnTarget.Remove(guid);
 
+        // JimsProxy (PR #161 follow-up — destroy-hook fast path): if any pending
+        // cast was aimed at this GUID, evict it now and emit synthetic
+        // CastFailed(BadTargets). Faster than waiting up to 2.5s for the
+        // watchdog and carries the correct popup reason since we know exactly
+        // why the cast can't proceed (target was just destroyed). Covers the
+        // Kronos "target dies mid-cast, no trailing CAST_FAILED" scenario at
+        // the source of the problem instead of the watchdog catch-all.
+        GetSession().EvictPendingCastsForDestroyedTarget(guid);
+
         UpdateObject updateObject = new UpdateObject(GetSession().GameState);
         updateObject.DestroyedGuids.Add(guid);
         SendPacketToClient(updateObject);

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2335,6 +2335,17 @@ public partial class WorldClient
             if (UNIT_NPC_EMOTESTATE >= 0 && updateMaskArray[UNIT_NPC_EMOTESTATE])
             {
                 updateData.UnitData.EmoteState = updates[UNIT_NPC_EMOTESTATE].Int32Value;
+                // JimsProxy (emote-state-diag 2026-05-07): user reports /dance staying active
+                // through movement on Kronos. Capture every EMOTESTATE update so we can see
+                // whether the server sends EMOTESTATE=0 on move (proxy is dropping it) or never
+                // sends it at all (server-side bug, fix via proxy synthesis on movement).
+                Framework.Logging.Log.Event("emote.state.update", new
+                {
+                    target_low = guid.GetCounter(),
+                    is_player_target = guid == GetSession().GameState.CurrentPlayerGuid,
+                    new_emote_state = updateData.UnitData.EmoteState,
+                    is_create = isCreate,
+                });
             }
             int UNIT_TRAINING_POINTS = LegacyVersion.GetUpdateField(UnitField.UNIT_TRAINING_POINTS);
             if (UNIT_TRAINING_POINTS >= 0 && updateMaskArray[UNIT_TRAINING_POINTS])

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -45,6 +45,39 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_MOVE_DOUBLE_JUMP)]
     void HandlePlayerMove(ClientPlayerMovement movement)
     {
+        // JimsProxy (PR #161 follow-up — movement preemption): mark any in-flight
+        // cast-time spell as movement-cancelled the moment the user starts moving.
+        // Vanilla cancels cast-time spells on movement; the modern 1.14 client
+        // predicts this client-side and dismisses its own cast bar before the
+        // server's SMSG_SPELL_FAILURE round-trips. Without the marker, the
+        // trailing failure surfaces as a misleading "You are in combat" popup
+        // (vmangos hardcodes the wire reason in SendInterrupted) or a redundant
+        // CastFailed that re-flashes the action button. Also arms the watchdog
+        // so the entry doesn't leak if the legacy server response never arrives.
+        switch (movement.GetUniversalOpcode())
+        {
+            case Opcode.CMSG_MOVE_START_FORWARD:
+            case Opcode.CMSG_MOVE_START_BACKWARD:
+            case Opcode.CMSG_MOVE_START_STRAFE_LEFT:
+            case Opcode.CMSG_MOVE_START_STRAFE_RIGHT:
+            case Opcode.CMSG_MOVE_START_SWIM:
+            case Opcode.CMSG_MOVE_START_ASCEND:
+            case Opcode.CMSG_MOVE_START_DESCEND:
+            case Opcode.CMSG_MOVE_JUMP:
+            case Opcode.CMSG_MOVE_DOUBLE_JUMP:
+                int marked = GetSession().GameState.MarkStartedCastsMovementCancelled(
+                    Environment.TickCount64 + 2500);
+                if (marked > 0)
+                {
+                    Framework.Logging.Log.Event("cast.movement_cancel_preempted", new
+                    {
+                        casts_marked = marked,
+                        trigger_opcode = movement.GetUniversalOpcode().ToString(),
+                    });
+                }
+                break;
+        }
+
         string opcodeName = movement.GetUniversalOpcode().ToString();
         opcodeName = opcodeName.Replace("CMSG", "MSG");
         uint opcode = Opcodes.GetOpcodeValueForVersion(opcodeName, Framework.Settings.ServerBuild);

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -45,6 +45,8 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_MOVE_DOUBLE_JUMP)]
     void HandlePlayerMove(ClientPlayerMovement movement)
     {
+        bool isMoveStart = IsMovementStartOpcode(movement.GetUniversalOpcode());
+
         // JimsProxy (PR #161 follow-up — movement preemption): mark any in-flight
         // cast-time spell as movement-cancelled the moment the user starts moving.
         // Vanilla cancels cast-time spells on movement; the modern 1.14 client
@@ -54,28 +56,37 @@ public partial class WorldSocket
         // (vmangos hardcodes the wire reason in SendInterrupted) or a redundant
         // CastFailed that re-flashes the action button. Also arms the watchdog
         // so the entry doesn't leak if the legacy server response never arrives.
-        switch (movement.GetUniversalOpcode())
+        if (isMoveStart)
         {
-            case Opcode.CMSG_MOVE_START_FORWARD:
-            case Opcode.CMSG_MOVE_START_BACKWARD:
-            case Opcode.CMSG_MOVE_START_STRAFE_LEFT:
-            case Opcode.CMSG_MOVE_START_STRAFE_RIGHT:
-            case Opcode.CMSG_MOVE_START_SWIM:
-            case Opcode.CMSG_MOVE_START_ASCEND:
-            case Opcode.CMSG_MOVE_START_DESCEND:
-            case Opcode.CMSG_MOVE_JUMP:
-            case Opcode.CMSG_MOVE_DOUBLE_JUMP:
-                int marked = GetSession().GameState.MarkStartedCastsMovementCancelled(
-                    Environment.TickCount64 + 2500);
-                if (marked > 0)
+            int marked = GetSession().GameState.MarkStartedCastsMovementCancelled(
+                Environment.TickCount64 + 2500);
+            if (marked > 0)
+            {
+                Framework.Logging.Log.Event("cast.movement_cancel_preempted", new
                 {
-                    Framework.Logging.Log.Event("cast.movement_cancel_preempted", new
-                    {
-                        casts_marked = marked,
-                        trigger_opcode = movement.GetUniversalOpcode().ToString(),
-                    });
-                }
-                break;
+                    casts_marked = marked,
+                    trigger_opcode = movement.GetUniversalOpcode().ToString(),
+                });
+            }
+        }
+
+        // JimsProxy (dance-stuck-on-movement 2026-05-07): if the player has an active
+        // client-looping emote (e.g. /dance) and just initiated movement, synthesize a stop
+        // SMSG_EMOTE to break the loop. Kronos/Twinstar never broadcast one for movement, so
+        // without this the dance loops forever until another emote is used.
+        if (GetSession().GameState.LastLoopingEmoteId != 0 && isMoveStart)
+        {
+            EmoteMessage stopEmote = new EmoteMessage();
+            stopEmote.EmoteID = 0; // EMOTE_ONESHOT_NONE — clears the looping animation
+            stopEmote.Guid = GetSession().GameState.CurrentPlayerGuid;
+            SendPacket(stopEmote);
+            Framework.Logging.Log.Event("emote.loop.broken_by_move", new
+            {
+                last_emote_id = GetSession().GameState.LastLoopingEmoteId,
+                age_ms = Environment.TickCount64 - GetSession().GameState.LastLoopingEmoteTickMs,
+                trigger_opcode = movement.GetUniversalOpcode().ToString(),
+            });
+            GetSession().GameState.LastLoopingEmoteId = 0;
         }
 
         string opcodeName = movement.GetUniversalOpcode().ToString();
@@ -89,6 +100,30 @@ public partial class WorldSocket
             packet.WritePackedGuid(movement.Guid.To64());
         movement.MoveInfo.WriteMovementInfoLegacy(packet);
         SendPacketToServer(packet);
+    }
+
+    /// <summary>
+    /// JimsProxy: true for movement-start CMSG opcodes that should break a client-side
+    /// looping emote. Excludes heartbeats (just position updates), stops, and turn/facing
+    /// changes (turning in place shouldn't break /dance).
+    /// </summary>
+    private static bool IsMovementStartOpcode(Opcode opcode)
+    {
+        switch (opcode)
+        {
+            case Opcode.CMSG_MOVE_START_FORWARD:
+            case Opcode.CMSG_MOVE_START_BACKWARD:
+            case Opcode.CMSG_MOVE_START_STRAFE_LEFT:
+            case Opcode.CMSG_MOVE_START_STRAFE_RIGHT:
+            case Opcode.CMSG_MOVE_START_SWIM:
+            case Opcode.CMSG_MOVE_START_ASCEND:
+            case Opcode.CMSG_MOVE_START_DESCEND:
+            case Opcode.CMSG_MOVE_JUMP:
+            case Opcode.CMSG_MOVE_DOUBLE_JUMP:
+                return true;
+            default:
+                return false;
+        }
     }
 
     [PacketHandler(Opcode.CMSG_MOVE_TELEPORT_ACK)]

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -218,6 +218,7 @@ public partial class WorldSocket
             castRequest.SpellId = cast.Cast.SpellID;
             castRequest.SpellXSpellVisualId = cast.Cast.SpellXSpellVisualID;
             castRequest.ClientGUID = cast.Cast.CastID;
+            castRequest.TargetGuid = cast.Cast.Target.Unit;
 
             // Get the appropriate tracking variable based on spell type
             ref ClientCastRequest? currentCast = ref (isAutoRepeat
@@ -251,6 +252,7 @@ public partial class WorldSocket
             castRequest.SpellId = cast.Cast.SpellID;
             castRequest.SpellXSpellVisualId = cast.Cast.SpellXSpellVisualID;
             castRequest.ClientGUID = cast.Cast.CastID;
+            castRequest.TargetGuid = cast.Cast.Target.Unit;
             castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, cast.Cast.SpellID, 10000 + cast.Cast.CastID.GetCounter());
 
             // JimsProxy (issue #43): off-GCD spells (Sprint, Evasion, Trinket, racials, etc)
@@ -483,6 +485,7 @@ public partial class WorldSocket
         castRequest.SpellId = cast.Cast.SpellID;
         castRequest.SpellXSpellVisualId = cast.Cast.SpellXSpellVisualID;
         castRequest.ClientGUID = cast.Cast.CastID;
+        castRequest.TargetGuid = cast.Cast.Target.Unit;
         castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, cast.Cast.SpellID, 10000 + cast.Cast.CastID.GetCounter());
 
         // Check if there's already a pet cast in progress - reject without forwarding to server
@@ -516,6 +519,7 @@ public partial class WorldSocket
         castRequest.SpellId = use.Cast.SpellID;
         castRequest.SpellXSpellVisualId = use.Cast.SpellXSpellVisualID;
         castRequest.ClientGUID = use.Cast.CastID;
+        castRequest.TargetGuid = use.Cast.Target.Unit;
         castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, use.Cast.SpellID, 10000 + use.Cast.CastID.GetCounter());
         castRequest.ItemGUID = use.CastItem;
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -141,6 +141,13 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_CAST_SPELL)]
     void HandleCastSpell(CastSpell cast)
     {
+        // JimsProxy (PR #161 follow-up): self-heal any leaked peek-without-CAST_FAILED
+        // before HasStartedNormalCast / HasNonStartedPendingCastForSpell run their
+        // gate checks below. Without this, a Kronos-style "no trailing CAST_FAILED"
+        // leak would block every subsequent cast until the user happened to retrigger
+        // the same spell that's leaked, which is unintuitive and looks like a freeze.
+        GetSession().RunWatchdogEviction();
+
         if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
             GetSession().GameState.LastDispellSpellId = (uint)cast.Cast.SpellID;
 


### PR DESCRIPTION
Body:
  ▎ The modern Classic 1.14 client treats EMOTE_ONESHOT_DANCE (10) as a
  ▎ looping animation client-side, continuing until another SMSG_EMOTE
  ▎ arrives. Vanilla 1.12 servers (Kronos / Twinstar) never broadcast a
  ▎ stop emote on player movement, so /dance loops indefinitely until
  ▎ the player triggers another emote.
  ▎
  ▎ Confirmed via diagnostic capture: zero UNIT_NPC_EMOTESTATE field
  ▎ updates flow through OBJECT_UPDATE for /dance — the loop is purely
  ▎ client-side.
  ▎
  ▎ Track the player's last looping emote in GlobalSessionData. When the
  ▎ modern client sends a movement-start CMSG (FORWARD/BACKWARD/STRAFE/
  ▎ SWIM/ASCEND/JUMP — excluding heartbeats, stops, and turn/facing),
  ▎ synthesize an SMSG_EMOTE with emote_id=0 to break the loop. Any new
  ▎ SMSG_EMOTE for the player also clears the tracker.
  ▎
  ▎ Note: depends on #161 (cast-failed-misleading-combat-popup) being
  ▎ merged first — both touch HandlePlayerMove and this branch is rebased
  ▎ onto #161's tip with the conflict resolved (uses shared
  ▎ IsMovementStartOpcode helper).
  ▎
  ▎ Diagnostic events: emote.broadcast, emote.state.update,
  ▎ emote.loop.broken_by_move.