### PR TITLE
Feature/threat engine synth v2

### DIFF
--- a/HermesProxy.Tests/World/TalentThreatModifierTests.cs
+++ b/HermesProxy.Tests/World/TalentThreatModifierTests.cs
@@ -35,9 +35,12 @@ public class TalentThreatModifierTests
     // Rank-id arrays MUST match the constants in ThreatTracker.cs verbatim.
     // These are the spell IDs the proxy reads off the player's known-spells
     // set; changing them silently is the kind of bug only a tester catches.
-    private static readonly uint[] DefianceRanks      = { 12303, 12788, 12789, 12791, 12792 };
-    private static readonly uint[] FeralInstinctRanks = { 16947, 16948, 16949, 16950, 16951 };
-    private static readonly uint[] SilentResolveRanks = { 14523, 14784, 14785, 14786, 14787 };
+    private static readonly uint[] DefianceRanks         = { 12303, 12788, 12789, 12791, 12792 };
+    private static readonly uint[] FeralInstinctRanks    = { 16947, 16948, 16949, 16950, 16951 };
+    private static readonly uint[] SilentResolveRanks    = { 14523, 14784, 14785, 14786, 14787 };
+    private static readonly uint[] ShadowAffinityRanks   = { 15272, 15318, 15320 };
+    private static readonly uint[] DruidSubtletyRanks    = { 17118, 17119, 17120, 17121, 17122 };
+    private static readonly uint[] ImpRighteousFuryRanks = { 20468, 20469, 20470 };
 
     // === Rank detection: highest known rank wins ===
 
@@ -169,5 +172,138 @@ public class TalentThreatModifierTests
         int rank = 0;
         double mod = rank > 0 ? 1.0 - (0.04 * rank) : 1.0;
         Assert.Equal(1.0, mod);
+    }
+
+    // === Shadow Affinity: Priest, explicit per-rank array, shadow spells only ===
+    // LTC2 uses a hard-coded array, NOT a 1 - 0.08 * rank formula — rank 3 is
+    // 0.75 (steeper than the linear 0.76). Pin the exact values.
+
+    [Theory]
+    [InlineData(1, 0.92)]
+    [InlineData(2, 0.84)]
+    [InlineData(3, 0.75)]
+    public void ShadowAffinity_PerRank_LtcArrayValue(int rank, double expected)
+    {
+        double mod = rank switch { 1 => 0.92, 2 => 0.84, 3 => 0.75, _ => 1.0 };
+        Assert.Equal(expected, mod);
+    }
+
+    [Fact]
+    public void ShadowAffinityRanks_AreCanonical()
+    {
+        Assert.Equal(new uint[] { 15272, 15318, 15320 }, ShadowAffinityRanks);
+    }
+
+    [Fact]
+    public void ShadowAffinity_AppliesOnlyToShadowSpells_SmokeMembership()
+    {
+        // Spot-check a few spell-id memberships against the canonical set
+        // (transcribed from LTC2 ClassModules/Classic/Priest.lua). Catches
+        // accidental drift if the set is reshuffled.
+        var shadowSet = new HashSet<uint>
+        {
+            589, 594, 970, 992, 2767, 10892, 10893, 10894,
+            8092, 8102, 8103, 8104, 8105, 8106, 10945, 10946, 10947,
+            15407, 17311, 17312, 17313, 17314, 18807,
+            2944, 19276, 19277, 19278, 19279,
+            15286,
+        };
+        Assert.Contains(589u, shadowSet);        // SW:P R1
+        Assert.Contains(10947u, shadowSet);      // Mind Blast R9
+        Assert.Contains(18807u, shadowSet);      // Mind Flay R6
+        Assert.Contains(2944u, shadowSet);       // Devouring Plague R1
+        Assert.DoesNotContain(585u, shadowSet);  // Smite (holy) — not in set
+        Assert.DoesNotContain(8004u, shadowSet); // Lesser Heal — not in set
+    }
+
+    // === Druid Subtlety: Druid, -0.04/rank, Arcane/Nature damage only ===
+
+    [Theory]
+    [InlineData(1, 0.96)]
+    [InlineData(3, 0.88)]
+    [InlineData(5, 0.80)]
+    public void DruidSubtlety_PerRank_Multiplier(int rank, double expected)
+    {
+        double mod = 1.0 - (0.04 * rank);
+        Assert.Equal(expected, mod, precision: 4);
+    }
+
+    [Fact]
+    public void DruidSubtletyRanks_AreCanonical()
+    {
+        Assert.Equal(new uint[] { 17118, 17119, 17120, 17121, 17122 }, DruidSubtletyRanks);
+    }
+
+    [Fact]
+    public void DruidSubtlety_AppliesOnlyToArcaneNatureSpells_SmokeMembership()
+    {
+        var subtletySet = new HashSet<uint>
+        {
+            8921, 8924, 8925, 8926, 8927, 8928, 8929, 9833, 9834, 9835, // Moonfire
+            2912, 8949, 8950, 8951, 9875, 9876, 25298,                  // Starfire
+            5176, 5177, 5178, 6780, 8905, 9912,                         // Wrath
+            16914, 17401, 17402,                                         // Hurricane
+        };
+        Assert.Contains(8921u, subtletySet);       // Moonfire R1
+        Assert.Contains(25298u, subtletySet);      // Starfire R7
+        Assert.Contains(9912u, subtletySet);       // Wrath R6
+        Assert.DoesNotContain(6807u, subtletySet); // Maul (physical) — not in set
+        Assert.DoesNotContain(8042u, subtletySet); // Earth Shock (shaman) — not in set
+    }
+
+    // === Improved Righteous Fury: Paladin, requires RF aura active ===
+    // Formula: 1 + 0.6 * (1 + irfRanks[rank]) where irfRanks = {0.16, 0.33, 0.5}.
+    // No-IRF base value (rank 0) = 1.6 (RF alone). With IRF the multiplier scales
+    // up to 1.9 at rank 3. Off-baseline only triggers when RF is active.
+
+    [Theory]
+    [InlineData(0, 1.6)]   // RF active, no IRF
+    [InlineData(1, 1.696)] // IRF 1/3
+    [InlineData(2, 1.798)] // IRF 2/3
+    [InlineData(3, 1.9)]   // IRF 3/3
+    public void ImpRighteousFury_RankToMultiplier_WhenRFActive(int irfRank, double expected)
+    {
+        double irfBonus = irfRank switch { 1 => 0.16, 2 => 0.33, 3 => 0.50, _ => 0.0 };
+        double mod = 1.0 + 0.6 * (1.0 + irfBonus);
+        Assert.Equal(expected, mod, precision: 4);
+    }
+
+    [Fact]
+    public void ImpRighteousFury_RFInactive_NoMultiplier()
+    {
+        // Without RF aura, GetSpellTalentMultiplier returns 1.0 regardless of
+        // IRF rank — paladin pays no holy threat tax outside tank mode.
+        bool rfActive = false;
+        int irfRank = 3; // full talent
+        double mod = rfActive ? 1.0 + 0.6 * (1.0 + 0.50) : 1.0;
+        Assert.Equal(1.0, mod);
+    }
+
+    [Fact]
+    public void ImpRighteousFuryRanks_AreCanonical()
+    {
+        Assert.Equal(new uint[] { 20468, 20469, 20470 }, ImpRighteousFuryRanks);
+    }
+
+    [Fact]
+    public void RighteousFurySpells_IncludesHolyDamageAndHeals()
+    {
+        // Catches drift if the spell-id catalogue is rewritten.
+        var rfSet = new HashSet<uint>
+        {
+            26573, 20116, 20922, 20923, 20924, 27983, // Consecration
+            20925, 20927, 20928,                      // Holy Shield
+            25912, 25911, 25902,                      // Holy Shock damage
+            25903, 25913, 25914,                      // Holy Shock heal
+            24239, 24274, 24275,                      // Hammer of Wrath
+            635, 639, 647, 1026, 1042, 3472, 10328, 10329, 25292, // Holy Light
+            19750, 19939, 19940, 19941, 19942, 19943, // Flash of Light
+            633, 2800, 10310,                          // Lay on Hands
+        };
+        Assert.Contains(26573u, rfSet);     // Consecration R1
+        Assert.Contains(635u, rfSet);       // Holy Light R1
+        Assert.Contains(19750u, rfSet);     // Flash of Light R1
+        Assert.Contains(25914u, rfSet);     // Holy Shock heal R3
+        Assert.DoesNotContain(853u, rfSet); // Hammer of Justice (no school) — not in set
     }
 }

--- a/HermesProxy.Tests/World/TalentThreatModifierTests.cs
+++ b/HermesProxy.Tests/World/TalentThreatModifierTests.cs
@@ -41,6 +41,7 @@ public class TalentThreatModifierTests
     private static readonly uint[] ShadowAffinityRanks   = { 15272, 15318, 15320 };
     private static readonly uint[] DruidSubtletyRanks    = { 17118, 17119, 17120, 17121, 17122 };
     private static readonly uint[] ImpRighteousFuryRanks = { 20468, 20469, 20470 };
+    private static readonly uint[] ImpPwsRanks           = { 14748, 14768, 14769 };
 
     // === Rank detection: highest known rank wins ===
 
@@ -283,6 +284,43 @@ public class TalentThreatModifierTests
     public void ImpRighteousFuryRanks_AreCanonical()
     {
         Assert.Equal(new uint[] { 20468, 20469, 20470 }, ImpRighteousFuryRanks);
+    }
+
+    // === Imp PW:S: Priest, +0.05/rank, applies to PW:S cast threat ===
+
+    [Theory]
+    [InlineData(0, 1.00)]
+    [InlineData(1, 1.05)]
+    [InlineData(2, 1.10)]
+    [InlineData(3, 1.15)]
+    public void ImpPws_PerRank_Multiplier(int rank, double expected)
+    {
+        double mod = rank > 0 ? 1.0 + (0.05 * rank) : 1.0;
+        Assert.Equal(expected, mod, precision: 4);
+    }
+
+    [Fact]
+    public void ImpPwsRanks_AreCanonical()
+    {
+        Assert.Equal(new uint[] { 14748, 14768, 14769 }, ImpPwsRanks);
+    }
+
+    [Fact]
+    public void PowerWordShieldAmounts_MatchLtcTable()
+    {
+        // LTC2 ClassModules/Classic/Priest.lua threatAmounts["pws"] — copied
+        // verbatim. Pinned here so a future refresh that reshuffles values is
+        // caught immediately.
+        var pwsTable = new Dictionary<uint, double>
+        {
+            [17]    = 22,    [592]   = 44,    [600]   = 79,    [3747]  = 117,
+            [6065]  = 150.5, [6066]  = 190.5, [10898] = 242,   [10899] = 302.5,
+            [10900] = 381.5, [10901] = 471,
+        };
+        Assert.Equal(10, pwsTable.Count);
+        Assert.Equal(22,    pwsTable[17]);     // R1
+        Assert.Equal(471,   pwsTable[10901]);  // R10
+        Assert.Equal(150.5, pwsTable[6065]);   // R5 (half-point amount preserved)
     }
 
     [Fact]

--- a/HermesProxy.Tests/World/TalentThreatModifierTests.cs
+++ b/HermesProxy.Tests/World/TalentThreatModifierTests.cs
@@ -217,7 +217,7 @@ public class TalentThreatModifierTests
         Assert.DoesNotContain(8004u, shadowSet); // Lesser Heal — not in set
     }
 
-    // === Druid Subtlety: Druid, -0.04/rank, Arcane/Nature damage only ===
+    // === Druid Subtlety: Druid, -0.04/rank, universal (damage AND heals) ===
 
     [Theory]
     [InlineData(1, 0.96)]
@@ -235,21 +235,19 @@ public class TalentThreatModifierTests
         Assert.Equal(new uint[] { 17118, 17119, 17120, 17121, 17122 }, DruidSubtletyRanks);
     }
 
-    [Fact]
-    public void DruidSubtlety_AppliesOnlyToArcaneNatureSpells_SmokeMembership()
+    [Theory]
+    [InlineData(0, 0, 1.0)]                 // no talent, no form
+    [InlineData(5, 0, 0.80)]                // full subtlety, no form: -20%
+    [InlineData(0, 5, 1.15)]                // no subtlety, bear+5 feral: +15%
+    [InlineData(5, 5, 0.80 * 1.15)]         // both stacked: multiplicative (= 0.92)
+    public void DruidPassive_SubtletyAndFeralInstinct_StackMultiplicatively(int subRank, int fiRank, double expected)
     {
-        var subtletySet = new HashSet<uint>
-        {
-            8921, 8924, 8925, 8926, 8927, 8928, 8929, 9833, 9834, 9835, // Moonfire
-            2912, 8949, 8950, 8951, 9875, 9876, 25298,                  // Starfire
-            5176, 5177, 5178, 6780, 8905, 9912,                         // Wrath
-            16914, 17401, 17402,                                         // Hurricane
-        };
-        Assert.Contains(8921u, subtletySet);       // Moonfire R1
-        Assert.Contains(25298u, subtletySet);      // Starfire R7
-        Assert.Contains(9912u, subtletySet);       // Wrath R6
-        Assert.DoesNotContain(6807u, subtletySet); // Maul (physical) — not in set
-        Assert.DoesNotContain(8042u, subtletySet); // Earth Shock (shaman) — not in set
+        // Subtlety is universal (heals included); Feral Instinct gates on bear form.
+        // GetTalentMultiplier in production multiplies them when both apply.
+        double sub = subRank > 0 ? 1.0 - (0.04 * subRank) : 1.0;
+        double fi  = fiRank  > 0 ? 1.0 + (0.03 * fiRank)  : 1.0;
+        double mult = sub * fi;
+        Assert.Equal(expected, mult, precision: 4);
     }
 
     // === Improved Righteous Fury: Paladin, requires RF aura active ===

