### PR TITLE
Spell: send SpellPrepare on hold-accept so CastFailed/SpellFailure ca…

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -922,10 +922,19 @@ public partial class WorldClient
             // SMSG_SPELL_START even for these) apart from real cast-time spells.
             pendingCast.StartedCastTimeMs = spell.Cast.CastTime;
 
-            SpellPrepare prepare = new();
-            prepare.ClientCastID = pendingCast.ClientGUID;
-            prepare.ServerCastID = spell.Cast.CastID;
-            SendPacketToClient(prepare);
+            // Skip SpellPrepare if the hold-accept path (or off-GCD path) already sent
+            // one for this cast. Without this guard, held casts get a duplicate
+            // SpellPrepare (one at hold-accept, one here); the modern client treats
+            // duplicates as idempotent, but suppressing the second is cleaner and makes
+            // the contract explicit.
+            if (!pendingCast.HasSentPrepare)
+            {
+                SpellPrepare prepare = new();
+                prepare.ClientCastID = pendingCast.ClientGUID;
+                prepare.ServerCastID = spell.Cast.CastID;
+                SendPacketToClient(prepare);
+                pendingCast.HasSentPrepare = true;
+            }
 
             // Clear non-started casts and send failures for them
             // (keeps the started cast so SPELL_GO can dequeue it)

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -332,9 +332,20 @@ public partial class WorldSocket
                     });
                     if (displaced != null)
                         SendCastFailedWithoutPrepare(displaced);
-                    // Don't ack-fail castRequest — keep the modern client's action-button GCD
-                    // anticipation lit until SpellPrepare arrives at SPELL_START time for the
-                    // refired cast. Matches the smooth feel of native 1.14.
+                    // Send SpellPrepare immediately on hold-accept so the client has a
+                    // ClientCastID → ServerCastID mapping to match any future SMSG_SPELL_FAILURE
+                    // for this cast. Mirrors the off-GCD path below — see that comment for the
+                    // underlying contract. Without this, server rejections (LoS / range /
+                    // out-of-mana race) arriving for the eventually-fired held cast leave the
+                    // action button permanently lit because SpellFailure has no SpellPrepare
+                    // to match against. Symptom is most prevalent on low-ping (~50ms) clients
+                    // in populated zones, where the proxy's hold delay + SMSG backlog from
+                    // other casters extends the time the client spends in queued-press state.
+                    SpellPrepare prepare = new SpellPrepare();
+                    prepare.ClientCastID = castRequest.ClientGUID;
+                    prepare.ServerCastID = castRequest.ServerGUID;
+                    SendPacket(prepare);
+                    castRequest.HasSentPrepare = true;
                     return;
                 }
 
@@ -387,9 +398,21 @@ public partial class WorldSocket
                             SendCastFailedWithoutPrepare(displaced);
                         }
 
-                        // Don't send SpellPrepare here — hide the queue from the client.
-                        // SpellPrepare will be sent at SPELL_GO time (Client/SpellHandler.cs
-                        // line 734-739) so button, animation, and GCD sweep all start together.
+                        // Send SpellPrepare immediately on hold-accept so the client has a
+                        // ClientCastID → ServerCastID mapping to match any future
+                        // SMSG_SPELL_FAILURE for this cast. Mirrors the off-GCD path below —
+                        // see that comment for the underlying contract. Without this, server
+                        // rejections (LoS / range / cooldown race) for the eventually-fired
+                        // held cast leave the action button permanently lit because
+                        // SpellFailure has no SpellPrepare to match against. Symptom is most
+                        // prevalent on low-ping (~50ms) clients in populated zones, where
+                        // the proxy's hold delay + SMSG backlog from other casters extends
+                        // the time the client spends in queued-press state.
+                        SpellPrepare prepare = new SpellPrepare();
+                        prepare.ClientCastID = castRequest.ClientGUID;
+                        prepare.ServerCastID = castRequest.ServerGUID;
+                        SendPacket(prepare);
+                        castRequest.HasSentPrepare = true;
                         return;
                     }
                     // Else: GCD expired between IsGcdHoldActive() and TryHoldCastDuringGcd() —
@@ -432,7 +455,15 @@ public partial class WorldSocket
                     });
                     if (displaced != null)
                         SendCastFailedWithoutPrepare(displaced);
-                    // Don't send SpellPrepare for the NEW hold — hide the queue from the client.
+                    // Send SpellPrepare on hold-accept so the client has a SpellPrepare to
+                    // match against any future SMSG_SPELL_FAILURE for this cast. Same
+                    // reasoning as the cast-time and GCD hold paths above — see the off-GCD
+                    // comment below (~line 460) for the underlying contract.
+                    SpellPrepare prepare = new SpellPrepare();
+                    prepare.ClientCastID = castRequest.ClientGUID;
+                    prepare.ServerCastID = castRequest.ServerGUID;
+                    SendPacket(prepare);
+                    castRequest.HasSentPrepare = true;
                     return;
                 }
 


### PR DESCRIPTION
…n match

Extends the off-GCD path's "send SpellPrepare immediately so failures have something to match against" contract to the three silent-hold paths (cast-time hold, GCD hold, forwarded-pending hold).

The off-GCD path comment already documented the underlying bug:

> Without this, if the server rejects the cast (LoS, range), the client has no
> SpellPrepare to match against SpellFailure and the button stays in a pending/lit
> state permanently.

All three silent-hold paths defer SpellPrepare to SPELL_START time, which means any SMSG_SPELL_FAILURE arriving for the eventually-forwarded held cast (LoS, range, cooldown race, drain-clear) lands on a client with no ClientCastID -> ServerCastID mapping. Result: action button stays permanently lit, sound looping, /reload doesn't fix it, only full game restart.

Symptom is most prevalent on low-ping (~50ms) clients in populated zones: the proxy's hold delay (15-78ms observed) plus SMSG backlog from other casters extends the time the client spends in queued-press state past its tolerance window, and crowded zones produce more SpellFailures (LoS blocked by other players, server-side cooldown races).

Also gates the SpellPrepare emit at HandleSpellStart so held casts (which now already sent SpellPrepare at hold-accept time) don't get a duplicate SpellPrepare when SPELL_START arrives. Same pattern the SPELL_GO handler already uses (line 1273). Makes the "exactly one SpellPrepare per ClientCastID" contract explicit and cleans up packet noise.

Mirrors the off-GCD path exactly -- no new behavior, just extends "send SpellPrepare on accept" to the hold-paths.