### PR TITLE
Fix/quest item overlay walk fallback

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1295,11 +1295,21 @@ public partial class WorldClient
                         resolved = dictCount;
                         fromDict = true;
                     }
-                    else if (obj.ObjectID > 0 && GetSession().GameState.IsFirstEnterWorld)
+                    else if (obj.ObjectID > 0)
                     {
-                        // Inventory walk fallback only during login — after that,
-                        // SMSG_QUEST_UPDATE_ADD_ITEM credit packets keep the dict
-                        // in sync and the walk is unnecessary overhead.
+                        // Inventory-walk fallback whenever the running-total dict
+                        // doesn't yet have an entry for this objective. The dict
+                        // is populated by SMSG_QUEST_UPDATE_ADD_ITEM credit packets,
+                        // but those NEVER fire for items the player logged in already
+                        // holding (e.g. quest items collected in a prior session) —
+                        // so a player relogging mid-quest with N items in bag would
+                        // otherwise render 0/N forever once IsFirstEnterWorld flipped
+                        // false on the first zone/teleport. Tester report 2026-05-13:
+                        // quest #546 "Souvenirs of Death" stuck at 0/30 with 30 skulls
+                        // in bag. The walk is ~60 slot reads × item-objective count,
+                        // and only runs when an OBJECT_UPDATE touches PLAYER_QUEST_LOG
+                        // fields (login + quest pickup/abandon/progress) — that's
+                        // sparse, not per-frame.
                         resolved = GetSession().GameState.CountItemsByEntry((uint)obj.ObjectID);
                     }
 


### PR DESCRIPTION
## Summary

  Tester Conical reports quest **#546 "Souvenirs of Death"** (Hillsbrad, 30 Hillsbrad Human Skulls) stuck at **0/30**
  with 30 skulls visible in bag across two stacks. Native 1.12 client and heitu sugarproxy display correctly. **Tester
  confirms turn-in is hard-blocked on this proxy** — not just a cosmetic display issue. The 1.14 client gates the gossip
   / "Complete Quest" flow on local `ObjectiveProgress`, so with 0/N showing it refuses to send
  `CMSG_QUEST_GIVER_COMPLETE_QUEST` even though server-side `m_itemcount[]` permits it.

  Regression introduced by `6508aee` (2026-05-12) which gated `CountItemsByEntry` behind `IsFirstEnterWorld` "to save
  perf."

  ## Root cause

  vmangos stores item-objective progress in a separate `m_itemcount[]` array, **not** in the quest log's bit-packed
  counters (`Player.cpp::SendQuestUpdateAddItem` writes to `slot + GOcount`, not the quest's own log slot). So the wire
  value of `ObjectiveProgress[StorageIndex]` for any item objective is always 0. The modern 1.14 client trusts the wire
  verbatim and renders 0/N unless we explicitly overlay the count.

  `6508aee`'s assumption was that after login, the `QuestItemObjectiveProgress` dict stays in sync via
  `SMSG_QUEST_UPDATE_ADD_ITEM` credit packets. But credit packets **never** fire for items the player logged in already
  holding (vanilla server has no "you already had these" replay). Combined with `IsFirstEnterWorld` flipping false on
  the first zone/teleport, the inventory-walk fallback stops firing and the dict stays empty — even on the very first
  OBJECT_UPDATE if the walk happens before the item objects in the same packet have populated
  `GetCachedObjectFieldsLegacy`.

  End result: a player relogging mid-quest with already-collected items renders 0/N permanently, and the 1.14 client
  refuses to let them turn the quest in.

  ## Fix

  Drop the `IsFirstEnterWorld` gate. The inventory walk now runs whenever the running-total dict has no entry for the
  objective. Cost: ~60 slot reads × number of item objectives, **only** when an OBJECT_UPDATE touches `PLAYER_QUEST_LOG`
   fields — that's login + quest pickup/abandon/progress, not per-frame. The perf claim in `6508aee` was overblown for
  the actual call frequency.