### PR TITLE
Fix/quest objective progress alignment

### DIFF
--- a/HermesProxy.Tests/World/QuestObjectiveLayoutTests.cs
+++ b/HermesProxy.Tests/World/QuestObjectiveLayoutTests.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Static simulator for vmangos's PLAYER_QUEST_LOG_X_2 bit-packing and the proxy's
+// modern-client StorageIndex assignment. Pins the algorithm in CI and demonstrates
+// the two bug classes that motivated commits 6d5e64b (StorageIndex=absolute slot)
+// and 9b88b91 (item-objective overlay):
+//
+//   1. SLOT-GAP bug — vmangos credits counters at the ABSOLUTE slot index in
+//      ReqCreatureOrGOId[0..3] (Player.cpp::SendQuestUpdateAddCreatureOrGo). If
+//      that array has a zero gap, the old proxy code's compressed StorageIndex
+//      mis-aligns the modern client's ObjectiveProgress[StorageIndex] lookup by
+//      one slot per gap. Repro: quest 905 "The Angry Scytheclaws", quest 877
+//      "The Stagnant Oasis".
+//
+//   2. ITEM-SIDECAR bug — vmangos writes item-objective counters to a DIFFERENT
+//      log slot (slot + GOcount, Player.cpp::SendQuestUpdateAddItem). The modern
+//      client can't read that, so the item objective renders at 0/N even after
+//      the player has collected enough to be server-completable. Repro: quest
+//      358 "Graverobbers", quest 891 "The Guns of Northwatch".
+//
+// Each [Theory] case mirrors a real or hypothetical Twinstar quest_template
+// layout. If the simulator says "BEFORE" produces a 0/N render at a given
+// objective AND the tester reports that exact symptom, the diagnosis is
+// conclusive. Run the new ones via `dotnet test --filter QuestObjectiveLayout`
+// when a future quest report comes in.
+public class QuestObjectiveLayoutTests
+{
+    // vmangos Player.h::SetQuestSlotCounter: val |= ((uint32)count << (counter * 6))
+    // 4 x 6-bit counters in bits 0..23, 8-bit state in bits 24..31.
+    public static uint PackQuestLogX2(int[] counters, byte state = 0)
+    {
+        uint v = 0;
+        for (int i = 0; i < counters.Length && i < 4; i++)
+            v |= ((uint)counters[i] & 0x3Fu) << (i * 6);
+        v |= ((uint)state) << 24;
+        return v;
+    }
+
+    public static (int[] Counters, byte State) UnpackQuestLogX2(uint v)
+    {
+        var counters = new int[4];
+        for (int i = 0; i < 4; i++)
+            counters[i] = (int)((v >> (i * 6)) & 0x3Fu);
+        return (counters, (byte)((v >> 24) & 0xFFu));
+    }
+
+    public record struct Objective(string Kind, int WireSlot, int StorageIndex, int TargetId);
+
+    // Mirrors QueryHandler.HandleQueryQuestInfoResponse storage-index assignment.
+    // applyFix = false reproduces the pre-6d5e64b compressed objectiveCounter++.
+    // applyFix = true reproduces the post-6d5e64b absolute-slot assignment for GO/Monster.
+    public static List<Objective> BuildModernTemplate(int[] reqCreatureOrGoId, int[] reqItemId, bool applyFix)
+    {
+        var result = new List<Objective>();
+        int objectiveCounter = 0;
+        for (int i = 0; i < 4 && i < reqCreatureOrGoId.Length; i++)
+        {
+            if (reqCreatureOrGoId[i] == 0)
+                continue;
+            int storageIndex;
+            if (applyFix)
+            {
+                storageIndex = i;
+                if (objectiveCounter < i + 1)
+                    objectiveCounter = i + 1;
+            }
+            else
+            {
+                storageIndex = objectiveCounter++;
+            }
+            result.Add(new Objective("GO", i, storageIndex, reqCreatureOrGoId[i]));
+        }
+        for (int i = 0; i < reqItemId.Length; i++)
+        {
+            if (reqItemId[i] == 0)
+                continue;
+            result.Add(new Objective("Item", i, objectiveCounter++, reqItemId[i]));
+        }
+        return result;
+    }
+
+    // Mirrors ReadQuestLogEntry's modern-side rendering: ObjectiveProgress[StorageIndex] is
+    // read from the unpacked bit-pack counters, with the item-overlay layered on top when
+    // overlay is non-empty (post-9b88b91 behavior). overlay key = StorageIndex.
+    public static int RenderObjective(Objective obj, int[] counters, IReadOnlyDictionary<int, int>? itemOverlay)
+    {
+        if (obj.Kind == "Item" && itemOverlay != null && itemOverlay.TryGetValue(obj.StorageIndex, out int ov))
+            return ov;
+        if (obj.StorageIndex >= 0 && obj.StorageIndex < counters.Length)
+            return counters[obj.StorageIndex];
+        return 0;
+    }
+
+    // Helper: compute counters[] the way vmangos's SetQuestSlotCounter writes them when
+    // CastedCreatureOrGO/KilledMonsterCredit fire. Item-sidecar counters are NOT placed
+    // in this quest's log slot — they go to slot+GOcount, which the modern client can't
+    // resolve back to this quest, so we leave them out (that's the BEFORE state).
+    public static int[] CreditCounters(int[] reqCreatureOrGoId, IReadOnlyDictionary<int, int> kills)
+    {
+        var counters = new int[4];
+        for (int i = 0; i < reqCreatureOrGoId.Length && i < 4; i++)
+        {
+            if (reqCreatureOrGoId[i] != 0 && kills.TryGetValue(reqCreatureOrGoId[i], out int n))
+                counters[i] = n;
+        }
+        return counters;
+    }
+
+    // === Quest 905 "The Angry Scytheclaws" — slot-0 gap, the original 6d5e64b repro ===
+    // Tester observation: Blue Raptor Nest stuck at 0/1 while quest is server-completable.
+
+    [Fact]
+    public void Quest905_SlotZeroGap_BeforeFix_BlueShows0Of1()
+    {
+        var go = new[] { 0, -6907, -6908, -6906 }; // Blue, Yellow, Red at slots 1/2/3
+        var counters = CreditCounters(go, new Dictionary<int, int> { [-6907] = 1, [-6908] = 1, [-6906] = 1 });
+        Assert.Equal(new[] { 0, 1, 1, 1 }, counters);
+
+        var template = BuildModernTemplate(go, new[] { 0, 0, 0, 0 }, applyFix: false);
+        var blue = template.Find(o => o.TargetId == -6907);
+        Assert.Equal(0, blue.StorageIndex); // compressed → 0, points at the empty counter[0]
+        Assert.Equal(0, RenderObjective(blue, counters, null)); // VISIBLE BUG
+    }
+
+    [Fact]
+    public void Quest905_SlotZeroGap_AfterFix_AllRender1()
+    {
+        var go = new[] { 0, -6907, -6908, -6906 };
+        var counters = CreditCounters(go, new Dictionary<int, int> { [-6907] = 1, [-6908] = 1, [-6906] = 1 });
+
+        var template = BuildModernTemplate(go, new[] { 0, 0, 0, 0 }, applyFix: true);
+        foreach (var obj in template)
+            Assert.Equal(1, RenderObjective(obj, counters, null));
+    }
+
+    // === Quest 358 "Graverobbers" — contiguous GO + item sidecar ===
+    // Tester observation: kills fine, Embalming Ichor stuck at 0/8 (quest still turn-in-able).
+
+    [Fact]
+    public void Quest358_ItemSidecar_BeforeFix_IchorShows0()
+    {
+        var go = new[] { 1941, 1675, 0, 0 }; // Graverobber, Mongrel
+        var items = new[] { 2834, 0, 0, 0 }; // Ichor
+        var counters = CreditCounters(go, new Dictionary<int, int> { [1941] = 8, [1675] = 5 });
+        Assert.Equal(new[] { 8, 5, 0, 0 }, counters);
+
+        var template = BuildModernTemplate(go, items, applyFix: false);
+        var ichor = template.Find(o => o.Kind == "Item" && o.TargetId == 2834);
+        Assert.Equal(2, ichor.StorageIndex); // compressed slot after the 2 GOs
+        Assert.Equal(0, RenderObjective(ichor, counters, null)); // VISIBLE BUG
+    }
+
+    [Fact]
+    public void Quest358_ItemSidecar_AfterFix_IchorShows8FromOverlay()
+    {
+        var go = new[] { 1941, 1675, 0, 0 };
+        var items = new[] { 2834, 0, 0, 0 };
+        var counters = CreditCounters(go, new Dictionary<int, int> { [1941] = 8, [1675] = 5 });
+
+        var template = BuildModernTemplate(go, items, applyFix: true);
+        var ichor = template.Find(o => o.Kind == "Item" && o.TargetId == 2834);
+        var overlay = new Dictionary<int, int> { [ichor.StorageIndex] = 8 }; // proxy walks inventory: 8 Ichor
+        Assert.Equal(8, RenderObjective(ichor, counters, overlay));
+    }
+
+    // === Quest 877 "The Stagnant Oasis" — single GO, slot-3 gap explains the report ===
+    // Tester observation: "Test the Dried Seeds" stuck at 0/1.
+
+    [Fact]
+    public void Quest877_SlotThreeGap_BeforeFix_GoShows0Of1()
+    {
+        var go = new[] { 0, 0, 0, 3737 }; // Dried Seeds GO at slot 3
+        var counters = CreditCounters(go, new Dictionary<int, int> { [3737] = 1 });
+        Assert.Equal(new[] { 0, 0, 0, 1 }, counters);
+
+        var template = BuildModernTemplate(go, new[] { 0, 0, 0, 0 }, applyFix: false);
+        var seeds = template.Find(o => o.TargetId == 3737);
+        Assert.Equal(0, seeds.StorageIndex); // compressed
+        Assert.Equal(0, RenderObjective(seeds, counters, null)); // VISIBLE BUG
+    }
+
+    [Fact]
+    public void Quest877_SlotThreeGap_AfterFix_GoShows1()
+    {
+        var go = new[] { 0, 0, 0, 3737 };
+        var counters = CreditCounters(go, new Dictionary<int, int> { [3737] = 1 });
+
+        var template = BuildModernTemplate(go, new[] { 0, 0, 0, 0 }, applyFix: true);
+        var seeds = template.Find(o => o.TargetId == 3737);
+        Assert.Equal(3, seeds.StorageIndex);
+        Assert.Equal(1, RenderObjective(seeds, counters, null));
+    }
+
+    [Fact]
+    public void Quest877_NoGap_BothBehaviorsRenderCorrectly()
+    {
+        // Sanity: if Twinstar's data didn't have a gap, neither fix would change behavior.
+        var go = new[] { 3737, 0, 0, 0 };
+        var counters = CreditCounters(go, new Dictionary<int, int> { [3737] = 1 });
+
+        var pre = BuildModernTemplate(go, new[] { 0, 0, 0, 0 }, applyFix: false);
+        var post = BuildModernTemplate(go, new[] { 0, 0, 0, 0 }, applyFix: true);
+        Assert.Equal(1, RenderObjective(pre[0], counters, null));
+        Assert.Equal(1, RenderObjective(post[0], counters, null));
+    }
+
+    // === Quest 891 "The Guns of Northwatch" — 3 named kills + item sidecar ===
+    // Tester observation: medals stuck at 0/10. Same shape as 358.
+
+    [Fact]
+    public void Quest891_Contiguous_BeforeFix_MedalsShow0()
+    {
+        var go = new[] { 3393, 3455, 3454, 0 }; // Fairmount, Whessan, Smythe
+        var items = new[] { 5078, 0, 0, 0 }; // Theramore Medal x10
+        var counters = CreditCounters(go, new Dictionary<int, int> { [3393] = 1, [3455] = 1, [3454] = 1 });
+        Assert.Equal(new[] { 1, 1, 1, 0 }, counters);
+
+        var template = BuildModernTemplate(go, items, applyFix: false);
+        var medal = template.Find(o => o.Kind == "Item");
+        Assert.Equal(3, medal.StorageIndex);
+        Assert.Equal(0, RenderObjective(medal, counters, null)); // VISIBLE BUG
+    }
+
+    [Fact]
+    public void Quest891_Contiguous_AfterFix_MedalsShow10FromOverlay()
+    {
+        var go = new[] { 3393, 3455, 3454, 0 };
+        var items = new[] { 5078, 0, 0, 0 };
+        var counters = CreditCounters(go, new Dictionary<int, int> { [3393] = 1, [3455] = 1, [3454] = 1 });
+
+        var template = BuildModernTemplate(go, items, applyFix: true);
+        var medal = template.Find(o => o.Kind == "Item");
+        var overlay = new Dictionary<int, int> { [medal.StorageIndex] = 10 };
+        Assert.Equal(10, RenderObjective(medal, counters, overlay));
+        // GO objectives still render correctly under absolute-slot assignment.
+        foreach (var obj in template)
+            if (obj.Kind == "GO")
+                Assert.Equal(1, RenderObjective(obj, counters, null));
+    }
+
+    // === Bit-pack round-trip — proves vmangos's 6-bit layout matches the proxy unpack ===
+
+    [Theory]
+    [InlineData(new[] { 0, 0, 0, 0 }, 0, 0x00000000u)]
+    [InlineData(new[] { 1, 1, 1, 0 }, 0, 0x00001041u)]   // Quest 891 contiguous after all 3 kills
+    [InlineData(new[] { 0, 1, 1, 1 }, 0, 0x00041040u)]   // Quest 905 slot-0 gap, all credited
+    [InlineData(new[] { 8, 5, 0, 0 }, 0, 0x00000148u)]   // Quest 358 kill counts only
+    [InlineData(new[] { 0, 0, 0, 1 }, 0, 0x00040000u)]   // Quest 877 slot-3 gap
+    [InlineData(new[] { 63, 63, 63, 63 }, 1, 0x01FFFFFFu)] // max counter values + state byte
+    public void PackUnpack_RoundTripsCorrectly(int[] counters, byte state, uint expectedPacked)
+    {
+        uint packed = PackQuestLogX2(counters, state);
+        Assert.Equal(expectedPacked, packed);
+
+        var (unpackedCounters, unpackedState) = UnpackQuestLogX2(packed);
+        Assert.Equal(counters, unpackedCounters);
+        Assert.Equal(state, unpackedState);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -149,6 +149,14 @@ public sealed class GameSessionData
     // so we always send a valid family, cleared only on explicit pet dismiss.
     public ConcurrentDictionary<WowGuid128, ushort> CachedPetCreatureFamily = new();
     public Dictionary<uint, WowGuid128> CachedPetNumbers = new();
+    // Tracks quest ids the proxy has issued its own CMSG_QUERY_QUEST_INFO for.
+    // The 1.14 client caches quest templates in WDB and will not re-query for
+    // quests it already knows, so SMSG_QUERY_QUEST_INFO_RESPONSE never reaches
+    // the proxy and the QuestTemplate stays empty. That breaks the item-objective
+    // overlay in ReadQuestLogEntry (no template = no item objectives to overlay).
+    // We proactively query on first sight of any quest in the player's log
+    // without a cached template; this set prevents spamming.
+    public HashSet<uint> ProxyIssuedQuestInfoQueries = new();
     public string LeftChannelName = "";
     public bool IsPassingOnLoot;
     public int GroupUpdateCounter;
@@ -594,6 +602,82 @@ public sealed class GameSessionData
     {
         uint count = GetLegacyFieldValueUInt32(itemGuid, ItemField.ITEM_FIELD_STACK_COUNT);
         return count > 0 ? count : 1;
+    }
+    //MIRASU - count all instances of itemEntry across equipped + backpack + bag contents.
+    //MIRASU   Mirrors vmangos Player::GetItemCount(item, /*inBankAlso=*/false). Used as a
+    //MIRASU   fallback for quest item-objective progress when the proxy hasn't yet seen a
+    //MIRASU   SMSG_QUEST_UPDATE_ADD_ITEM credit (typical case: player relogs mid-quest with
+    //MIRASU   the item already in inventory; vmangos writes item counters to slot+GOcount
+    //MIRASU   in PLAYER_QUEST_LOG, which is unreadable by the modern client because that
+    //MIRASU   "extra" log slot belongs to a different quest in vanilla's allocation scheme,
+    //MIRASU   so the modern client renders item objectives at 0/N until we synthesize the
+    //MIRASU   count ourselves).
+    public uint CountItemsByEntry(uint itemEntry)
+    {
+        if (itemEntry == 0)
+            return 0;
+
+        uint total = 0;
+        int objectFieldEntry = LegacyVersion.GetUpdateField(ObjectField.OBJECT_FIELD_ENTRY);
+        if (objectFieldEntry < 0)
+            return 0;
+
+        //MIRASU - equipped slots 0..18 + backpack 23..38. Skip the bag slots themselves
+        //MIRASU   (19..22) — we iterate their contents in the separate loop below.
+        for (int slot = 0; slot < World.Enums.Vanilla.InventorySlots.ItemEnd; slot++)
+        {
+            if (slot >= World.Enums.Vanilla.InventorySlots.BagStart && slot < World.Enums.Vanilla.InventorySlots.BagEnd)
+                continue;
+
+            var itemGuid64 = GetInventorySlotItem(slot);
+            if (itemGuid64 == WowGuid64.Empty)
+                continue;
+
+            var itemGuid128 = itemGuid64.To128(this);
+            var itemFields = GetCachedObjectFieldsLegacy(itemGuid128);
+            if (itemFields == null)
+                continue;
+
+            if (itemFields.TryGetValue(objectFieldEntry, out var entryVal) && entryVal.UInt32Value == itemEntry)
+                total += GetItemStackCount(itemGuid128);
+        }
+
+        int containerSlotField = LegacyVersion.GetUpdateField(ContainerField.CONTAINER_FIELD_SLOT_1);
+        int numSlotsField = LegacyVersion.GetUpdateField(ContainerField.CONTAINER_FIELD_NUM_SLOTS);
+        if (containerSlotField < 0 || numSlotsField < 0)
+            return total;
+
+        for (int bagIdx = World.Enums.Vanilla.InventorySlots.BagStart; bagIdx < World.Enums.Vanilla.InventorySlots.BagEnd; bagIdx++)
+        {
+            var bagGuid64 = GetInventorySlotItem(bagIdx);
+            if (bagGuid64 == WowGuid64.Empty)
+                continue;
+
+            var bagGuid128 = bagGuid64.To128(this);
+            var bagFields = GetCachedObjectFieldsLegacy(bagGuid128);
+            if (bagFields == null)
+                continue;
+            if (!bagFields.TryGetValue(numSlotsField, out var numSlotsValue))
+                continue;
+            int numSlots = (int)numSlotsValue.UInt32Value;
+
+            for (int s = 0; s < numSlots; s++)
+            {
+                var slotGuid64 = bagFields.GetGuidValue(containerSlotField + s * 2);
+                if (slotGuid64 == WowGuid64.Empty)
+                    continue;
+
+                var slotGuid128 = slotGuid64.To128(this);
+                var slotFields = GetCachedObjectFieldsLegacy(slotGuid128);
+                if (slotFields == null)
+                    continue;
+
+                if (slotFields.TryGetValue(objectFieldEntry, out var entryVal) && entryVal.UInt32Value == itemEntry)
+                    total += GetItemStackCount(slotGuid128);
+            }
+        }
+
+        return total;
     }
     public (byte containerSlot, byte slot)? FindItemInInventory(WowGuid64 itemGuid64)
     {

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -301,6 +301,38 @@ public partial class WorldClient
         //MIRASU   can now resolve their QuestObjective. Replay them so the over-head toast doesn't
         //MIRASU   drop the first pickup of an unfamiliar quest item (off-by-1 bug).
         ReplayPendingQuestItemCredits();
+
+        // Re-emit the player's quest log entry for this quest so the modern client
+        // re-renders ObjectiveProgress with the now-resolvable item-objective overlay
+        // applied (see ReadQuestLogEntry's item-overlay block). Without this re-emit,
+        // a proxy-issued CMSG_QUERY_QUEST_INFO during login (UpdateHandler's quest
+        // log walk) populates the template *after* the initial OBJECT_UPDATE has
+        // already been serialized to the modern client at 0/N, leaving the visual
+        // permanently stale until some unrelated event triggers another quest log
+        // field update. Only re-emit when the quest actually has item objectives —
+        // pure-kill quests don't need this round-trip.
+        if (quest.Objectives.Exists(o => o.Type == QuestObjectiveType.Item))
+        {
+            var playerGuid = GetSession().GameState.CurrentPlayerGuid;
+            var playerFields = GetSession().GameState.GetCachedObjectFieldsLegacy(playerGuid);
+            if (playerFields != null)
+            {
+                int questLogSize = LegacyVersion.GetQuestLogSize();
+                for (int slot = 0; slot < questLogSize; slot++)
+                {
+                    var logEntry = ReadQuestLogEntry(slot, null, playerFields);
+                    if (logEntry == null || logEntry.QuestID != response.QuestID)
+                        continue;
+
+                    ObjectUpdate refresh = new ObjectUpdate(playerGuid, UpdateTypeModern.Values, GetSession());
+                    refresh.PlayerData.QuestLog[slot] = logEntry;
+                    UpdateObject refreshPacket = new UpdateObject(GetSession().GameState);
+                    refreshPacket.ObjectUpdates.Add(refresh);
+                    SendPacketToClient(refreshPacket);
+                    break;
+                }
+            }
+        }
     }
 
     [PacketHandler(Opcode.SMSG_QUERY_CREATURE_RESPONSE)]

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -194,14 +194,27 @@ public partial class WorldClient
 
             if (creatureOrGoId != 0 && creatureOrGoAmount != 0)
             {
+                // StorageIndex must equal the vanilla server's counter index, which is the
+                // ABSOLUTE slot 'i' in ReqCreatureOrGOId[0..3] — vmangos credits via
+                // SetQuestSlotCounter(slot, creatureOrGO_idx, count) where creatureOrGO_idx
+                // is this loop's 'i' (Player.cpp::SendQuestUpdateAddCreatureOrGo). The
+                // modern client reads ObjectiveProgress[StorageIndex] for progress, so if
+                // we compressed via objectiveCounter++ it would mis-align whenever
+                // ReqCreatureOrGOId has a zero gap (e.g. Twinstar quest #905 "The Angry
+                // Scytheclaws" — slot 0 is empty, Blue/Yellow/Red at slots 1/2/3 — the
+                // unticked counter[0] showed under whichever objective got compressed
+                // StorageIndex 0, leaving Blue Raptor Nest perpetually 0/1 in the modern
+                // client even though the quest was server-completable).
                 QuestObjective objective = new QuestObjective();
                 objective.QuestID = response.QuestID;
                 objective.Id = QuestObjective.QuestObjectiveCounter++;
-                objective.StorageIndex = objectiveCounter++;
+                objective.StorageIndex = (sbyte)i;
                 objective.Type = isGo ? QuestObjectiveType.GameObject : QuestObjectiveType.Monster;
                 objective.ObjectID = creatureOrGoId;
                 objective.Amount = creatureOrGoAmount;
                 quest.Objectives.Add(objective);
+                if (objectiveCounter < i + 1)
+                    objectiveCounter = (sbyte)(i + 1);
             }
 
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
@@ -244,8 +257,30 @@ public partial class WorldClient
         for (int i = 0; i < 4; i++)
         {
             string objectiveText = packet.ReadCString();
-            if (quest.Objectives.Count > i)
-                quest.Objectives[i].Description = objectiveText;
+            if (string.IsNullOrEmpty(objectiveText))
+                continue;
+            // ObjectiveText[i] is keyed by ABSOLUTE wire slot in vmangos
+            // (Quest.cpp::QuestQueryResponse::AppendBodyTo), matching ReqCreatureOrGOId[i].
+            // With the StorageIndex=i alignment above, the description for slot i belongs
+            // to whichever objective sits at StorageIndex == i (GO/Monster objectives
+            // only — item/rep objectives keep their compressed StorageIndex). Falling
+            // back to creation order only when no matching slot exists preserves
+            // pre-existing behavior for non-GO objectives.
+            QuestObjective? match = null;
+            for (int oi = 0; oi < quest.Objectives.Count; oi++)
+            {
+                var obj = quest.Objectives[oi];
+                if (obj.StorageIndex == i &&
+                    (obj.Type == QuestObjectiveType.GameObject || obj.Type == QuestObjectiveType.Monster))
+                {
+                    match = obj;
+                    break;
+                }
+            }
+            if (match == null && quest.Objectives.Count > i)
+                match = quest.Objectives[i];
+            if (match != null)
+                match.Description = objectiveText;
         }
 
         // Placeholders

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1246,6 +1246,53 @@ public partial class WorldClient
             questLog.EndTime = updates[index + timerOffset].UInt32Value;
         }
 
+        if (questLog != null && questLog.QuestID != null && questLog.QuestID != 0)
+        {
+            // Overlay item-objective progress that vmangos never makes available via this
+            // log slot. vmangos's SendQuestUpdateAddItem writes item counters to
+            // SetQuestSlotCounter(slot + GOcount, item_idx, count) — a DIFFERENT log slot
+            // than the quest occupies (Player.cpp:14583-14586). In vanilla 1.12 the native
+            // client recomputes item progress from inventory so the misrouted counter
+            // doesn't matter, but the modern 1.14 client trusts the ObjectiveProgress array
+            // verbatim — so without this overlay, mixed-objective quests like #358
+            // "Graverobbers" (2 kills + Embalming Ichor x8) render the item objective
+            // perpetually at 0/N even when the server allows turn-in via its separate
+            // m_itemcount[] tracking. Preference order: proxy's running-total dict (kept in
+            // sync by SMSG_QUEST_UPDATE_ADD_ITEM) → inventory count fallback (mirrors what
+            // vmangos's GetItemCount() returns for the same input).
+            var template = GameData.GetQuestTemplate((uint)questLog.QuestID);
+            if (template != null)
+            {
+                var itemProgress = GetSession().GameState.QuestItemObjectiveProgress;
+                foreach (var obj in template.Objectives)
+                {
+                    if (obj.Type != QuestObjectiveType.Item)
+                        continue;
+                    if (obj.StorageIndex < 0 || obj.StorageIndex >= questLog.ObjectiveProgress.Length)
+                        continue;
+
+                    uint resolved = 0;
+                    bool fromDict = false;
+                    var key = ((uint)questLog.QuestID, obj.StorageIndex);
+                    if (itemProgress.TryGetValue(key, out uint dictCount))
+                    {
+                        resolved = dictCount;
+                        fromDict = true;
+                    }
+                    else if (obj.ObjectID > 0)
+                    {
+                        resolved = GetSession().GameState.CountItemsByEntry((uint)obj.ObjectID);
+                    }
+
+                    if (resolved > 0 || fromDict)
+                    {
+                        short clamped = (short)Math.Min(resolved, (uint)(obj.Amount > 0 ? obj.Amount : (int)resolved));
+                        questLog.ObjectiveProgress[obj.StorageIndex] = clamped;
+                    }
+                }
+            }
+        }
+
         return questLog;
     }
 