--- a/HermesProxy.Tests/World/TalentThreatModifierTests.cs
+++ b/HermesProxy.Tests/World/TalentThreatModifierTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Pins the talent-derived threat multiplier formulas shipped in
+// ThreatTracker.GetTalentMultiplier, plus the rank-id arrays they read against
+// the player's known-spells set.
+//
+// Values match LibThreatClassic2's per-class formulas (the reference addons
+// every threat meter — ThreatPlates, ThreatClassic2, Details TinyThreat —
+// compute against). When the proxy emits SMSG_THREAT_UPDATE values matching
+// this table, all those addons should agree with the proxy.
+//
+// Rank id arrays are pinned here so a future Talent.dbc refresh that
+// reorganizes spell ids is caught immediately rather than silently shifting
+// threat output. Sourced from the 1.14.2 Talent.dbc via wago.tools build
+// 42597, cross-referenced against SpellName.dbc.
+public class TalentThreatModifierTests
+{
+    // Mirrors ThreatTracker.GetTalentRank. Returns the highest 1-based rank
+    // index the player has, or 0 if untalented. The lookup must walk both the
+    // real CurrentPlayerKnownSpells (server-side state) AND
+    // SynthesizedTalentRanks (proxy-injected predecessor IDs) — without the
+    // latter, only the highest rank would be detectable.
+    public static int GetTalentRank(uint[] rankIds, HashSet<uint> known, HashSet<uint> synthesized)
+    {
+        int highest = 0;
+        for (int i = 0; i < rankIds.Length; i++)
+            if (known.Contains(rankIds[i]) || synthesized.Contains(rankIds[i]))
+                highest = i + 1;
+        return highest;
+    }
+
+    // Rank-id arrays MUST match the constants in ThreatTracker.cs verbatim.
+    // These are the spell IDs the proxy reads off the player's known-spells
+    // set; changing them silently is the kind of bug only a tester catches.
+    private static readonly uint[] DefianceRanks      = { 12303, 12788, 12789, 12791, 12792 };
+    private static readonly uint[] FeralInstinctRanks = { 16947, 16948, 16949, 16950, 16951 };
+    private static readonly uint[] SilentResolveRanks = { 14523, 14784, 14785, 14786, 14787 };
+
+    // === Rank detection: highest known rank wins ===
+
+    [Fact]
+    public void GetTalentRank_NoMatch_Returns0()
+    {
+        var known = new HashSet<uint>();
+        var synth = new HashSet<uint>();
+        Assert.Equal(0, GetTalentRank(DefianceRanks, known, synth));
+    }
+
+    [Fact]
+    public void GetTalentRank_OnlyHighestInRealKnown_ReturnsTopRank()
+    {
+        // Mirrors the post-talent-injection state where server only tracks rank 5,
+        // proxy synthesized rank 1-4 into the side set.
+        var known = new HashSet<uint> { 12792 };  // Defiance rank 5
+        var synth = new HashSet<uint> { 12303, 12788, 12789, 12791 };
+        Assert.Equal(5, GetTalentRank(DefianceRanks, known, synth));
+    }
+
+    [Fact]
+    public void GetTalentRank_PicksHighestEvenAcrossBothSets()
+    {
+        // Edge case: rank 3 in synthesized, rank 5 in real-known. Must return 5.
+        var known = new HashSet<uint> { 12792 };
+        var synth = new HashSet<uint> { 12789 };
+        Assert.Equal(5, GetTalentRank(DefianceRanks, known, synth));
+    }
+
+    [Fact]
+    public void GetTalentRank_PartiallySpent_ReturnsThatRank()
+    {
+        var known = new HashSet<uint> { 12788 };  // Defiance rank 2 only
+        var synth = new HashSet<uint> { 12303 };
+        Assert.Equal(2, GetTalentRank(DefianceRanks, known, synth));
+    }
+
+    // === Defiance: Warrior, +0.03/rank, Defensive Stance only ===
+
+    [Theory]
+    [InlineData(1, 1.03)]
+    [InlineData(2, 1.06)]
+    [InlineData(3, 1.09)]
+    [InlineData(4, 1.12)]
+    [InlineData(5, 1.15)]
+    public void Defiance_PerRank_Multiplier(int rank, double expected)
+    {
+        double mod = 1.0 + (0.03 * rank);
+        Assert.Equal(expected, mod, precision: 4);
+    }
+
+    [Fact]
+    public void Defiance_FullDefensiveStanceWithMaxRank_Yields1Point495()
+    {
+        // Defensive Stance baseline 1.30 × Defiance 5/5 (1.15) = 1.495.
+        // Same number LibThreatClassic2 computes for a fully-talented prot warrior.
+        double passive = 1.30 * (1.0 + 0.03 * 5);
+        Assert.Equal(1.495, passive, precision: 4);
+    }
+
+    // === Feral Instinct: Druid, +0.03/rank, Bear / Dire Bear only ===
+
+    [Theory]
+    [InlineData(1, 1.03)]
+    [InlineData(3, 1.09)]
+    [InlineData(5, 1.15)]
+    public void FeralInstinct_PerRank_Multiplier(int rank, double expected)
+    {
+        double mod = 1.0 + (0.03 * rank);
+        Assert.Equal(expected, mod, precision: 4);
+    }
+
+    [Fact]
+    public void FeralInstinct_BearFormFullRank_Yields1Point495()
+    {
+        // Bear Form baseline 1.30 × Feral Instinct 5/5 = 1.495.
+        double passive = 1.30 * (1.0 + 0.03 * 5);
+        Assert.Equal(1.495, passive, precision: 4);
+    }
+
+    // === Silent Resolve: Priest, -0.04/rank, always-on ===
+
+    [Theory]
+    [InlineData(1, 0.96)]
+    [InlineData(2, 0.92)]
+    [InlineData(3, 0.88)]
+    [InlineData(4, 0.84)]
+    [InlineData(5, 0.80)]
+    public void SilentResolve_PerRank_Multiplier(int rank, double expected)
+    {
+        double mod = 1.0 - (0.04 * rank);
+        Assert.Equal(expected, mod, precision: 4);
+    }
+
+    // === Rank id arrays — locked against silent Talent.dbc reshuffles ===
+
+    [Fact]
+    public void DefianceRanks_AreCanonical()
+    {
+        Assert.Equal(new uint[] { 12303, 12788, 12789, 12791, 12792 }, DefianceRanks);
+    }
+
+    [Fact]
+    public void FeralInstinctRanks_AreCanonical()
+    {
+        Assert.Equal(new uint[] { 16947, 16948, 16949, 16950, 16951 }, FeralInstinctRanks);
+    }
+
+    [Fact]
+    public void SilentResolveRanks_AreCanonical()
+    {
+        Assert.Equal(new uint[] { 14523, 14784, 14785, 14786, 14787 }, SilentResolveRanks);
+    }
+
+    // === Boundary cases ===
+
+    [Fact]
+    public void Defiance_Untalented_NoChange()
+    {
+        int rank = 0;
+        double mod = rank > 0 ? 1.0 + (0.03 * rank) : 1.0;
+        Assert.Equal(1.0, mod);
+    }
+
+    [Fact]
+    public void SilentResolve_Untalented_NoChange()
+    {
+        int rank = 0;
+        double mod = rank > 0 ? 1.0 - (0.04 * rank) : 1.0;
+        Assert.Equal(1.0, mod);
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -60,6 +60,20 @@ public static class Settings
     // the client doesn't show red error text during rapid spam. Independent of
     // LowLatencyMode — useful as a companion setting but not required.
     public static bool SuppressSpellCastErrors;
+    // JimsProxy (PR #228 follow-up): synthesize SMSG_THREAT_UPDATE / HIGHEST /
+    // CLEAR so the modern client's native threat APIs (UnitDetailedThreatSituation,
+    // UNIT_THREAT_LIST_UPDATE) populate. Default on. Disable for players who
+    // don't use threat meters or who want to rule the engine out as the cause
+    // of an issue without swapping proxy versions.
+    //
+    // Gate placement: only blocks ThreatTracker per-event work (damage/heal/
+    // energize/spell-cast intake, set-bonus counting, hysteresis, SMSG emission).
+    // The talent synthesizer in SpellHandler.cs (SynthesizedTalentRanks reconcile)
+    // runs unconditionally — other systems consume that data.
+    //
+    // Default-init to true so tests / paths that bypass LoadAndVerifyFrom get
+    // the safe default; LoadAndVerifyFrom still overrides from config below.
+    public static bool ThreatEngine = true;
 
     public static bool LoadAndVerifyFrom(ConfigurationParser config)
     {
@@ -91,6 +105,7 @@ public static class Settings
         EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
+        ThreatEngine = config.GetBoolean("ThreatEngine", true);
         Log.StructuredLogEnabled = StructuredLog;
         Log.VerboseLogEnabled = VerboseLog;
         // Open the JSONL file now so session.start's payload can include the full path.

--- a/HermesProxy/HermesProxy.config
+++ b/HermesProxy/HermesProxy.config
@@ -118,5 +118,6 @@
             Range:       0-50 (clamped)
     -->
     <add key="SpellCastEarlyFireOffsetMs" value="0" />
+    <add key="ThreatEngine" value="true" />
   </appSettings>
 </configuration>

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -181,6 +181,12 @@ public partial class WorldClient
         GetSession().GameState.DeferredAttackStop = false;
         CancelCombat combat = new();
         SendPacketToClient(combat);
+
+        // Drop every mob's threat list — vanilla 1.12 doesn't emit a
+        // "threat ended" signal, so without this the modern client retains
+        // every mob we ever fought and Luna / ThreatPlates leave red
+        // indicators lit on stale nameplates.
+        GetSession().ThreatTracker.OnLocalPlayerLeftCombat();
     }
     [PacketHandler(Opcode.SMSG_AI_REACTION)]
     void HandleAIReaction(WorldPacket packet)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3056,7 +3056,10 @@ public partial class WorldClient
             {
                 GetSession().GameState.GetAuraDuration(target, slot, out durationLeft, out durationFull);
                 if (durationFull <= 0)
-                    durationFull = GameData.GetAuraSpellDuration(spellId);
+                {
+                    int? talentDur = GameData.TryGetTalentDuration(spellId, GetSession().GameState.CurrentPlayerKnownSpells);
+                    durationFull = talentDur ?? GameData.GetAuraSpellDuration(spellId);
+                }
             }
 
             if (durationFull > 0)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -2622,6 +2622,19 @@ public partial class WorldClient
             if (effectiveHotHeal > 0)
                 GetSession().ThreatTracker.OnHeal(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, effectiveHotHeal);
         }
+
+        // Periodic energize threat (Spirit Tap, Innervate, Mana Tide ticks,
+        // Vampiric Embrace mana-return). Each effect can carry its own
+        // power type via SchoolMaskOrPower — process per-effect rather than
+        // summing.
+        foreach (var effect in spell.Effects)
+        {
+            if (effect.Effect == (uint)AuraType.PeriodicEnergize && effect.Amount > 0)
+            {
+                var powerType = (PowerType)effect.SchoolMaskOrPower;
+                GetSession().ThreatTracker.OnEnergize(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, powerType, effect.Amount);
+            }
+        }
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_ENERGIZE_LOG)]
@@ -2634,6 +2647,11 @@ public partial class WorldClient
         spell.Type = (PowerType)packet.ReadUInt32();
         spell.Amount = packet.ReadInt32();
         SendPacketToClient(spell);
+
+        // Threat translation: energize generates caster-side threat per LTC2
+        // (mana ×0.5, others ×5). Server pre-caps amount to actual gain so
+        // zero-gain energizes don't reach us.
+        GetSession().ThreatTracker.OnEnergize(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, spell.Type, spell.Amount);
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_DELAYED)]

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -2426,9 +2426,9 @@ public partial class WorldClient
         SendPacketToClient(spell);
 
         // Threat translation: heal threat = 0.5 x effective heal, distributed
-        // across every mob in combat with the heal target. Overheal generates
-        // no threat — feed only the effective amount.
-        long effectiveHeal = (long)spell.HealAmount - (long)spell.OverHeal;
+        // across every mob in combat with the heal target. Overheal AND absorbed
+        // generate no threat — feed only the amount that actually landed on hp.
+        long effectiveHeal = (long)spell.HealAmount - (long)spell.OverHeal - (long)spell.Absorbed;
         if (effectiveHeal > 0)
         {
             GetSession().ThreatTracker.OnHeal(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, effectiveHeal);
@@ -2613,10 +2613,14 @@ public partial class WorldClient
         }
         if (hotHeal > 0)
         {
-            // HoT ticks don't carry overheal info on the wire, so we feed
-            // the raw amount. Slight overcount when the target is at max hp;
-            // acceptable at this stage.
-            GetSession().ThreatTracker.OnHeal(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, hotHeal);
+            // HoT ticks don't carry overheal on the wire; compute it from the
+            // unit HP cache so a Rejuv tick on a topped-off target produces
+            // 0 threat instead of full-tick threat (resto-druid raid healing).
+            ComputeOverHealFromCache(spell.TargetGUID, (int)hotHeal, wireHadOverheal: false,
+                out uint hotOverheal, out _, out _, out _);
+            double effectiveHotHeal = hotHeal - hotOverheal;
+            if (effectiveHotHeal > 0)
+                GetSession().ThreatTracker.OnHeal(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, effectiveHotHeal);
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1654,7 +1654,8 @@ public partial class WorldClient
 
         if (GameData.SpellEffectPoints.TryGetValue(spellId, out var basePoints))
             data.Points = basePoints;
-        int duration = GameData.GetAuraSpellDuration(spellId);
+        int? talentDuration = GameData.TryGetTalentDuration(spellId, GetSession().GameState.CurrentPlayerKnownSpells);
+        int duration = talentDuration ?? GameData.GetAuraSpellDuration(spellId);
         if (duration > 0)
         {
             data.Duration = duration;
@@ -2990,7 +2991,11 @@ public partial class WorldClient
                                 // (Cheap Shot, flat 4 s) is the primary case; any other spell with
                                 // an AuraDurations CSV row also benefits.
                                 if (durationFull <= 0)
-                                    durationFull = GameData.GetAuraSpellDuration((uint)aura.AuraData.SpellID);
+                                {
+                                    uint auraSpellId = (uint)aura.AuraData.SpellID;
+                                    int? talentDur = GameData.TryGetTalentDuration(auraSpellId, GetSession().GameState.CurrentPlayerKnownSpells);
+                                    durationFull = talentDur ?? GameData.GetAuraSpellDuration(auraSpellId);
+                                }
                             }
 
                             if (durationLeft > 0 && durationFull > 0)

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -489,6 +489,152 @@ public static partial class GameData
         return formula.BaseMs + formula.PerCpMs * comboPoints;
     }
 
