### PR TITLE
Fix vanilla SMSG_PET_CAST_FAILED parser crashing the proxy

### DIFF
--- a/HermesProxy.Tests/World/PetCastFailedParserTests.cs
+++ b/HermesProxy.Tests/World/PetCastFailedParserTests.cs
@@ -1,0 +1,125 @@
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Wire-level coverage for the vanilla SMSG_PET_CAST_FAILED parsing semantics.
+// The handler at SpellHandler.cs:HandlePetCastFailed has crashed the proxy on
+// Kronos 5 (TrinityCore-based 1.12) because vanilla SMSG_PET_CAST_FAILED bodies
+// vary between server flavors:
+//   cMaNGOS / vmangos canonical:  uint32 SpellID, uint8 Result        (5 bytes)
+//   Kronos 5 (TrinityCore-1.12):  uint32 SpellID only                  (4 bytes)
+// The fix uses CanRead() to defensively read Result. These tests verify the
+// parsing semantics on both wire shapes against a hand-crafted WorldPacket.
+public class PetCastFailedParserTests
+{
+    static PetCastFailedParserTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    private const ushort VanillaOpcodeRaw = 0x138; // SMSG_PET_CAST_FAILED in 1.12
+
+    private static byte[] BuildPacketBuffer(uint spellId, byte? reason)
+    {
+        // The proxy receive loop hands WorldPacket a buffer where bytes [0..1]
+        // are the opcode (the WorldPacket(byte[]) constructor consumes them)
+        // and bytes [2..] are the body. Mimic that here.
+        int bodyLen = 4 + (reason.HasValue ? 1 : 0);
+        var buffer = new byte[2 + bodyLen];
+        buffer[0] = (byte)(VanillaOpcodeRaw & 0xFF);
+        buffer[1] = (byte)((VanillaOpcodeRaw >> 8) & 0xFF);
+        buffer[2] = (byte)(spellId & 0xFF);
+        buffer[3] = (byte)((spellId >> 8) & 0xFF);
+        buffer[4] = (byte)((spellId >> 16) & 0xFF);
+        buffer[5] = (byte)((spellId >> 24) & 0xFF);
+        if (reason.HasValue)
+            buffer[6] = reason.Value;
+        return buffer;
+    }
+
+    [Fact]
+    public void Kronos5FourByteBody_ReadsSpellIdAndReportsNoReason()
+    {
+        // Kronos 5 (TrinityCore-1.12) sends 4-byte body (just SpellID). The
+        // defensive parser must read SpellID and then see CanRead==false
+        // without throwing.
+        const uint TestSpellId = 17767u; // Consume Shadows rank 1 (Voidwalker)
+        var packet = new WorldPacket(BuildPacketBuffer(TestSpellId, reason: null));
+
+        uint spellId = packet.ReadUInt32();
+        bool hasReason = packet.CanRead();
+
+        Assert.Equal(TestSpellId, spellId);
+        Assert.False(hasReason);
+    }
+
+    [Fact]
+    public void CMaNGOSFiveByteBody_ReadsSpellIdAndReason()
+    {
+        // cMaNGOS / vmangos canonical layout: SpellID followed by uint8 Result.
+        const uint TestSpellId = 17767u;
+        const byte TestReason = 1; // SpellCastResultVanilla.AlreadyAtFullHealth
+        var packet = new WorldPacket(BuildPacketBuffer(TestSpellId, reason: TestReason));
+
+        uint spellId = packet.ReadUInt32();
+        bool hasReason = packet.CanRead();
+        byte reason = hasReason ? packet.ReadUInt8() : (byte)0;
+
+        Assert.Equal(TestSpellId, spellId);
+        Assert.True(hasReason);
+        Assert.Equal(TestReason, reason);
+        Assert.False(packet.CanRead()); // exactly one reason byte, no trailing data
+    }
+
+    [Fact]
+    public void Kronos5FourByteBody_DoesNotThrowOnCanReadCheck()
+    {
+        // The original bug: ReadUInt8() ran past end-of-buffer. The defensive
+        // pattern (`hasReason = CanRead(); if (hasReason) ReadUInt8();`) must
+        // not throw on a 4-byte body — that's the exact scenario captured in
+        // jimsproxy-20260510-115151.jsonl that crashed the proxy.
+        var packet = new WorldPacket(BuildPacketBuffer(17767u, reason: null));
+
+        var ex = Record.Exception(() =>
+        {
+            uint spellId = packet.ReadUInt32();
+            if (packet.CanRead())
+                packet.ReadUInt8();
+        });
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(0, "AffectingCombat")]
+    [InlineData(1, "AlreadyAtFullHealth")]
+    [InlineData(2, "AlreadyAtFullPower")]
+    [InlineData(46, "Moving")]
+    [InlineData(67, "NoAmmo")]
+    [InlineData(77, "NoPower")]
+    public void CMaNGOSFiveByteBody_VariousReasonCodes_DoNotThrow(byte reason, string expectedName)
+    {
+        // Smoke test that every realistic cMaNGOS reason code parses cleanly.
+        // Pre-fix the vanilla handler swallowed every code != 2 silently and
+        // crashed on code == 2. With the new defensive read, no code crashes
+        // and all are routed.
+        var packet = new WorldPacket(BuildPacketBuffer(17767u, reason: reason));
+
+        var ex = Record.Exception(() =>
+        {
+            uint spellId = packet.ReadUInt32();
+            if (packet.CanRead())
+            {
+                byte r = packet.ReadUInt8();
+                Assert.Equal(reason, r);
+            }
+        });
+
+        Assert.Null(ex);
+        Assert.Contains(expectedName, ((SpellCastResultVanilla)reason).ToString());
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -287,14 +287,36 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_PET_CAST_FAILED, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]
     void HandlePetCastFailed(WorldPacket packet)
     {
+        // Vanilla SMSG_PET_CAST_FAILED wire format varies between server flavors:
+        //   cMaNGOS / vmangos canonical:  uint32 SpellID, uint8 Result.
+        //   Kronos 5 (TrinityCore-1.12):  uint32 SpellID only (4 body bytes).
+        // The original implementation always read SpellID + uint8 status, gated on
+        // status==2, then read another uint8 reason. On Kronos 5 that meant:
+        //   (a) the very first ReadUInt8 ran past end-of-buffer when SpellID
+        //       consumed the entire 4-byte body → IndexOutOfRangeException in
+        //       the world-client receive loop → connection died → a follow-on
+        //       CMSG_CHAT_ADDON_MESSAGE NRE'd HandleAddonMessage → process crash;
+        //   (b) on cMaNGOS-style 5-byte bodies, reason!=2 silently dropped the
+        //       failure (action button stayed lit), and reason==2 crashed on the
+        //       second ReadUInt8.
+        // Repro that surfaced the crash: warlock /cast Consume Shadows on a pet
+        // that's full-HP via macro (Kronos 5, captured in
+        // jimsproxy-20260510-115151.jsonl, packet body size 4).
         uint spellId = packet.ReadUInt32();
-        var status = packet.ReadUInt8();
-        if (status != 2)
-            return;
+        bool hasReason = packet.CanRead();
+        uint legacyReason = hasReason ? packet.ReadUInt8() : 0u;
 
         // Look up pending pet cast by SpellId (queue-based, FIFO order)
         if (!GetSession().GameState.TryDequeuePendingPetCast(spellId, out var pendingCast))
+        {
+            Log.Event("pet.cast_failed.no_pending", new
+            {
+                spell_id = spellId,
+                has_reason = hasReason,
+                legacy_reason = legacyReason,
+            });
             return;
+        }
 
         // JimsProxy (PR #161 follow-up — movement preemption parity): mirror
         // the player-side suppression. If the pet's pending cast was marked
@@ -311,12 +333,25 @@ public partial class WorldClient
 
         PetCastFailed spell = new PetCastFailed();
         spell.SpellID = spellId;
-        uint reason = packet.ReadUInt8();
-        spell.Reason = movementSuppressed
+        // If movement-suppressed OR the wire didn't carry a reason byte
+        // (Kronos-style 4-byte body), send DontReport so the action button
+        // releases without a misleading popup.
+        spell.Reason = (movementSuppressed || !hasReason)
             ? (uint)SpellCastResultClassic.DontReport
-            : LegacyVersion.ConvertSpellCastResult(reason);
+            : LegacyVersion.ConvertSpellCastResult(legacyReason);
         spell.CastID = pendingCast.ServerGUID;
         SendPacketToClient(spell);
+
+        Log.Event("pet.cast_failed.routed", new
+        {
+            spell_id = spellId,
+            has_reason = hasReason,
+            legacy_reason = legacyReason,
+            translated_reason = spell.Reason,
+            movement_suppressed = movementSuppressed,
+            had_started = pendingCast.HasStarted,
+            cast_id = pendingCast.ServerGUID.ToString(),
+        });
     }
 
     [PacketHandler(Opcode.SMSG_PET_CAST_FAILED, ClientVersionBuild.V2_0_1_6180)]


### PR DESCRIPTION
## Summary

  `HandlePetCastFailed` (vanilla path, `< 2.0.1`) crashed the world-client receive loop on **Kronos 5 (TrinityCore-based
   1.12)** with `IndexOutOfRangeException`. Vanilla `SMSG_PET_CAST_FAILED` body size varies between server flavors:

  | Server | Body |
  |---|---|
  | cMaNGOS / vmangos canonical | `uint32 SpellID + uint8 Result` (5 bytes) |
  | Kronos 5 (TrinityCore-1.12) | `uint32 SpellID` only (4 bytes) |

  The original handler unconditionally read `SpellID + uint8 status`, gated on `status==2`, then read another byte for
  the reason. Two failures in one:

  1. **On Kronos 5's 4-byte body**, the first `ReadUInt8` ran past end-of-buffer → `IndexOutOfRangeException` →
  world-client receive loop died → a follow-on `CMSG_CHAT_ADDON_MESSAGE` NRE'd `HandleAddonMessage` (state torn down by
  the disconnect) → process crash → modern client DC.

  2. **On cMaNGOS-style 5-byte bodies**, every failure with `reason != 2` was silently dropped — the modern client never
   received the failure → action buttons stayed lit, players thought their pet macro was broken. `reason == 2`
  specifically crashed the second `ReadUInt8`.

  Captured in two tester bundles (`jimsproxy-20260510-115151.jsonl` line 7283 + `jimsproxy-20260510-112848.jsonl` line
  46856), both showing `SMSG_PET_CAST_FAILED size=6` (header.Size = opcode_2 + body_4) → `packet.error
  IndexOutOfRangeException at ByteBuffer.ReadUInt8 line 148` → `worldclient_receive_loop_exception`.

  Repro: warlock `/cast Consume Shadows` macro (Voidwalker channeled heal-self) when the pet is full HP — TrinityCore
  rejects, sends SMSG_PET_CAST_FAILED, parser crashes.

  ## Approach

  Read SpellID, then read Result only if `packet.CanRead()` so both wire shapes parse cleanly. When the wire doesn't
  carry a Result (Kronos 5's 4-byte body), send `SpellCastResultClassic.DontReport` so the modern client releases the
  action button without showing a misleading popup. Drop the bogus `if (status != 2)` cargo-cult check entirely.

  Two new diag events (`pet.cast_failed.routed`, `pet.cast_failed.no_pending`) include `has_reason` so future bundles
  surface the wire shape unambiguously.

  ## Test plan

  - [x] 9 unit tests in `HermesProxy.Tests/World/PetCastFailedParserTests.cs` covering both 4- and 5-byte bodies, the
  no-throw guarantee on the Kronos 5 shape, and a `[Theory]` across realistic vanilla reason codes (0/1/2/46/67/77).
  - [x] Full test suite passes (408/408 on this branch).
  - [x] Bug-hunter agent reviewed — no issues, all six concerns checked out.
  - [ ] In-game on Kronos 5: warlock summons Voidwalker, lets it reach full HP, runs `/cast Consume Shadows` macro —
  proxy stays alive, modern client receives no popup but the action button releases cleanly.
  - [ ] Same macro at < full HP: pet casts normally, no regression.

  ## Notes

  - Same `if (status != 2)` cargo-cult pattern exists in `HandleCastFailed` (player path) but hasn't crashed because
  Kronos 5's player `SMSG_CAST_FAILED` bodies happen to include the status byte. Worth a future hardening pass but out
  of scope here.
  - The secondary `HandleAddonMessage` NRE (state-torn-down race) is left for a follow-up — fixing this root cause
  prevents the world-client receive loop from dying in this scenario, so the secondary crash doesn't fire.