### PR TITLE
Fix zone chat channel not updating overland (JimsPlus addon sideband)

### DIFF
--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -10,6 +10,7 @@ Core.lua
 Options.lua
 PetFix.lua
 TaxiFix.lua
+ZoneSync.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua
 castbars/Data.lua

--- a/Addons/JimsPlus/ZoneSync.lua
+++ b/Addons/JimsPlus/ZoneSync.lua
@@ -1,0 +1,32 @@
+-- JimsPlus ZoneSync
+-- Reports the player's current zone to the proxy on every overland zone
+-- change so it can flip the General/Trade/LocalDefense channels to the new
+-- zone-suffixed names.
+--
+-- Why: vmangos's Player::UpdateLocalChannels is empty server-side (comment:
+-- "Updated client-side"). The 1.12 native client drives zone-channel rejoin
+-- itself by sending CMSG_LEAVE_CHANNEL/CMSG_JOIN_CHANNEL on every zone
+-- change. The 1.14 modern client doesn't emit those on zone change (the
+-- modern wire protocol moved to server-tracked zone state, which vmangos
+-- doesn't implement). Result: chat header keeps showing the old zone's
+-- channel until relog.
+--
+-- The proxy intercepts the JP "Z\t<zoneName>" sideband, looks up the area
+-- ID, and synthesizes the leave/join CMSGs to the legacy server. Server's
+-- regular CMSG_JOIN_CHANNEL handler echoes back SMSG_CHANNEL_NOTIFY YouJoined,
+-- which the proxy forwards to the modern client and the chat header flips.
+
+local f = CreateFrame("Frame")
+local lastSentZone
+
+local function SendZone()
+    local zone = GetRealZoneText()
+    if not zone or zone == "" then return end
+    if zone == lastSentZone then return end
+    lastSentZone = zone
+    C_ChatInfo.SendAddonMessage("JP", "Z\t" .. zone, "WHISPER", UnitName("player"))
+end
+
+f:RegisterEvent("PLAYER_ENTERING_WORLD")
+f:RegisterEvent("ZONE_CHANGED_NEW_AREA")
+f:SetScript("OnEvent", SendZone)

--- a/HermesProxy/CSV/ChatChannels.csv
+++ b/HermesProxy/CSV/ChatChannels.csv
@@ -1,4 +1,4 @@
-"Id","Flags,"Name"
+"Id","Flags","Name"
 "1","3","General"
 "2","59","Trade"
 "22","65539","LocalDefense"

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -749,4 +749,41 @@ public partial class WorldClient
         packet.WriteCString(channelName);
         SendPacketToServer(packet);
     }
+
+    // JimsProxy: vmangos's Player::UpdateLocalChannels is empty (comment:
+    // "Updated client-side") — the 1.12 native client drives zone-based chat
+    // channel rejoin itself by sending CMSG_LEAVE/JOIN with zone-suffixed
+    // names on every zone change. The 1.14 modern client doesn't do this, so
+    // the proxy has to. Called from SMSG_INIT_WORLD_STATES (capitals/BGs/
+    // instances) and from the JimsPlus JP zone sideband (overland transitions).
+    public void SyncZoneChannels(uint oldZoneId, uint newZoneId)
+    {
+        string oldZoneName = GameData.GetAreaName(oldZoneId);
+        string newZoneName = GameData.GetAreaName(newZoneId);
+        var channels = GameData.GetChatChannelsWithFlags(ChannelFlags.AutoJoin | ChannelFlags.ZoneBased);
+
+        Log.Event("chat.zone_sync.enter", new
+        {
+            old_zone_id = oldZoneId,
+            new_zone_id = newZoneId,
+            old_zone_name = oldZoneName,
+            new_zone_name = newZoneName,
+            channel_count = channels.Count,
+        });
+
+        if (string.IsNullOrEmpty(newZoneName)) return;
+
+        foreach (var channel in channels)
+        {
+            string newName = channel.Name + " - " + newZoneName;
+            if (!string.IsNullOrEmpty(oldZoneName))
+            {
+                string oldName = channel.Name + " - " + oldZoneName;
+                Log.Event("chat.zone_sync.leave", new { channel = oldName });
+                SendChatLeaveChannel(1, oldName);
+            }
+            Log.Event("chat.zone_sync.join", new { channel = newName });
+            SendChatJoinChannel(1, newName, "");
+        }
+    }
 }

