### PR TITLE
Fix/spell go phantom misscount

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1633,6 +1633,54 @@ public partial class WorldClient
             }
 
             var missCount = packet.ReadUInt8();
+            // Vanilla TC-1.12 forks (Kronos) emit an extra uint8 between the hit
+            // section and targetFlags that the proxy reads as missCount. Treating
+            // it as a real miss target sends the parser into a bogus 8-byte GUID +
+            // missType read, shredding alignment and overrunning the Vector3 in
+            // target data — which #180 catches but then drains the player's active
+            // cast queue, making their cast bar vanish mid-cast.
+            // The phantom byte varies (0x01, 0x03 observed). Detect it by either:
+            //  (a) the would-be missType peek lands on an invalid value (>Reflect=11), OR
+            //  (b) missCount demands more bytes than the packet can possibly hold —
+            //      a real server never claims more misses than data.
+            // Real misses (vmangos-style) have a valid missType and fit the packet.
+            if (missCount > 0)
+            {
+                bool isPhantom = false;
+                string phantomReason = "";
+
+                if (missCount * 9 > packet.BytesRemaining)
+                {
+                    isPhantom = true;
+                    phantomReason = "overrun";
+                }
+                else
+                {
+                    packet.Skip(8); // past would-be miss GUID
+                    byte peekMissType = packet.ReadUInt8();
+                    packet.Skip(-9); // rewind to start of miss section
+                    if (peekMissType > (byte)SpellMissInfo.Reflect)
+                    {
+                        isPhantom = true;
+                        phantomReason = $"invalid_misstype_{peekMissType}";
+                    }
+                }
+
+                if (isPhantom)
+                {
+                    Log.Event("spell.spell_go.phantom_misscount_skipped", new
+                    {
+                        spell_id = dbdata.SpellID,
+                        misscount_byte = missCount,
+                        reason = phantomReason,
+                        cast_flags = dbdata.CastFlags,
+                        hit_count = hitCount,
+                        bytes_remaining = packet.BytesRemaining,
+                    });
+                    missCount = 0;
+                }
+            }
+
             // Same bounds check for miss-target loop. Floor 9 bytes per entry (GUID +
             // missType byte); reflect adds an optional byte, so 9 * missCount is the
             // minimum. Underestimating is fine — individual reads still succeed up to

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1644,7 +1644,10 @@ public partial class WorldClient
             //  (b) missCount demands more bytes than the packet can possibly hold —
             //      a real server never claims more misses than data.
             // Real misses (vmangos-style) have a valid missType and fit the packet.
-            if (missCount > 0)
+            // Gated to vanilla only: TBC+ uses uint32 targetFlags and a different trailer
+            // alignment, so the heuristic's invariants don't translate cleanly and could
+            // mask unrelated parse drift instead of throwing.
+            if (missCount > 0 && LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
             {
                 bool isPhantom = false;
                 string phantomReason = "";


### PR DESCRIPTION
 ## Summary
  - TC-1.12 forks (Kronos) emit an extra `uint8` between the hit section and `targetFlags` in `SMSG_SPELL_GO` that
  vmangos does not. The proxy reads it as `missCount`, then parses a non-existent miss entry, which shreds alignment and
   overruns `ReadVector3` in target data.
  - `#180`'s try/catch caught the crash (preventing DC), but its orphan-cast drain cancels the player's active cast —
  **user-visible regression in v5.1.3-beta.2: cast bar vanishes mid-cast near Bloodscalp Witch Doctor and WSG enemy
  shamans** 
  - This PR detects the phantom byte and skips it. Heuristic only fires when structural invariants real miss sections
  never violate are violated.

  ## Detection
  After `ReadUInt8 missCount`, treat as phantom when EITHER:
  - `missCount * 9 > BytesRemaining` (real server never declares more misses than data), OR
  - Peek of would-be missType byte > `SpellMissInfo.Reflect` (11)

  Gated to `LegacyVersion.RemovedInVersion(V2_0_1_6180)` so TBC+ fall through to existing #216 overrun check unchanged.

  The phantom byte value varies (0x01, 0x03 observed) — its identity in TC-1.12 wire format is still unknown. Once
  mapped via Kronos source or 1.12 client disassembly, the heuristic should be replaced with a labeled named-field read.

  ## Field test (60 pally, STV Bloodscalp coast)

  | | spell.parse_failed | queue_drained | phantom_misscount_skipped |
  |---|---:|---:|---:|
  | **Before** | 16 | 2 (= 2 cast bar drops) | n/a |
  | **After**  | 0 | 0 | 27 |

  Cast bars complete cleanly. Both heuristic branches exercised (`reason: "overrun"` and `reason:
  "invalid_misstype_48"`).

  ## Test plan
  - [x] STV totem-mob repro on Kronos — 27/27 caught, zero crashes, zero orphans
  - [ ] WSG enemy shaman Earth Shock (1152) — shares trailer structure, expected to resolve
  - [ ] Witch Doctor Lightning Shield (8377) — same expected outcome
  - [ ] vmangos regression check — real misses pass both invariants, unchanged behavior

  ## Known limitation (documented in commit)
  Rare false-negative possible when phantom byte happens to be small (≤ BytesRemaining/9) AND the peek-at-+8 byte lands
  in a Vector3 mantissa range (0-11). In that case the parser still overruns and #180's existing safety net catches it —
   same symptom as pre-fix, just rare. Estimated <5% on player-target AoE scenarios; zero on creature casters (peek
  always lands on `0x30`).