### PR TITLE
Cancel caster spell visual on local-player cast failures

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -781,6 +781,33 @@ public partial class WorldClient
             }
         }
 
+        // JimsProxy (cast-failure-stuck-visual 2026-05-10): For local-player cast
+        // failures where SPELL_START was forwarded, the modern 1.14 client does not
+        // reliably cancel the caster-side visual kit (casting pose, looping channel
+        // sound, bow-draw / wand-aim) from SMSG_SPELL_FAILURE alone. Two repros in
+        // bundle 20260509-111449:
+        //   1. Holy Light: server emits SPELL_START + SPELL_FAILURE in the same
+        //      packet batch (vmangos/Twinstar post-START LoS/range rejection).
+        //      The just-anchored visual kit stays running through the failure.
+        //   2. Holy Light during movement: SpellFailure broadcast suppressed
+        //      (client-side cast-bar prediction already unwound the bar) but the
+        //      casting pose is not part of that prediction.
+        // User reports the same stuck-visual on Auto Shot (75) every session.
+        // Mirrors the pet block above — purely additive, idempotent on the client.
+        if (casterIsLocalPlayer && wasStarted && !sentCancelVisual)
+        {
+            resolvedSpellVisualId = GameData.GetSpellVisualIdFromXSpellVisual(spellVisual);
+            if (resolvedSpellVisualId != 0)
+            {
+                CancelSpellVisual cancelVisual = new CancelSpellVisual();
+                cancelVisual.Source = casterUnit;
+                cancelVisual.SpellVisualID = (int)resolvedSpellVisualId;
+                SendPacketToClient(cancelVisual);
+                sentCancelVisual = true;
+                cancelVisualSourceLow = cancelVisual.Source.GetCounter();
+            }
+        }
+
         Log.Event("spell.failure.routed", new
         {
             spellId,


### PR DESCRIPTION
## Problem

  Local-player cast-time spells leave their casting visual kit (caster pose,
  looping channel sound, bow-draw / wand-aim animation) running indefinitely
  in two scenarios. Tested repro on Holy Light, Flash of Light, and Auto Shot.

  `SMSG_SPELL_FAILURE` alone does not reliably cancel the modern 1.14
  client's caster-side spell visual kit. The existing `CancelSpellVisual`
  synthesis in `HandleSpellFailure` is gated on `!casterIsPlayer && !casterIsPet`,
  so it only fires for *enemy* casts (Counterspell / Kick targets). The pet
  auto-cast block was added later but the local-player path was never
  extended.

  ### Repros from bundle 20260509-111449

  **1. Same-instant SPELL_START + SPELL_FAILURE**
  Server emits both opcodes in the same packet batch (vmangos / Twinstar
  post-START LoS / range / state rejection). The just-anchored visual kit
  stays running through the failure forwarding.

  **2. Movement preemption**
  Player starts moving during a cast-time spell. Proxy suppresses the
  `SpellFailure` broadcast (client-side cast-bar prediction has already
  unwound the bar), but the casting pose / channel sound is *not* part of
  that prediction.

  7 `SMSG_SPELL_FAILURE` events for spell 635 (Holy Light) by the local
  player in that bundle; multiple left the visual stuck until the user
  logged to character select.

  ## Fix

  Mirror the pet auto-cast cancel block (line 770) for the local-player
  path: when `casterIsLocalPlayer && wasStarted && !sentCancelVisual`,
  resolve the spell visual and emit `CancelSpellVisual` explicitly. Purely
  additive — no existing flow changes (SpellPrepare + CastFailed,
  broadcast suppression, GCD / button-lit handling all unchanged).
  Idempotent on the client.

  ## Verified

  Bundle 20260510-023421 (60 paladin on Kronos V, deliberate
  move-cancel / re-cast spam):

  | Spell | Failures | `sentCancelVisual` | `resolvedSpellVisualId` |
  |---|---|---|---|
  | Holy Light (25292) | 15 | **true** | 2936 |
  | Flash of Light (19943) | 8 | **true** | 6623 |
  | Find Herbs (2383, instant) | 1 | false (correct) | 0 |

  All 23 failures handled; no stuck visuals reported.