### PR TITLE
Suppress SPELL_START for pet instant auto-casts to fix double-sound

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -764,9 +764,11 @@ public partial class WorldClient
             foreach (var failed in failedCasts)
                 GetSession().InstanceSocket.SendCastRequestFailed(failed, false);
         }
-        else if (casterIsLocalPet &&
-                 GetSession().GameState.TryMarkPendingPetCastStarted((uint)spell.Cast.SpellID, out var pendingPetCast))
+        bool petCastWasPlayerPressed = false;
+        if (casterIsLocalPet &&
+            GetSession().GameState.TryMarkPendingPetCastStarted((uint)spell.Cast.SpellID, out var pendingPetCast))
         {
+            petCastWasPlayerPressed = true;
             spell.Cast.CastID = pendingPetCast!.ServerGUID;
             spell.Cast.SpellXSpellVisualID = pendingPetCast.SpellXSpellVisualId;
             if (pendingPetCast.LegacySpellId != 0)
@@ -824,6 +826,30 @@ public partial class WorldClient
                 caster_is_player = casterIsLocalPlayer,
                 caster_is_pet = casterIsLocalPet,
             });
+        }
+
+        // JimsProxy (pet-instant-buff-double-sound): suppress SMSG_SPELL_START for pet
+        // server-driven AUTO-CASTS that are instant. For these, SPELL_START + SPELL_GO
+        // arrive in the same millisecond — the modern Classic 1.14 client's SpellVisualKit
+        // fires sound on each, producing a noticeably stuck/repeated sound (tester first
+        // reported succubus Lesser Invisibility 7870; says all 4 warlock pets exhibit it
+        // on their auto-cast spawn abilities). SPELL_GO arrives normally and plays the
+        // single correct sound; the pet aura still applies via aura.slot.set independent
+        // of whether SPELL_START reached the client.
+        //
+        // Heuristic: pet caster + CastTime == 0 + no matching pending CMSG_PET_CAST_SPELL.
+        // The pending check distinguishes auto-casts from player-pressed pet-bar abilities
+        // (Sacrifice, Spell Lock, manually-triggered Lesser Invisibility, etc.) where the
+        // START visual matters for snappy feel — those still forward as before.
+        if (casterIsLocalPet && spell.Cast.CastTime == 0 && !petCastWasPlayerPressed)
+        {
+            Log.Event("spell.start.suppressed_pet_auto_double_sound", new
+            {
+                spell_id = spell.Cast.SpellID,
+                spell_visual_id = spell.Cast.SpellXSpellVisualID,
+                caster_low = spell.Cast.CasterUnit.GetCounter(),
+            });
+            return;
         }
 
         SendPacketToClient(spell);

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -72,6 +72,7 @@ public static partial class GameData
     // SMSG_SPELL_START forwarded so the modern client can initialize the channel bar.
     // Sourced from SpellMisc DBC (Attributes_1 & 0x44), same data as JimsPlus castbars.
     public static FrozenSet<uint> ChanneledSpells = FrozenSet<uint>.Empty;
+
     public static FrozenSet<uint> AuraSpells = FrozenSet<uint>.Empty;
     public static FrozenDictionary<uint, int> AuraDurations = FrozenDictionary<uint, int>.Empty;
     // JimsProxy: vanilla 1.12 spell aura effects, keyed by spell id, each value is the array of


### PR DESCRIPTION
Tester reports the FIRST spell each warlock pet uses (server-driven auto-cast on spawn / behavior) plays its sound twice / sounds stuck. First confirmed on succubus Lesser Invisibility 7870 via bundle jimsproxy-20260509-135002:

  t=1778323838528 SPELL_START spell=7870 visual=241167 cast_time=0
  t=1778323838528 SPELL_GO    spell=7870 visual=241167

Same millisecond, same spell_visual_id — modern Classic 1.14 SpellVisualKit fires sound on each, two sounds for one cast. Tester confirmed the pattern repeats across all 4 warlock pets, so the fix generalizes via a heuristic rather than enumerating spell IDs.

Heuristic: caster is local pet AND CastTime == 0 AND no matching pending CMSG_PET_CAST_SPELL. The pending check distinguishes server-driven auto-casts (the bug) from player-pressed pet-bar abilities (where the START visual matters for snappy feel and there IS a pending entry from the client press).

This deliberately covers all auto-cast pet instants, not just an allowlist — accepting a small risk that some non-bugged pet auto-cast sound goes from "plays once" to "plays once on GO instead of START." Net change to user is none-or-better in those cases. Easy rollback to allowlist if regression surfaces.

Files:
- HermesProxy/World/Client/PacketHandlers/SpellHandler.cs:HandleSpellStart — track petCastWasPlayerPressed in the existing pet-pending branch; early-return after pending-cast tracking + SpellPrepare when the heuristic matches. spell.start.suppressed_pet_auto_double_sound diagnostic event for telemetry coverage.

Pet aura still applies normally — aura.slot.set / pet.update_object arrive independently of SPELL_START. Verified in bundle: Lesser Invisibility aura applied at t=1778323838541 (13ms after the spell packets), unaffected by the suppression path.

Player-pressed pet-bar abilities (Sacrifice, Spell Lock, manually triggered Lesser Invisibility) unaffected — they have a matching pending entry from the CMSG_PET_CAST_SPELL press, so the suppression heuristic doesn't fire. Cast-time pet spells (Imp Firebolt, Succubus Seduction) unaffected — CastTime > 0 filters them out. Player and NPC casts unaffected — the casterIsLocalPet check filters them out.