+    // JimsProxy: talent-modified aura durations. The legacy server applies the talent-
+    // scaled duration server-side at cast time but doesn't echo it back for ENEMY
+    // debuffs — only self-cast auras get SMSG_UPDATE_AURA_DURATION. AuraDurations1.csv
+    // holds the un-talented base from LibClassicDurations / SpellDuration.dbc, so an
+    // Improved Shadow Word: Pain 18s + 6s (2/2 ranks) lands as a 18 s ticker on the
+    // enemy's bar without this table.
+    //
+    // Each entry describes a single rank of a player spell (rank-specific because the
+    // base differs across ranks for e.g. Bash). At evaluation time we look up which
+    // ranks of the modifier talent are in the player's known-spells set and apply the
+    // formula. Ported from LibClassicDurations classAbilities.lua `duration = function`
+    // blocks that reference Talent(...). Set-bonus and pvpduration paths are skipped
+    // (Phase 1) — they require equipped-item tracking and explicit PvP-zone detection.
+    public sealed record TalentDurationFormula(
+        float BaseSeconds,
+        uint[] RankSpellIds,
+        float PerRankAddSeconds = 0f,
+        float PerRankMultiplier = 0f,
+        bool GateRequired = false);
+
+    public static readonly FrozenDictionary<uint, TalentDurationFormula> TalentDurationModifiers =
+        new Dictionary<uint, TalentDurationFormula>
+        {
+            // Druid — Brutal Impact (16940 R1, 16941 R2): +0.5 s per rank to Bash/Pounce
+            { 5211, new(2f, new uint[] { 16940, 16941 }, PerRankAddSeconds: 0.5f) }, // Bash R1
+            { 6798, new(3f, new uint[] { 16940, 16941 }, PerRankAddSeconds: 0.5f) }, // Bash R2
+            { 8983, new(4f, new uint[] { 16940, 16941 }, PerRankAddSeconds: 0.5f) }, // Bash R3
+            { 9005, new(2f, new uint[] { 16940, 16941 }, PerRankAddSeconds: 0.5f) }, // Pounce R1
+            { 9823, new(2f, new uint[] { 16940, 16941 }, PerRankAddSeconds: 0.5f) }, // Pounce R2
+            { 9827, new(2f, new uint[] { 16940, 16941 }, PerRankAddSeconds: 0.5f) }, // Pounce R3
+
+            // Priest — Improved SW:P (15275 R1, 15317 R2): +3 s per rank, all 8 SW:P ranks share 18 s base
+            { 589,   new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+            { 594,   new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+            { 970,   new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+            { 992,   new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+            { 2767,  new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+            { 10892, new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+            { 10893, new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+            { 10894, new(18f, new uint[] { 15275, 15317 }, PerRankAddSeconds: 3f) },
+
+            // Priest — Shadow Weaving prereq (15257 R1, 15331-15334): aura 15258 only ticks if you have the talent
+            { 15258, new(15f, new uint[] { 15257, 15331, 15332, 15333, 15334 }, GateRequired: true) },
+
+            // Rogue — Improved Gouge (13741, 13793, 13792): +0.5 s per rank, all 5 Gouge ranks share 4 s base
+            { 1776,  new(4f, new uint[] { 13741, 13793, 13792 }, PerRankAddSeconds: 0.5f) },
+            { 1777,  new(4f, new uint[] { 13741, 13793, 13792 }, PerRankAddSeconds: 0.5f) },
+            { 8629,  new(4f, new uint[] { 13741, 13793, 13792 }, PerRankAddSeconds: 0.5f) },
+            { 11285, new(4f, new uint[] { 13741, 13793, 13792 }, PerRankAddSeconds: 0.5f) },
+            { 11286, new(4f, new uint[] { 13741, 13793, 13792 }, PerRankAddSeconds: 0.5f) },
+
+            // Warrior — Booming Voice (12321 R1, 12835-12838 R5): ×(1 + 0.1 × rank) to Battle/Demo Shout
+            { 6673,  new(120f, new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) }, // Battle Shout R1
+            { 5242,  new(120f, new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 6192,  new(120f, new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 11549, new(120f, new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 11550, new(120f, new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 11551, new(120f, new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 25289, new(120f, new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 1160,  new(30f,  new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) }, // Demo Shout R1
+            { 6190,  new(30f,  new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 11554, new(30f,  new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 11555, new(30f,  new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+            { 11556, new(30f,  new uint[] { 12321, 12835, 12836, 12837, 12838 }, PerRankMultiplier: 0.1f) },
+
+            // Warrior — Improved Disarm (12313, 12804, 12807): +1 s per rank to Disarm
+            { 676, new(10f, new uint[] { 12313, 12804, 12807 }, PerRankAddSeconds: 1f) },
+
+            // Warlock — Improved Succubus (18754, 18755, 18756): ×(1 + 0.1 × rank) to Seduction
+            { 6358, new(15f, new uint[] { 18754, 18755, 18756 }, PerRankMultiplier: 0.1f) },
+
+            // Paladin — Improved Blessing of Freedom (20174, 20175): +3 s per rank
+            { 1044, new(10f, new uint[] { 20174, 20175 }, PerRankAddSeconds: 3f) },
+
+            // Paladin — Improved Judgement (20359, 20360, 20361): +10 s per rank to Judgement of Light/Wisdom
+            { 20185, new(10f, new uint[] { 20359, 20360, 20361 }, PerRankAddSeconds: 10f) }, // JoL R1
+            { 20344, new(10f, new uint[] { 20359, 20360, 20361 }, PerRankAddSeconds: 10f) },
+            { 20345, new(10f, new uint[] { 20359, 20360, 20361 }, PerRankAddSeconds: 10f) },
+            { 20346, new(10f, new uint[] { 20359, 20360, 20361 }, PerRankAddSeconds: 10f) },
+            { 20186, new(10f, new uint[] { 20359, 20360, 20361 }, PerRankAddSeconds: 10f) }, // JoW R1
+            { 20354, new(10f, new uint[] { 20359, 20360, 20361 }, PerRankAddSeconds: 10f) },
+            { 20355, new(10f, new uint[] { 20359, 20360, 20361 }, PerRankAddSeconds: 10f) },
+
+            // Hunter — Clever Traps (19239, 19245): ×(1 + 0.15 × rank) to Freezing Trap
+            { 3355,  new(10f, new uint[] { 19239, 19245 }, PerRankMultiplier: 0.15f) },
+            { 14308, new(15f, new uint[] { 19239, 19245 }, PerRankMultiplier: 0.15f) },
+            { 14309, new(20f, new uint[] { 19239, 19245 }, PerRankMultiplier: 0.15f) },
+
+            // Mage — Permafrost (11175 R1, 12569 R2, 12571 R3): +1 s per rank to Frostbolt slow / Cone of Cold / Frost Armor Chilled
+            { 116,   new(5f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) }, // Frostbolt R1
+            { 205,   new(6f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 837,   new(6f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 7322,  new(7f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 8406,  new(7f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 8407,  new(8f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 8408,  new(8f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 10179, new(9f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 10180, new(9f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 10181, new(9f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 25304, new(9f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 120,   new(8f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) }, // Cone of Cold R1
+            { 8492,  new(8f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 10159, new(8f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 10160, new(8f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 10161, new(8f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) },
+            { 6136,  new(5f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) }, // Frost Armor Chilled
+            { 7321,  new(5f, new uint[] { 11175, 12569, 12571 }, PerRankAddSeconds: 1f) }, // Ice Armor Chilled
+
+            // Mage — gated prerequisite auras: only show duration when the prereq talent is taken.
+            { 22959, new(30f, new uint[] { 11095, 12872, 12873 }, GateRequired: true) }, // Fire Vulnerability (needs Imp Scorch)
+            { 12579, new(15f, new uint[] { 11180, 28592, 28593, 28594, 28595 }, GateRequired: true) }, // Winter's Chill stack
+        }.ToFrozenDictionary();
+
+    /// <summary>
+    /// JimsProxy (talent-modified duration): if <paramref name="spellId"/> is in the
+    /// talent-modifier table, returns the talent-scaled duration in milliseconds based
+    /// on the player's known-spells set (used as a proxy for "rank you have learned of
+    /// the modifier talent"). Returns null otherwise — caller falls back to CSV. Only
+    /// safe for casts assumed to come from the LOCAL PLAYER; other casters with different
+    /// talent loadouts would land on the same value, but the fallback path is dominated
+    /// by self-cast scenarios in practice.
+    /// </summary>
+    public static int? TryGetTalentDuration(uint spellId, System.Collections.Generic.HashSet<uint> knownSpells)
+    {
+        if (knownSpells == null || knownSpells.Count == 0)
+            return null;
+        if (!TalentDurationModifiers.TryGetValue(spellId, out var f))
+            return null;
+
+        int rank = 0;
+        for (int i = 0; i < f.RankSpellIds.Length; i++)
+        {
+            if (knownSpells.Contains(f.RankSpellIds[i]))
+                rank = i + 1;
+        }
+        if (f.GateRequired && rank == 0)
+            return null;
+
+        float seconds;
+        if (f.PerRankMultiplier > 0f)
+            seconds = f.BaseSeconds * (1f + rank * f.PerRankMultiplier);
+        else
+            seconds = f.BaseSeconds + rank * f.PerRankAddSeconds;
+        return (int)(seconds * 1000f);
+    }
+
     /// <summary>
     /// JimsProxy: true if the spell is a CP-scaling enemy-debuff finisher we compute
     /// duration for locally. Used by the CMSG_CAST_SPELL handler to decide whether to

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -169,6 +169,15 @@ internal static class ThreatModules
         [17751] = 450, [17752] = 600,
     };
 
+    // Warlock Succubus — Soothing Kiss. Pet self-debuff: reduces the pet's
+    // OWN threat on the kissed mob (Succubus de-aggro tool, NOT a player-
+    // targeted threat-wipe). Negative flat — same shape as Cower.
+    private static readonly Dictionary<int, double> SoothingKissAmount = new()
+    {
+        [6360] = -45, [7813] = -75,
+        [11784] = -127, [11785] = -165,
+    };
+
     // Warrior — sunderFactor = 261/58, with R5 hardcoded to 261.
     private static readonly Dictionary<int, double> SunderArmorAmount = new()
     {
@@ -563,6 +572,10 @@ internal static class ThreatModules
             apBaseBonus: 124, apLevelMalus: 0, apFactor: 0.547,
             gateOnPositiveThreshold: false, aoeAllTargets: true);
         foreach (var id in SufferingAmount.Keys) map[id] = petSuffering;
+
+        // Pet — Warlock Succubus
+        var petSoothingKiss = PetSingleTargetFlat("soothing_kiss", SoothingKissAmount);
+        foreach (var id in SoothingKissAmount.Keys) map[id] = petSoothingKiss;
 
         // Warrior
         var sunder = PlayerSingleTargetFlat("sunder_armor", SunderArmorAmount);

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -178,6 +178,22 @@ internal static class ThreatModules
         [11784] = -127, [11785] = -165,
     };
 
+    // Hunter pet — Intimidation (Beast Mastery 31-point talent). 5-sec stun
+    // + taunt-equivalent flat threat for the pet on the target. Per LTC2
+    // Pet.lua line 50-55: flat 580 single-target.
+    private static readonly Dictionary<int, double> IntimidationAmount = new()
+    {
+        [24394] = 580,
+    };
+
+    // Hunter pet — Scorpid Poison (ranks 1-4). Tiny flat per cast, but the
+    // pet fires it on auto-attack rotation so it accumulates over a fight.
+    // Per LTC2 Pet.lua line 58-62: flat 5 per rank, no AP scaling.
+    private static readonly Dictionary<int, double> ScorpidPoisonAmount = new()
+    {
+        [24640] = 5, [24583] = 5, [24586] = 5, [24587] = 5,
+    };
+
     // Warrior — sunderFactor = 261/58, with R5 hardcoded to 261.
     private static readonly Dictionary<int, double> SunderArmorAmount = new()
     {
@@ -586,6 +602,14 @@ internal static class ThreatModules
         // Pet — Warlock Succubus
         var petSoothingKiss = PetSingleTargetFlat("soothing_kiss", SoothingKissAmount);
         foreach (var id in SoothingKissAmount.Keys) map[id] = petSoothingKiss;
+
+        // Pet — Hunter Intimidation (Beast Mastery 31-point talent).
+        var petIntimidation = PetSingleTargetFlat("intimidation", IntimidationAmount);
+        foreach (var id in IntimidationAmount.Keys) map[id] = petIntimidation;
+
+        // Pet — Hunter Scorpid Poison (auto-cast on-attack).
+        var petScorpidPoison = PetSingleTargetFlat("scorpid_poison", ScorpidPoisonAmount);
+        foreach (var id in ScorpidPoisonAmount.Keys) map[id] = petScorpidPoison;
 
         // Warrior
         var sunder = PlayerSingleTargetFlat("sunder_armor", SunderArmorAmount);

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -115,6 +115,17 @@ internal static class ThreatModules
     // LibThreatClassic2 ClassModules/Classic/*.lua.
     // -----------------------------------------------------------------------
 
+    // Priest Power Word: Shield — cast-time flat threat per rank. Values from
+    // LTC2 ClassModules/Classic/Priest.lua threatAmounts["pws"]. The threat
+    // tracker layers Imp PW:S (talent rank-based 1.05 - 1.15 multiplier) and
+    // Silent Resolve (via passive modifier) on top.
+    private static readonly Dictionary<int, double> PowerWordShieldAmount = new()
+    {
+        [17]    = 22,    [592]   = 44,    [600]   = 79,    [3747]  = 117,
+        [6065]  = 150.5, [6066]  = 190.5, [10898] = 242,   [10899] = 302.5,
+        [10900] = 381.5, [10901] = 471,
+    };
+
     // Hunter
     private static readonly Dictionary<int, double> DistractingShotAmount = new()
     {
@@ -501,6 +512,25 @@ internal static class ThreatModules
 
         var vanish = PlayerZeroAllMobs("vanish");
         foreach (var id in new[] { 1856, 1857 }) map[id] = vanish;
+
+        // Priest Power Word: Shield — fixed per-rank cast threat × Imp PW:S
+        // multiplier, distributed across mobs in combat with the shield target.
+        // Per-rank amounts mirror LTC2 ClassModules/Classic/Priest.lua's
+        // threatAmounts["pws"] table; Imp PW:S layer is read from the player's
+        // known-spells set via ThreatTracker.GetImpPwsMultiplier (Talent.dbc
+        // ranks 14748 / 14768 / 14769, formula 1 + 0.05 × rank).
+        var pws = (ThreatHandler)((tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPlayerGuid) return;
+            if (!PowerWordShieldAmount.TryGetValue(spellId, out double baseAmount)) return;
+            // PW:S targets a single recipient (the shield buff target). Use the
+            // first hit target as the shield recipient — same convention as the
+            // other single-target handlers. Threat distributes to mobs in combat
+            // with that recipient inside OnPowerWordShield.
+            var shieldTarget = hitTargets.Count > 0 ? hitTargets[0] : caster;
+            tracker.OnPowerWordShield(caster, shieldTarget, spellId, baseAmount);
+        });
+        foreach (var id in PowerWordShieldAmount.Keys) map[id] = pws;
 
         // Paladin
         map[4987] = PlayerAddToAllMobs("cleanse", 40);

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -502,8 +502,11 @@ internal static class ThreatModules
         // Druid Growl is a player taunt (bear form).
         map[6795] = PlayerSetToTop("growl_druid");
 
-        // Mage
-        map[2139] = PlayerSingleTargetFlat("counterspell", new Dictionary<int, double> { [2139] = 300 });
+        // Mage Counterspell ranks 1-2 — flat 300 threat per LTC2 Mage.lua.
+        var counterspell = PlayerSingleTargetFlat("counterspell",
+            new Dictionary<int, double> { [2139] = 300, [18469] = 300 });
+        map[2139] = counterspell;
+        map[18469] = counterspell;
         map[475]  = PlayerAddToAllMobs("remove_lesser_curse", 14);
 
         // Rogue

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -460,16 +460,34 @@ internal static class ThreatModules
 
             double apBonus = 0;
             uint petLevel = 0;
+            int petBaseAP = 0;
+            int petApModPos = 0;
+            int petApModNeg = 0;
             int petAP = 0;
             var fields = session.GameState.GetCachedObjectFieldsLegacy(caster);
             if (fields != null)
             {
                 int levelIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_LEVEL);
                 int apIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_ATTACK_POWER);
+                int apModsIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_ATTACK_POWER_MODS);
                 if (levelIdx >= 0 && fields.TryGetValue(levelIdx, out var levelField))
                     petLevel = levelField.UInt32Value;
                 if (apIdx >= 0 && fields.TryGetValue(apIdx, out var apField))
-                    petAP = apField.Int32Value;
+                    petBaseAP = apField.Int32Value;
+                // Legacy UNIT_FIELD_ATTACK_POWER_MODS packs pos/neg buff
+                // magnitudes into one int (low 16 = neg, high 16 = pos).
+                // LTC2's UnitAttackPower("pet") returns base + pos + neg
+                // where neg is negative, so effective = base + pos − neg.
+                // Without this, an Aspect-of-the-Hawk / Battle Shout / TSA
+                // buffed pet reads as just base AP and falls under the
+                // LTC2 threshold, gating out the Growl AP bonus entirely.
+                if (apModsIdx >= 0 && fields.TryGetValue(apModsIdx, out var apModsField))
+                {
+                    int packed = apModsField.Int32Value;
+                    petApModNeg = packed & 0xFFFF;
+                    petApModPos = (packed >> 16) & 0xFFFF;
+                }
+                petAP = petBaseAP + petApModPos - petApModNeg;
 
                 double threshold = petLevel * apLevelMalus - apBaseBonus;
                 bool gated = gateOnPositiveThreshold && threshold <= 0;
@@ -495,6 +513,9 @@ internal static class ThreatModules
                 ap_bonus = apBonus,
                 pet_level = petLevel,
                 pet_ap = petAP,
+                pet_base_ap = petBaseAP,
+                pet_ap_mod_pos = petApModPos,
+                pet_ap_mod_neg = petApModNeg,
             });
         };
 

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -1,5 +1,7 @@
 using Framework.Logging;
+using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
+using System;
 using System.Collections.Generic;
 
 namespace HermesProxy.World;
@@ -147,6 +149,20 @@ internal static class ThreatModules
     {
         [1742] = -30, [1753] = -55, [1754] = -85,
         [1755] = -125, [1756] = -175, [16697] = -225,
+    };
+
+    // Warlock Voidwalker — Torment (single-target high threat, AP-scaled).
+    private static readonly Dictionary<int, double> TormentAmount = new()
+    {
+        [3716]  = 45,  [7809]  = 75,  [7810]  = 125,
+        [7811]  = 215, [11774] = 300, [11775] = 395,
+    };
+
+    // Warlock Voidwalker — Suffering (AoE high threat, AP-scaled, per-target).
+    private static readonly Dictionary<int, double> SufferingAmount = new()
+    {
+        [17735] = 150, [17750] = 300,
+        [17751] = 450, [17752] = 600,
     };
 
     // Warrior — sunderFactor = 261/58, with R5 hardcoded to 261.
@@ -366,6 +382,83 @@ internal static class ThreatModules
             });
         };
 
+    // JimsProxy (pet-ap-scaling 2026-05-17): LibThreatClassic2 Pet.lua applies
+    // an AP-scaled bonus on top of rank-flat threat for several pet abilities:
+    //
+    //   threat = rankFlat + max(0, petAP - (petLevel * apLevelMalus - apBaseBonus)) * apFactor
+    //
+    // Per-ability constants from LTC2 (verified 2026-05-17):
+    //
+    //                                apBaseBonus  apLevelMalus  apFactor
+    //   Hunter pet Growl              1235.6      28.14         5.7
+    //   Voidwalker Torment             123         0            0.385
+    //   Voidwalker Suffering (AoE)     124         0            0.547
+    //
+    // Growl's high apFactor (5.7) + steep level term mean the threshold flips
+    // sign at petLevel ~44 — below that the formula would produce silly large
+    // bonuses for low-AP pets. gateOnPositiveThreshold=true skips the bonus
+    // when the threshold is negative (Growl only). Torment/Suffering have
+    // apLevelMalus=0 → threshold is constant negative; their small apFactor
+    // (≤0.547) keeps bonuses sane at all pet levels, so they don't need the
+    // gate.
+    //
+    // Without these scaled bonuses, raid-geared L60 pets were under-credited
+    // (TinyThreat addon showing pet threat lower than expected, 2026-05-17
+    // log jimsproxy-20260517-114718.jsonl).
+    private static ThreatHandler PetCasterAPScaled(
+        string eventTag,
+        Dictionary<int, double> rankFlats,
+        double apBaseBonus,
+        double apLevelMalus,
+        double apFactor,
+        bool gateOnPositiveThreshold,
+        bool aoeAllTargets = false)
+        => (tracker, session, spellId, caster, hitTargets) =>
+        {
+            if (caster != session.GameState.CurrentPetGuid) return;
+            if (hitTargets.Count == 0) return;
+            if (!rankFlats.TryGetValue(spellId, out double rankFlat)) return;
+
+            double apBonus = 0;
+            uint petLevel = 0;
+            int petAP = 0;
+            var fields = session.GameState.GetCachedObjectFieldsLegacy(caster);
+            if (fields != null)
+            {
+                int levelIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_LEVEL);
+                int apIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_ATTACK_POWER);
+                if (levelIdx >= 0 && fields.TryGetValue(levelIdx, out var levelField))
+                    petLevel = levelField.UInt32Value;
+                if (apIdx >= 0 && fields.TryGetValue(apIdx, out var apField))
+                    petAP = apField.Int32Value;
+
+                double threshold = petLevel * apLevelMalus - apBaseBonus;
+                bool gated = gateOnPositiveThreshold && threshold <= 0;
+                if (!gated)
+                    apBonus = Math.Max(0, petAP - threshold) * apFactor;
+            }
+
+            double amount = rankFlat + apBonus;
+            int targetCount = aoeAllTargets ? hitTargets.Count : 1;
+            for (int i = 0; i < targetCount; i++)
+            {
+                var target = hitTargets[i];
+                tracker.AddModifiedThreat(target, caster, amount);
+            }
+
+            Log.Event("threat.spell." + eventTag, new
+            {
+                spell_id = spellId,
+                target_low = hitTargets[0].GetCounter(),
+                target_count = targetCount,
+                amount,
+                rank_flat = rankFlat,
+                ap_bonus = apBonus,
+                pet_level = petLevel,
+                pet_ap = petAP,
+            });
+        };
+
     private static ThreatHandler PlayerSetToTop(string eventTag)
         => (tracker, session, spellId, caster, hitTargets) =>
         {
@@ -447,12 +540,25 @@ internal static class ThreatModules
 
         map[5384] = PlayerZeroAllMobs("feign_death");
 
-        // Pet
-        var petGrowl = PetSingleTargetFlat("growl", GrowlAmount);
+        // Pet — Hunter
+        var petGrowl = PetCasterAPScaled("growl", GrowlAmount,
+            apBaseBonus: 1235.6, apLevelMalus: 28.14, apFactor: 5.7,
+            gateOnPositiveThreshold: true);
         foreach (var id in GrowlAmount.Keys) map[id] = petGrowl;
 
         var petCower = PetSingleTargetFlat("cower_pet", CowerPetAmount);
         foreach (var id in CowerPetAmount.Keys) map[id] = petCower;
+
+        // Pet — Warlock Voidwalker
+        var petTorment = PetCasterAPScaled("torment", TormentAmount,
+            apBaseBonus: 123, apLevelMalus: 0, apFactor: 0.385,
+            gateOnPositiveThreshold: false);
+        foreach (var id in TormentAmount.Keys) map[id] = petTorment;
+
+        var petSuffering = PetCasterAPScaled("suffering", SufferingAmount,
+            apBaseBonus: 124, apLevelMalus: 0, apFactor: 0.547,
+            gateOnPositiveThreshold: false, aoeAllTargets: true);
+        foreach (var id in SufferingAmount.Keys) map[id] = petSuffering;
 
         // Warrior
         var sunder = PlayerSingleTargetFlat("sunder_armor", SunderArmorAmount);

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -343,14 +343,24 @@ internal static class ThreatModules
             if (hitTargets.Count == 0) return;
             if (!amounts.TryGetValue(spellId, out double amount)) return;
 
+            // Gear set-bonus multiplier (Warrior Might 8-set: Sunder x1.15;
+            // Rogue Bloodfang 5-set: Feint x1.25). Returns 1.0 for spells
+            // outside the gated list, so non-set-affected flats pass through
+            // unchanged.
+            var playerClass = (Class)session.GameState.CurrentPlayerClass;
+            double gearMult = ThreatSetBonuses.GetGearSpellMultiplier(session.GameState, playerClass, spellId);
+            double finalAmount = amount * gearMult;
+
             var target = hitTargets[0];
-            tracker.AddModifiedThreat(target, caster, amount);
+            tracker.AddModifiedThreat(target, caster, finalAmount);
 
             Log.Event("threat.spell." + eventTag, new
             {
                 spell_id = spellId,
                 target_low = target.GetCounter(),
-                amount,
+                amount = finalAmount,
+                base_amount = amount,
+                gear_mult = gearMult,
             });
         };
 

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -104,6 +104,10 @@ internal static class ThreatModules
 
         // Paladin Holy Shield reflect damage (R1..3)
         [20925] = 1.2, [20927] = 1.2, [20928] = 1.2,
+
+        // Warrior Execute (R1..5) — finisher designed as threat spike
+        [5308] = 1.25, [20658] = 1.25, [20660] = 1.25,
+        [20661] = 1.25, [20662] = 1.25,
     };
 
     public static double GetDamageMultiplier(int spellId)

--- a/HermesProxy/World/ThreatNPCModules.cs
+++ b/HermesProxy/World/ThreatNPCModules.cs
@@ -1,0 +1,156 @@
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace HermesProxy.World;
+
+// LibThreatClassic2's per-boss NPC modules — abilities that wipe or modify
+// player threat on the casting boss. Direct port of NPCModules/*/*.lua. All
+// vanilla 1.12 raid + outdoor bosses with documented threat-affecting spells.
+//
+// Two trigger shapes:
+//
+//   CastHandlers   — SPELL_CAST_SUCCESS on the boss. Used by abilities that
+//                    fire a "wipe / modify" effect on the SPELL TARGET (player
+//                    or full raid) without a damage component. E.g. Ragnaros
+//                    Wrath, Shazzrah Gate, Hakkar Aspect of Arlokk.
+//
+//   DamageHandlers — SPELL_DAMAGE on the boss. Used by knock-back style
+//                    abilities that modify the damaged player's threat
+//                    proportionally to a hit-confirmation. E.g. Broodlord
+//                    Knock Away, Wing Buffet, Sand Blast.
+//
+// Some bosses chain-trigger off chat events (Onyxia phase 3 yell, Nefarian
+// phase 2 yell). Not ported — proxy doesn't have a clean chat-text observer
+// and the wipe is also predictable on HP threshold by addons doing their
+// own bookkeeping. Translation tables in LTC2 NPCModules are skipped.
+internal static class ThreatNPCModules
+{
+    public enum NPCThreatAction
+    {
+        WipeRaidOnMob,       // Boss's whole threat list cleared (raid reset).
+        WipeSource,          // Specific player's threat on boss set to 0.
+        HalveSource,         // Specific player's threat on boss × 0.5.
+        QuarterReduceSource, // Specific player's threat on boss × 0.75 (Onyxia Knock Away).
+    }
+
+    // (creatureEntry, spellId) → action. Frozen for fast lookup; called on
+    // every player-targeted SMSG_SPELL_GO that has an NPC source — needs to be
+    // O(1).
+    private static readonly FrozenDictionary<(uint, int), NPCThreatAction> CastHandlers =
+        BuildCastHandlers().ToFrozenDictionary();
+
+    private static readonly FrozenDictionary<(uint, int), NPCThreatAction> DamageHandlers =
+        BuildDamageHandlers().ToFrozenDictionary();
+
+    private static Dictionary<(uint, int), NPCThreatAction> BuildCastHandlers()
+    {
+        var map = new Dictionary<(uint, int), NPCThreatAction>();
+
+        // Molten Core — Ragnaros 11502 / Wrath 20566
+        map[(11502, 20566)] = NPCThreatAction.WipeRaidOnMob;
+
+        // Molten Core — Shazzrah 12264 / Gate 23138
+        map[(12264, 23138)] = NPCThreatAction.WipeRaidOnMob;
+
+        // Naxxramas — Kel'Thuzad 15990 / Chains of Kel'Thuzad 28410
+        map[(15990, 28410)] = NPCThreatAction.WipeRaidOnMob;
+
+        // Zul'Gurub — Hakkar 14834 / Aspect of Arlokk 24690
+        map[(14834, 24690)] = NPCThreatAction.WipeSource;
+
+        // Onyxia 10184 / Fireball 18392 (wipe one player)
+        map[(10184, 18392)] = NPCThreatAction.WipeSource;
+        // Onyxia 10184 / Knock Away 19633 (0.75× one player)
+        map[(10184, 19633)] = NPCThreatAction.QuarterReduceSource;
+
+        return map;
+    }
+
+    private static Dictionary<(uint, int), NPCThreatAction> BuildDamageHandlers()
+    {
+        var map = new Dictionary<(uint, int), NPCThreatAction>();
+
+        // AQ40 — Ouro 15517 / Sand Blast 26102 (wipe one player)
+        map[(15517, 26102)] = NPCThreatAction.WipeSource;
+
+        // BWL — Broodlord Lashlayer 12017 / Knock Away 18670 (0.5×)
+        map[(12017, 18670)] = NPCThreatAction.HalveSource;
+
+        // BWL drakes — Ebonroc / Firemaw / Flamegor / Wing Buffet 23339
+        map[(14601, 23339)] = NPCThreatAction.HalveSource;  // Ebonroc
+        map[(11983, 23339)] = NPCThreatAction.HalveSource;  // Firemaw
+        map[(11981, 23339)] = NPCThreatAction.HalveSource;  // Flamegor
+
+        // Molten Core — Molten Giant 11658 / Knock Away 18945 (0.5×)
+        map[(11658, 18945)] = NPCThreatAction.HalveSource;
+
+        return map;
+    }
+
+    // Naxxramas Noth uses BUFF_GAIN (29211 Blink), not cast or damage. Handled
+    // separately via the aura-applied observer if we wire one in the future.
+    public const int NOTH_BLINK_AURA = 29211;
+    public const uint NOTH_NPC_ID = 15954;
+
+    // Look up the cached creature_template entry for a unit GUID via
+    // OBJECT_FIELD_ENTRY. Returns 0 if the unit isn't cached or isn't an NPC.
+    public static uint GetCreatureEntry(GameSessionData state, WowGuid128 guid)
+    {
+        if (guid.IsEmpty()) return 0;
+        var fields = state.GetCachedObjectFieldsLegacy(guid);
+        if (fields == null) return 0;
+        int entryIdx = LegacyVersion.GetUpdateField(ObjectField.OBJECT_FIELD_ENTRY);
+        if (entryIdx < 0) return 0;
+        if (!fields.TryGetValue(entryIdx, out var entryField)) return 0;
+        return entryField.UInt32Value;
+    }
+
+    // Dispatch a SPELL_CAST_SUCCESS event from an NPC. Returns true if the
+    // (npcEntry, spellId) pair matched a registered handler. Caller resolves
+    // npcEntry from npcGuid via GetCreatureEntry before calling.
+    public static bool TryHandleNPCCast(ThreatTracker tracker, WowGuid128 npcGuid, uint npcEntry, int spellId, WowGuid128 targetGuid)
+    {
+        if (!CastHandlers.TryGetValue((npcEntry, spellId), out var action)) return false;
+        ApplyAction(tracker, npcGuid, npcEntry, spellId, targetGuid, action, "cast_success");
+        return true;
+    }
+
+    // Dispatch a SPELL_DAMAGE event from an NPC. Returns true if matched.
+    public static bool TryHandleNPCDamage(ThreatTracker tracker, WowGuid128 npcGuid, uint npcEntry, int spellId, WowGuid128 victimGuid)
+    {
+        if (!DamageHandlers.TryGetValue((npcEntry, spellId), out var action)) return false;
+        ApplyAction(tracker, npcGuid, npcEntry, spellId, victimGuid, action, "spell_damage");
+        return true;
+    }
+
+    private static void ApplyAction(ThreatTracker tracker, WowGuid128 npcGuid, uint npcEntry, int spellId, WowGuid128 victimGuid, NPCThreatAction action, string trigger)
+    {
+        switch (action)
+        {
+            case NPCThreatAction.WipeRaidOnMob:
+                tracker.WipeRaidThreatOnMob(npcGuid);
+                break;
+            case NPCThreatAction.WipeSource:
+                tracker.MultiplyTargetThreat(npcGuid, victimGuid, 0.0);
+                break;
+            case NPCThreatAction.HalveSource:
+                tracker.MultiplyTargetThreat(npcGuid, victimGuid, 0.5);
+                break;
+            case NPCThreatAction.QuarterReduceSource:
+                tracker.MultiplyTargetThreat(npcGuid, victimGuid, 0.75);
+                break;
+        }
+
+        Framework.Logging.Log.Event("threat.npc_module_fired", new
+        {
+            npc_low = npcGuid.GetCounter(),
+            npc_entry = npcEntry,
+            spell_id = spellId,
+            victim_low = victimGuid.GetCounter(),
+            action = action.ToString(),
+            trigger,
+        });
+    }
+}

--- a/HermesProxy/World/ThreatSetBonuses.cs
+++ b/HermesProxy/World/ThreatSetBonuses.cs
@@ -1,0 +1,247 @@
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace HermesProxy.World;
+
+// LibThreatClassic2's set-bonus threat modifiers. Eight vanilla 1.12 sets
+// apply gear-dependent threat adjustments — multipliers on specific spells,
+// class-wide damage reductions, or heal threat scaling. Pure proxy-side
+// reads (UNIT_FIELD_INV_SLOT_HEAD via the cached object fields). No
+// sideband, no addon required.
+//
+// Implementation: per-event lookup. Iterates the player's 18 equipped slots
+// (head..feet + relic + tabard + rings + trinkets) and counts how many of
+// each known set's items are present. Returns the highest-tier bonus that
+// the equipped count satisfies. ~18 dictionary lookups per threat event;
+// acceptable at our event rate. Add caching if profiling shows hot.
+internal static class ThreatSetBonuses
+{
+    public const int SET_WARRIOR_MIGHT = 1;
+    public const int SET_MAGE_NETHERWIND = 2;
+    public const int SET_MAGE_ARCANIST = 3;
+    public const int SET_WARLOCK_NEMESIS = 4;
+    public const int SET_WARLOCK_PLAGUEHEART = 5;
+    public const int SET_PRIEST_VESTMENTS_OF_FAITH = 6;
+    public const int SET_ROGUE_BONESCYTHE = 7;
+    public const int SET_ROGUE_BLOODFANG = 8;
+
+    // Item entry ID → set ID. Source: LibThreatClassic2 ClassModules/Classic
+    // per-class set tables (verified 2026-05-17).
+    private static readonly FrozenDictionary<uint, int> ItemToSet =
+        BuildItemToSetMap().ToFrozenDictionary();
+
+    private static Dictionary<uint, int> BuildItemToSetMap()
+    {
+        var map = new Dictionary<uint, int>();
+
+        // Warrior — Battlegear of Might (T1, 8 pieces). Sunder Armor x1.15.
+        foreach (var id in new uint[] { 16866, 16867, 16868, 16869, 16860, 16861, 16862, 16863 })
+            map[id] = SET_WARRIOR_MIGHT;
+
+        // Mage — Netherwind Regalia (T2, 8 pieces). Per-spell flat threat
+        // reductions on Scorch/Fireball/Frostbolt/Arcane Missiles at 3-set.
+        foreach (var id in new uint[] { 16914, 16917, 16916, 16818, 16915, 16818, 16819, 16920 })
+            map[id] = SET_MAGE_NETHERWIND;
+
+        // Mage — Arcanist Regalia (T1, 8 pieces). x0.85 to fire/frost/arcane
+        // damage threat at 8-set.
+        foreach (var id in new uint[] { 16795, 16796, 16797, 16798, 16799, 16800, 16801, 16802 })
+            map[id] = SET_MAGE_ARCANIST;
+
+        // Warlock — Nemesis Raiment (T2, 8 pieces). x0.8 to Searing Pain +
+        // Destruction school spells at 8-set.
+        foreach (var id in new uint[] { 16927, 16928, 16929, 16930, 16931, 16932, 16933, 16934 })
+            map[id] = SET_WARLOCK_NEMESIS;
+
+        // Warlock — Plagueheart Raiment (T3, 8 pieces). x0.75 spell threat
+        // at 8-set (additional crit penalty deferred — needs crit-event hook).
+        foreach (var id in new uint[] { 22504, 22505, 22506, 22507, 22508, 22509, 22510, 22511, 23063 })
+            map[id] = SET_WARLOCK_PLAGUEHEART;
+
+        // Priest — Vestments of Faith (T3, 8 pieces). x0.9 to heal threat at
+        // 8-set.
+        foreach (var id in new uint[] { 22512, 22513, 22514, 22515, 22516, 22517, 22518, 22519, 23064 })
+            map[id] = SET_PRIEST_VESTMENTS_OF_FAITH;
+
+        // Rogue — Bonescythe Armor (T3, 8 pieces). x0.92 to Sinister Strike,
+        // Backstab, Hemorrhage, Eviscerate at 8-set.
+        foreach (var id in new uint[] { 22476, 22477, 22478, 22479, 22480, 22481, 22482, 22483, 23060 })
+            map[id] = SET_ROGUE_BONESCYTHE;
+
+        // Rogue — Bloodfang Armor (T2, 8 pieces). Feint x1.25 at 5-set.
+        foreach (var id in new uint[] { 16832, 16905, 16906, 16907, 16908, 16909, 16910, 16911 })
+            map[id] = SET_ROGUE_BLOODFANG;
+
+        return map;
+    }
+
+    // Count equipped pieces per set the player has on right now. Iterates
+    // slots 0..18 (head..feet + tabard + rings + trinkets) reading the
+    // cached OBJECT_FIELD_ENTRY for each item GUID. Skips empty slots and
+    // items whose entries aren't in any tracked set.
+    public static Dictionary<int, int> CountEquippedSetPieces(GameSessionData state)
+    {
+        var counts = new Dictionary<int, int>();
+        int entryIdx = LegacyVersion.GetUpdateField(ObjectField.OBJECT_FIELD_ENTRY);
+        if (entryIdx < 0) return counts;
+
+        // Equipment slots only (0..18, head..tabard). BagStart=19 begins the
+        // bag slots themselves, which carry containers not equippable gear.
+        for (int slot = 0; slot < Enums.Vanilla.InventorySlots.BagStart; slot++)
+        {
+            var itemGuid64 = state.GetInventorySlotItem(slot);
+            if (itemGuid64 == WowGuid64.Empty) continue;
+
+            var itemGuid128 = itemGuid64.To128(state);
+            var itemFields = state.GetCachedObjectFieldsLegacy(itemGuid128);
+            if (itemFields == null) continue;
+
+            if (!itemFields.TryGetValue(entryIdx, out var entryField)) continue;
+            uint itemEntry = entryField.UInt32Value;
+            if (itemEntry == 0) continue;
+
+            if (ItemToSet.TryGetValue(itemEntry, out int setId))
+                counts[setId] = counts.GetValueOrDefault(setId) + 1;
+        }
+        return counts;
+    }
+
+    // Per-spell damage multipliers conditional on set bonuses. Combined with
+    // the per-class general multiplier from GetClassWideDamageMultiplier.
+    private static readonly HashSet<int> NemesisDestructionSpells = new()
+    {
+        // Shadow Bolt R1..10
+        686, 695, 705, 1088, 1106, 7641, 11659, 11660, 11661, 25307,
+        // Searing Pain R1..6 (already in DamageMultipliers but Nemesis stacks)
+        5676, 17919, 17920, 17921, 17922, 17923,
+        // Conflagrate R1..4
+        17962, 18931, 18932, 18933,
+        // Immolate R1..8
+        348, 707, 1094, 2941, 11665, 11667, 11668, 25309,
+        // Rain of Fire R1..4
+        5740, 6219, 11677, 11678,
+        // Hellfire R1..4 (damage tick)
+        1949, 11683, 11684, 11685,
+        // Soul Fire R1..2
+        6353, 17924,
+    };
+
+    private static readonly HashSet<int> BonescytheSpells = new()
+    {
+        // Sinister Strike R1..9
+        1752, 1757, 1758, 1759, 1760, 8621, 11293, 11294, 26862,
+        // Backstab R1..10
+        53, 2589, 2590, 2591, 8721, 11279, 11280, 11281, 25300, 26863,
+        // Hemorrhage R1..4
+        16511, 17347, 17348, 26864,
+        // Eviscerate R1..9
+        2098, 6760, 6761, 6762, 8623, 8624, 11299, 11300, 31016,
+    };
+
+    // Returns the gear-derived damage multiplier for this spell (1.0 = no
+    // adjustment). Applied alongside the base ThreatModules.DamageMultipliers
+    // — caller multiplies the two together.
+    public static double GetGearDamageMultiplier(GameSessionData state, Class playerClass, int spellId)
+    {
+        var counts = CountEquippedSetPieces(state);
+        double mult = 1.0;
+
+        switch (playerClass)
+        {
+            case Class.Mage:
+                // Arcanist 8-set: x0.85 fire/frost/arcane (all mage damage).
+                if (counts.GetValueOrDefault(SET_MAGE_ARCANIST) >= 8)
+                    mult *= 0.85;
+                break;
+
+            case Class.Warlock:
+                if (counts.GetValueOrDefault(SET_WARLOCK_NEMESIS) >= 8 &&
+                    NemesisDestructionSpells.Contains(spellId))
+                    mult *= 0.8;
+                // Plagueheart 8-set: x0.75 to ALL warlock damage spells.
+                if (counts.GetValueOrDefault(SET_WARLOCK_PLAGUEHEART) >= 8)
+                    mult *= 0.75;
+                break;
+
+            case Class.Rogue:
+                if (counts.GetValueOrDefault(SET_ROGUE_BONESCYTHE) >= 8 &&
+                    BonescytheSpells.Contains(spellId))
+                    mult *= 0.92;
+                break;
+        }
+
+        return mult;
+    }
+
+    // Heal-side multiplier (Vestments of Faith 8-set on Priest: x0.9 to
+    // every heal threat event).
+    public static double GetGearHealMultiplier(GameSessionData state, Class playerClass)
+    {
+        if (playerClass != Class.Priest) return 1.0;
+        var counts = CountEquippedSetPieces(state);
+        return counts.GetValueOrDefault(SET_PRIEST_VESTMENTS_OF_FAITH) >= 8 ? 0.9 : 1.0;
+    }
+
+    // Per-spell flat threat ADD (not multiplier) for specific set effects.
+    // Mage Netherwind 3-set: -100 flat on Scorch/Fireball/Frostbolt, -20 on
+    // Arcane Missiles tick. Applied additively to the per-event threat.
+    public static double GetGearDamageFlatAdjust(GameSessionData state, Class playerClass, int spellId)
+    {
+        if (playerClass != Class.Mage) return 0.0;
+        var counts = CountEquippedSetPieces(state);
+        if (counts.GetValueOrDefault(SET_MAGE_NETHERWIND) < 3) return 0.0;
+
+        // Scorch R1..9
+        if (spellId == 2948 || spellId == 8444 || spellId == 8445 || spellId == 8446 ||
+            spellId == 10205 || spellId == 10206 || spellId == 10207 || spellId == 27073 ||
+            spellId == 27074)
+            return -100.0;
+        // Fireball R1..13
+        if (spellId == 133 || spellId == 143 || spellId == 145 || spellId == 3140 ||
+            spellId == 8400 || spellId == 8401 || spellId == 8402 || spellId == 10148 ||
+            spellId == 10149 || spellId == 10150 || spellId == 10151 || spellId == 25306 ||
+            spellId == 38692)
+            return -100.0;
+        // Frostbolt R1..11
+        if (spellId == 116 || spellId == 205 || spellId == 837 || spellId == 7322 ||
+            spellId == 8406 || spellId == 8407 || spellId == 8408 || spellId == 10179 ||
+            spellId == 10180 || spellId == 10181 || spellId == 25304)
+            return -100.0;
+        // Arcane Missiles (tick) R1..7
+        if (spellId == 5143 || spellId == 5144 || spellId == 5145 || spellId == 8416 ||
+            spellId == 8417 || spellId == 10211 || spellId == 10212 || spellId == 25345)
+            return -20.0;
+
+        return 0.0;
+    }
+
+    // Spell-specific MULTIPLIER set bonuses (Bloodfang Feint, Might Sunder).
+    // These wrap flat-threat spells where the value lives in ThreatModules'
+    // per-rank table — caller multiplies the flat amount by this scalar.
+    public static double GetGearSpellMultiplier(GameSessionData state, Class playerClass, int spellId)
+    {
+        var counts = CountEquippedSetPieces(state);
+
+        // Warrior Might 8-set: Sunder Armor x1.15
+        if (playerClass == Class.Warrior && counts.GetValueOrDefault(SET_WARRIOR_MIGHT) >= 8 &&
+            IsSunderArmor(spellId))
+            return 1.15;
+
+        // Rogue Bloodfang 5-set: Feint x1.25
+        if (playerClass == Class.Rogue && counts.GetValueOrDefault(SET_ROGUE_BLOODFANG) >= 5 &&
+            IsFeint(spellId))
+            return 1.25;
+
+        return 1.0;
+    }
+
+    private static bool IsSunderArmor(int spellId) =>
+        spellId == 7386 || spellId == 7405 || spellId == 8380 ||
+        spellId == 11596 || spellId == 11597;
+
+    private static bool IsFeint(int spellId) =>
+        spellId == 1966 || spellId == 6768 || spellId == 8637 ||
+        spellId == 11303 || spellId == 25302;
+}

--- a/HermesProxy/World/ThreatSetBonuses.cs
+++ b/HermesProxy/World/ThreatSetBonuses.cs
@@ -37,12 +37,12 @@ internal static class ThreatSetBonuses
         var map = new Dictionary<uint, int>();
 
         // Warrior — Battlegear of Might (T1, 8 pieces). Sunder Armor x1.15.
-        foreach (var id in new uint[] { 16866, 16867, 16868, 16869, 16860, 16861, 16862, 16863 })
+        foreach (var id in new uint[] { 16861, 16862, 16863, 16864, 16865, 16866, 16867, 16868 })
             map[id] = SET_WARRIOR_MIGHT;
 
         // Mage — Netherwind Regalia (T2, 8 pieces). Per-spell flat threat
         // reductions on Scorch/Fireball/Frostbolt/Arcane Missiles at 3-set.
-        foreach (var id in new uint[] { 16914, 16917, 16916, 16818, 16915, 16818, 16819, 16920 })
+        foreach (var id in new uint[] { 16818, 16912, 16913, 16914, 16915, 16916, 16917, 16918 })
             map[id] = SET_MAGE_NETHERWIND;
 
         // Mage — Arcanist Regalia (T1, 8 pieces). x0.85 to fire/frost/arcane
@@ -60,9 +60,9 @@ internal static class ThreatSetBonuses
         foreach (var id in new uint[] { 22504, 22505, 22506, 22507, 22508, 22509, 22510, 22511, 23063 })
             map[id] = SET_WARLOCK_PLAGUEHEART;
 
-        // Priest — Vestments of Faith (T3, 8 pieces). x0.9 to heal threat at
-        // 8-set.
-        foreach (var id in new uint[] { 22512, 22513, 22514, 22515, 22516, 22517, 22518, 22519, 23064 })
+        // Priest — Vestments of Faith (T3, 8 pieces + Ring of Faith). x0.9 to
+        // heal threat at 8-set.
+        foreach (var id in new uint[] { 22512, 22513, 22514, 22515, 22516, 22517, 22518, 22519, 23061 })
             map[id] = SET_PRIEST_VESTMENTS_OF_FAITH;
 
         // Rogue — Bonescythe Armor (T3, 8 pieces). x0.92 to Sinister Strike,

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -144,6 +144,42 @@ public sealed class ThreatTracker
         }
     }
 
+    // NPC-module primitive: multiply a SPECIFIC threater's threat on a SPECIFIC
+    // mob by a factor. Used by boss knock-back / fear-style abilities (Broodlord
+    // Knock Away, Ebonroc/Firemaw/Flamegor Wing Buffet, Onyxia Knock Away,
+    // Hakkar Aspect of Arlokk, Ouro Sand Blast). LTC2's ModifyThreat shape.
+    public void MultiplyTargetThreat(WowGuid128 mob, WowGuid128 threater, double factor)
+    {
+        if (mob == default || threater == default) return;
+        if (!_threatLists.TryGetValue(mob, out var list)) return;
+        if (!list.TryGetValue(threater, out double current)) return;
+
+        double updated = current * factor;
+        if (updated < 0) updated = 0;
+        list[threater] = updated;
+        _dirty.Add(mob);
+    }
+
+    // NPC-module primitive: wipe every threater off a mob's list (full raid
+    // threat reset). Used by Ragnaros Wrath, Shazzrah Gate, Kel'Thuzad Chains,
+    // Noth Blink. Empties the threater dict but keeps the mob entry (it's
+    // still in combat with the raid — they just have to re-build threat).
+    public void WipeRaidThreatOnMob(WowGuid128 mob)
+    {
+        if (mob == default) return;
+        if (!_threatLists.TryGetValue(mob, out var list)) return;
+        if (list.Count == 0) return;
+
+        list.Clear();
+        _lastHighest.Remove(mob);
+        _dirty.Add(mob);
+
+        Framework.Logging.Log.Event("threat.npc_raid_wipe", new
+        {
+            mob_low = mob.GetCounter(),
+        });
+    }
+
     // Bring threater up to the current top of mob's list (taunt semantics).
     // Used by Warrior Taunt, Mocking Blow, Druid Growl. If the threater is
     // already at or above the top, no-op. Marks dirty on success so the next
@@ -497,6 +533,23 @@ public sealed class ThreatTracker
         if (rawDamage <= 0) return;
         if (!IsRelevantThreater(attacker))
         {
+            // Before dropping, check NPC-boss damage handlers. Some bosses
+            // (Ouro Sand Blast, Broodlord/drake Knock Away, Wing Buffet,
+            // Molten Giant Knock Away) modify the DAMAGED player's threat
+            // on the boss when the spell connects. Direction is inverted:
+            // attacker = NPC boss, victim = friendly player whose threat
+            // gets modified ON the boss.
+            if (spellId != 0)
+            {
+                uint npcEntry = ThreatNPCModules.GetCreatureEntry(_session.GameState, attacker);
+                if (npcEntry != 0 &&
+                    ThreatNPCModules.TryHandleNPCDamage(this, attacker, npcEntry, spellId, victim))
+                {
+                    EmitDirty();
+                    return;
+                }
+            }
+
             // Tester bundles will show this when a damage event fires but
             // we filtered the attacker out of the group / pet / self set —
             // e.g. a stranger's pet hitting our shared mob, or a groupmate
@@ -723,10 +776,29 @@ public sealed class ThreatTracker
     {
         if (caster == default) return;
 
-        if (!ThreatModules.TryHandle(this, _session, spellId, caster, hitTargets))
+        // First try player/pet handlers. If matched, flush + return.
+        if (ThreatModules.TryHandle(this, _session, spellId, caster, hitTargets))
+        {
+            EmitDirty();
             return;
+        }
 
-        EmitDirty();
+        // Fall through to NPC-boss handlers (Ragnaros Wrath, Shazzrah Gate,
+        // Hakkar Aspect of Arlokk, Onyxia Knock Away, etc.). Resolve the
+        // caster's creature entry from cached object fields, then look up
+        // (entry, spellId). targetGuid = first hit-target (the wipe-source
+        // boss abilities are single-target; raid-wide wipes ignore it).
+        uint npcEntry = ThreatNPCModules.GetCreatureEntry(_session.GameState, caster);
+        if (npcEntry != 0)
+        {
+            WowGuid128 targetGuid = hitTargets.Count > 0 ? hitTargets[0] : default;
+            if (ThreatNPCModules.TryHandleNPCCast(this, caster, npcEntry, spellId, targetGuid))
+            {
+                EmitDirty();
+                return;
+            }
+        }
+
     }
 
     // True if the given GUID is the local player, a unit they own (pet,

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -269,10 +269,23 @@ public sealed class ThreatTracker
             }
             SendToClient(update);
 
+            _lastHighest.TryGetValue(mob, out var prevHighest);
+            bool highestChanged = prevHighest != newHighest;
+
+            Log.Event("threat.emit_update", new
+            {
+                mob_low = mob.GetCounter(),
+                threater_count = list.Count,
+                highest_low = newHighest.GetCounter(),
+                highest_value = (long)highestValue,
+                highest_is_local = newHighest == _session.GameState.CurrentPlayerGuid,
+                highest_changed = highestChanged,
+                threaters = ThreaterSnapshot(list),
+            });
+
             // Emit HIGHEST only when the top changes — saves churn but keeps
             // tank-aggro indicators (red border, nameplate color) snappy.
-            _lastHighest.TryGetValue(mob, out var prevHighest);
-            if (prevHighest != newHighest)
+            if (highestChanged)
             {
                 _lastHighest[mob] = newHighest;
                 var highest = new HighestThreatUpdatePkt
@@ -289,8 +302,33 @@ public sealed class ThreatTracker
                     });
                 }
                 SendToClient(highest);
+
+                Log.Event("threat.highest_changed", new
+                {
+                    mob_low = mob.GetCounter(),
+                    prev_highest_low = prevHighest.GetCounter(),
+                    new_highest_low = newHighest.GetCounter(),
+                    new_highest_is_local = newHighest == _session.GameState.CurrentPlayerGuid,
+                    new_highest_value = (long)highestValue,
+                });
             }
         }
+    }
+
+    // Compact one-line representation of a mob's threater list for the JSONL
+    // bundle. Keeps the snapshot small — counter + value pairs — so it's
+    // readable in a diagnostic without flooding context.
+    private static string ThreaterSnapshot(Dictionary<WowGuid128, double> list)
+    {
+        var sb = new System.Text.StringBuilder();
+        bool first = true;
+        foreach (var (threater, value) in list)
+        {
+            if (!first) sb.Append(',');
+            first = false;
+            sb.Append(threater.GetCounter()).Append('=').Append((long)value);
+        }
+        return sb.ToString();
     }
 
     // Wipe everything — used on session disconnect / character switch. Doesn't
@@ -352,7 +390,22 @@ public sealed class ThreatTracker
     public void OnDamage(WowGuid128 attacker, WowGuid128 victim, int spellId, double rawDamage)
     {
         if (rawDamage <= 0) return;
-        if (!IsRelevantThreater(attacker)) return;
+        if (!IsRelevantThreater(attacker))
+        {
+            // Tester bundles will show this when a damage event fires but
+            // we filtered the attacker out of the group / pet / self set —
+            // e.g. a stranger's pet hitting our shared mob, or a groupmate
+            // who hasn't been seen in CurrentGroups yet (login race).
+            Log.Event("threat.drop_irrelevant_attacker", new
+            {
+                attacker_low = attacker.GetCounter(),
+                attacker_high = attacker.GetHighType().ToString(),
+                victim_low = victim.GetCounter(),
+                spell_id = spellId,
+                damage = (long)rawDamage,
+            });
+            return;
+        }
         if (victim == default) return;
 
         double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -46,11 +46,13 @@ public sealed class ThreatTracker
 
     private readonly GlobalSessionData _session;
 
-    // Passive threat multiplier cache. Recomputed on every threat operation
-    // (cheap) but the threat.passive_modifier event only emits on change,
-    // so testers can spot stance / form transitions without spamming logs.
-    private double _cachedPassiveModifier = 1.0;
-    private uint _cachedStanceFormAuraId = 0;
+    // Passive threat multiplier cache, keyed by threater GUID. Recomputed
+    // on every threat operation (cheap) but the threat.passive_modifier
+    // event only emits on change, so testers can spot stance / form
+    // transitions without spamming logs. Phase 6.0 widened from a single
+    // pair (local player only) to a per-threater dict so groupmates'
+    // stance / form changes are also tracked.
+    private readonly Dictionary<WowGuid128, (uint stanceForm, double modifier)> _passiveCache = new();
 
     public ThreatTracker(GlobalSessionData session)
     {
@@ -350,7 +352,7 @@ public sealed class ThreatTracker
     public void OnDamage(WowGuid128 attacker, WowGuid128 victim, int spellId, double rawDamage)
     {
         if (rawDamage <= 0) return;
-        if (!IsLocalThreater(attacker)) return;
+        if (!IsRelevantThreater(attacker)) return;
         if (victim == default) return;
 
         double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);
@@ -392,7 +394,7 @@ public sealed class ThreatTracker
     public void OnHeal(WowGuid128 healer, WowGuid128 healTarget, int spellId, double effectiveHeal)
     {
         if (effectiveHeal <= 0) return;
-        if (!IsLocalThreater(healer)) return;
+        if (!IsRelevantThreater(healer)) return;
         if (healTarget == default) return;
 
         // Collect mobs whose threater list contains the heal target.
@@ -450,17 +452,27 @@ public sealed class ThreatTracker
         EmitDirty();
     }
 
-    // True if the given GUID is the local player or a unit they currently own
-    // (pet, totem, guardian). Pet ownership is read from UNIT_FIELD_SUMMONEDBY
+    // True if the given GUID is the local player, a unit they own (pet,
+    // totem, guardian), any party / raid member, or a pet owned by any
+    // party / raid member. Pet ownership is read from UNIT_FIELD_SUMMONEDBY
     // on the unit's cached fields, which the legacy server populates and the
     // proxy mirrors. We re-check on every event rather than caching because
     // pets get swapped (Hunter Call Pet, Warlock summon swap) and the cost
     // of one dictionary lookup per damage event is negligible.
-    private bool IsLocalThreater(WowGuid128 guid)
+    //
+    // JimsProxy Phase 6.0 (group-aware threat): widened from local-player +
+    // local-pet to the full party / raid so addons (Details TinyThreat,
+    // TidyPlates_ThreatPlates) see threat for everyone in your group, not
+    // just yourself. Vanilla 1.12 servers broadcast combat-log packets
+    // (SMSG_ATTACKER_STATE_UPDATE, SMSG_SPELL_NON_MELEE_DAMAGE_LOG) to
+    // every client in range, so each proxy can compute group-wide threat
+    // unilaterally — no peer cooperation needed for in-range groupmates.
+    private bool IsRelevantThreater(WowGuid128 guid)
     {
         if (guid == default) return false;
         var playerGuid = _session.GameState.CurrentPlayerGuid;
         if (guid == playerGuid) return true;
+        if (IsAnyPartyMember(guid)) return true;
 
         var fields = _session.GameState.GetCachedObjectFieldsLegacy(guid);
         if (fields == null) return false;
@@ -472,7 +484,26 @@ public sealed class ThreatTracker
         if (summonedBy64 == WowGuid64.Empty) return false;
 
         WowGuid128 summonedBy128 = summonedBy64.To128(_session.GameState);
-        return summonedBy128 == playerGuid;
+        return summonedBy128 == playerGuid || IsAnyPartyMember(summonedBy128);
+    }
+
+    // Iterates both home + battleground party slots so we recognise
+    // everyone in the user's current group regardless of context.
+    private bool IsAnyPartyMember(WowGuid128 guid)
+    {
+        if (guid == default) return false;
+        var groups = _session.GameState.CurrentGroups;
+        for (int i = 0; i < groups.Length; i++)
+        {
+            var group = groups[i];
+            if (group == null) continue;
+            foreach (var member in group.PlayerList)
+            {
+                if (member.GUID == guid)
+                    return true;
+            }
+        }
+        return false;
     }
 
     // -----------------------------------------------------------------------
@@ -523,40 +554,61 @@ public sealed class ThreatTracker
     };
 
     // Returns the passive multiplier to apply to threater's flat-add threat.
-    // Pet (and other local threaters that aren't the player) always return 1.0
-    // since vanilla pets carry no stance / form / class modifier.
+    // Phase 6.1 generalised to any group threater: class via party-list
+    // lookup (or local-player class for self), stance / form via the
+    // threater's own UNIT_FIELD_AURA cache. Pets / charms / unknown class
+    // fall through to 1.0 since vanilla pets carry no stance / form /
+    // class modifier.
     //
     // Side effect: emits threat.passive_modifier on every value change so
     // testers can correlate stance switches with threat shifts in the JSONL.
     private double GetPassiveModifier(WowGuid128 threater)
     {
-        if (threater != _session.GameState.CurrentPlayerGuid)
-            return 1.0;
+        var threaterClass = GetThreaterClass(threater);
+        uint formAura = ScanStanceFormAura(threater);
+        double modifier = ComputePassiveModifier(threaterClass, formAura);
 
-        uint formAura = ScanPlayerStanceFormAura();
-        var playerClass = (Class)_session.GameState.CurrentPlayerClass;
-        double modifier = ComputePassiveModifier(playerClass, formAura);
-
-        if (formAura != _cachedStanceFormAuraId || modifier != _cachedPassiveModifier)
+        _passiveCache.TryGetValue(threater, out var cached);
+        if (cached.stanceForm != formAura || cached.modifier != modifier)
         {
             Log.Event("threat.passive_modifier", new
             {
-                player_class = (byte)playerClass,
+                threater_low = threater.GetCounter(),
+                is_local_player = threater == _session.GameState.CurrentPlayerGuid,
+                player_class = (byte)threaterClass,
                 stance_form_spell = formAura,
                 modifier,
-                previous_modifier = _cachedPassiveModifier,
-                previous_stance_form_spell = _cachedStanceFormAuraId,
+                previous_modifier = cached.modifier,
+                previous_stance_form_spell = cached.stanceForm,
             });
-            _cachedStanceFormAuraId = formAura;
-            _cachedPassiveModifier = modifier;
+            _passiveCache[threater] = (formAura, modifier);
         }
 
         return modifier;
     }
 
-    private uint ScanPlayerStanceFormAura()
+    private Class GetThreaterClass(WowGuid128 guid)
     {
-        var fields = _session.GameState.GetCachedObjectFieldsLegacy(_session.GameState.CurrentPlayerGuid);
+        if (guid == _session.GameState.CurrentPlayerGuid)
+            return (Class)_session.GameState.CurrentPlayerClass;
+
+        var groups = _session.GameState.CurrentGroups;
+        for (int i = 0; i < groups.Length; i++)
+        {
+            var group = groups[i];
+            if (group == null) continue;
+            foreach (var member in group.PlayerList)
+            {
+                if (member.GUID == guid)
+                    return member.ClassId;
+            }
+        }
+        return Class.None;
+    }
+
+    private uint ScanStanceFormAura(WowGuid128 guid)
+    {
+        var fields = _session.GameState.GetCachedObjectFieldsLegacy(guid);
         if (fields == null) return 0;
 
         int unitFieldAura = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_AURA);

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -363,6 +363,34 @@ public sealed class ThreatTracker
                 }
             }
 
+            // Server-truth override: the mob's UNIT_FIELD_TARGET is what the
+            // server actually has as the aggro target. LTC2's predict-by-margin
+            // logic claims "you're pulling" as soon as our model exceeds the
+            // current tank by 1.30× (ranged) / 1.10× (melee), but flat-threat
+            // bonuses (Distracting Shot, Mocking Blow, Misdirection) routinely
+            // push the model past that threshold without the server agreeing.
+            // Snap to actual server target so TinyThreat / ThreatPlates show
+            // who the mob is REALLY hitting instead of who LTC2 predicts.
+            WowGuid128 serverTarget = ReadMobCurrentTarget(mob);
+            bool snappedToServerTarget = false;
+            if (serverTarget != default && serverTarget != newHighest &&
+                list.TryGetValue(serverTarget, out var serverTargetValue))
+            {
+                Log.Event("threat.snap_to_server_target", new
+                {
+                    mob_low = mob.GetCounter(),
+                    predicted_top_low = newHighest.GetCounter(),
+                    predicted_top_value = (long)highestValue,
+                    server_target_low = serverTarget.GetCounter(),
+                    server_target_value = (long)serverTargetValue,
+                    predicted_was_local = newHighest == _session.GameState.CurrentPlayerGuid,
+                    server_target_is_local = serverTarget == _session.GameState.CurrentPlayerGuid,
+                });
+                newHighest = serverTarget;
+                highestValue = serverTargetValue;
+                snappedToServerTarget = true;
+            }
+
             var update = new ThreatUpdatePkt { UnitGUID = mob };
             foreach (var (threater, value) in list)
             {
@@ -397,6 +425,7 @@ public sealed class ThreatTracker
                 highest_value = (long)highestValue,
                 highest_is_local = newHighest == _session.GameState.CurrentPlayerGuid,
                 highest_changed = highestChanged,
+                snapped_to_server_target = snappedToServerTarget,
                 threaters = ThreaterSnapshot(list),
             });
 
@@ -830,6 +859,24 @@ public sealed class ThreatTracker
     // (SMSG_ATTACKER_STATE_UPDATE, SMSG_SPELL_NON_MELEE_DAMAGE_LOG) to
     // every client in range, so each proxy can compute group-wide threat
     // unilaterally — no peer cooperation needed for in-range groupmates.
+    // Reads the mob's UNIT_FIELD_TARGET from the cached legacy fields. This
+    // is the unit the server says the mob is actually attacking — the only
+    // source of ground truth for who has aggro, since vanilla doesn't
+    // broadcast threat values over the wire. Returns default when the mob
+    // isn't cached, the field isn't mapped, or the mob has no current
+    // target (out of combat / mid-spawn).
+    private WowGuid128 ReadMobCurrentTarget(WowGuid128 mob)
+    {
+        if (mob.IsEmpty()) return default;
+        var fields = _session.GameState.GetCachedObjectFieldsLegacy(mob);
+        if (fields == null) return default;
+        int targetIdx = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_TARGET);
+        if (targetIdx < 0) return default;
+        WowGuid64 target64 = fields.GetGuidValue(targetIdx);
+        if (target64 == WowGuid64.Empty) return default;
+        return target64.To128(_session.GameState);
+    }
+
     private bool IsRelevantThreater(WowGuid128 guid)
     {
         if (guid == default) return false;

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -44,15 +44,18 @@ public sealed class ThreatTracker
     // SMSG_HIGHEST_THREAT_UPDATE when the top actually changes.
     private readonly Dictionary<WowGuid128, WowGuid128> _lastHighest = new();
 
-    // Vanilla melee aggro hysteresis: a challenger must exceed the current
-    // tank's threat by 10% before aggro flips. Without this, two threaters
-    // doing similar damage rapidly swap the "highest" position on every
-    // damage event and the modern client paints Luna red on every party
-    // member simultaneously. 1.10 = melee threshold; ranged is 1.30 but
-    // we can't tell from a damage event whether the challenger is in melee
-    // range so we use the more permissive value (matches the local-player
-    // case which is by far the dominant one).
-    private const double AggroFlipMargin = 1.10;
+    // Vanilla aggro hysteresis: a challenger must exceed the current tank's
+    // threat by N% before aggro flips. LibThreatClassic2 picks the margin
+    // per challenger class:
+    //   1.10 — Warrior, Rogue, Druid in Bear/Cat form (melee)
+    //   1.30 — Hunter, Mage, Priest, Warlock, Shaman, Paladin, caster druid
+    //   1.10 — unknown / other players (LTC2 default for classId == nil)
+    // Without per-class margins a hunter at 1.2× pet threat would show as
+    // "pulling" in TinyThreat even though the server still hands aggro to
+    // the pet (ranged class needs 1.30×). See GetAggroFlipMargin below;
+    // values cross-referenced against LibThreatClassic2.lua line 1708.
+    private const double AggroFlipMarginMelee = 1.10;
+    private const double AggroFlipMarginRanged = 1.30;
 
     private readonly GlobalSessionData _session;
 
@@ -301,19 +304,25 @@ public sealed class ThreatTracker
                 newHighest = prevHighest;
                 highestValue = prevValue;
             }
-            else if (rawTopValue >= prevValue * AggroFlipMargin)
-            {
-                // Challenger crossed the 110% threshold — flip.
-                newHighest = rawTop;
-                highestValue = rawTopValue;
-            }
             else
             {
-                // Challenger numerically ahead but inside the hysteresis
-                // band — vanilla server would still target prev. Hold.
-                newHighest = prevHighest;
-                highestValue = prevValue;
-                aggroFlipHeld = true;
+                // Per-challenger margin: melee classes (warrior / rogue / bear /
+                // cat druid) need 1.10×, ranged casters & hunters need 1.30×.
+                double margin = GetAggroFlipMargin(rawTop);
+                if (rawTopValue >= prevValue * margin)
+                {
+                    // Challenger crossed the class-specific threshold — flip.
+                    newHighest = rawTop;
+                    highestValue = rawTopValue;
+                }
+                else
+                {
+                    // Challenger numerically ahead but inside the hysteresis
+                    // band — vanilla server would still target prev. Hold.
+                    newHighest = prevHighest;
+                    highestValue = prevValue;
+                    aggroFlipHeld = true;
+                }
             }
 
             var update = new ThreatUpdatePkt { UnitGUID = mob };
@@ -338,7 +347,7 @@ public sealed class ThreatTracker
                     held_value = (long)highestValue,
                     challenger_low = rawTop.GetCounter(),
                     challenger_value = (long)rawTopValue,
-                    margin_required = AggroFlipMargin,
+                    margin_required = GetAggroFlipMargin(rawTop),
                 });
             }
 
@@ -564,22 +573,35 @@ public sealed class ThreatTracker
         if (!IsRelevantThreater(healer)) return;
         if (healTarget == default) return;
 
-        // Collect mobs whose threater list contains the heal target.
-        List<WowGuid128>? mobsThreateningTarget = null;
+        // LTC2 ThreatClassModuleCore.lua line 1148 (prototype:AddThreat):
+        //
+        //     threat = threat / EncounterMobs()
+        //     for k, v in pairs(self.targetThreat) do
+        //         self:AddTargetThreat(k, threat)
+        //     end
+        //
+        // self.targetThreat is the CASTER's mob list, not the heal target's.
+        // So heal threat lands on mobs the HEALER is fighting — not mobs the
+        // recipient is fighting. Mend Pet (hunter healing pet) is the canonical
+        // case: hunter at range firing on Mob A, bear tanking A+B+C. Mend Pet
+        // tick threat goes ONLY to Mob A (hunter's combat list). Bear retains
+        // pet-only threat on B and C. Validated via 2026-05-17 log
+        // jimsproxy-20260517-135658.jsonl (TinyThreat showed hunter at top on
+        // bear-only mobs because we were splitting on recipient mobs instead).
+        List<WowGuid128>? mobsThreateningHealer = null;
         foreach (var (mob, list) in _threatLists)
         {
-            if (list.ContainsKey(healTarget))
+            if (list.ContainsKey(healer))
             {
-                mobsThreateningTarget ??= new List<WowGuid128>();
-                mobsThreateningTarget.Add(mob);
+                mobsThreateningHealer ??= new List<WowGuid128>();
+                mobsThreateningHealer.Add(mob);
             }
         }
 
-        if (mobsThreateningTarget == null || mobsThreateningTarget.Count == 0)
+        if (mobsThreateningHealer == null || mobsThreateningHealer.Count == 0)
         {
-            // Healed someone we don't know is in combat — drop. Avoids
-            // putting threat on every mob we've ever fought just because we
-            // healed a friendly out of nowhere.
+            // Healer isn't on any mob's threat list — pure-healer-out-of-combat
+            // case. Server doesn't generate heal threat either; drop.
             return;
         }
 
@@ -598,9 +620,13 @@ public sealed class ThreatTracker
         }
 
         double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier * gearHealMultiplier;
-        double threatPerMob = totalThreat / mobsThreateningTarget.Count;
+        // LTC2 divides by EncounterMobs() — total mobs in the encounter, not
+        // just the caster's combat list. We approximate with the caster's mob
+        // count (close enough for solo/small-group; full encounter sync is a
+        // group-threat-sync follow-up).
+        double threatPerMob = totalThreat / mobsThreateningHealer.Count;
 
-        foreach (var mob in mobsThreateningTarget)
+        foreach (var mob in mobsThreateningHealer)
             AddThreat(mob, healer, threatPerMob);
 
         Log.Event("threat.heal_added", new
@@ -611,7 +637,7 @@ public sealed class ThreatTracker
             effective_heal = (long)effectiveHeal,
             passive_mod = passiveModifier,
             talent_mult = talentMultiplier,
-            mobs_split = mobsThreateningTarget.Count,
+            mobs_split = mobsThreateningHealer.Count,
             threat_per_mob = (long)threatPerMob,
             total_threat = (long)totalThreat,
         });
@@ -624,6 +650,35 @@ public sealed class ThreatTracker
     //   33778 — Lifebloom final bloom (overheal-like effect)
     private static bool IsEnergizeExempt(int spellId) =>
         spellId == 34299 || spellId == 33778;
+
+    // Per-challenger aggro flip margin, matching LibThreatClassic2's
+    // GetPullAggroRangeModifier (LibThreatClassic2.lua line 1679-1713).
+    // Returns the multiplier the challenger's threat must exceed the current
+    // top's threat by before we flip SMSG_HIGHEST_THREAT_UPDATE. Pets and
+    // unknown threaters default to 1.10 (LTC2's nil-classId branch).
+    private double GetAggroFlipMargin(WowGuid128 challenger)
+    {
+        if (challenger == _session.GameState.CurrentPlayerGuid)
+        {
+            var playerClass = (Class)_session.GameState.CurrentPlayerClass;
+            if (playerClass == Class.Warrior || playerClass == Class.Rogue)
+                return AggroFlipMarginMelee;
+            if (playerClass == Class.Druid)
+            {
+                uint formAura = ScanStanceFormAura(challenger);
+                // 5487 Bear, 9634 Dire Bear, 768 Cat — melee forms only.
+                if (formAura == 5487 || formAura == 9634 || formAura == 768)
+                    return AggroFlipMarginMelee;
+                return AggroFlipMarginRanged;
+            }
+            return AggroFlipMarginRanged;
+        }
+
+        if (challenger == _session.GameState.CurrentPetGuid)
+            return AggroFlipMarginMelee;
+
+        return AggroFlipMarginMelee;
+    }
 
     // Energize-event threat. LibThreatClassic2 fires on SPELL_ENERGIZE and
     // SPELL_PERIODIC_ENERGIZE: mana gain × 0.5, all other power types × 5.

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -504,6 +504,7 @@ public sealed class ThreatTracker
         }
         if (victim == default) return;
 
+        SnapshotTalentStateIfChanged();
         double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);
         double passiveModifier = GetPassiveModifier(attacker);
         double talentMultiplier = GetSpellTalentMultiplier(attacker, spellId);
@@ -522,6 +523,7 @@ public sealed class ThreatTracker
                 damage = (long)rawDamage,
                 ability_mult = abilityMultiplier,
                 passive_mod = passiveModifier,
+                talent_mult = talentMultiplier,
                 threat_added = (long)scaledThreat,
                 new_total = (long)newTotal,
                 threater_count = list.Count,
@@ -566,6 +568,7 @@ public sealed class ThreatTracker
             return;
         }
 
