### PR TITLE
Mana gems: skip ItemEffect slot-mismatch hotfix to preserve cached re…

### DIFF
--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -3974,8 +3974,7 @@ public static partial class GameData
     // LegacySlotIndex=1, but the vanilla 1.12 server places the use-spell at slot 0.
     // Without an override the modern client never finds the spell at slot 1 and
     // strips the "Use:" tooltip line / blocks action-bar binding. Pairs are
-    // (record_id, parent_item_id) per CSV/ItemEffect2.csv lines 820/822-823/833/1133
-    // plus 5513 (Twinstar repurposed to Mana Jade, same slot bug).
+    // (record_id, parent_item_id) per CSV/ItemEffect2.csv lines 820/822-823/833/1133.
     //
     // The reactive path in GenerateItemEffectUpdateIfNeeded fixes this when an item
     // is freshly queried via CMSG_ITEM_QUERY_SINGLE, but the client only queries
@@ -3990,9 +3989,22 @@ public static partial class GameData
         (97906u, 5510),
         (97937u, 5511),
         (97875u, 5512),
-        (97663u, 5513),
         (99320u, 9421),
     };
+
+    // Mage mana gems were removed in retail; the modern client's SpellDB no longer
+    // recognizes vanilla "Restore Mana" rank spells (5405, 10052, 10053, 10054).
+    // Pre-#196 the client rendered the Use: line via its untouched retail ItemEffect
+    // record (whatever Blizzard left behind), and right-click consume worked because
+    // the legacy server handles the cast. PR #196's slot-mismatch hotfix overwrites
+    // those records with the vanilla SpellID, which the client can't resolve →
+    // Use: line vanishes and the item becomes inert.
+    //
+    // Items 5513/5514 are the only mana gems present in our ItemEffect CSVs (record
+    // ids 97663 / 97664). Citrine (5515) / Ruby (5516) have no CSV record so the
+    // slot-mismatch path never fires for them. Excluding 5513/5514 from the override
+    // restores the working pre-#196 behavior without affecting healthstones.
+    internal static readonly HashSet<uint> ManaGemItemEntries = new() { 5513u, 5514u, 5515u, 5516u };
 
     public static List<Server.Packets.HotFixMessage> PushKnownItemEffectFixes()
     {
@@ -4031,6 +4043,13 @@ public static partial class GameData
 
     public static Server.Packets.HotFixMessage? GenerateItemEffectUpdateIfNeeded(ItemTemplate item, byte slot)
     {
+        // Mana gems: leave the client's cached retail ItemEffect record untouched. Any
+        // mutation pushed via hotfix binds the record to a vanilla "Restore Mana" spell
+        // id the modern client's SpellDB doesn't know, stripping the Use: line. See
+        // ManaGemItemEntries above for the full rationale.
+        if (ManaGemItemEntries.Contains(item.Entry))
+            return null;
+
         ItemEffect? effect = GetItemEffectByItemId(item.Entry, slot);
         if (effect != null)
         {


### PR DESCRIPTION
…tail record

PR #208 (which proactively pushes the slot-mismatch hotfix at every login) regressed mage mana gems on 2026-05-11. Tester Conical reports Mana Jade (item 5513) suddenly became "unusable in bags" — tooltip lost its "Use:" line, action-bar binding stopped working. Timing matches PR #208 ship exactly. Pre-#208 the regression was latent because #196's reactive path only fired when the client queried the item, and cached mana gems never trigger a query.

Root cause: vanilla "Restore Mana" rank spells (5405 / 10052 / 10053 / 10054) were removed from the modern 1.14 client's SpellDB along with the mana-gem feature in retail. The slot-mismatch hotfix rewrites the cached retail ItemEffect record to bind to the vanilla SpellID; the client can't resolve it, so the Use: line is stripped and right-click consume goes inert. Healthstones survived because warlock heal spell ids (5720/5723/ 6263/6262/11732) are still in retail's SpellDB.

Fix: gate GenerateItemEffectUpdateIfNeeded with a ManaGemItemEntries set (5513/5514/5515/5516) — early-return on mana gems leaves the cached retail record untouched. Use: line keeps rendering off the client's stock data, right-click consume keeps working because the legacy server handles the cast regardless of what the client thinks the spell is. Also removes (97663u, 5513) from KnownHealthstoneItemEffects so the proactive at-login push no longer relocates Mana Jade.

All 502 tests pass.