### PR TITLE
Fix/healthstone itemeffect slot mismatch

### DIFF
--- a/HermesProxy.Tests/World/ItemEffectSlotMismatchTests.cs
+++ b/HermesProxy.Tests/World/ItemEffectSlotMismatchTests.cs
@@ -1,0 +1,270 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using Framework.IO;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Healthstone slot-mismatch preservation: vmangos/cmangos place item-use effects at
+// slot 0; modern CSV reference data has them at slot 1 (TBC era moved them) with the
+// shared SpellCategoryID + CategoryCoolDownMSec. Without preservation the proxy strips
+// the CSV record and adds a bare slot-0 record, so the modern client renders no "Use:"
+// tooltip line and no heal animation. Tests cover the full cycle: first query
+// relocates and emits a hotfix; second query (relog) must not strip the preserved
+// fields back to vanilla server's stripped zeros.
+[Collection("GameDataStaticState")]
+public class ItemEffectSlotMismatchTests
+{
+    static ItemEffectSlotMismatchTests()
+    {
+        // ModernVersion's static constructor needs a real build before any test
+        // exercises packet construction (HotFixMessage looks up opcodes).
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    private const uint TestItemEntry = 9_999_001;
+    private const int TestSpellId = 9_999_101;
+    private const int TestRecordId = 9_999_201;
+
+    private static ItemTemplate MakeVanillaServerItem()
+    {
+        var item = new ItemTemplate
+        {
+            Entry = TestItemEntry,
+        };
+        // Vanilla server places the on-use spell at slot 0 with no category info.
+        item.TriggeredSpellIds[0] = TestSpellId;
+        item.TriggeredSpellTypes[0] = 0; // USE
+        item.TriggeredSpellCharges[0] = -1;
+        item.TriggeredSpellCooldowns[0] = 0;
+        item.TriggeredSpellCategories[0] = 0;
+        item.TriggeredSpellCategoryCooldowns[0] = 0;
+        return item;
+    }
+
+    private static GameData.ItemEffect SeedCsvEffectAtSlot1()
+    {
+        var csvEffect = new GameData.ItemEffect
+        {
+            Id = TestRecordId,
+            LegacySlotIndex = 1,
+            TriggerType = 0,
+            Charges = -1,
+            CoolDownMSec = 0,
+            CategoryCoolDownMSec = 120000,
+            SpellCategoryID = 1153,
+            SpellID = TestSpellId,
+            ChrSpecializationID = 0,
+            ParentItemID = (int)TestItemEntry,
+        };
+        GameData.ItemEffectStore[(uint)csvEffect.Id] = csvEffect;
+        return csvEffect;
+    }
+
+    private static FrozenDictionary<uint, GameData.ItemSpellsData> InjectSpellsData()
+    {
+        var prev = GameData.ItemSpellsDataStore;
+        var dict = new Dictionary<uint, GameData.ItemSpellsData>(prev);
+        dict[(uint)TestSpellId] = new GameData.ItemSpellsData
+        {
+            Id = TestSpellId,
+            Category = 30,
+            RecoveryTime = 0,
+            CategoryRecoveryTime = 0,
+        };
+        GameData.ItemSpellsDataStore = dict.ToFrozenDictionary();
+        return prev;
+    }
+
+    private static void Cleanup(FrozenDictionary<uint, GameData.ItemSpellsData> prevSpellsData)
+    {
+        GameData.ItemEffectStore.Remove((uint)TestRecordId);
+        GameData.PreservedItemEffectIds.Remove(TestRecordId);
+        GameData.ItemSpellsDataStore = prevSpellsData;
+    }
+
+    [Fact]
+    public void FirstQuery_RelocatesCsvRecordToServerSlotAndPreservesCategory()
+    {
+        var csvEffect = SeedCsvEffectAtSlot1();
+        var prevSpellsData = InjectSpellsData();
+        try
+        {
+            var item = MakeVanillaServerItem();
+
+            var hotfix = GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+
+            Assert.NotNull(hotfix);
+            Assert.Equal(0, csvEffect.LegacySlotIndex);
+            Assert.Equal(TestSpellId, csvEffect.SpellID);
+            Assert.Equal((ushort)1153, csvEffect.SpellCategoryID);
+            Assert.Equal(120000, csvEffect.CategoryCoolDownMSec);
+            Assert.Equal(0, csvEffect.CoolDownMSec);
+            Assert.Equal(-1, csvEffect.Charges);
+            Assert.Contains(TestRecordId, GameData.PreservedItemEffectIds);
+        }
+        finally
+        {
+            Cleanup(prevSpellsData);
+        }
+    }
+
+    [Fact]
+    public void OriginalCsvSlot_AfterRelocation_NoLongerHasRecord()
+    {
+        SeedCsvEffectAtSlot1();
+        var prevSpellsData = InjectSpellsData();
+        try
+        {
+            var item = MakeVanillaServerItem();
+
+            // Slot 0 query relocates...
+            GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+            // ...slot 1 query must now find nothing and emit no hotfix (server has no spell at slot 1).
+            var slot1Reply = GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 1);
+
+            Assert.Null(slot1Reply);
+        }
+        finally
+        {
+            Cleanup(prevSpellsData);
+        }
+    }
+
+    [Fact]
+    public void SecondQuerySameSlot_DoesNotStripPreservedCategoryAndCooldown()
+    {
+        // Regression guard: the existing wrongCategory/wrongCatCooldown comparison
+        // would interpret server-zero as disagreement with CSV's 1153 / 120000 and
+        // strip the values via UpdateItemEffectRecord. The PreservedItemEffectIds
+        // marker must short-circuit subsequent queries.
+        var csvEffect = SeedCsvEffectAtSlot1();
+        var prevSpellsData = InjectSpellsData();
+        try
+        {
+            var item = MakeVanillaServerItem();
+
+            GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+            var second = GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+
+            Assert.Null(second);
+            Assert.Equal((ushort)1153, csvEffect.SpellCategoryID);
+            Assert.Equal(120000, csvEffect.CategoryCoolDownMSec);
+            Assert.Equal(TestSpellId, csvEffect.SpellID);
+            Assert.Equal((byte)0, csvEffect.LegacySlotIndex);
+        }
+        finally
+        {
+            Cleanup(prevSpellsData);
+        }
+    }
+
+    [Fact]
+    public void NoCsvRecord_FallsThroughToAddNew()
+    {
+        // Regression guard: items where CSV has no matching SpellID at any slot must
+        // still go through the original AddItemEffectRecord path. The relocation
+        // logic only triggers when a same-spell record exists at a different slot.
+        var prevSpellsData = InjectSpellsData();
+        try
+        {
+            var item = MakeVanillaServerItem();
+            var beforeIds = new HashSet<uint>(GameData.ItemEffectStore.Keys);
+
+            var hotfix = GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+
+            Assert.NotNull(hotfix);
+            // A new record should have been added (not relocated, since no match existed).
+            var added = new HashSet<uint>(GameData.ItemEffectStore.Keys);
+            added.ExceptWith(beforeIds);
+            Assert.Single(added);
+            var newRecord = GameData.ItemEffectStore[added.First()];
+            Assert.Equal((int)TestItemEntry, newRecord.ParentItemID);
+            Assert.Equal((byte)0, newRecord.LegacySlotIndex);
+            Assert.Equal(TestSpellId, newRecord.SpellID);
+            // Newly-added records do not get preserved (no CSV value to preserve).
+            Assert.DoesNotContain(newRecord.Id, GameData.PreservedItemEffectIds);
+
+            // Cleanup the freshly-added record.
+            foreach (var id in added)
+                GameData.ItemEffectStore.Remove(id);
+        }
+        finally
+        {
+            Cleanup(prevSpellsData);
+        }
+    }
+
+    [Fact]
+    public void RelocatedRecord_HotfixPayloadCarriesPreservedFields()
+    {
+        // Wire-level guarantee: the hotfix sent to the modern client must carry
+        // LegacySlotIndex=0 (relocated) and SpellCategoryID=1153 / CategoryCoolDownMSec=120000
+        // (preserved from CSV) — those are exactly the fields the modern client needs to
+        // render the "Use:" tooltip line and the shared 120s healthstone cooldown.
+        var csvEffect = SeedCsvEffectAtSlot1();
+        var prevSpellsData = InjectSpellsData();
+        try
+        {
+            var item = MakeVanillaServerItem();
+            GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+
+            var buffer = new ByteBuffer();
+            GameData.WriteItemEffectHotfix(csvEffect, buffer);
+            var bytes = buffer.GetData();
+            var reader = new ByteBuffer(bytes);
+
+            // Wire layout (see WriteItemEffectHotfix): u8 LegacySlotIndex, i8 TriggerType,
+            // i16 Charges, i32 CoolDownMSec, i32 CategoryCoolDownMSec, u16 SpellCategoryID,
+            // i32 SpellID, u16 ChrSpecializationID, i32 ParentItemID.
+            Assert.Equal((byte)0, reader.ReadUInt8());
+            Assert.Equal((sbyte)0, reader.ReadInt8());
+            Assert.Equal((short)-1, reader.ReadInt16());
+            Assert.Equal(0, reader.ReadInt32());
+            Assert.Equal(120000, reader.ReadInt32());
+            Assert.Equal((ushort)1153, reader.ReadUInt16());
+            Assert.Equal(TestSpellId, reader.ReadInt32());
+            Assert.Equal((ushort)0, reader.ReadUInt16());
+            Assert.Equal((int)TestItemEntry, reader.ReadInt32());
+        }
+        finally
+        {
+            Cleanup(prevSpellsData);
+        }
+    }
+
+    [Fact]
+    public void PreservedMarker_DroppedWhenServerChangesSpellID()
+    {
+        // Defensive guard: if the legacy server ever switches the bound SpellID at the
+        // same slot across queries, the relocated record gets mutated through the
+        // existing comparison-block path. The preservation marker must be cleared so
+        // future queries don't lock in whatever stripped state the comparison produced.
+        var csvEffect = SeedCsvEffectAtSlot1();
+        var prevSpellsData = InjectSpellsData();
+        try
+        {
+            var item = MakeVanillaServerItem();
+            GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+            Assert.Contains(TestRecordId, GameData.PreservedItemEffectIds);
+
+            // Server now reports a different SpellID at slot 0 for the same item.
+            const int OtherSpellId = 9_999_777;
+            item.TriggeredSpellIds[0] = OtherSpellId;
+
+            GameData.GenerateItemEffectUpdateIfNeeded(item, slot: 0);
+
+            Assert.DoesNotContain(TestRecordId, GameData.PreservedItemEffectIds);
+            Assert.Equal(OtherSpellId, csvEffect.SpellID);
+        }
+        finally
+        {
+            Cleanup(prevSpellsData);
+        }
+    }
+}

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -305,6 +305,23 @@ public static partial class GameData
         return null;
     }
 