+        SnapshotTalentStateIfChanged();
         double passiveModifier = GetPassiveModifier(healer);
         // School-gated talent on heals: paladin Imp Righteous Fury boosts holy
         // heal threat when RF aura is active. Other classes' heals are no-op.
@@ -583,6 +586,7 @@ public sealed class ThreatTracker
             spell_id = spellId,
             effective_heal = (long)effectiveHeal,
             passive_mod = passiveModifier,
+            talent_mult = talentMultiplier,
             mobs_split = mobsThreateningTarget.Count,
             threat_per_mob = (long)threatPerMob,
             total_threat = (long)totalThreat,
@@ -731,6 +735,7 @@ public sealed class ThreatTracker
     private static readonly uint[] ShadowAffinityRanks      = { 15272, 15318, 15320 };
     private static readonly uint[] DruidSubtletyRanks       = { 17118, 17119, 17120, 17121, 17122 };
     private static readonly uint[] ImpRighteousFuryRanks    = { 20468, 20469, 20470 };
+    private static readonly uint[] ImpPwsRanks              = { 14748, 14768, 14769 };
 
     private const uint RighteousFuryAura = 25780;
 
@@ -813,6 +818,106 @@ public sealed class ThreatTracker
                 highest = i + 1;
         }
         return highest;
