### PR TITLE
Clear stale auto-repeat state at login (fix first-press press-twice)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -279,6 +279,27 @@ public partial class WorldClient
         setup.ServerExpansionLevel = (byte)(LegacyVersion.ExpansionVersion - 1);
         SendPacketToClient(setup);
 
+        // Clear any stale "is auto-repeating" flag the modern 1.14 client may have
+        // entered the world with. Confirmed via bundle jimsproxy-20260511-111421:
+        // on a fresh hunter login, the first Auto Shot button press sends both
+        // CMSG_CAST_SPELL (75) AND CMSG_CANCEL_AUTO_REPEAT_SPELL in the same 1ms
+        // packet burst — because the client thinks auto-repeat is currently active
+        // (stale flag) and the action button's toggle-off path fires alongside the
+        // cast. Server processes the cast first, then the cancel, emits
+        // SMSG_SPELL_START + SMSG_SPELL_FAILURE, and the user has to press a second
+        // time. Same symptom on wand "Shoot" (5019) first press for casters.
+        // Vanilla 1.12 servers don't preserve auto-repeat state across login, so
+        // we have no legitimate auto-repeat to break — this is purely a state
+        // reset on the modern client.
+        var cancelStaleRepeat = new CancelAutoRepeat();
+        cancelStaleRepeat.Guid = GetSession().GameState.CurrentPlayerGuid;
+        SendPacketToClient(cancelStaleRepeat);
+        Framework.Logging.Log.Event("ranged.auto_repeat.cleared_at_login", new
+        {
+            player_guid_low = GetSession().GameState.CurrentPlayerGuid.GetCounter(),
+            map_id = verify.MapID,
+        });
+
         LoadCUFProfiles cuf = new();
         cuf.Data = GetSession().AccountDataMgr.LoadCUFProfiles();
         SendPacketToClient(cuf);


### PR DESCRIPTION
Confirmed via bundle jimsproxy-20260511-111421 on a fresh hunter login: the modern 1.14 client enters the world with its IsAutoRepeating UI flag set to TRUE. Pressing the Auto Shot action button the first time triggers the toggle-OFF path AND the cast attempt in the same 1ms packet burst:

    CMSG_CAST_SPELL (75)
    CMSG_SET_SHEATHED
    CMSG_ATTACK_SWING
    CMSG_SET_SHEATHED
    CMSG_CANCEL_AUTO_REPEAT_SPELL  <-- co-burst cancel

Server processes the cast (starts auto-shot) then the cancel (immediately stops it), emits SMSG_SPELL_START + SMSG_SPELL_FAILURE. User sees the bow draw briefly then go limp, has to press a second time to actually start firing.

The second press doesn't include the cancel (flag was cleared by the failed first attempt), so it succeeds.

Same symptom on wand "Shoot" (spell 5019) first press for casters.

Vanilla 1.12 servers don't preserve ranged-auto-repeat state across login, so emitting SMSG_CANCEL_AUTO_REPEAT in HandleLoginVerifyWorld has no legitimate auto-repeat to break — it just clears whatever stale flag the client entered with. Subsequent first-presses of the session then take the toggle-ON path cleanly.

Diagnostic event ranged.auto_repeat.cleared_at_login fires once per login for verification in future bundles.

Does NOT fix the mid-session wand looping sound (separate mechanism — no SpellVisualKit exists for spells 75/5019 in the modern client, so CancelSpellVisual can't dismiss the weapon-state-bound sound).