### PR TITLE
JimsPlus Tooltip: stop recoloring slot/hand lines red

### DIFF
--- a/Addons/JimsPlus/TooltipFix.lua
+++ b/Addons/JimsPlus/TooltipFix.lua
@@ -478,17 +478,23 @@ local function ApplyTooltipFeatures(tooltip, link)
         else
             subclassNames = SUBCLASS_TOOLTIP_NAMES.weapon[subClassId]
         end
-        -- Build candidate list: subclass display names + the equip-loc
-        -- display string (e.g. "Two-Hand" for INVTYPE_2HWEAPON, "Feet"
-        -- for INVTYPE_FEET) so the slot/hand line on the left recolors
-        -- alongside the subclass line on the right.
+        -- Build candidate list: subclass display names ONLY. We deliberately
+        -- skip the equip-loc string (e.g. "Two-Hand", "Finger", "Waist",
+        -- "Main Hand") — slot/hand lines have no proficiency relationship:
+        -- everyone can wear a ring, everyone can equip an offhand slot, and
+        -- one-hand weapons are the same hand-type regardless of weapon
+        -- subclass. The "you can't use this" signal lives entirely on the
+        -- subclass line (Sword/Mace/Leather/Plate/etc.), so that's the only
+        -- line we recolor.
+        --
+        -- Bonus side-effect: items whose subclass has no SUBCLASS_TOOLTIP_NAMES
+        -- entry (Fishing Poles subClass 20, Miscellaneous subClass 14 for
+        -- Mining Picks / Blacksmith Hammers / similar profession tools) now
+        -- get an empty candidate list and no recolor — which is the desired
+        -- behavior since those items have no proficiency requirement.
         local candidateNames = {}
         if subclassNames then
             for _, n in ipairs(subclassNames) do table.insert(candidateNames, n) end
-        end
-        local equipLocStr = equipLoc and _G[equipLoc]
-        if equipLocStr and equipLocStr ~= "" then
-            table.insert(candidateNames, equipLocStr)
         end
         if #candidateNames > 0 then
             -- Tooltip type-line color reflects ONLY proficiency, not level.


### PR DESCRIPTION
Removed the equipLoc append in ApplyTooltipFeatures so candidateNames contains only the proficiency-bearing subclass names (Sword/Mace/ Leather/Plate/etc.). Slot lines (Head, Chest, Waist, Legs, Feet, Hands, Wrist, Shoulder, Finger, Trinket, Back, Tabard, Shirt) and hand lines (Main Hand, Off Hand, One-Hand, Two-Hand) never reflect proficiency in WoW and shouldn't be recolored — only the subclass line carries the off-class signal.

Bonus side effect: items whose subclass has no SUBCLASS_TOOLTIP_NAMES entry — Fishing Poles (subClass 20), Miscellaneous tools like Mining Picks and Blacksmith Hammers (subClass 14) — now produce an empty candidate list and aren't recolored at all, which is correct since these items have no class proficiency requirement.

User-reported cases this fixes:
- Apprentice's Shirt: "Shirt" no longer red
- Defias Renegade Ring: "Finger" no longer red
- Rawhide Belt: "Waist" no longer red (Leather still red if off-class)
- Canne à pêche (Fishing Pole): "Deux mains" no longer red
- Pioche de mineur (Miner's Pick): "Main droite" no longer red
- Notched Shortsword: "À une main" no longer red (Épées still red if off-class)
- Off-hand items: "Off Hand" no longer red