### PR TITLE
Fix/scale revert and bat

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -3970,7 +3970,18 @@ public partial class WorldClient
                     cms = GameData.GetDisplayInfo((uint)displayId).DisplayScale;
 
                 bool isWarlockPet = WarlockPetDisplayIds.Contains(displayId);
-                float k = isWarlockPet ? K_warlock : K_hunter;
+                // Bat-family hunter pets render ~2× oversized at K=1.5 — same symptom
+                // and same K=0.75 correction as warlock pets. Detection by ModelId so
+                // we cover every DisplayID using the bat M2 (25 in our CSV today, more
+                // if future content adds bats reusing the model). ModelId 411 was
+                // identified via Ressan the Needler (DisplayId 9750, ModelId 411,
+                // ModelScale 1.0) — Wowhead-confirmed bat, user-reported 2× oversize
+                // in-world 2026-05-11.
+                uint modelIdForFamilyDetect = (displayId > 0)
+                    ? GameData.GetDisplayInfo((uint)displayId).ModelId
+                    : 0;
+                bool isBatPet = modelIdForFamilyDetect == 411;
+                float k = (isWarlockPet || isBatPet) ? K_warlock : K_hunter;
 
                 // Skip normalization if CMS data is missing/invalid — fall back to a flat
                 // K multiply so the pet still gets a size bump rather than passing through
@@ -3987,7 +3998,7 @@ public partial class WorldClient
                     display_id = displayId,
                     creature_model_scale = cms,
                     k = k,
-                    family = isWarlockPet ? "warlock" : "hunter",
+                    family = isWarlockPet ? "warlock" : (isBatPet ? "hunter-bat" : "hunter"),
                     raw_scale = rawScale,
                     emitted_scale = emit,
                     matched_via = (currentPetGuid != default && guid == currentPetGuid) ? "current_pet_guid" : "summoned_by",

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2070,47 +2070,6 @@ public partial class WorldClient
             if (UNIT_FIELD_DISPLAYID >= 0 && updateMaskArray[UNIT_FIELD_DISPLAYID])
             {
                 updateData.UnitData.DisplayID = updates[UNIT_FIELD_DISPLAYID].Int32Value;
-
-                // JimsProxy (npc-scale-vanilla-parity): set UNIT_FIELD_DISPLAY_SCALE = 1/CMS
-                // so the modern client's `wire × CMS × DisplayScale` collapses to `wire`,
-                // matching vanilla 1.12's rendering of `wire × M` (where M is a per-model
-                // constant, NOT the same as CreatureModelScale). Verified empirically against
-                // matched-camera screenshots of Varimathras DisplayID 11658 (CMS 1.2):
-                //   * Vanilla 1.12 client:    Varimathras renders at 2.07× player height
-                //   * Modern with no comp:    Varimathras renders at 2.41× player height
-                //                             (over by ~16%, ratio 2.41/2.07 ≈ CMS itself)
-                //   * Modern with 1/CMS comp: Varimathras renders at ~2.01× (within 3% of
-                //                             vanilla — eyeball margin).
-                // The original developer's intuition was right; my "vanilla also multiplies
-                // by CMS" hypothesis was wrong. Vanilla 1.12 effectively ignores CreatureModel-
-                // Scale at render time (uses model's native size + wire scale only).
-                //
-                // The bundled CreatureDisplayInfo.csv has been refreshed from wago.tools so
-                // the lookup is now accurate (was previously stale, with ~2k spurious diffs
-                // from current modern Classic data).
-                //
-                // Pet path is independent — pets use the inverse-CMS bake-in at the SCALE_X
-                // read site (pet-scale-vanilla-parity). The 1.14 client doesn't honor
-                // UNIT_FIELD_DISPLAY_SCALE for local-player-pet units (verified by direct
-                // 1.12 vs proxy screenshots of a Felhunter and Dire Wolf), so the pet fix
-                // bakes its correction into wire SCALE_X instead.
-                if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
-                {
-                    uint dispId = (uint)updateData.UnitData.DisplayID;
-                    float complete = GameData.GetUnitCompleteDisplayScale(dispId);
-                    if (complete > 0)
-                        updateData.UnitData.DisplayScale = 1.0f / complete;
-
-                    Log.Event("unit.scale.display_scale_set", new
-                    {
-                        guid = guid.ToString(),
-                        entry = updateData.ObjectData.EntryID,
-                        display_id = dispId,
-                        modern_cms = GameData.GetDisplayInfo(dispId).DisplayScale,
-                        complete_display_scale = complete,
-                        emitted_display_scale = (float)(updateData.UnitData.DisplayScale ?? 1.0f),
-                    });
-                }
             }
             int UNIT_FIELD_NATIVEDISPLAYID = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_NATIVEDISPLAYID);
             if (UNIT_FIELD_NATIVEDISPLAYID >= 0 && updateMaskArray[UNIT_FIELD_NATIVEDISPLAYID])


### PR DESCRIPTION
 ## Summary

  Two related scale fixes:

  1. **Revert PR #117's `UnitData.DisplayScale = 1.0f / GetUnitCompleteDisplayScale(...)` write** — wire bundle 194209
  showed the proxy emitting DisplayScale=0.8 for a Bluffwatcher (DisplayId 9392, CMS 1.0, ModelScale 1.25) yet he still
  rendered ~2× the player Tauren druid's height. Native 1.12 client renders them 1:1. The 1.14 modern client appears to
  not honor `UNIT_FIELD_DISPLAY_SCALE` for visible model scale; the PR's "Varimathras 2.41→2.01" verification was likely
   a camera/collision shift, not actual scaling. Verified in-game by user: Tauren NPCs now match vanilla after the
  revert.

  2. **Bat-family hunter pets use `K_warlock = 0.75` instead of `K_hunter = 1.5`** — bats render ~2× oversized at K=1.5
  for the same reason warlock pets did pre-PR-#151. Detection by ModelId 411 (the bat M2) covers 25 DisplayIds in our
  current CSV (Dusk Bats, Cave Bats, Plagued Bats, Ressan the Needler, etc.) and any future bat content reusing the
  model. ModelId identified by cross-referencing Ressan (NPC 10357, classicdb modelid 9750) → DisplayId 9750 → ModelId
  411, ModelScale 1.0.

  ## What's preserved from #117

  Pet inverse-CMS bake-in (the K-based path itself), CreatureDisplayInfo.csv refresh, mount/quest/destroy diagnostics,
  and the Charge stun visual fix are all left in place. Only the NPC `DisplayScale` write block is removed.

  ## Test plan
  - [x] Tauren NPCs (Bluffwatcher, Maggran Earthbinder) match player Tauren druid height in Thunder Bluff —
  user-verified in-game
  - [ ] Bat hunter pet renders dwarf-sized next to owner (parity with Wowhead vanilla reference
  pending in-world repro
  - [x] Build clean on .NET 10
  - [x] Pet diagnostic `unit.pet_scale.applied` now emits `family: "hunter-bat"` for matched units so future bundles
  confirm detection