@@ -2751,7 +2798,29 @@ public partial class WorldClient
                 int questsCount = LegacyVersion.GetQuestLogSize();
                 for (int i = 0; i < questsCount; i++)
                 {
-                    updateData.PlayerData.QuestLog[i] = ReadQuestLogEntry(i, updateMaskArray, updates)!;
+                    var entry = ReadQuestLogEntry(i, updateMaskArray, updates)!;
+                    updateData.PlayerData.QuestLog[i] = entry;
+
+                    // Proactive template query for quests in the log without a cached
+                    // template (mirrors the pet-scale CMSG_QUERY_CREATURE path). The 1.14
+                    // client caches quest templates in WDB and will not re-query for
+                    // quests it already knows, so ReadQuestLogEntry's item-objective
+                    // overlay can't populate ObjectiveProgress[item_storage] without the
+                    // template. Without this, mixed-objective quests (e.g. #358
+                    // "Graverobbers" — 2 kills + Embalming Ichor x8) render the item
+                    // objective at 0/N on the modern client even though the server
+                    // permits turn-in. The response will land in QueryHandler, populate
+                    // the template, and the next OBJECT_UPDATE for the player (typically
+                    // any combat tick or quest-state change) will overlay the correct
+                    // item progress.
+                    if (entry != null && entry.QuestID != null && entry.QuestID > 0 &&
+                        GameData.GetQuestTemplate((uint)entry.QuestID) == null &&
+                        GetSession().GameState.ProxyIssuedQuestInfoQueries.Add((uint)entry.QuestID))
+                    {
+                        WorldPacket queryPacket = new WorldPacket(Opcode.CMSG_QUERY_QUEST_INFO);
+                        queryPacket.WriteUInt32((uint)entry.QuestID);
+                        SendPacketToServer(queryPacket);
+                    }
                 }
             }
             int PLAYER_CHOSEN_TITLE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_CHOSEN_TITLE);