+    }
+
+    // Cached snapshot of detected talent ranks so the diagnostic event below
+    // only fires when the rank set actually changes (login, learn, respec).
+    // Initialized to all -1 sentinels so the first call after construction
+    // always emits a baseline snapshot for tester observability.
+    private (int defiance, int feralInstinct, int silentResolve,
+             int shadowAffinity, int druidSubtlety, int impRighteousFury,
+             int impPws) _lastTalentSnapshot = (-1, -1, -1, -1, -1, -1, -1);
+
+    // Emits a `threat.talent_snapshot` JSONL event whenever the detected
+    // talent-rank set differs from the last observation. Lets a solo tester
+    // run the proxy, log in on any character, attack any mob once, and grep
+    // the bundle for the snapshot line to confirm the talent injection +
+    // detection pipeline is working — even for characters that are too low
+    // level to have any of these talents (all ranks would log as 0).
+    private void SnapshotTalentStateIfChanged()
+    {
+        var playerClass = (Class)_session.GameState.CurrentPlayerClass;
+        int defiance       = playerClass == Class.Warrior ? GetTalentRank(DefianceRanks)         : 0;
+        int feralInstinct  = playerClass == Class.Druid   ? GetTalentRank(FeralInstinctRanks)    : 0;
+        int silentResolve  = playerClass == Class.Priest  ? GetTalentRank(SilentResolveRanks)    : 0;
+        int shadowAffinity = playerClass == Class.Priest  ? GetTalentRank(ShadowAffinityRanks)   : 0;
+        int druidSubtlety  = playerClass == Class.Druid   ? GetTalentRank(DruidSubtletyRanks)    : 0;
+        int irf            = playerClass == Class.Paladin ? GetTalentRank(ImpRighteousFuryRanks) : 0;
+        int impPws         = playerClass == Class.Priest  ? GetTalentRank(ImpPwsRanks)           : 0;
+        var current = (defiance, feralInstinct, silentResolve, shadowAffinity, druidSubtlety, irf, impPws);
+        if (current == _lastTalentSnapshot)
+            return;
+        _lastTalentSnapshot = current;
+        Log.Event("threat.talent_snapshot", new
+        {
+            player_class = (byte)playerClass,
+            defiance_rank = defiance,
+            feral_instinct_rank = feralInstinct,
+            silent_resolve_rank = silentResolve,
+            shadow_affinity_rank = shadowAffinity,
+            druid_subtlety_rank = druidSubtlety,
+            imp_righteous_fury_rank = irf,
+            imp_pws_rank = impPws,
+            real_known_count = _session.GameState.CurrentPlayerKnownSpells.Count,
+            synthesized_count = _session.GameState.SynthesizedTalentRanks.Count,
+        });
+    }
+
+    // Returns the Imp PW:S multiplier (1.0 + 0.05 × rank). Called from the
+    // PW:S cast handler in ThreatModules. Public so the cast handler can
+    // pre-multiply the table amount before adding threat.
+    public double GetImpPwsMultiplier()
+    {
+        if (_session.GameState.CurrentPlayerClass != (byte)Class.Priest)
+            return 1.0;
+        int rank = GetTalentRank(ImpPwsRanks);
+        return rank > 0 ? 1.0 + (0.05 * rank) : 1.0;
+    }
+
+    // PW:S cast threat: fixed per-rank amount × Imp PWS × passive (Silent
+    // Resolve included via GetPassiveModifier) × distribution across all
+    // mobs in combat with the shield recipient. Same shape as OnHeal but
+    // uses the table amount instead of effective-heal × 0.5.
+    public void OnPowerWordShield(WowGuid128 caster, WowGuid128 shieldTarget, int spellId, double baseAmount)
+    {
+        if (baseAmount <= 0) return;
+        if (caster != _session.GameState.CurrentPlayerGuid) return;
+        if (shieldTarget == default) return;
+
+        List<WowGuid128>? mobsInCombat = null;
+        foreach (var (mob, list) in _threatLists)
+        {
+            if (list.ContainsKey(shieldTarget))
+            {
+                mobsInCombat ??= new List<WowGuid128>();
+                mobsInCombat.Add(mob);
+            }
+        }
+        if (mobsInCombat == null || mobsInCombat.Count == 0)
+            return;
+
+        SnapshotTalentStateIfChanged();
+        double passive = GetPassiveModifier(caster);
+        double impPwsMult = GetImpPwsMultiplier();
+        double totalThreat = baseAmount * impPwsMult * passive;
+        double threatPerMob = totalThreat / mobsInCombat.Count;
+
+        foreach (var mob in mobsInCombat)
+            AddThreat(mob, caster, threatPerMob);
+
+        Log.Event("threat.spell.power_word_shield", new
+        {
+            spell_id = spellId,
+            shield_target_low = shieldTarget.GetCounter(),
+            base_amount = baseAmount,
+            imp_pws_mult = impPwsMult,
+            passive_mod = passive,
+            mobs_split = mobsInCombat.Count,
+            threat_per_mob = (long)threatPerMob,
+            total_threat = (long)totalThreat,
+        });
+
+        EmitDirty();
     }
 
     // Returns the passive multiplier to apply to threater's flat-add threat.

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -763,18 +763,6 @@ public sealed class ThreatTracker
         15286,
     };
 
