### PR TITLE
Fix/pet spells parse fallback

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
@@ -158,7 +158,7 @@ public partial class WorldClient
         }
         catch (Exception ex)
         {
-            Log.Print(LogType.Error, $"PetSpellsMessage parse failed (non-fatal, packet dropped): packetSize={dbgPacketSize} {ex.GetType().Name}: {ex.Message}");
+            Log.Print(LogType.Error, $"PetSpellsMessage parse failed (non-fatal): packetSize={dbgPacketSize} {ex.GetType().Name}: {ex.Message}");
             Log.Event("pet.spells_message.parse_failed", new
             {
                 exception_type = ex.GetType().Name,
@@ -166,6 +166,48 @@ public partial class WorldClient
                 packet_size = dbgPacketSize,
                 packet_hex = HexDump(dbgRawBytes),
             });
+
+            // Pre-fix behavior was to silently drop the malformed packet, leaving
+            // the modern client with no pet bars for a pet that's alive in the
+            // world. Symptom: player summons a fresh Voidwalker, the legacy
+            // server emits an SMSG_PET_SPELLS_MESSAGE in a shape we can't fully
+            // parse (e.g. 144-byte variant on Twinstar; quest tame on Kronos via
+            // spell 19684), parser throws partway through, packet dropped, no
+            // pet bars ever appear, pet uncommandable until dismiss+resummon
+            // hits a parseable shape. Observed once in jimsproxy-20260511-114307
+            // (Voidwalker via spell 697 → 144-byte SMSG_PET_SPELLS_MESSAGE →
+            // ArgumentOutOfRangeException → silent drop → 203 sec of no pet
+            // control until manual dismiss).
+            //
+            // The GUID was successfully read at the very top of the try (line
+            // ~42) and saved to GameState.CurrentPetGuid before any of the
+            // downstream reads could throw. Use that to emit a minimal PetSpells
+            // fallback: pet bars exist on the modern client, action buttons
+            // empty, react/command state defaulted so the dropdown menus still
+            // work (dismiss / stay / follow / attack-mode toggle remain
+            // operable). Better than the silent drop — player has SOME control
+            // path back to a working state instead of being stuck.
+            var fallbackGuid = GetSession().GameState.CurrentPetGuid;
+            if (!fallbackGuid.IsEmpty())
+            {
+                var fallback = new PetSpells
+                {
+                    PetGUID = fallbackGuid,
+                    CreatureFamily = 1, // Wolf — generic beast, safe for paper-doll tooltip
+                    ReactState = ReactStates.Defensive,
+                    CommandState = CommandStates.Follow,
+                    Flag = 0,
+                };
+                // ActionButtons stays as default uint[10] of zeros — empty bar
+                // but the pet bar frame is visible.
+                Log.Event("pet.spells.fallback_sent", new
+                {
+                    pet_guid = fallbackGuid.ToString(),
+                    reason = "parse_failed",
+                    parsed_packet_size = dbgPacketSize,
+                });
+                SendPacketToClient(fallback);
+            }
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
@@ -136,7 +136,8 @@ public partial class WorldClient
 
                 cooldown.Category = packet.ReadUInt16();
                 cooldown.Duration = packet.ReadUInt32();
-                cooldown.CategoryDuration = packet.ReadUInt32();
+                if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_0_9767))
+                    cooldown.CategoryDuration = packet.ReadUInt32();
 
                 spells.Cooldowns.Add(cooldown);
             }

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -315,12 +315,76 @@ public partial class WorldClient
         // Look up pending pet cast by SpellId (queue-based, FIFO order)
         if (!GetSession().GameState.TryDequeuePendingPetCast(spellId, out var pendingCast))
         {
-            Log.Event("pet.cast_failed.no_pending", new
+            // JimsProxy: CMSG_PET_ACTION (player presses a pet ability button)
+            // doesn't populate PendingPetCasts the way CMSG_PET_CAST_SPELL does,
+            // so a failed pet action arrives here with no pending entry to match.
+            // Previously we logged and dropped, leaving the modern client's pet
+            // UI in a stuck "casting" state because it never received a failure
+            // signal for the press it had locally predicted. Warlock testers
+            // report this as "pet sound stuck" / "stuck pet animation" — the
+            // modern client appears to loop the casting indicator + any tied
+            // sound until /reload.
+            //
+            // Emit a defensive fallback PetCastFailed with a deterministic
+            // CastID (matching the seed pattern HandleSpellStartOrGo uses for
+            // pet casts so a future CastID match still works) and DontReport
+            // reason — the client unwinds button + state cleanly without a
+            // misleading popup. Also send CancelSpellVisual for any visual
+            // kit anchored on press: pet auto-cast spells like 7809 / 17735 /
+            // 17850 DO have valid SpellVisualKit entries in modern Classic
+            // 1.14.2 (unlike spells 75 / 5019), so the cancel actually lands.
+            var petGuid = GetSession().GameState.CurrentPetGuid;
+            // Defense in depth: only emit the fallback when we have a real
+            // spell ID and a real pet GUID to anchor the synthesized CastID
+            // and CancelSpellVisual source. SpellID == 0 would produce a
+            // wonky CastID the client almost certainly ignores; targeting an
+            // empty pet GUID is meaningless.
+            if (!petGuid.IsEmpty() && spellId != 0)
             {
-                spell_id = spellId,
-                has_reason = hasReason,
-                legacy_reason = legacyReason,
-            });
+                uint spellVisual = GameData.GetSpellVisual(spellId);
+                uint resolvedSpellVisualId = GameData.GetSpellVisualIdFromXSpellVisual(spellVisual);
+                if (resolvedSpellVisualId != 0)
+                {
+                    CancelSpellVisual cancelVisual = new CancelSpellVisual();
+                    cancelVisual.Source = petGuid;
+                    cancelVisual.SpellVisualID = (int)resolvedSpellVisualId;
+                    SendPacketToClient(cancelVisual);
+                }
+
+                PetCastFailed fallback = new PetCastFailed();
+                fallback.SpellID = spellId;
+                fallback.Reason = (uint)SpellCastResultClassic.DontReport;
+                fallback.CastID = WowGuid128.Create(
+                    HighGuidType703.Cast,
+                    SpellCastSource.Normal,
+                    (uint)(GetSession().GameState.CurrentMapId ?? 0),
+                    spellId,
+                    (ulong)spellId + petGuid.GetCounter());
+                SendPacketToClient(fallback);
+
+                Log.Event("pet.cast_failed.no_pending", new
+                {
+                    spell_id = spellId,
+                    has_reason = hasReason,
+                    legacy_reason = legacyReason,
+                    fallback_sent = true,
+                    pet_guid_low = petGuid.GetCounter(),
+                    spell_visual = spellVisual,
+                    resolved_visual_id = resolvedSpellVisualId,
+                });
+            }
+            else
+            {
+                Log.Event("pet.cast_failed.no_pending", new
+                {
+                    spell_id = spellId,
+                    has_reason = hasReason,
+                    legacy_reason = legacyReason,
+                    fallback_sent = false,
+                    pet_guid_empty = petGuid.IsEmpty(),
+                    spell_id_zero = spellId == 0,
+                });
+            }
             return;
         }
 


