### PR TITLE
WSG fix

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -679,6 +679,11 @@ public class ByteBuffer : IDisposable
         return (uint)_length;
     }
 
+    // JimsProxy: bytes still unread on a read-mode buffer. Used by parse paths that
+    // need to validate a declared count (e.g. SMSG_SPELL_GO hitCount) against the
+    // actual remaining buffer before entering a fixed-stride read loop.
+    public int BytesRemaining => _length - _position;
+
     [Obsolete("Use GetData() instead. This creates a MemoryStream copy for compatibility.")]
     public Stream GetCurrentStream()
     {

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1531,6 +1531,20 @@ public partial class WorldClient
         if (isSpellGo)
         {
             var hitCount = packet.ReadUInt8();
+            // JimsProxy: bounds-check the declared hitCount against actual remaining
+            // packet bytes BEFORE entering the fixed-stride read loop. If hitCount * 8
+            // (one full GUID per target) exceeds what's left, throw a descriptive
+            // exception that the outer try/catch in HandleSpellGo logs along with the
+            // packet hex bytes. Without this guard, ReadGuid() bottoms out in
+            // BinaryPrimitives.ReadUInt64LittleEndian and throws a generic
+            // ArgumentOutOfRangeException with no spell context — diagnostically
+            // useless and (on builds that lack the outer try/catch) caused player DCs.
+            // Most likely trigger: an earlier optional field was read with the wrong
+            // LegacyVersion gate, shifting byte alignment so hitCount lands on a bogus
+            // value like 0xFF, producing a 2040-byte target list demand.
+            if (hitCount * 8 > packet.BytesRemaining)
+                throw new InvalidOperationException(
+                    $"SMSG_SPELL_GO parse overrun: spell={dbdata.SpellID} hitCount={hitCount} needs {hitCount * 8} bytes but only {packet.BytesRemaining} remain");
             for (var i = 0; i < hitCount; i++)
             {
                 WowGuid128 hitTarget = packet.ReadGuid().To128(GetSession().GameState);
@@ -1538,6 +1552,13 @@ public partial class WorldClient
             }
 
             var missCount = packet.ReadUInt8();
+            // Same bounds check for miss-target loop. Floor 9 bytes per entry (GUID +
+            // missType byte); reflect adds an optional byte, so 9 * missCount is the
+            // minimum. Underestimating is fine — individual reads still succeed up to
+            // the actual end, and the outer try/catch handles any residual overrun.
+            if (missCount * 9 > packet.BytesRemaining)
+                throw new InvalidOperationException(
+                    $"SMSG_SPELL_GO parse overrun: spell={dbdata.SpellID} missCount={missCount} needs {missCount * 9} bytes but only {packet.BytesRemaining} remain (after {hitCount} hit targets)");
             for (var i = 0; i < missCount; i++)
             {
                 WowGuid128 missTarget = packet.ReadGuid().To128(GetSession().GameState);


### PR DESCRIPTION
…-stride reads

In-the-wild WSG crash report: a SMSG_SPELL_GO arrives with a declared hit or miss target count that exceeds the remaining packet bytes. ReadGuid() bottoms out in BinaryPrimitives.ReadUInt64LittleEndian and throws a generic ArgumentOutOfRangeException with no spell context — diagnostically useless and (on proxy builds predating PR #180's outer try/catch) escapes the receive loop and DCs the player.

Most likely trigger: an earlier optional field in HandleSpellStartOrGo gets read under the wrong LegacyVersion gate, shifting byte alignment so the hit/miss count bytes land on bogus values (commonly 0xFF), producing a 2040-byte declared target list demand against a ~200-byte packet.

Add explicit bounds checks before each fixed-stride read loop:
  - hitCount * 8 (full GUID per target) <= BytesRemaining
  - missCount * 9 (GUID + missType byte) <= BytesRemaining

When either check fails, throw InvalidOperationException with the spell ID, the count, the needed bytes, and the actual bytes remaining. The outer try/catch in HandleSpellGo (PR #180) catches this cleanly and logs a spell.parse_failed structured event with the full packet hex dump, so the next time a WSG-style misalignment fires we have everything to root-cause it without a follow-up diagnostic round-trip.

Also exposes BytesRemaining on ByteBuffer so other parse paths can adopt the same pattern.

Does NOT fix builds that predate PR #180 — the throw still escapes there. The tester needs to be on current beta for the resilience path to catch this.