-    private static readonly HashSet<uint> DruidSubtletySpells = new()
-    {
-        // Moonfire (R1..10)
-        8921, 8924, 8925, 8926, 8927, 8928, 8929, 9833, 9834, 9835,
-        // Starfire (R1..7)
-        2912, 8949, 8950, 8951, 9875, 9876, 25298,
-        // Wrath (R1..6)
-        5176, 5177, 5178, 6780, 8905, 9912,
-        // Hurricane (R1..3)
-        16914, 17401, 17402,
-    };
-
     // Spells the Righteous Fury (+ Imp RF) multiplier applies to. Holy damage
     // and Holy heals — paladin's RF aura boosts threat for both. List taken
     // from LTC2 Paladin.lua's HolyHealIDs + holyShieldIDs + paladin damage
@@ -798,6 +786,16 @@ public sealed class ThreatTracker
         19750, 19939, 19940, 19941, 19942, 19943,
         // Lay on Hands (R1..3)
         633, 2800, 10310,
+        // Judgement: server emits damage via "umbrella" IDs and per-seal IDs.
+        // 23590 is the most common engine event; 20184/85/86/87/88, 20271, 20286,
+        // 20425 cover Justice/Light/Wisdom/Righteousness/Crusader/Command variants.
+        23590, 23591, 20271, 20184, 20185, 20186, 20187, 20188, 20286, 20425,
+        // Seal of Righteousness damage proc (R1..8) — fires on every melee swing
+        20154, 20287, 20288, 20289, 20290, 20291, 20292, 20293, 21084, 25713,
+        // Holy Wrath (R1..2)
+        2812, 10318,
+        // Exorcism (R1..6)
+        879, 5614, 5615, 10312, 10313, 10314,
     };
 
     // Returns the highest rank (1..N) of a talent the player has, or 0 if untaken.
@@ -990,12 +988,9 @@ public sealed class ThreatTracker
                 }
                 return 1.0;
             case Class.Druid:
-                if (DruidSubtletySpells.Contains(sid))
-                {
-                    int rank = GetTalentRank(DruidSubtletyRanks);
-                    if (rank > 0)
-                        return 1.0 - (0.04 * rank);
-                }
+                // Druid Subtlety moved to GetTalentMultiplier (universal passive,
+                // applies to heals too — was previously gated to Balance damage
+                // spells only, missing the resto-druid heal-threat reduction).
                 return 1.0;
             case Class.Paladin:
                 if (PaladinRighteousFurySpells.Contains(sid) && IsRighteousFuryActive())
@@ -1056,14 +1051,21 @@ public sealed class ThreatTracker
                 return 1.0;
 
             case Class.Druid:
+            {
+                double mult = 1.0;
                 // Feral Instinct: +0.03 / rank, Bear / Dire Bear only.
                 if (formAura == 5487 || formAura == 9634)
                 {
-                    int rank = GetTalentRank(FeralInstinctRanks);
-                    if (rank > 0)
-                        return 1.0 + (0.03 * rank);
+                    int fiRank = GetTalentRank(FeralInstinctRanks);
+                    if (fiRank > 0) mult *= 1.0 + (0.03 * fiRank);
                 }
-                return 1.0;
+                // Subtlety (Restoration tier 1): −0.04 / rank, applies to all
+                // spells (damage AND heals). Universal per LTC2 Druid.lua —
+                // not school-gated, despite the name's overlap with rogue Subtlety.
+                int subRank = GetTalentRank(DruidSubtletyRanks);
+                if (subRank > 0) mult *= 1.0 - (0.04 * subRank);
+                return mult;
+            }
 
             case Class.Priest:
                 // Silent Resolve: −0.04 / rank, applies to all damage and heals.

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -595,6 +595,47 @@ public sealed class ThreatTracker
         EmitDirty();
     }
 