### PR DESCRIPTION
## Updated 2026-05-11 — added pet cast-failed no-pending fallback

  Third commit (`39414c9`) addresses the "pet sound stuck" / "stuck pet animation"
  reports from warlock testers. Companion to the existing parse-fallback work in
  this PR.

  ### Symptom
  Player presses a pet ability action button (CMSG_PET_ACTION path). Server
  rejects the cast and emits `SMSG_PET_CAST_FAILED`. Proxy's
  `HandlePetCastFailed` previously logged `pet.cast_failed.no_pending` and
  dropped the packet — `CMSG_PET_ACTION` doesn't populate `PendingPetCasts`
  the way `CMSG_PET_CAST_SPELL` does, so the dequeue lookup misses. Modern
  client never receives a failure signal and its pet UI stays in a stuck
  "casting" state with whatever visual/sound the press anchored locally
  looping until `/reload`.

  ### Fix
  On the no_pending path (gated on non-empty pet GUID + non-zero spell ID),
  emit two defensive packets:

  1. **`SMSG_CANCEL_SPELL_VISUAL`** for the pet's GUID using the resolved
     `SpellVisualID`. Verified on wago.tools build 42597 that pet ability
     spells (e.g. Voidwalker Suffering ranks 7809 / 17735 / 17850, Felhunter
     abilities, etc.) have valid `SpellXSpellVisual` entries — so the cancel
     actually lands and dismisses the kit + tied sound. Inner check skips
     the send if the visual lookup returns 0.

  2. **`SMSG_PET_CAST_FAILED`** synthesized with `DontReport` reason and a
     deterministic `CastID` matching the seed pattern `HandleSpellStartOrGo`
     uses for pet casts (`spellId + pet.GetCounter()`). If the client tracked
     a `SPELL_START` earlier with the matching seed, the failure unwinds
     cleanly with no popup spam.

  ### Edge case audit
  - **Empty pet GUID** → guard skips both packets, logs `fallback_sent: false`
  - **`spellId == 0`** → guard skips both packets (defense in depth)
  - **CSV miss on SpellVisual** → inner guard skips `CancelSpellVisual` only;
    `PetCastFailed` still sends
  - **MapID null** → `?? 0` fallback keeps GUID valid
  - **Happy path** (pending entry found) is untouched starting at line 411 —
    zero regression risk
  - **Synthesized CastID doesn't match client** → both packets are no-ops →
    same outcome as the previous drop-and-return

  ### Test plan
  - [ ] Warlock with Voidwalker — press Suffering on a target out of range
        → pet UI unwinds, no stuck sound, no popup
  - [ ] Warlock with Felhunter — press Devour Magic when there's no buff to
        strip → same
  - [ ] Bundle inspection: `pet.cast_failed.no_pending` event shows
        `fallback_sent: true` with non-zero `resolved_visual_id` for valid
        spells