### PR DESCRIPTION
## Summary

  Two coordinated fixes for `SMSG_QUERY_QUEST_INFO_RESPONSE` translation plus a refresh hook for the modern client's
  quest log. Resolves a tester-visible bug class where quest objectives stick at `0/N` in the 1.14 client while the
  vanilla server still permits turn-in.

  Static reasoning only (the four affected quests aren't repeatable). Cross-referenced against vmangos
  `Player.cpp:14613` (`SendQuestUpdateAddCreatureOrGo`), `Player.cpp:14583-14586` (`SendQuestUpdateAddItem`),
  `Quest.cpp:510-522` (`QueryResponse` serialization), and the proxy's own `ObjectiveProgress[StorageIndex]` lookup at
  `ItemHandler.cs:103` / `QuestHandler.cs:633`.

  ## Bug class 1 — slot-gap misalignment (StorageIndex)

  vmangos credits counters via `SetQuestSlotCounter(slot, creatureOrGO_idx, count)` keyed by the **absolute** index into
   `ReqCreatureOrGOId[0..3]`. The proxy was compressing zero entries via `objectiveCounter++` when building the modern
  template, mis-aligning each label by one slot per gap.

  Concrete repro — quest 905 "The Angry Scytheclaws" (Twinstar `ReqCreatureOrGOId = [0, -6907, -6908, -6906]`):
  - `PLAYER_QUEST_LOG_X_2 = 0x00041040` → counter[0]=0, [1..3]=1
  - Old: Blue rendered as `0/1` (compressed StorageIndex 0 reads the empty counter[0])
  - New: All three render `1/1`

  Tester observation: "Blue gets no visible count, can turn the quest in anyway."

  Also fixes 877 "The Stagnant Oasis" (single GO objective sitting in a non-zero slot).

  ## Bug class 2 — item-objective sidecar

  vmangos's `SendQuestUpdateAddItem` writes item counters to `SetQuestSlotCounter(slot + GOcount, item_idx, count)` — a
  **different** log slot than the quest's own. Vanilla 1.12 client recomputes item progress from inventory and doesn't
  care, but the 1.14 client trusts `ObjectiveProgress[StorageIndex]` verbatim → mixed-objective quests (kills +
  delivery) show `0/N` on the item objective forever.

  Three coordinated changes resolve it:

  1. **`GlobalSessionData.CountItemsByEntry`** — walks equipped + backpack + bag contents mirroring vmangos
  `Player::GetItemCount(item, false)`, so the proxy mirrors the server-side count without depending on the wire push.

  2. **`ReadQuestLogEntry` post-pass** — for every item-type objective in the cached template, overlay
  `ObjectiveProgress[StorageIndex]` from `QuestItemObjectiveProgress` (proxy's `SMSG_QUEST_UPDATE_ADD_ITEM` running
  total) first, falling back to `CountItemsByEntry` (typical relog-mid-quest case).

  3. **Proactive `CMSG_QUERY_QUEST_INFO`** — the 1.14 client caches templates in WDB and skips queries for known quests;
   without the template the overlay above can't know which objectives are item-type. Mirror the pet-scale first-sight
  pattern: when `ReadQuestLogEntry` sees a quest without a cached template, emit `CMSG_QUERY_QUEST_INFO` (gated by
  `ProxyIssuedQuestInfoQueries` against spam).

  4. **Synthetic re-emit on template arrival** — `HandleQueryQuestInfoResponse` builds a Values-update `ObjectUpdate`
  containing only the affected `QuestLog[slot]` entry, so the modern client re-renders with the now-applied overlay.
  Only fires when the quest has item objectives.

  Concrete repro — quest 358 "Graverobbers" (`ReqCreatureOrGOId = [1941, 1675, 0, 0]`, `ReqItemId = [2834, 0, 0, 0]`):
  - Old: Graverobber `8/8`, Mongrel `5/5`, **Embalming Ichor `0/8`** (sidecar)
  - New: All three render correctly; Ichor reads `8` from inventory walk

  Tester observation (verbatim): "this one is just visual bug (u can turn in at npc even if your quest log say youre not
   done)".

  Also fixes 891 "The Guns of Northwatch" (3 named kills + 10 Theramore Medals — same shape).

  ## Tests

  `HermesProxy.Tests/World/QuestObjectiveLayoutTests.cs` — 15 xUnit cases pinning both algorithms. Each fix has paired
  BEFORE/AFTER tests demonstrating the failing render and the corrected render. The bit-pack `[Theory]` validates the
  exact `PLAYER_QUEST_LOG_X_2` hex values for each scenario. Future quest-bug reports drop a new (`ReqCreatureOrGOId`,
  `ReqItemId`, kills, items) tuple into a new test case — output proves which fix applies (or flags a third bug class).