### PR TITLE
Evict per-target aura state on SMSG_DESTROY_OBJECT

### DIFF
--- a/HermesProxy.Tests/World/AuraStateEvictionTests.cs
+++ b/HermesProxy.Tests/World/AuraStateEvictionTests.cs
@@ -1,0 +1,75 @@
+using HermesProxy;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class AuraStateEvictionTests
+{
+    private static WowGuid128 MakeUnit(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 12345, counter);
+
+    // Validates the bug fix: SMSG_DESTROY_OBJECT must drop ALL per-target
+    // aura state, not just ObjectCache + LastAuraCasterOnTarget. Pre-fix
+    // the modern client surfaced stale buffs after a render roundtrip.
+    [Fact]
+    public void EvictUnitAuraState_PopulatedTarget_ClearsAllFourTables()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var target = MakeUnit(1);
+        var caster = MakeUnit(99);
+
+        state.StoreAuraDurationLeft(target, slot: 0, duration: 30000, currentTime: 1000);
+        state.StoreAuraDurationLeft(target, slot: 1, duration: 60000, currentTime: 1000);
+        state.StoreAuraDurationFull(target, slot: 0, duration: 30000);
+        state.StoreAuraCaster(target, slot: 0, caster);
+
+        Assert.True(state.UnitAuraDurationLeft.ContainsKey(target));
+        Assert.True(state.UnitAuraDurationUpdateTime.ContainsKey(target));
+        Assert.True(state.UnitAuraDurationFull.ContainsKey(target));
+        Assert.True(state.UnitAuraCaster.ContainsKey(target));
+
+        int evicted = state.EvictUnitAuraState(target);
+
+        // Eviction count reflects the number of aura slots present in the
+        // duration-left table (the canonical "how many auras did we know
+        // about" signal — used in the object.destroy diagnostic).
+        Assert.Equal(2, evicted);
+        Assert.False(state.UnitAuraDurationLeft.ContainsKey(target));
+        Assert.False(state.UnitAuraDurationUpdateTime.ContainsKey(target));
+        Assert.False(state.UnitAuraDurationFull.ContainsKey(target));
+        Assert.False(state.UnitAuraCaster.ContainsKey(target));
+    }
+
+    // Other targets' state is untouched — eviction is strictly per-guid.
+    [Fact]
+    public void EvictUnitAuraState_OnlyAffectsRequestedGuid()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var keep = MakeUnit(1);
+        var evict = MakeUnit(2);
+
+        state.StoreAuraDurationLeft(keep, slot: 0, duration: 30000, currentTime: 1000);
+        state.StoreAuraDurationLeft(evict, slot: 0, duration: 30000, currentTime: 1000);
+        state.StoreAuraCaster(keep, slot: 0, MakeUnit(99));
+        state.StoreAuraCaster(evict, slot: 0, MakeUnit(99));
+
+        state.EvictUnitAuraState(evict);
+
+        Assert.True(state.UnitAuraDurationLeft.ContainsKey(keep));
+        Assert.True(state.UnitAuraCaster.ContainsKey(keep));
+        Assert.False(state.UnitAuraDurationLeft.ContainsKey(evict));
+        Assert.False(state.UnitAuraCaster.ContainsKey(evict));
+    }
+
+    // No-op when the guid was never seen — must not throw.
+    [Fact]
+    public void EvictUnitAuraState_UnknownGuid_ReturnsZero()
+    {
+        var state = GameSessionData.CreateForTesting();
+        int evicted = state.EvictUnitAuraState(MakeUnit(42));
+        Assert.Equal(0, evicted);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -766,6 +766,21 @@ public sealed class GameSessionData
         if (UnitAuraCaster.TryGetValue(guid, out var dict))
             dict.Remove(slot);
     }
+    // JimsProxy (target-buffs-stuck-after-render-roundtrip): drop all
+    // per-target aura state when a unit is destroyed (left render
+    // distance, despawned, or died). Without this, the modern client
+    // surfaces stale buffs the next time the target re-enters render.
+    // Returns the number of (slot,duration) entries evicted from
+    // UnitAuraDurationLeft so the caller can record diagnostics.
+    public int EvictUnitAuraState(WowGuid128 guid)
+    {
+        int evicted = UnitAuraDurationLeft.TryGetValue(guid, out var leftDict) ? leftDict.Count : 0;
+        UnitAuraDurationUpdateTime.Remove(guid);
+        UnitAuraDurationLeft.Remove(guid);
+        UnitAuraDurationFull.Remove(guid);
+        UnitAuraCaster.Remove(guid);
+        return evicted;
+    }
     public WowGuid128 GetAuraCaster(WowGuid128 target, byte slot)
     {
         if (UnitAuraCaster.TryGetValue(target, out var dict) &&

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -48,6 +48,14 @@ public partial class WorldClient
         // those mount GUIDs around aggro/death time.
         int cachedEntry = GetSession().GameState.GetLegacyFieldValueInt32(guid, ObjectField.OBJECT_FIELD_ENTRY);
         int cachedDisplayId = GetSession().GameState.GetLegacyFieldValueInt32(guid, UnitField.UNIT_FIELD_DISPLAYID);
+
+        // JimsProxy (target-buffs-stuck-after-render-roundtrip): drop the
+        // four per-target aura tables for this guid. Without this, the
+        // modern client surfaces stale buffs when the unit re-enters
+        // render distance — fresh OBJECT_UPDATE deltas don't reliably
+        // overwrite the old slot data before the addon's first read.
+        int aurasEvicted = GetSession().GameState.EvictUnitAuraState(guid);
+
         Log.Event("object.destroy", new
         {
             guid = guid.ToString(),
@@ -55,6 +63,7 @@ public partial class WorldClient
             guid_entry = guid.GetEntry(),
             cached_entry = cachedEntry,
             cached_display_id = cachedDisplayId,
+            auras_evicted = aurasEvicted,
         });
 
         lock (GetSession().GameState.ObjectCacheLock)


### PR DESCRIPTION
 Body:
  ▎ The four per-target aura tables on GameSessionData (UnitAuraDurationLeft /
  ▎ UnitAuraDurationUpdateTime / UnitAuraDurationFull / UnitAuraCaster) had
  ▎ no per-unit cleanup — only wholesale wipe on character logout. When a
  ▎ target left render and re-entered, cached aura slots served before fresh
  ▎ OBJECT_UPDATE deltas overwrote them — surfaced as "ghost buffs the target
  ▎ doesn't actually have." Every unit ever targeted accumulated entries
  ▎ forever — memory growth bounded only by session length.
  ▎
  ▎ HandleDestroyObject already cleaned ObjectCacheLegacy/Modern,
  ▎ LastAuraCasterOnTarget, and the threat tracker — the aura tables were
  ▎ the unique miss.
  ▎
  ▎ Fix extracts per-unit cleanup into GameSessionData.EvictUnitAuraState and
  ▎ calls it from HandleDestroyObject. object.destroy JSONL grows an
  ▎ auras_evicted field for bug-bundle visibility.
  ▎
  ▎ Tests: 3 new xUnit cases (full eviction, per-guid scope, no-op on unknown).