### PR TITLE
Chat: hand off default-channel joins to the modern client (Chat Fix V2)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -796,10 +796,31 @@ public partial class WorldClient
             channel_count = channels.Count,
         });
 
+        // Skip first-login init (oldZoneId==0). The 1.14 modern client auto-joins
+        // default channels itself ~1.7s after login with its own zone-suffix
+        // strings (General/LocalDefense use the current zone name, Trade uses
+        // the literal "City"). Pre-empting with proxy JOINs races the client:
+        // server YouJoined arrives before the client has allocated a slot,
+        // gets orphaned, and the client's own JOIN then gets PlayerAlreadyMember.
+        // Net result: slot binds to no live channel — user sees echoes but
+        // can't send (greyed). Trade survives by accident because proxy used
+        // "Trade - <zone>" while client used "Trade - City" (two different
+        // server-side channels, no race on the client-driven one).
+        if (oldZoneId == 0) return;
+
         if (string.IsNullOrEmpty(newZoneName)) return;
 
         foreach (var channel in channels)
         {
+            // Skip OnlyInCities channels (Trade, GuildRecruitment, LFG). The
+            // modern client manages these as "<Name> - City" (literal) across
+            // all cities and never sends LEAVE/JOIN on zone changes. If the
+            // proxy LEAVEs/JOINs them as "<Name> - <ZoneName>", the server
+            // creates ad-hoc custom channels per zone and the matching
+            // YouJoined re-binds the modern client's slot to a stale name —
+            // slot greys out on subsequent zone transitions.
+            if ((channel.Flags & ChannelFlags.OnlyInCities) != 0) continue;
+
             string newName = channel.Name + " - " + newZoneName;
             if (!string.IsNullOrEmpty(oldZoneName))
             {


### PR DESCRIPTION
SyncZoneChannels was pre-empting the 1.14 client's own auto-join at login and churning OnlyInCities channels on every zone change. Wire evidence in JSONL bundles 184557 / 185622 / 190701 shows:

- ~1.7s after login the modern client sends its own CMSG_CHAT_JOIN_CHANNEL for General/Trade/LocalDefense. The proxy's pre-emptive JOINs land first; the resulting server YouJoineds reach the client before it has allocated a slot for that channel name and get orphaned. The client's own JOIN then gets PlayerAlreadyMember (no YouJoined). Net effect: slots show as joined visually but bind to no live server channel — the user sees messages echoed by name but cannot send (greyed-out chat box).

- The modern client uses the literal "Trade - City" (per the OnlyInCities flag, 0x10) globally across cities and never sends LEAVE/JOIN on zone changes. SyncZoneChannels was sending CMSG_LEAVE "Trade - <oldZone>" + CMSG_JOIN "Trade - <newZone>" on every cross, which made vmangos create ad-hoc per-zone Trade channels; the resulting YouJoineds re-bound the client's slot 2 to a stale fabricated name that the server doesn't recognize, greying the slot after the first zone change.

Two-line fix:
1. Return early when oldZoneId==0 (login init) — let the client win the auto-join race.
2. Skip channels with ChannelFlags.OnlyInCities in the resync loop — leave Trade/GuildRecruitment/LFG to the modern client.

Comments on both branches explain the why so the next maintainer doesn't reintroduce the pre-emption.