### PR TITLE
Fix/rp walk opcode modern

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -129,9 +129,18 @@ public partial class WorldClient
         // --- Mirasu RP Walk Bug Fix ---
         // The 1.14 client forgets to un-toggle Walk mode after CC wears off.
         // When control is returned, we explicitly force a run speed update to reset the UI toggle.
+        //
+        // Use the modern universal opcode SMSG_MOVE_SET_RUN_SPEED here — MoveSetSpeed
+        // extends ServerPacket whose constructor calls ModernVersion.GetCurrentOpcode().
+        // The legacy-only SMSG_FORCE_RUN_SPEED_CHANGE has no entry in the modern (1.14)
+        // opcode table so the lookup returns 0, tripping Trace.Assert(opcode != 0) in
+        // Packet.cs:73 (visible Linux Debug crash) and serializing 0x0000 as the wire
+        // opcode on Release builds (silent — modern client drops the malformed packet,
+        // so the fix has historically been a no-op). The neighboring handler at line
+        // ~298 already does the same SMSG_FORCE_*_CHANGE → SMSG_MOVE_SET_* translation.
         if (control.HasControl && control.Guid == GetSession().GameState.CurrentPlayerGuid)
         {
-            MoveSetSpeed runFix = new MoveSetSpeed(Opcode.SMSG_FORCE_RUN_SPEED_CHANGE);
+            MoveSetSpeed runFix = new MoveSetSpeed(Opcode.SMSG_MOVE_SET_RUN_SPEED);
             runFix.MoverGUID = control.Guid;
             runFix.MoveCounter = 0;
             runFix.Speed = 7.0f; // Default WoW running speed

--- a/HermesProxy/World/KnownBenignOpcodes.cs
+++ b/HermesProxy/World/KnownBenignOpcodes.cs
@@ -106,6 +106,20 @@ public static class KnownBenignOpcodes
         // 2x SMSG_LEARNED_SPELL translated successfully alongside the 2
         // TRAINER_BUY_SUCCEEDED warnings in the same session).
         Opcode.SMSG_TRAINER_BUY_SUCCEEDED,
+
+        // Added 2026-05-10 from Linux build-from-source community report:
+        // MSG_MOVE_TIME_SKIPPED (vanilla 0x319) is the legacy server's
+        // peer-sync broadcast — when *another* player nearby time-skips,
+        // the server tells us so our local prediction can compensate. The
+        // modern 1.14 client doesn't have an equivalent inbound opcode and
+        // handles peer drift via its own movement extrapolation, so a
+        // silent drop is correct. The c2s direction (CMSG_MOVE_TIME_SKIPPED,
+        // own player time-skipped → forward to server) still has its
+        // dedicated handler at Server/PacketHandlers/MovementHandler.cs.
+        // Pre-fix this fired a noisy "No handler for opcode" warning on
+        // every nearby player's time-skip event, which on Linux Debug
+        // builds also flooded the terminal alongside the actual fault.
+        Opcode.MSG_MOVE_TIME_SKIPPED,
     };
 
     /// <summary>True if the opcode is known to originate from a modern-client


### PR DESCRIPTION
## Summary

  Two small Linux-quality fixes surfaced by community testers building from source on PikaOS / Ubuntu:

  1. **RP Walk opcode crash** — `HandleControlUpdate`'s "Mirasu RP Walk Bug Fix" was constructing `MoveSetSpeed` with
  the legacy-only `SMSG_FORCE_RUN_SPEED_CHANGE` opcode. Modern (1.14) opcode table doesn't have it → `Trace.Assert`
  fires loudly on Debug builds (Linux source-builds), or the proxy silently emits a wire packet with opcode `0x0000` on
  Release (modern client drops the malformed packet, so the RP Walk fix has been a no-op on every build since it was
  added).
  2. **MSG_MOVE_TIME_SKIPPED warning noise** — vanilla server's peer-sync broadcast (when a *nearby* player
  time-skipped). Modern client doesn't have an equivalent inbound opcode and handles peer drift via its own
  extrapolation. Pre-fix this fired a "No handler" warning on every nearby player's time-skip; on Linux Debug builds it
  flooded the terminal alongside an unrelated AccessViolationException, making the real fault harder to spot.
  Silent-dropped via the existing `KnownBenignOpcodes.ModernOnly` mechanism.

  [Existing per-platform symptom table from the original RP Walk PR body]

  ## Test plan

  - [x] Builds clean against current upstream/beta.
  - [x] Full test suite passes (399/399).
  - [ ] Linux source-build: warlock summons pet → CC → CC wears off → proxy stays alive (was: crash). Terminal no longer
   floods with MSG_MOVE_TIME_SKIPPED warnings.
  - [ ] Windows: walk-toggle gets reset after CC. The RP Walk fix actually does what its comment claims for the first
  time.