+    // LTC2 ExemptGains: spells that should NOT generate energize threat.
+    //   34299 — Improved Leader of the Pack (heal-side, no threat)
+    //   33778 — Lifebloom final bloom (overheal-like effect)
+    private static bool IsEnergizeExempt(int spellId) =>
+        spellId == 34299 || spellId == 33778;
+
+    // Energize-event threat. LibThreatClassic2 fires on SPELL_ENERGIZE and
+    // SPELL_PERIODIC_ENERGIZE: mana gain × 0.5, all other power types × 5.
+    // Threat goes to the CASTER and is added to EVERY mob the caster is on
+    // (replicated, not split — matches LTC2's per-mob iteration in
+    // ThreatClassModuleCore.lua line 588). Server pre-caps the amount to
+    // actual gain (zero-gain energizes don't fire), so no client-side cap
+    // math needed proxy-side.
+    public void OnEnergize(WowGuid128 caster, WowGuid128 recipient, int spellId, PowerType powerType, double amount)
+    {
+        if (amount <= 0) return;
+        if (!IsRelevantThreater(caster)) return;
+        if (IsEnergizeExempt(spellId)) return;
+
+        double multiplier = powerType == PowerType.Mana ? 0.5 : 5.0;
+        double rawThreat = amount * multiplier;
+
+        // AddThreatToAllMobs applies the passive modifier internally and
+        // skips mobs the caster isn't already on (no aggro pull from
+        // off-combat energize — matches lib semantics).
+        AddThreatToAllMobs(caster, rawThreat);
+
+        Framework.Logging.Log.Event("threat.energize", new
+        {
+            caster_low = caster.GetCounter(),
+            recipient_low = recipient.GetCounter(),
+            spell_id = spellId,
+            power_type = powerType.ToString(),
+            amount = (long)amount,
+            multiplier,
+            raw_threat = (long)rawThreat,
+        });
+
+        EmitDirty();
+    }
+
     // Called from SMSG_SPELL_GO observer for any spell cast that may modify
     // threat (Distracting Shot, Disengage, Feign Death, Growl, Cower, ...).
     // Routes to ThreatModules' per-spell-id handler. Auto-flushes the dirty

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -506,7 +506,8 @@ public sealed class ThreatTracker
 
         double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);
         double passiveModifier = GetPassiveModifier(attacker);
-        double scaledThreat = rawDamage * abilityMultiplier * passiveModifier;
+        double talentMultiplier = GetSpellTalentMultiplier(attacker, spellId);
+        double scaledThreat = rawDamage * abilityMultiplier * passiveModifier * talentMultiplier;
         AddThreat(victim, attacker, scaledThreat);
 
         if (_threatLists.TryGetValue(victim, out var list) &&
@@ -566,7 +567,10 @@ public sealed class ThreatTracker
         }
 
         double passiveModifier = GetPassiveModifier(healer);
-        double totalThreat = effectiveHeal * 0.5 * passiveModifier;
+        // School-gated talent on heals: paladin Imp Righteous Fury boosts holy
+        // heal threat when RF aura is active. Other classes' heals are no-op.
+        double talentMultiplier = GetSpellTalentMultiplier(healer, spellId);
+        double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier;
         double threatPerMob = totalThreat / mobsThreateningTarget.Count;
 
         foreach (var mob in mobsThreateningTarget)
@@ -710,10 +714,86 @@ public sealed class ThreatTracker
     // Talent rank spell ID arrays — ordered rank 1 → rank N. Matched against
     // CurrentPlayerKnownSpells ∪ SynthesizedTalentRanks via GetTalentRank.
     // Source: 1.14.2 Talent.dbc cross-referenced against SpellName.dbc.
-    // (Defiance talent_id 144, Feral Instinct 799, Silent Resolve 352.)
-    private static readonly uint[] DefianceRanks       = { 12303, 12788, 12789, 12791, 12792 };
-    private static readonly uint[] FeralInstinctRanks  = { 16947, 16948, 16949, 16950, 16951 };
-    private static readonly uint[] SilentResolveRanks  = { 14523, 14784, 14785, 14786, 14787 };
+    //
+    // Flat-passive layer (apply on GetPassiveModifier):
+    //   Defiance        (Warrior Protection, talent_id 144)
+    //   Feral Instinct  (Druid Feral Combat, talent_id 799)
+    //   Silent Resolve  (Priest Discipline,  talent_id 352)
+    //
+    // School-gated layer (apply on GetSpellTalentMultiplier):
+    //   Shadow Affinity        (Priest Shadow,         talent_id 461)
+    //   Druid Subtlety         (Druid Restoration,     talent_id 841)
+    //   Improved Righteous Fury (Paladin Holy,         talent_id 1501)
+    //                                                   gated on RF aura 25780 active
+    private static readonly uint[] DefianceRanks            = { 12303, 12788, 12789, 12791, 12792 };
+    private static readonly uint[] FeralInstinctRanks       = { 16947, 16948, 16949, 16950, 16951 };
+    private static readonly uint[] SilentResolveRanks       = { 14523, 14784, 14785, 14786, 14787 };
+    private static readonly uint[] ShadowAffinityRanks      = { 15272, 15318, 15320 };
+    private static readonly uint[] DruidSubtletyRanks       = { 17118, 17119, 17120, 17121, 17122 };
+    private static readonly uint[] ImpRighteousFuryRanks    = { 20468, 20469, 20470 };
+
+    private const uint RighteousFuryAura = 25780;
+
+    // School-affected spell-ID sets, transcribed from LibThreatClassic2's
+    // ClassModules/Classic/{Priest,Druid,Paladin}.lua. Each set is the canonical
+    // list of vanilla spells the corresponding talent's multiplier applies to.
+    //
+    // Curated lists rather than school lookup because the proxy doesn't carry
+    // SpellMisc.SchoolMask in a queryable form; LTC2 also curates because
+    // school-based gating alone would miss heal/damage variants that share a
+    // spell family but differ in school (e.g. paladin Hammer of Wrath is Holy
+    // damage; Hammer of Justice is no-school CC — both Hammer-named).
+
+    private static readonly HashSet<uint> ShadowAffinitySpells = new()
+    {
+        // Shadow Word: Pain (R1..8)
+        589, 594, 970, 992, 2767, 10892, 10893, 10894,
+        // Mind Blast (R1..9)
+        8092, 8102, 8103, 8104, 8105, 8106, 10945, 10946, 10947,
+        // Mind Flay (R1..6)
+        15407, 17311, 17312, 17313, 17314, 18807,
+        // Devouring Plague (R1..5)
+        2944, 19276, 19277, 19278, 19279,
+        // Vampiric Embrace (passive damage→heal — counted as shadow threat)
+        15286,
+    };
+
+    private static readonly HashSet<uint> DruidSubtletySpells = new()
+    {
+        // Moonfire (R1..10)
+        8921, 8924, 8925, 8926, 8927, 8928, 8929, 9833, 9834, 9835,
+        // Starfire (R1..7)
+        2912, 8949, 8950, 8951, 9875, 9876, 25298,
+        // Wrath (R1..6)
+        5176, 5177, 5178, 6780, 8905, 9912,
+        // Hurricane (R1..3)
+        16914, 17401, 17402,
+    };
+
+    // Spells the Righteous Fury (+ Imp RF) multiplier applies to. Holy damage
+    // and Holy heals — paladin's RF aura boosts threat for both. List taken
+    // from LTC2 Paladin.lua's HolyHealIDs + holyShieldIDs + paladin damage
+    // catalogue. Heal-side application is gated to RF being active (no RF =
+    // baseline 1.0); damage-side is gated likewise.
+    private static readonly HashSet<uint> PaladinRighteousFurySpells = new()
+    {
+        // Consecration (R1..6)
+        26573, 20116, 20922, 20923, 20924, 27983,
+        // Holy Shield damage proc (R1..3) — also has its own 1.2x abilityMul
+        20925, 20927, 20928,
+        // Holy Shock damage (R1..3)
+        25912, 25911, 25902,
+        // Holy Shock heal (R1..3)
+        25903, 25913, 25914,
+        // Hammer of Wrath (R1..3)
+        24239, 24274, 24275,
+        // Holy Light (R1..9)
+        635, 639, 647, 1026, 1042, 3472, 10328, 10329, 25292,
+        // Flash of Light (R1..6)
+        19750, 19939, 19940, 19941, 19942, 19943,
+        // Lay on Hands (R1..3)
+        633, 2800, 10310,
+    };
 
     // Returns the highest rank (1..N) of a talent the player has, or 0 if untaken.
     // Walks the rank ids in ascending order; the last index that matches the
@@ -775,6 +855,76 @@ public sealed class ThreatTracker
         }
 
         return modifier;
+    }
+
+    // Per-spell talent multiplier for school-gated talents. Reads the local
+    // player's known-spells set to detect ranks; non-local-player attackers
+    // always get 1.0 since we can't see their talents. The aura-gated case
+    // (Paladin RF active) is checked here too.
+    //
+    // Applies on top of GetPassiveModifier — so a Paladin tank with 3/3 IRF
+    // and RF active gets the flat passive (1.0 currently — paladins have no
+    // flat-passive talent in the LTC2 model) × IRF multiplier of 1.9 for any
+    // PaladinRighteousFurySpells.Contains(spellId) damage/heal event.
+    public double GetSpellTalentMultiplier(WowGuid128 attacker, int spellId)
+    {
+        if (spellId <= 0) return 1.0;
+        if (attacker != _session.GameState.CurrentPlayerGuid) return 1.0;
+        uint sid = (uint)spellId;
+        var playerClass = (Class)_session.GameState.CurrentPlayerClass;
+        switch (playerClass)
+        {
+            case Class.Priest:
+                if (ShadowAffinitySpells.Contains(sid))
+                {
+                    int rank = GetTalentRank(ShadowAffinityRanks);
+                    // LTC2 explicit array: [0.92, 0.84, 0.75] — rank 3 is NOT
+                    // 1-3*0.08=0.76 (the lib hard-codes the 0.75 for a slightly
+                    // steeper drop at 3/3).
+                    return rank switch { 1 => 0.92, 2 => 0.84, 3 => 0.75, _ => 1.0 };
+                }
+                return 1.0;
+            case Class.Druid:
+                if (DruidSubtletySpells.Contains(sid))
+                {
+                    int rank = GetTalentRank(DruidSubtletyRanks);
+                    if (rank > 0)
+                        return 1.0 - (0.04 * rank);
+                }
+                return 1.0;
+            case Class.Paladin:
+                if (PaladinRighteousFurySpells.Contains(sid) && IsRighteousFuryActive())
+                {
+                    int rank = GetTalentRank(ImpRighteousFuryRanks);
+                    // LTC2 Paladin.lua: righteousFuryMod = 1 + 0.6 * (1 + irfRanks[rank+1])
+                    // irfRanks = {0, 0.16, 0.33, 0.5}.
+                    double irfBonus = rank switch { 1 => 0.16, 2 => 0.33, 3 => 0.50, _ => 0.0 };
+                    return 1.0 + 0.6 * (1.0 + irfBonus);
+                }
+                return 1.0;
+            default:
+                return 1.0;
+        }
+    }
+
+    // Scans the player's aura list for Righteous Fury (25780). Used to gate
+    // Improved Righteous Fury multiplication in GetSpellTalentMultiplier.
+    // Same scan shape as ScanStanceFormAura but with a single target spell id.
+    private bool IsRighteousFuryActive()
+    {
+        var fields = _session.GameState.GetCachedObjectFieldsLegacy(_session.GameState.CurrentPlayerGuid);
+        if (fields == null) return false;
+        int unitFieldAura = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_AURA);
+        if (unitFieldAura < 0) return false;
+        int slots = LegacyVersion.GetAuraSlotsCount();
+        for (int i = 0; i < slots; i++)
+        {
+            if (!fields.TryGetValue(unitFieldAura + i, out var field))
+                continue;
+            if (field.UInt32Value == RighteousFuryAura)
+                return true;
+        }
+        return false;
     }
 
     // Computes the talent-layered multiplier to apply on top of the class+stance

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -508,7 +508,22 @@ public sealed class ThreatTracker
         double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);
         double passiveModifier = GetPassiveModifier(attacker);
         double talentMultiplier = GetSpellTalentMultiplier(attacker, spellId);
-        double scaledThreat = rawDamage * abilityMultiplier * passiveModifier * talentMultiplier;
+
+        // Set-bonus gear adjustments (Mage Arcanist x0.85, Warlock Nemesis x0.8
+        // on Destruction, Warlock Plagueheart x0.75, Rogue Bonescythe x0.92,
+        // Mage Netherwind -100/-20 flat). Player-only; pets / guardians don't
+        // carry sets. Layered on top of ability/passive/talent multipliers.
+        double gearMultiplier = 1.0;
+        double gearFlat = 0.0;
+        if (attacker == _session.GameState.CurrentPlayerGuid)
+        {
+            var playerClass = (Class)_session.GameState.CurrentPlayerClass;
+            gearMultiplier = ThreatSetBonuses.GetGearDamageMultiplier(_session.GameState, playerClass, spellId);
+            gearFlat = ThreatSetBonuses.GetGearDamageFlatAdjust(_session.GameState, playerClass, spellId);
+        }
+
+        double scaledThreat = (rawDamage * abilityMultiplier * gearMultiplier + gearFlat) * passiveModifier * talentMultiplier;
+        if (scaledThreat < 0) scaledThreat = 0;
         AddThreat(victim, attacker, scaledThreat);
 
         if (_threatLists.TryGetValue(victim, out var list) &&
@@ -573,7 +588,16 @@ public sealed class ThreatTracker
         // School-gated talent on heals: paladin Imp Righteous Fury boosts holy
         // heal threat when RF aura is active. Other classes' heals are no-op.
         double talentMultiplier = GetSpellTalentMultiplier(healer, spellId);
-        double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier;
+
+        // Set-bonus heal-threat scalar (Priest Vestments of Faith 8-set: x0.9).
+        double gearHealMultiplier = 1.0;
+        if (healer == _session.GameState.CurrentPlayerGuid)
+        {
+            var playerClass = (Class)_session.GameState.CurrentPlayerClass;
+            gearHealMultiplier = ThreatSetBonuses.GetGearHealMultiplier(_session.GameState, playerClass);
+        }
+
+        double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier * gearHealMultiplier;
         double threatPerMob = totalThreat / mobsThreateningTarget.Count;
 
         foreach (var mob in mobsThreateningTarget)

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -44,6 +44,16 @@ public sealed class ThreatTracker
     // SMSG_HIGHEST_THREAT_UPDATE when the top actually changes.
     private readonly Dictionary<WowGuid128, WowGuid128> _lastHighest = new();
 
+    // Vanilla melee aggro hysteresis: a challenger must exceed the current
+    // tank's threat by 10% before aggro flips. Without this, two threaters
+    // doing similar damage rapidly swap the "highest" position on every
+    // damage event and the modern client paints Luna red on every party
+    // member simultaneously. 1.10 = melee threshold; ranged is 1.30 but
+    // we can't tell from a damage event whether the challenger is in melee
+    // range so we use the more permissive value (matches the local-player
+    // case which is by far the dominant one).
+    private const double AggroFlipMargin = 1.10;
+
     private readonly GlobalSessionData _session;
 
     // Passive threat multiplier cache, keyed by threater GUID. Recomputed
@@ -245,17 +255,65 @@ public sealed class ThreatTracker
             if (!_threatLists.TryGetValue(mob, out var list) || list.Count == 0)
                 continue;
 
-            // Find the top threater. Ties broken arbitrarily — vanilla itself
-            // has tie-breaking quirks but they don't matter for display.
-            WowGuid128 newHighest = default;
-            double highestValue = -1;
+            // Find the raw top threater (max value, no hysteresis).
+            WowGuid128 rawTop = default;
+            double rawTopValue = -1;
             foreach (var (threater, value) in list)
             {
-                if (value > highestValue)
+                if (value > rawTopValue)
                 {
-                    highestValue = value;
-                    newHighest = threater;
+                    rawTopValue = value;
+                    rawTop = threater;
                 }
+            }
+
+            // Apply vanilla aggro hysteresis. Vanilla 1.12 requires a melee
+            // challenger to exceed the current tank's threat by 10% (130% for
+            // ranged) before aggro flips. Numerically passing the top by 1
+            // threat point is NOT enough — the server holds aggro on the
+            // current tank until the threshold is crossed.
+            //
+            // Why this matters for addons: the modern client computes
+            // UnitThreatSituation status against HighestThreatGUID. If we
+            // re-flip the top on every close-tie swing (two players doing
+            // similar damage, tank + DPS within 10%, etc.), each threater
+            // briefly becomes "the highest" and the modern client reports
+            // status 2-3 for both, painting Luna red on every party member
+            // simultaneously. Holding the current top until the 110%
+            // threshold is crossed restores vanilla's "one tank, one aggro"
+            // feel — DPS sit at status 0/1 (hidden / yellow) while the actual
+            // tank sits at status 3 (red).
+            _lastHighest.TryGetValue(mob, out var prevHighest);
+            WowGuid128 newHighest;
+            double highestValue;
+            bool aggroFlipHeld = false;
+            if (prevHighest == default || !list.TryGetValue(prevHighest, out var prevValue))
+            {
+                // No prior top, or prior top has dropped off the list (left
+                // party / died / despawned). No hysteresis to apply — pick
+                // the raw top.
+                newHighest = rawTop;
+                highestValue = rawTopValue;
+            }
+            else if (rawTop == prevHighest)
+            {
+                // Current top still on top — no flip to consider.
+                newHighest = prevHighest;
+                highestValue = prevValue;
+            }
+            else if (rawTopValue >= prevValue * AggroFlipMargin)
+            {
+                // Challenger crossed the 110% threshold — flip.
+                newHighest = rawTop;
+                highestValue = rawTopValue;
+            }
+            else
+            {
+                // Challenger numerically ahead but inside the hysteresis
+                // band — vanilla server would still target prev. Hold.
+                newHighest = prevHighest;
+                highestValue = prevValue;
+                aggroFlipHeld = true;
             }
 
             var update = new ThreatUpdatePkt { UnitGUID = mob };
@@ -269,8 +327,20 @@ public sealed class ThreatTracker
             }
             SendToClient(update);
 
-            _lastHighest.TryGetValue(mob, out var prevHighest);
             bool highestChanged = prevHighest != newHighest;
+
+            if (aggroFlipHeld)
+            {
+                Log.Event("threat.aggro_flip_held", new
+                {
+                    mob_low = mob.GetCounter(),
+                    held_threater_low = prevHighest.GetCounter(),
+                    held_value = (long)highestValue,
+                    challenger_low = rawTop.GetCounter(),
+                    challenger_value = (long)rawTopValue,
+                    margin_required = AggroFlipMargin,
+                });
+            }
 
             Log.Event("threat.emit_update", new
             {
@@ -338,6 +408,32 @@ public sealed class ThreatTracker
         _threatLists.Clear();
         _lastHighest.Clear();
         _dirty.Clear();
+    }
+
+    // Called from SMSG_CANCEL_COMBAT — the legacy server told the local player
+    // they've left combat. The 1.12 server does NOT broadcast leave-combat
+    // for other party members and doesn't emit a "drop the threat list" packet
+    // for mobs that evade / run away / lose interest. Without an explicit
+    // clear, the modern client retains the stale threat list and Luna /
+    // ThreatPlates keep their red indicators lit on every nameplate the
+    // player fought during the session.
+    //
+    // Aggressive but matches vanilla feel: if WE'RE not in combat, nothing
+    // should display threat anywhere. If a groupmate is still fighting, their
+    // own subsequent damage events will re-populate the relevant mob's list.
+    public void OnLocalPlayerLeftCombat()
+    {
+        if (_threatLists.Count == 0) return;
+
+        var mobsCleared = _threatLists.Count;
+        var mobsToClear = new List<WowGuid128>(_threatLists.Keys);
+        foreach (var mob in mobsToClear)
+            ClearMob(mob);
+
+        Log.Event("threat.local_player_left_combat", new
+        {
+            mobs_cleared = mobsCleared,
+        });
     }
 
     // Called from the SMSG_DESTROY_OBJECT handler. Two cases to clean up:

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -656,37 +656,42 @@ public sealed class ThreatTracker
     }
 
     // -----------------------------------------------------------------------