--- a/HermesProxy/World/Client/PacketHandlers/WorldStateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/WorldStateHandler.cs
@@ -51,17 +51,9 @@ public partial class WorldClient
 
         if (GetSession().GameState.CurrentZoneId != states.ZoneID)
         {
-            string oldZoneName = GameData.GetAreaName(GetSession().GameState.CurrentZoneId);
-            string newZoneName = GameData.GetAreaName(states.ZoneID);
+            uint oldZoneId = GetSession().GameState.CurrentZoneId;
             GetSession().GameState.CurrentZoneId = states.ZoneID;
-            if (!String.IsNullOrEmpty(oldZoneName) && !String.IsNullOrEmpty(newZoneName))
-            {
-                foreach (var channel in GameData.GetChatChannelsWithFlags(ChannelFlags.AutoJoin | ChannelFlags.ZoneBased))
-                {
-                    SendChatLeaveChannel(1, channel.Name + " - " + oldZoneName);
-                    SendChatJoinChannel(1, channel.Name + " - " + newZoneName, "");
-                }
-            }
+            SyncZoneChannels(oldZoneId, states.ZoneID);
         }
     }
 

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -52,6 +52,7 @@ public static partial class GameData
     public static FrozenDictionary<uint, CreatureModelCollisionHeight> CreatureModelCollisionHeights = FrozenDictionary<uint, CreatureModelCollisionHeight>.Empty;
     public static FrozenDictionary<uint, uint> TransportPeriods = FrozenDictionary<uint, uint>.Empty;
     public static FrozenDictionary<uint, string> AreaNames = FrozenDictionary<uint, string>.Empty;
+    public static FrozenDictionary<string, uint> AreaIdsByName = FrozenDictionary<string, uint>.Empty;
     public static FrozenDictionary<uint, uint> RaceFaction = FrozenDictionary<uint, uint>.Empty;
     public static FrozenSet<uint> DispellSpells = FrozenSet<uint>.Empty;
     public static Dictionary<uint, List<float>> SpellEffectPoints = [];
@@ -1304,14 +1305,21 @@ public static partial class GameData
         var path = Path.Combine("CSV", $"AreaNames.csv");
         using var reader = Sep.Reader(o => o with { HasHeader = true, Unescape = true }).FromFile(path);
         var dict = new Dictionary<uint, string>(EstimateRowCount(path, 40));
+        var byName = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var row in reader)
         {
             uint id = uint.Parse(row[0].Span);
             string name = row[1].ToString();
             dict.Add(id, name);
+            // First-write-wins. Round-trips name → id → name correctly because
+            // GetAreaName(id) yields the same string back regardless of which
+            // duplicate-named area we picked, so zone-channel suffix matching
+            // ("General - <name>") stays consistent.
+            byName.TryAdd(name, id);
         }
         AreaNames = dict.ToFrozenDictionary();
