### PR TITLE
Fix RP Walk speed-reset clobbering active speed buffs on login

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -62,6 +62,15 @@ public sealed class GameSessionData
     // the dismount logic (e.g. seeing true after handler set it false).
     public bool IsInTaxiFlight;
     public bool IsWaitingForTaxiStart;
+    // JimsProxy (rp-walk-control-transition): tracks whether the most recent
+    // SMSG_CONTROL_UPDATE for the player carried HasControl=true. Used by the
+    // RP-walk speed-reset fix to gate firing on a real false→true transition
+    // (CC release) and skip the no-op true→true case (login, /reload). Without
+    // this gate the login flow's HasControl=true blanket-fires the speed reset
+    // and clobbers any active speed buff (mount, sprint, aspect of the cheetah)
+    // by hardcoding 7.0f. Default true: a player who has never been CC'd is
+    // always in control, so the natural login state is "has control already."
+    public bool LastObservedHasControl = true;
     // JimsProxy (taxi-flight-robustness): when set, signals a pending taxi-dismount Task
     // scheduled to fire at TaxiDismountFiresAtTickMs. The CTS is cancelled+disposed on
     // (a) clean session disconnect, (b) early landing CMSG, (c) a fresh taxi spline

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -128,10 +128,37 @@ public partial class WorldClient
 
         // --- Mirasu RP Walk Bug Fix ---
         // The 1.14 client forgets to un-toggle Walk mode after CC wears off.
-        // When control is returned, we explicitly force a run speed update to reset the UI toggle.
-        if (control.HasControl && control.Guid == GetSession().GameState.CurrentPlayerGuid)
+        // When control is RESTORED (false → true transition) we explicitly force
+        // a run speed update to reset the UI toggle.
+        //
+        // Two correctness gates:
+        //
+        // 1. Use the modern universal opcode SMSG_MOVE_SET_RUN_SPEED. MoveSetSpeed
+        //    extends ServerPacket whose constructor calls
+        //    ModernVersion.GetCurrentOpcode(). The legacy-only
+        //    SMSG_FORCE_RUN_SPEED_CHANGE has no entry in the modern (1.14) opcode
+        //    table so the lookup returns 0 and trips Trace.Assert(opcode != 0)
+        //    in Packet.cs:73 (visible Linux Debug crash) and serializes 0x0000
+        //    onto the wire on Release (silent — modern client drops the malformed
+        //    packet, so the fix has historically been a no-op). The neighboring
+        //    handler at MovementHandler.cs:~298 already does the
+        //    SMSG_FORCE_*_CHANGE → SMSG_MOVE_SET_* translation when forwarding
+        //    incoming legacy speed-change packets.
+        //
+        // 2. Only fire on a *transition* from no-control → has-control. The
+        //    server emits SMSG_CONTROL_UPDATE(HasControl=true) on login and on
+        //    /reload too, not just when CC ends. Without this gate the login
+        //    handler hardcodes 7.0f and clobbers any active speed buff (mount,
+        //    sprint, aspect of the cheetah, druid travel form) — observable as
+        //    "log in mounted, walk at unmounted speed until I remount."
+        bool isLocalPlayer = control.Guid == GetSession().GameState.CurrentPlayerGuid;
+        bool justRegainedControl = control.HasControl && !GetSession().GameState.LastObservedHasControl;
+        if (isLocalPlayer)
+            GetSession().GameState.LastObservedHasControl = control.HasControl;
+
+        if (isLocalPlayer && justRegainedControl)
         {
-            MoveSetSpeed runFix = new MoveSetSpeed(Opcode.SMSG_FORCE_RUN_SPEED_CHANGE);
+            MoveSetSpeed runFix = new MoveSetSpeed(Opcode.SMSG_MOVE_SET_RUN_SPEED);
             runFix.MoverGUID = control.Guid;
             runFix.MoveCounter = 0;
             runFix.Speed = 7.0f; // Default WoW running speed


### PR DESCRIPTION
Summary

  Two coupled fixes to HandleControlUpdate's RP Walk Bug Fix in MovementHandler.cs. Supersedes the earlier standalone
  opcode-only branch.

  1. Switch to the modern speed opcode

  The handler synthesized new MoveSetSpeed(Opcode.SMSG_FORCE_RUN_SPEED_CHANGE). MoveSetSpeed extends ServerPacket whose
  constructor calls ModernVersion.GetCurrentOpcode(universalOpcode). The legacy-only SMSG_FORCE_RUN_SPEED_CHANGE has no
  entry in the modern (1.14) opcode table, so:

  - Linux Debug builds (community testers building from source — PikaOS / Ubuntu / WSL): Trace.Assert(opcode != 0) in
  Packet.cs:73 fires loudly, proxy crashes immediately after CC wears off and the player regains control.
  - Linux/Windows Release: Trace.Assert writes to stderr and execution continues. The packet gets opcode 0, which
  WorldSocket serializes as 0x0000 onto the wire. Modern client drops the malformed packet → the RP Walk Bug Fix has
  been a silent no-op on every Release build since it was added. The walk-toggle UI bug was never actually being fixed;
  players with rare repros just lived with it.

  The neighboring handler at MovementHandler.cs:~298 already does the correct SMSG_FORCE_*_CHANGE → SMSG_MOVE_SET_*
  translation when forwarding incoming legacy speed-change packets to the modern client. The RP Walk fix forgot to do
  the same translation. Switching to Opcode.SMSG_MOVE_SET_RUN_SPEED both stops the Linux crash AND makes the fix do what
   its comment claims for the first time.

  2. Gate firing on a real false → true control transition

  Once #1 makes the speed reset actually function, a second bug surfaces: the server emits
  SMSG_CONTROL_UPDATE(HasControl=true) on login and on /reload too, not just when CC wears off. The handler's
  unconditional if (control.HasControl) then hardcodes 7.0f and clobbers any active speed-modifying buff — observable as
   "log in while mounted, walk at unmounted speed until I remount." Affects mount, sprint, aspect of the cheetah, druid
  travel form, etc.

  Track LastObservedHasControl on GlobalSessionData (defaults true — matches the natural never-CC'd state). Fire the
  speed reset only on a genuine false → true transition.