-    // Phase 5 — passive threat multipliers from class + stance / form.
+    // Phase 6 — passive threat multipliers from class + stance / form + talents.
     //
-    // Vanilla LibThreatClassic2 reads GetShapeshiftForm() and class talents to
-    // compute a `passiveThreatModifiers` value applied to every flat-add threat
-    // operation. We can't introspect talents from the proxy side (they live in
-    // the client), so we ship the no-talent baselines:
+    // Mirrors LibThreatClassic2's per-class `passiveThreatModifiers` model. The
+    // proxy reads the player's known-spells set (now reliable thanks to the
+    // talent-rank injection fix: CurrentPlayerKnownSpells holds the highest
+    // rank the server has granted, SynthesizedTalentRanks holds proxy-injected
+    // predecessor ranks). Highest rank of each talent is resolved by walking
+    // the rank IDs from low to high and remembering the highest match.
     //
+    // Baselines (apply unconditionally):
     //   Warrior:
-    //     Defensive Stance (71)   → 1.30  (no Defiance)
+    //     Defensive Stance (71)   → 1.30  ×  (1 + 0.03 × Defiance rank)
     //     Berserker Stance (2458) → 0.80
     //     Battle Stance (2457) /
     //       no stance             → 0.80  (matches the lib's quirk; lib treats
     //                                      non-Defensive warriors as 0.8, see
     //                                      ClassModules/Classic/Warrior.lua)
-    //
     //   Druid:
     //     Bear / Dire Bear Form
-    //       (5487 / 9634)         → 1.30  (no Feral Instinct)
+    //       (5487 / 9634)         → 1.30  ×  (1 + 0.03 × Feral Instinct rank)
     //     Cat (768) /
     //       Travel (783) /
     //       Aquatic (1066)        → 0.71
     //     Caster                  → 1.00
-    //
-    //   Rogue:                    → 0.71  (always; passive at ClassEnable)
+    //   Rogue:                    → 0.71  (always; the lib's 0.71 IS the rogue
+    //                                      passive — vanilla rogue Subtlety
+    //                                      tab has no flat-threat talent on
+    //                                      top of this)
+    //   Priest                    → 1.00  ×  (1 - 0.04 × Silent Resolve rank)
     //   All other classes:        → 1.00
     //
-    // Future Phase 6+ will layer talent reads (Defiance, Feral Instinct,
-    // Subtlety, Shadow Affinity, Improved PWS) on top — those need the proxy
-    // to start mirroring talent state from CMSG_LEARN_TALENT and
-    // SMSG_INITIALIZE_FACTIONS-era talent data. Until then, these baselines
-    // run ~3-9% under the actual server-side numbers for talented characters.
+    // Talent rank IDs sourced from CSV/TalentSpellRanks.csv (built from the
+    // 1.14.2 Talent.dbc) — same data the talent-rank injection fix relies on.
+    // Per-rank values pulled from LibThreatClassic2's ClassModules/Classic/
+    // {Warrior,Druid,Priest}.lua so what we compute matches what existing
+    // threat addons compute server-side from GetTalentInfo.
 
     // Stance / form spell IDs we watch on the player's aura table. HashSet so
     // the per-event scan is O(slots) with O(1) per-slot membership check.
@@ -702,6 +707,34 @@ public sealed class ThreatTracker
         1066,  // Druid — Aquatic Form
     };
 
+    // Talent rank spell ID arrays — ordered rank 1 → rank N. Matched against
+    // CurrentPlayerKnownSpells ∪ SynthesizedTalentRanks via GetTalentRank.
+    // Source: 1.14.2 Talent.dbc cross-referenced against SpellName.dbc.
+    // (Defiance talent_id 144, Feral Instinct 799, Silent Resolve 352.)
+    private static readonly uint[] DefianceRanks       = { 12303, 12788, 12789, 12791, 12792 };
+    private static readonly uint[] FeralInstinctRanks  = { 16947, 16948, 16949, 16950, 16951 };
+    private static readonly uint[] SilentResolveRanks  = { 14523, 14784, 14785, 14786, 14787 };
+
+    // Returns the highest rank (1..N) of a talent the player has, or 0 if untaken.
+    // Walks the rank ids in ascending order; the last index that matches the
+    // player's known-spells set is the talent's current rank. Reads both the
+    // real server-tracked CurrentPlayerKnownSpells and the proxy-injected
+    // SynthesizedTalentRanks — without the latter, only the highest rank would
+    // be visible (vanilla LearnTalent RemoveSpell's predecessors).
+    private int GetTalentRank(uint[] rankIds)
+    {
+        var known = _session.GameState.CurrentPlayerKnownSpells;
+        var synth = _session.GameState.SynthesizedTalentRanks;
+        int highest = 0;
+        for (int i = 0; i < rankIds.Length; i++)
+        {
+            uint sid = rankIds[i];
+            if (known.Contains(sid) || synth.Contains(sid))
+                highest = i + 1;
+        }
+        return highest;
+    }
+
     // Returns the passive multiplier to apply to threater's flat-add threat.
     // Phase 6.1 generalised to any group threater: class via party-list
     // lookup (or local-player class for self), stance / form via the
@@ -716,6 +749,14 @@ public sealed class ThreatTracker
         var threaterClass = GetThreaterClass(threater);
         uint formAura = ScanStanceFormAura(threater);
         double modifier = ComputePassiveModifier(threaterClass, formAura);
+
+        // Talent layer only applies to the local player — the proxy can read its
+        // own known-spells set but has no view into group members' talents.
+        // Without this gate, group members would carry the local player's talent
+        // multiplier (wrong), since the GetTalentMultiplier helper reads our
+        // session's CurrentPlayerKnownSpells / SynthesizedTalentRanks.
+        if (threater == _session.GameState.CurrentPlayerGuid)
+            modifier *= GetTalentMultiplier(threaterClass, formAura);
 
         _passiveCache.TryGetValue(threater, out var cached);
         if (cached.stanceForm != formAura || cached.modifier != modifier)
@@ -734,6 +775,51 @@ public sealed class ThreatTracker
         }
 
         return modifier;
+    }
+
+    // Computes the talent-layered multiplier to apply on top of the class+stance
+    // baseline. Returns 1.0 for any class without known threat-talents (Hunter,
+    // Mage, Shaman, Warlock, Paladin pre-Holy-spec — Paladin Imp Righteous Fury
+    // is school-gated and lives in a separate code path).
+    //
+    // Each modifier follows the per-rank formula from LibThreatClassic2's
+    // matching ClassModule. Talents that gate on a specific stance/form return
+    // 1.0 outside the gating condition so respecs and form switches take effect
+    // on the next GetPassiveModifier call without flushing any state.
+    private double GetTalentMultiplier(Class playerClass, uint formAura)
+    {
+        switch (playerClass)
+        {
+            case Class.Warrior:
+                // Defiance: +0.03 / rank, Defensive Stance only.
+                if (formAura == 71)
+                {
+                    int rank = GetTalentRank(DefianceRanks);
+                    if (rank > 0)
+                        return 1.0 + (0.03 * rank);
+                }
+                return 1.0;
+
+            case Class.Druid:
+                // Feral Instinct: +0.03 / rank, Bear / Dire Bear only.
+                if (formAura == 5487 || formAura == 9634)
+                {
+                    int rank = GetTalentRank(FeralInstinctRanks);
+                    if (rank > 0)
+                        return 1.0 + (0.03 * rank);
+                }
+                return 1.0;
+
+            case Class.Priest:
+                // Silent Resolve: −0.04 / rank, applies to all damage and heals.
+                int srRank = GetTalentRank(SilentResolveRanks);
+                if (srRank > 0)
+                    return 1.0 - (0.04 * srRank);
+                return 1.0;
+
+            default:
+                return 1.0;
+        }
     }
 
     private Class GetThreaterClass(WowGuid128 guid)

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -82,7 +82,8 @@ public sealed class ThreatTracker
     public void AddModifiedThreat(WowGuid128 mob, WowGuid128 threater, double rawAmount)
     {
         double modifier = GetPassiveModifier(threater);
-        AddThreat(mob, threater, rawAmount * modifier);
+        double auraMult = ScanThreatMultiplierAuras(threater);
+        AddThreat(mob, threater, rawAmount * modifier * auraMult);
     }
 
     // Add (or subtract, if amount is negative) raw threat from a threater
@@ -216,7 +217,8 @@ public sealed class ThreatTracker
         if (threater == default || rawAmount == 0) return;
 
         double modifier = GetPassiveModifier(threater);
-        double scaledAmount = rawAmount * modifier;
+        double auraMult = ScanThreatMultiplierAuras(threater);
+        double scaledAmount = rawAmount * modifier * auraMult;
 
         foreach (var (mob, list) in _threatLists)
         {
@@ -584,7 +586,14 @@ public sealed class ThreatTracker
             gearFlat = ThreatSetBonuses.GetGearDamageFlatAdjust(_session.GameState, playerClass, spellId);
         }
 
-        double scaledThreat = (rawDamage * abilityMultiplier * gearMultiplier + gearFlat) * passiveModifier * talentMultiplier;
+        // Aura-based threat multiplier (Blessing of Salvation x0.7, Greater
+        // Bless of Salvation x0.7, Tranquil Air totem x0.8). Stacks
+        // multiplicatively. Salvation alone is the single biggest raid threat
+        // correction — every buffed raider's threat goes down 30% from where
+        // we'd otherwise compute it.
+        double auraMultiplier = ScanThreatMultiplierAuras(attacker);
+
+        double scaledThreat = (rawDamage * abilityMultiplier * gearMultiplier + gearFlat) * passiveModifier * talentMultiplier * auraMultiplier;
         if (scaledThreat < 0) scaledThreat = 0;
         AddThreat(victim, attacker, scaledThreat);
 
@@ -672,7 +681,12 @@ public sealed class ThreatTracker
             gearHealMultiplier = ThreatSetBonuses.GetGearHealMultiplier(_session.GameState, playerClass);
         }
 
-        double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier * gearHealMultiplier;
+        // Aura-based threat multiplier (Salvation x0.7 etc.) applies to heal
+        // threat just like damage threat — LTC2 puts it in threatMods() which
+        // wraps all threat output regardless of source event.
+        double auraMultiplier = ScanThreatMultiplierAuras(healer);
+
+        double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier * gearHealMultiplier * auraMultiplier;
         // LTC2 divides by EncounterMobs() — total mobs in the encounter, not
         // just the caster's combat list. We approximate with the caster's mob
         // count (close enough for solo/small-group; full encounter sync is a
@@ -1308,6 +1322,48 @@ public sealed class ThreatTracker
                 return spellId;
         }
         return 0;
+    }
+
+    // LTC2 BuffModifiers / DebuffModifiers — auras that multiply a unit's
+    // threat output globally. Vanilla 1.12 set; TBC+ auras (Pain Suppression,
+    // Arcane Shroud, etc.) deliberately omitted since our scope is vanilla.
+    // Source: ThreatClassModuleCore.lua line 190-289 (BuffHandlers /
+    // DebuffHandlers blocks that set buffThreatMultipliers / debuffThreatMultipliers).
+    //
+    // Blessing of Salvation is THE raid threat reducer — every tank gets it
+    // (or Greater Bless of Salvation from a paladin). Tranquil Air is the
+    // shaman alternative. Without these, every buffed raider's threat shows
+    // ~30%+ higher in TinyThreat than server reality.
+    private static readonly Dictionary<uint, double> ThreatMultiplierAuras = new()
+    {
+        [1038]  = 0.7,   // Blessing of Salvation
+        [25895] = 0.7,   // Greater Blessing of Salvation
+        [25909] = 0.8,   // Tranquil Air Totem (shaman raid aura)
+    };
+
+    // Stacked multiplier from all threat-multiplier auras currently on the
+    // unit. Returns 1.0 if no matching auras (most common case). Iterates
+    // the unit's aura slots once and multiplies in each match — order doesn't
+    // matter since multiplication commutes.
+    private double ScanThreatMultiplierAuras(WowGuid128 guid)
+    {
+        var fields = _session.GameState.GetCachedObjectFieldsLegacy(guid);
+        if (fields == null) return 1.0;
+
+        int unitFieldAura = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_AURA);
+        if (unitFieldAura < 0) return 1.0;
+
+        double mult = 1.0;
+        int slots = LegacyVersion.GetAuraSlotsCount();
+        for (int i = 0; i < slots; i++)
+        {
+            if (!fields.TryGetValue(unitFieldAura + i, out var field))
+                continue;
+            uint spellId = field.UInt32Value;
+            if (spellId != 0 && ThreatMultiplierAuras.TryGetValue(spellId, out double m))
+                mult *= m;
+        }
+        return mult;
     }
 
     private static double ComputePassiveModifier(Class playerClass, uint stanceFormAura)

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -1,3 +1,4 @@
+using Framework;
 using Framework.Logging;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -484,6 +485,7 @@ public sealed class ThreatTracker
         _threatLists.Clear();
         _lastHighest.Clear();
         _dirty.Clear();
+        _passiveCache.Clear();
     }
 
     // Called from SMSG_CANCEL_COMBAT — the legacy server told the local player
@@ -561,6 +563,7 @@ public sealed class ThreatTracker
 
     public void OnDamage(WowGuid128 attacker, WowGuid128 victim, int spellId, double rawDamage)
     {
+        if (!Settings.ThreatEngine) return;
         if (rawDamage <= 0) return;
         if (!IsRelevantThreater(attacker))
         {
@@ -660,6 +663,7 @@ public sealed class ThreatTracker
     // off-healers who DPS, and self-heals while in combat.
     public void OnHeal(WowGuid128 healer, WowGuid128 healTarget, int spellId, double effectiveHeal)
     {
+        if (!Settings.ThreatEngine) return;
         if (effectiveHeal <= 0) return;
         if (!IsRelevantThreater(healer)) return;
         if (healTarget == default) return;
@@ -785,6 +789,7 @@ public sealed class ThreatTracker
     // math needed proxy-side.
     public void OnEnergize(WowGuid128 caster, WowGuid128 recipient, int spellId, PowerType powerType, double amount)
     {
+        if (!Settings.ThreatEngine) return;
         if (amount <= 0) return;
         if (!IsRelevantThreater(caster)) return;
         if (IsEnergizeExempt(spellId)) return;
@@ -817,6 +822,7 @@ public sealed class ThreatTracker
     // set so the threat-update SMSG goes out alongside the SpellGo packet.
     public void OnSpellCast(WowGuid128 caster, int spellId, IList<WowGuid128> hitTargets)
     {
+        if (!Settings.ThreatEngine) return;
         if (caster == default) return;
 
         // First try player/pet handlers. If matched, flush + return.
@@ -1131,6 +1137,7 @@ public sealed class ThreatTracker
     // uses the table amount instead of effective-heal × 0.5.
     public void OnPowerWordShield(WowGuid128 caster, WowGuid128 shieldTarget, int spellId, double baseAmount)
     {
+        if (!Settings.ThreatEngine) return;
         if (baseAmount <= 0) return;
         if (caster != _session.GameState.CurrentPlayerGuid) return;
         if (shieldTarget == default) return;


### PR DESCRIPTION
 ## Summary

  Adds a synthesized threat-tracking engine to the proxy so modern 1.14 client
  threat addons (Plater, ThreatPlates, Details, OmniThreat, etc.) work against
  vanilla 1.12 servers that don't emit SMSG_THREAT_UPDATE natively.

  Stack of 9 commits, in order:

  - **6.0 + 6.1** — full-party threat from observed combat log (damage + heal)
  - **Diagnostics** — emit/drop-path JSONL events for addon debugging
  - **6.2** — aggro hysteresis + leave-combat reset to prevent flicker
  - **Talent predecessor injection** — synthesize lower talent ranks the vanilla
    server unlearns via SMSG_UNLEARNED_SPELL so IsPlayerSpell(rankN) works for
    every rank the player has earned (foundation for talent-aware threat math)
  - **6.3** — passive talents: Defiance, Feral Instinct, Silent Resolve
  - **6.4** — school-gated talents: Shadow Affinity, Druid Subtlety, Imp Righteous Fury
  - **6.5** — Imp Power Word: Shield layer + threat.talent_snapshot diagnostic
  - **Talent corrections** — Druid Subtlety moved to universal passive (was
    incorrectly school-gated to Balance damage spells, missing resto-druid heal
    threat reduction); Paladin RF allowlist extended with Judgement / SoR /
    Holy Wrath / Exorcism IDs for completeness
  - **Bug-hunt fixes** — pre-beta audit caught three issues:
    - HoT ticks (Rejuvenation, Regrowth) were generating full-amount threat on
      topped-off targets instead of zero (now uses ComputeOverHealFromCache)
    - Mage Counterspell rank 2 (18469) had no threat module registered
    - Heal threat formula didn't subtract Absorbed (defensive — vanilla wire
      doesn't carry the field, but TC-1.12 forks may back-port it)

  All formulas ported from LibThreatClassic2 (LTC2). Per-class spell allowlists
  sourced from LTC2's `ClassModules/Classic/*.lua`. Talent rank IDs canonical
  per 1.14.2 Talent.dbc (wago.tools build 42597).

  Diagnostics: every threat-relevant event emits a structured JSONL entry
  (`threat.damage_added`, `threat.heal_added`, `threat.emit_update`,
  `threat.passive_modifier`, `threat.talent_snapshot`, `threat.drop_irrelevant_attacker`)
  so testers can attach a JSONL bundle with any threat-related bug report.

  ## Test plan

  - [ ] Local: 487 tests pass (no regressions in solution test suite)
  - [ ] Beta tester — warrior tank, normal threat ordering on heroic strike + sunder pull
  - [ ] Beta tester — feral druid tank, Maul/Swipe threat ratio sane
  - [ ] Beta tester — resto druid healer, Rejuvenation on full-HP tank shows zero threat tick (this fix)
  - [ ] Beta tester — paladin tank attempt, Imp RF rank N shows expected mult on Consecrate/SoR/Judgement
  - [ ] Beta tester — shadow priest, Mind Blast + Mind Flay threat reduced by Shadow Affinity (and further by Silent
  Resolve)
  - [ ] No JSONL log explosion in 40-man raids — `threat.drop_irrelevant_attacker` not pathologically chatty