### PR TITLE
Block CMSG_CAST_SPELL for unknown spells to prevent server autoban

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -96,6 +96,13 @@ public partial class WorldClient
         }
         spells.SpellID.Add(spellId);
         spells.Superceded.Add(supercededId);
+        // JimsProxy (cast-block-unknown-spells): keep CurrentPlayerKnownSpells in sync
+        // so the outbound CMSG_CAST_SPELL guard sees the actual server-side known set.
+        // Without this, a rank-up replaces the action-bar binding but the proxy still
+        // thinks the old rank is known and never tracks the new one.
+        var knownSpellsSuperseded = GetSession().GameState.CurrentPlayerKnownSpells;
+        knownSpellsSuperseded.Remove(supercededId);
+        knownSpellsSuperseded.Add(spellId);
         SendPacketToClient(spells);
     }
 
@@ -105,6 +112,9 @@ public partial class WorldClient
         LearnedSpells spells = new LearnedSpells();
         uint spellId = packet.ReadUInt32();
         spells.Spells.Add(spellId);
+        // JimsProxy (cast-block-unknown-spells): track newly-learned spells so the
+        // outbound CMSG_CAST_SPELL guard doesn't false-positive on trainer/talent grants.
+        GetSession().GameState.CurrentPlayerKnownSpells.Add(spellId);
         SendPacketToClient(spells);
     }
 
@@ -113,10 +123,14 @@ public partial class WorldClient
     {
         SendUnlearnSpells spells = new SendUnlearnSpells();
         uint spellCount = packet.ReadUInt32();
+        var knownSpellsSendUnlearn = GetSession().GameState.CurrentPlayerKnownSpells;
         for (uint i = 0; i < spellCount; i++)
         {
             uint spellId = packet.ReadUInt32();
             spells.Spells.Add(spellId);
+            // JimsProxy (cast-block-unknown-spells): drop unlearned spells from the
+            // proxy-side known set so the CMSG_CAST_SPELL guard matches the real server state.
+            knownSpellsSendUnlearn.Remove(spellId);
         }
         SendPacketToClient(spells);
     }
@@ -131,6 +145,12 @@ public partial class WorldClient
         else
             spellId = packet.ReadUInt16();
         spells.Spells.Add(spellId);
+        // JimsProxy (cast-block-unknown-spells): GMs deleveling players (PTR) and talent
+        // respecs (live) both unlearn spells via this opcode. Without removing from the
+        // proxy-side known set, the outbound CMSG_CAST_SPELL guard would still allow casts
+        // for unlearned spells — same autoban path Nellag confirmed (server treats CMSG_CAST_SPELL
+        // for an unknown spell as cheating and bans).
+        GetSession().GameState.CurrentPlayerKnownSpells.Remove(spellId);
         SendPacketToClient(spells);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -141,6 +141,39 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_CAST_SPELL)]
     void HandleCastSpell(CastSpell cast)
     {
+        // JimsProxy (cast-block-unknown-spells): vanilla 1.12 server autobans clients that
+        // emit CMSG_CAST_SPELL for spells they don't know. Native 1.12 clients block this
+        // locally and never send the packet; modern Classic 1.14 clients send it through to
+        // the server (UI gray-out is cosmetic). Without this guard, `.level` deleveling
+        // (PTR, via players with GM commands) and talent respecs (live) both unlearn spells
+        // server-side while the modern client's action bar binding lingers — pressing the
+        // button → autoban. Three live PTR bans observed on Ice Block / Cone of Cold R5 /
+        // Fireball R12 after delevels, all matching this pattern. The guard is parity-
+        // restoring (matches native 1.12 client behavior), not a new behavior.
+        //
+        // Safety net: only enforce if CurrentPlayerKnownSpells is populated (SMSG_SEND_KNOWN_SPELLS
+        // already arrived). An empty set means the initial-spells packet hasn't landed yet, and
+        // a fast-clicker at login could otherwise be blocked from legitimate casts.
+        var knownSpellsForCastGuard = GetSession().GameState.CurrentPlayerKnownSpells;
+        uint guardSpellId = (uint)cast.Cast.SpellID;
+        if (knownSpellsForCastGuard.Count > 0 && !knownSpellsForCastGuard.Contains(guardSpellId))
+        {
+            Log.Event("spell.cast.blocked_unknown_spell", new
+            {
+                spell_id = guardSpellId,
+                spell_visual_id = cast.Cast.SpellXSpellVisualID,
+                known_spell_count = knownSpellsForCastGuard.Count,
+                client_cast_id = cast.Cast.CastID.ToString(),
+            });
+            CastFailed failed = new();
+            failed.SpellID = guardSpellId;
+            failed.SpellXSpellVisualID = cast.Cast.SpellXSpellVisualID;
+            failed.Reason = (uint)SpellCastResultClassic.NotKnown;
+            failed.CastID = cast.Cast.CastID;
+            SendPacket(failed);
+            return;
+        }
+
         if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
             GetSession().GameState.LastDispellSpellId = (uint)cast.Cast.SpellID;
 


### PR DESCRIPTION
Vanilla 1.12 server (Twinstar/Kronos) autobans clients that emit CMSG_CAST_SPELL for spells the player no longer knows. Reproduced on PTR with three confirmed bans (Ice Block, Cone of Cold R5, Fireball R12) — players had been deleveled below the spells' required level by other PTR players using GM commands. The action-bar binding stayed put after the unlearn, the modern Classic 1.14 client sent the cast on click, server treated it as cheating.

Native 1.12 client blocks this client-side and never sends the packet — proven by the fact that natives don't get this autoban under the same conditions. Modern Classic 1.14 client's UI gray-out is cosmetic; macros and keybinds still emit the cast. The proxy is the only place we can restore parity for proxy users.

Per feedback_dc_parity_with_direct_client memory: proxy-introduced divergence from a direct 1.12 connection is a bug. This guard restores parity, not introduces new behavior.

Changes:

Client/SpellHandler.cs — keep CurrentPlayerKnownSpells in sync with server-side spell-list mutations, so the outbound guard sees actual known set:
- HandleLearnedSpell: add new spell to set (trainer / talent grant)
- HandleUnlearnedSpells: remove single unlearned spell (delevel / respec)
- HandleSendUnlearnSpells: remove bulk unlearned spells
- HandleSupercededSpells: swap (remove old rank, add new rank) on rank-up

Server/SpellHandler.cs — early-return guard at top of HandleCastSpell:
- If CurrentPlayerKnownSpells is non-empty AND spell not in set, synthesize SMSG_CAST_FAILED(NotKnown) back to client and don't forward.
- Empty-set safety net: skip enforcement until SMSG_SEND_KNOWN_SPELLS has populated the set, so a fast-clicker at login can't be blocked.
- Diagnostics: spell.cast.blocked_unknown_spell event with spell_id, visual, known_spell_count, client_cast_id for telemetry audit.

Pet casts (CMSG_PET_CAST_SPELL) intentionally not gated in v1 — pet known-spells list isn't tracked the same way and no PTR bans observed for pet casts. Follow-up if needed.

Per-cast cost: 1 HashSet<uint>.Contains() call (~10-20 ns) + 1 branch. No allocations on the legitimate-cast path. Invisible in profiling.

Tests: 325/325 passing. Build clean.