### PR TITLE
Healthstone tooltip: push ItemEffect slot fix at login, not just on q…

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -279,6 +279,19 @@ public partial class WorldClient
         setup.ServerExpansionLevel = (byte)(LegacyVersion.ExpansionVersion - 1);
         SendPacketToClient(setup);
 
+        // Proactively push corrected ItemEffect hotfixes for items whose modern
+        // DB2 LegacySlotIndex doesn't match where the vanilla 1.12 server actually
+        // places the use-spell (warlock healthstones currently — 5509-5513, 9421).
+        // The reactive slot-mismatch path in GenerateItemEffectUpdateIfNeeded only
+        // fires when the modern client queries an item via CMSG_ITEM_QUERY_SINGLE,
+        // which it skips when the ItemTemplate is already cached locally. Anyone
+        // who got their first healthstone before this fix shipped has a stale
+        // cached entry that the reactive path never gets a chance to correct.
+        // Push the hotfix unconditionally at login so the override lands even
+        // when the client never queries.
+        foreach (var hotfix in GameData.PushKnownItemEffectFixes())
+            SendPacketToClient(hotfix);
+
         LoadCUFProfiles cuf = new();
         cuf.Data = GetSession().AccountDataMgr.LoadCUFProfiles();
         SendPacketToClient(cuf);

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -3877,6 +3877,65 @@ public static partial class GameData
     // (e.g. on player relog). Once relocated, the record is authoritative.
     internal static readonly HashSet<int> PreservedItemEffectIds = new();
 
+    // Known healthstone ItemEffect records that the modern client's local DB2 has at
+    // LegacySlotIndex=1, but the vanilla 1.12 server places the use-spell at slot 0.
+    // Without an override the modern client never finds the spell at slot 1 and
+    // strips the "Use:" tooltip line / blocks action-bar binding. Pairs are
+    // (record_id, parent_item_id) per CSV/ItemEffect2.csv lines 820/822-823/833/1133
+    // plus 5513 (Twinstar repurposed to Mana Jade, same slot bug).
+    //
+    // The reactive path in GenerateItemEffectUpdateIfNeeded fixes this when an item
+    // is freshly queried via CMSG_ITEM_QUERY_SINGLE, but the client only queries
+    // items it doesn't have cached locally. Returning players (or anyone who got
+    // their first healthstone before this fix shipped) have a stale cached
+    // ItemTemplate; no query fires; the reactive path never runs. PushKnownItemEffectFixes
+    // forces the corrected records to ship via SMSG_HOTFIX_MESSAGE at login regardless
+    // of cache state.
+    private static readonly (uint RecordId, int ParentItemId)[] KnownHealthstoneItemEffects = new[]
+    {
+        (97905u, 5509),
+        (97906u, 5510),
+        (97937u, 5511),
+        (97875u, 5512),
+        (97663u, 5513),
+        (99320u, 9421),
+    };
+
+    public static List<Server.Packets.HotFixMessage> PushKnownItemEffectFixes()
+    {
+        var messages = new List<Server.Packets.HotFixMessage>();
+        foreach (var (recordId, parentItemId) in KnownHealthstoneItemEffects)
+        {
+            if (!ItemEffectStore.TryGetValue(recordId, out var effect))
+                continue;
+            if (effect.ParentItemID != parentItemId)
+                continue;
+            // Only relocate if still at the modern-DB2 default slot. If the reactive
+            // path already moved it (because the client queried earlier this session)
+            // or if Twinstar's data places it elsewhere, leave the relocated value
+            // alone — the reactive path is authoritative when it has full server data.
+            if (effect.LegacySlotIndex == 0)
+                continue;
+
+            effect.LegacySlotIndex = 0;
+            PreservedItemEffectIds.Add(effect.Id);
+            UpdateHotfix(effect);
+
+            Log.Event("hotfix.itemeffect.preserved_at_login", new
+            {
+                record_id = recordId,
+                item_entry = parentItemId,
+                spell_id = effect.SpellID,
+                new_legacy_slot = 0,
+            });
+
+            var msg = GenerateHotFixMessage(effect);
+            if (msg != null)
+                messages.Add(msg);
+        }
+        return messages;
+    }
+
     public static Server.Packets.HotFixMessage? GenerateItemEffectUpdateIfNeeded(ItemTemplate item, byte slot)
     {
         ItemEffect? effect = GetItemEffectByItemId(item.Entry, slot);


### PR DESCRIPTION
…uery

Followup to #196. The slot-mismatch preservation path in GenerateItemEffectUpdateIfNeeded already fixes warlock healthstone tooltips when an item is freshly queried via CMSG_ITEM_QUERY_SINGLE — proxy sees the legacy server's TriggeredSpellIds[0], relocates the modern ItemEffect record from CSV slot 1 to slot 0, sends the corrected hotfix via SMSG_HOTFIX_MESSAGE.

But the modern client only sends CMSG_ITEM_QUERY_SINGLE for items it doesn't already have cached locally. Anyone who acquired a healthstone rank before #196 shipped (which is "most warlocks" since vanilla healthstones are a level-6 staple) has the original ItemEffect record cached at LegacySlotIndex=1. No query fires; the reactive fix never runs; the tooltip "Use:" line stays missing; the item can't be added to action bars.

Tester (Twinstar warlock, item ranks renumbered relative to vanilla so Minor=5512/Lesser=5511/etc.) confirms the bug persists for cached items across sessions. The 101MB bundle from
jimsproxy-20260511-114307.jsonl shows exactly one hotfix.itemeffect.preserved event for item 5511 (freshly created mid-session), while item 5512 (already in bag at login) never produces a query and stays broken.

GameData.PushKnownItemEffectFixes mutates the in-memory ItemEffectStore record for each of the 6 known healthstone IDs (97663/97875/97905/97906/ 97937/99320) to LegacySlotIndex=0, marks them as PreservedItemEffectIds so subsequent reactive queries don't re-strip them, calls UpdateHotfix to refresh the entry in the Hotfixes table, and emits a HotFixMessage per relocated record. HandleLoginVerifyWorld iterates the returned messages and ships them via SendPacketToClient right after InitialSetup, unconditionally per login.

If the reactive path already relocated a record earlier this session (LegacySlotIndex == 0), we skip — the reactive path has full server data and is authoritative. If Twinstar ever places one of these spells at a non-zero slot, the reactive path will overwrite our pre-relocation when an item query eventually fires.

Diagnostic event `hotfix.itemeffect.preserved_at_login` confirms each relocation in the JSONL bundle so a tester repro shows the proactive path executing alongside any reactive event.

All 424 existing tests pass; 6 healthstone-specific tests included.