+        AreaIdsByName = byName.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     public static void LoadRaceFaction()

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -234,7 +234,7 @@ public partial class WorldSocket
     {
         if (packet.Params.Prefix == "JP")
         {
-            GetSession().GameState.JimsPlusSideband = packet.Params.Text == "1";
+            HandleJimsPlusSideband(packet.Params.Text);
             return;
         }
 
@@ -260,7 +260,7 @@ public partial class WorldSocket
     {
         if (packet.Params.Prefix == "JP")
         {
-            GetSession().GameState.JimsPlusSideband = packet.Params.Text == "1";
+            HandleJimsPlusSideband(packet.Params.Text);
             return;
         }
 
@@ -442,5 +442,67 @@ public partial class WorldSocket
         if (session?.WorldClient == null) return;
         var msg = new ChatPkt(session, ChatMessageTypeModern.System, text);
         session.WorldClient.SendPacketToClient(msg);
+    }
+
+    // JimsProxy sideband: addon-driven commands the 1.14 modern client wire
+    // protocol no longer carries. Body grammar:
+    //   "1" / "0"          — handshake on/off (legacy castbar/HC interop)
+    //   "<cmd>\t<args>..." — structured command, e.g. "Z\tStormwind City"
+    private void HandleJimsPlusSideband(string body)
+    {
+        if (string.IsNullOrEmpty(body)) return;
+
+        if (body == "0" || body == "1")
+        {
+            GetSession().GameState.JimsPlusSideband = body == "1";
+            return;
+        }
+
+        int tab = body.IndexOf('\t');
+        if (tab <= 0) return;
+
+        string cmd = body.Substring(0, tab);
+        string args = body.Substring(tab + 1);
+
+        switch (cmd)
+        {
+            case "Z":
+                HandleZoneSideband(args);
+                break;
+        }
+    }
+
+    // Zone sideband: addon's ZONE_CHANGED_NEW_AREA hook reports the player's
+    // new zone name (GetRealZoneText). vmangos's Player::UpdateLocalChannels
+    // is a server-side no-op — the 1.12 native client drives zone-channel
+    // rejoin itself via CMSG_LEAVE/JOIN, but the 1.14 modern client doesn't.
+    // We synthesize that behavior here so General/Trade/LocalDefense flip
+    // to the new zone without a relog.
+    private void HandleZoneSideband(string zoneName)
+    {
+        if (string.IsNullOrWhiteSpace(zoneName)) return;
+        zoneName = zoneName.Trim();
+
+        if (!GameData.AreaIdsByName.TryGetValue(zoneName, out uint newZoneId))
+        {
+            Log.Event("chat.zone_sideband.unknown_name", new { zone_name = zoneName });
+            return;
+        }
+
+        var gs = GetSession().GameState;
+        uint oldZoneId = gs.CurrentZoneId;
+        if (oldZoneId == newZoneId) return;
+
+        var worldClient = GetSession().WorldClient;
+        Log.Event("chat.zone_sideband", new
+        {
+            zone_name = zoneName,
+            old_zone_id = oldZoneId,
+            new_zone_id = newZoneId,
+            world_client_alive = worldClient != null,
+        });
+
+        gs.CurrentZoneId = newZoneId;
+        worldClient?.SyncZoneChannels(oldZoneId, newZoneId);
     }
 }


### PR DESCRIPTION
Walking across an overland zone boundary (e.g. Stormwind City → Elwynn Forest) didn't flip the General/Trade/LocalDefense channel suffixes — the chat header kept showing the old zone's name until relog.

Root cause is two-fold:

1. vmangos's Player::UpdateLocalChannels is empty server-side (literal comment: "Updated client-side"). The 1.12 native client drives zone-based chat channel rejoin itself by sending CMSG_LEAVE_CHANNEL + CMSG_JOIN_CHANNEL with zone-suffixed names on every zone change. The 1.14 modern client doesn't — modern wire protocol moved to server-tracked zone state, which vmangos doesn't implement — so without intervention nothing rejoins.

2. ChatChannels.csv had a malformed header — '"Id","Flags,"Name"' with an unclosed quote merged Flags+Name into one column, so Sep failed to populate the ChatChannels FrozenDictionary entirely. GetChatChannelsWithFlags(AutoJoin | ZoneBased) was always returning an empty list, which silently no-op'd the existing SMSG_INIT_WORLD_STATES auto-rejoin path too. Capital transitions only appeared to work because the modern client itself auto-joins default channels on PLAYER_ENTERING_WORLD.

Fix:

- Repair ChatChannels.csv header so Sep parses the 3 zone-based default channels correctly.
- Refactor the existing inline rejoin loop in WorldStateHandler into a reusable WorldClient.SyncZoneChannels(oldZoneId, newZoneId) helper.
- Extend the existing JimsPlus "JP" addon-message prefix with structured commands ("<cmd>\t<args>"). New "Z\t<zoneName>" command resolves the zone name to an area ID via a fresh GameData.AreaIdsByName reverse index built at LoadAreaNames time, updates GameState.CurrentZoneId, and invokes SyncZoneChannels.
- New addon module Addons/JimsPlus/ZoneSync.lua hooks PLAYER_ENTERING_WORLD + ZONE_CHANGED_NEW_AREA, sends "JP\tZ\t<GetRealZoneText>" via SendAddonMessage on every zone change. Name-deduped to avoid spam on intra-zone PLAYER_ENTERING_WORLD fires.
- Diagnostics: chat.zone_sideband, chat.zone_sync.enter, chat.zone_sync.{leave,join} structured events log every step of the rejoin pipeline so future bug bundles surface CSV gaps, null WorldClient races, or zone-name mismatches without code-level repro.