+    // Used by the slot-mismatch preservation path in GenerateItemEffectUpdateIfNeeded:
+    // CSV reference data sometimes holds the same SpellID for an item at a different
+    // slot than the legacy server places it (TBC-era moved item-use effects from
+    // slot 0 down to slot 1+). We relocate the existing record instead of
+    // remove-and-add so CSV's SpellCategoryID + CoolDownMSec survive.
+    public static ItemEffect? FindItemEffectBySpellId(uint itemId, int spellId, byte excludeSlot)
+    {
+        foreach (var item in ItemEffectStore)
+        {
+            if (item.Value.ParentItemID == itemId &&
+                item.Value.SpellID == spellId &&
+                item.Value.LegacySlotIndex != excludeSlot)
+                return item.Value;
+        }
+        return null;
+    }
+
     public static uint GetFirstFreeId<T>(Dictionary<uint, T> dict, uint after = 0)
     {
         uint candidate = after + 1;
@@ -3845,11 +3862,30 @@ public static partial class GameData
         return null;
     }
 
+    // Records relocated by the slot-mismatch preservation path below. Future queries
+    // for the same item must not run the wrongCategory/wrongCooldown comparison: it
+    // treats "server didn't echo the field" (TriggeredSpellCategories[slot]=0) as
+    // disagreement with our CSV values and would strip them on the second query
+    // (e.g. on player relog). Once relocated, the record is authoritative.
+    internal static readonly HashSet<int> PreservedItemEffectIds = new();
+
     public static Server.Packets.HotFixMessage? GenerateItemEffectUpdateIfNeeded(ItemTemplate item, byte slot)
     {
         ItemEffect? effect = GetItemEffectByItemId(item.Entry, slot);
         if (effect != null)
         {
+            // Relocated CSV records: leave alone on subsequent queries as long as the
+            // server-provided fields (SpellID/TriggerType/Charges) still match what we
+            // already have. The CSV-only fields (SpellCategoryID, CoolDownMSec,
+            // CategoryCoolDownMSec) stay preserved.
+            if (PreservedItemEffectIds.Contains(effect.Id) &&
+                effect.SpellID == item.TriggeredSpellIds[slot] &&
+                effect.TriggerType == (sbyte)item.TriggeredSpellTypes[slot] &&
+                effect.Charges == (short)item.TriggeredSpellCharges[slot])
+            {
+                return null;
+            }
+
             // compare to spell data
             bool wrongCategory = false;
             bool wrongCooldown = false;
@@ -3878,6 +3914,11 @@ public static partial class GameData
                 wrongCategory ||
                 effect.SpellID != item.TriggeredSpellIds[slot])
             {
+                // Reaching the mutation block means at least one server-provided field
+                // diverged from the existing record, so the slot-mismatch preservation
+                // guarantee no longer holds — drop the marker before the record changes.
+                PreservedItemEffectIds.Remove(effect.Id);
+
                 if (item.TriggeredSpellIds[slot] > 0)
                 {
                     Log.Print(LogType.Storage, $"ItemEffect for item #{item.Entry} slot #{slot} needs to be updated.");
@@ -3924,6 +3965,42 @@ public static partial class GameData
         }
         else if (item.TriggeredSpellIds[slot] > 0)
         {
+            // Slot-mismatch preservation: if the modern CSV holds an ItemEffect with this
+            // same SpellID for this item but at a different slot than the legacy server
+            // places it, relocate the existing CSV record (carrying SpellCategoryID,
+            // CoolDownMSec, CategoryCoolDownMSec) instead of remove-and-add. The default
+            // pair would strip the shared category cooldown — for vanilla healthstones
+            // that loses category 1153 + 120s and the modern client renders neither the
+            // "Use:" tooltip line nor the heal animation, even though the heal numerically
+            // lands. CSV ItemEffect2.csv lines 820 / 822-823 / 833 / 1133 (items
+            // 5509/5510/5511/5512/9421) are the warlock healthstone case.
+            ItemEffect? mismatch = FindItemEffectBySpellId(item.Entry, item.TriggeredSpellIds[slot], slot);
+            if (mismatch != null)
+            {
+                byte previousSlot = mismatch.LegacySlotIndex;
+                mismatch.LegacySlotIndex = slot;
+                mismatch.TriggerType = (sbyte)item.TriggeredSpellTypes[slot];
+                mismatch.Charges = (short)item.TriggeredSpellCharges[slot];
+                // Preserve SpellCategoryID, CoolDownMSec, CategoryCoolDownMSec, SpellID from CSV.
+                CollectionsMarshal.GetValueRefOrAddDefault(ItemEffectStore, (uint)mismatch.Id, out _) = mismatch;
+                PreservedItemEffectIds.Add(mismatch.Id);
+                UpdateHotfix(mismatch);
+
+                Log.Event("hotfix.itemeffect.preserved", new
+                {
+                    item_entry = item.Entry,
+                    spell_id = mismatch.SpellID,
+                    csv_slot = previousSlot,
+                    legacy_slot = slot,
+                    preserved_category = mismatch.SpellCategoryID,
+                    preserved_cooldown_ms = mismatch.CoolDownMSec,
+                    preserved_category_cooldown_ms = mismatch.CategoryCoolDownMSec,
+                    record_id = mismatch.Id,
+                });
+
+                return GenerateHotFixMessage(mismatch);
+            }
+
             // there is a spell so add new record
             //Log.Print(LogType.Storage, $"ItemEffect for item #{item.Entry} slot #{slot} needs to be created.");
             effect = AddItemEffectRecord(item, slot);


### PR DESCRIPTION
 ## Summary

  Vanilla warlock healthstones (items 5509/5510/5511/5512/9421) bind their on-use spell at slot 0 in vmangos/cmangos
  data, but modern CSV reference data (`HermesProxy/CSV/ItemEffect2.csv` lines 820/822/823/833/1133) has the same
  SpellID at slot 1 with the TBC-era `SpellCategoryID=1153` (shared healthstone group) and `CategoryCoolDownMSec=120000`
   (the shared 120s cooldown).

  `GenerateItemEffectUpdateIfNeeded` was doing remove-and-add when it saw this slot mismatch:
  - removed CSV record at slot 1 (stripping category 1153 + the 120s shared cooldown);
  - added a bare slot-0 record with no category info.

  Result on the modern 1.14 client: no "Use: Restores X life" tooltip line, no heal animation. The heal numerically
  lands (`SMSG_SPELL_HEAL_LOG` arrives with `heal_amount` and `UPDATE_OBJECT` ticks UNIT_FIELD_HEALTH up correctly), but
   the player sees no green heal numbers and the healthstone tooltip is missing its use line. Reported by Cedur and at
  least one other warlock on Kronos.

  ## Approach

  Detect the slot mismatch by SpellID (`FindItemEffectBySpellId(itemId, spellId, excludeSlot)`) and relocate the
  existing CSV record in place:

  - Update `LegacySlotIndex` / `TriggerType` / `Charges` from the legacy server.
  - **Preserve** `SpellCategoryID` / `CoolDownMSec` / `CategoryCoolDownMSec` / `SpellID` from CSV.
  - Send a single `Valid` hotfix update for the existing record id (instead of `RecordRemoved` + new `Valid` pair).

  A second-query regression guard (`PreservedItemEffectIds` HashSet) was needed because the existing `wrongCategory`
  comparison interprets server-zero as disagreement with the CSV's 1153 and would strip the values on relog. Records
  that have been relocated short-circuit at the top of the function as long as the server's
  `SpellID/TriggerType/Charges` still match. The marker is cleared if the mutation block ever fires for any reason.

  A `hotfix.itemeffect.preserved` JSONL diag event records every relocation with the preserved CSV fields so the
  behavior is observable in tester bundles.

  ## Test plan

  - [x] 6 unit tests in `HermesProxy.Tests/World/ItemEffectSlotMismatchTests.cs`:
    - relocate-on-first-query preserves CSV fields
    - original CSV slot is empty after relocation (no spurious slot-1 hotfix)
    - second query with same slot/spell returns null (the regression guard)
    - items with no CSV match still fall through to `AddItemEffectRecord`
    - **wire-level byte assertion**: serialized hotfix payload carries `LegacySlotIndex=0 + SpellCategoryID=1153 +
  CategoryCoolDownMSec=120000`
    - preserved marker is cleared if the server later changes the bound SpellID
  - [x] Full test suite passes (405/405).
  - [ ] In-game on Kronos: warlock conjures Minor/Lesser/Healthstone/Greater/Major Healthstone, sees "Use: Restores X
  life" on the tooltip, click triggers green heal numbers + visual + 120s shared cooldown.

  ## Notes

  - Targets only items where the legacy server places a SpellID at a slot different from where modern CSV data has that
  same SpellID. Items where everything already lines up are unaffected.
  - The dual `SMSG_CAST_FAILED + SMSG_SPELL_GO` curiosity from the captured JSONL trace is left alone — the working
  hypothesis is the visible breakage was entirely the stripped ItemEffect record, not the cast-failed pairing.