### PR TITLE
GameObject use: filter forwarding on cached interaction type

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
@@ -36,6 +36,41 @@ public partial class WorldSocket
             SendPacket(notify);
         }
 
+        // Kronos and similar 1.12 servers disable meeting stones server-side
+        // (no summon ritual, no LFG queue). The 1.14 client doesn't know this
+        // — right-clicking a meeting stone GO as group leader still initiates
+        // the summon-ritual UI flow locally. Drop the CMSG_GAME_OBJ_USE at the
+        // proxy boundary so no server-side state changes and no SMSG_SUMMON_*
+        // packets get generated. Surface a notification so the player knows
+        // the click did register (just intentionally no-op'd).
+        //
+        // Vanilla GameObjectType 23 = TYPE_MEETINGSTONE. Read the cached
+        // GAMEOBJECT_TYPE_ID for this GUID — populated when the legacy server
+        // CREATE_OBJECT'd the GO. Falls through if we somehow never cached
+        // the type (rare; would require interacting with an unknown GO).
+        var goFields = GetSession().GameState.GetCachedObjectFieldsLegacy(use.Guid);
+        if (goFields != null)
+        {
+            int goTypeFieldIdx = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_TYPE_ID);
+            if (goTypeFieldIdx >= 0 && goFields.TryGetValue(goTypeFieldIdx, out var typeField))
+            {
+                const int TYPE_MEETINGSTONE = 23;
+                if (typeField.Int32Value == TYPE_MEETINGSTONE)
+                {
+                    Log.Event("meeting_stone.use_blocked", new
+                    {
+                        guid = use.Guid.ToString(),
+                        entry = entry,
+                    });
+
+                    PrintNotification notify = new PrintNotification();
+                    notify.NotifyText = "Meeting stones are disabled on this server";
+                    SendPacket(notify);
+                    return;
+                }
+            }
+        }
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_GAME_OBJ_USE);
         packet.WriteGuid(use.Guid.To64());
         SendPacketToServer(packet);


### PR DESCRIPTION
The 1.14 client knows about more GameObject interaction types than every vanilla 1.12 server actually implements. When the modern client triggers its local interaction UI (e.g. type-23 summon-ritual GOs as group leader), the resulting `CMSG_GAME_OBJ_USE` still reaches the legacy server. Depending on the server's exact handling this can produce `SMSG_SUMMON_*` follow-ups for an interaction the server doesn't actually support, surfacing a half-working flow that confuses both the initiator and nearby party members.

Add a type-id check on the cached GAMEOBJECT_TYPE_ID for the targeted GUID (populated when the legacy server CREATE_OBJECT'd the GO). For type 23 (TYPE_MEETINGSTONE) drop the CMSG at the proxy boundary and surface an SMSG_PRINT_NOTIFICATION so the click registers visibly as no-op rather than vanishing silently.

The handler already special-cases MC Runes of Warding entries 176951-176957 at the top — that path is untouched. The type filter runs after the rune branch and only short-circuits on exact type match. CMSG_GAME_OBJ_USE semantics for every other GO type (chests, doors, quest objects, fishing nodes, etc.) are unchanged.

A `meeting_stone.use_blocked` Log.Event fires on each drop so the behavior is observable in tester bundles.