### PR TITLE
Vendor sold-out grey: addon-side desaturate + proxy refresh + diagnos…

### DIFF
--- a/Addons/JimsPlus/Core.lua
+++ b/Addons/JimsPlus/Core.lua
@@ -1,6 +1,6 @@
 local ADDON_NAME, namespace = ...
 
-namespace.BUILD = 18
+namespace.BUILD = 19
 
 print("|cFF00FF00[JimsPlus]|r Core loaded (build " .. namespace.BUILD .. ")")
 

--- a/Addons/JimsPlus/TooltipFix.lua
+++ b/Addons/JimsPlus/TooltipFix.lua
@@ -557,6 +557,22 @@ local function FixMerchantUsability()
         local index = (page - 1) * perPage + i
         local button = _G["MerchantItem" .. i .. "ItemButton"]
         if button and index <= total then
+            -- Sold-out detection: GetMerchantItemInfo's 5th return is numAvailable
+            -- (0 = sold out, -1 = unlimited, N = stock left). The 1.14 Classic
+            -- Era client ignores the wire's VendorItem.Quantity=0 for icon-grey
+            -- rendering, so we apply the grey here. 1.12 native client greys
+            -- these reliably — this restores parity.
+            local _, _, _, _, numAvailable = GetMerchantItemInfo(index)
+            local soldOut = (numAvailable == 0)
+
+            -- Always toggle icon desaturation per-button so a button reused
+            -- for a non-sold-out slot doesn't carry stale grey from a prior
+            -- page or vendor.
+            local iconTex = _G["MerchantItem" .. i .. "ItemButtonIconTexture"]
+            if iconTex and iconTex.SetDesaturated then
+                iconTex:SetDesaturated(soldOut)
+            end
+
             local link = GetMerchantItemLink(index)
             if link then
                 local _, _, quality, _, itemMinLevel, _, _, _, _, _, _, classId, subClassId = GetItemInfo(link)
@@ -572,8 +588,9 @@ local function FixMerchantUsability()
                     end
                     local usable = proficient and PlayerMeetsLevel(itemMinLevel)
                     local r, g, b
-                    if usable then r, g, b = 1.0, 1.0, 1.0
-                    else            r, g, b = 0.9, 0.0, 0.0 end
+                    if soldOut    then r, g, b = 0.65, 0.65, 0.65
+                    elseif usable then r, g, b = 1.0,  1.0,  1.0
+                    else               r, g, b = 0.9,  0.0,  0.0 end
 
                     -- Icon + border tint.
                     if SetItemButtonTextureVertexColor       then SetItemButtonTextureVertexColor(button, r, g, b)       end
@@ -625,9 +642,16 @@ local function FixMerchantUsability()
                         rowSlot:SetVertexColor(r, g, b)
                     end
 
-                    -- Leave item name text at the client's default yellow.
-                    -- Proficiency is communicated via icon/border tinting;
-                    -- vanilla never recolors the name text for proficiency.
+                    -- Item name text: grey only when sold out. Otherwise
+                    -- leave at the client's default — proficiency/usability
+                    -- is communicated via icon/border tinting; vanilla never
+                    -- recolored the name text for proficiency.
+                    if soldOut then
+                        local nameFs = _G["MerchantItem" .. i .. "Name"]
+                        if nameFs and nameFs.SetTextColor then
+                            nameFs:SetTextColor(0.65, 0.65, 0.65)
+                        end
+                    end
                 end
             end
         end

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Framework;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -27,6 +28,26 @@ public partial class WorldClient
         buy.NewQuantity = packet.ReadInt32();
         buy.QuantityBought = packet.ReadUInt32();
         SendPacketToClient(buy);
+
+        // Modern 1.14 client greys a sold-out vendor slot based on the Quantity
+        // field in SMSG_VENDOR_INVENTORY, not on SMSG_BUY_SUCCEEDED's NewQuantity.
+        // Buying the last stack leaves the icon visually available until the next
+        // full list refresh. Proxy-issue a CMSG_LIST_INVENTORY so the server
+        // resends the list with the correct Quantity (0) for the just-emptied
+        // slot, and the modern client greys it without the player having to
+        // close and reopen the vendor window.
+        if (buy.NewQuantity == 0)
+        {
+            WorldPacket refresh = new WorldPacket(Opcode.CMSG_LIST_INVENTORY);
+            refresh.WriteGuid(buy.VendorGUID.To64());
+            SendPacketToServer(refresh);
+            Log.Event("vendor.list.refresh", new
+            {
+                vendor_guid_low = buy.VendorGUID.GetCounter(),
+                reason = "buy_succeeded_zero_remaining",
+                slot = buy.Slot,
+            });
+        }
     }
     [PacketHandler(Opcode.SMSG_ITEM_PUSH_RESULT)]
     void HandleItemPushResult(WorldPacket packet)
@@ -176,8 +197,47 @@ public partial class WorldClient
         BuyFailed fail = new BuyFailed();
         fail.VendorGUID = packet.ReadGuid().To128(GetSession().GameState);
         fail.Slot = packet.ReadUInt32();
-        fail.Reason = (BuyResult)packet.ReadUInt8();
+        byte rawReason = packet.ReadUInt8();
+        fail.Reason = (BuyResult)rawReason;
         SendPacketToClient(fail);
+
+        Log.Event("vendor.buy.failed", new
+        {
+            vendor_guid_low = fail.VendorGUID.GetCounter(),
+            slot = fail.Slot,
+            reason_raw = rawReason,
+            reason_name = fail.Reason.ToString(),
+        });
+
+        // The modern 1.14 client renders the red "currently sold out" tooltip
+        // text from this reason code, but it does NOT grey the icon — that's
+        // driven by SMSG_VENDOR_INVENTORY's Quantity field, which the legacy
+        // server doesn't proactively resend on a failed buy. Tester JSONL
+        // 20260513-043134 shows 3 consecutive CMSG_BUY_ITEM → SMSG_BUY_FAILED
+        // pairs with zero intervening SMSG_VENDOR_INVENTORY refreshes.
+        //
+        // Refresh on any reason that implies the vendor's stock or slot table
+        // is now wrong relative to what the modern client thinks it knows:
+        // CantFindItem (0), ItemAlreadySold (1), ItemSoldOut (7). Skip the
+        // reasons where stock is fine and only the player state is the
+        // problem (NotEnoughtMoney/SellerDontLikeYou/DistanceTooFar/
+        // CantCarryMore/RankRequire/ReputationRequire) — no point burning a
+        // round-trip there.
+        if (fail.Reason == BuyResult.ItemSoldOut ||
+            fail.Reason == BuyResult.ItemAlreadySold ||
+            fail.Reason == BuyResult.CantFindItem)
+        {
+            WorldPacket refresh = new WorldPacket(Opcode.CMSG_LIST_INVENTORY);
+            refresh.WriteGuid(fail.VendorGUID.To64());
+            SendPacketToServer(refresh);
+            Log.Event("vendor.list.refresh", new
+            {
+                vendor_guid_low = fail.VendorGUID.GetCounter(),
+                reason = "buy_failed",
+                buy_result = fail.Reason.ToString(),
+                slot = fail.Slot,
+            });
+        }
     }
     [PacketHandler(Opcode.SMSG_INVENTORY_CHANGE_FAILURE, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]
     void HandleInventoryChangeFailureVanilla(WorldPacket packet)

--- a/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Framework;
 using Framework.GameMath;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -96,9 +97,16 @@ public partial class WorldClient
         {
             vendor.Reason = packet.ReadUInt8();
             SendPacketToClient(vendor);
+            Log.Event("vendor.list.received", new
+            {
+                vendor_guid_low = vendor.VendorGUID.GetCounter(),
+                item_count = 0,
+                reason = vendor.Reason,
+            });
             return;
         }
 
+        int soldOutCount = 0;
         for (byte i = 0; i < itemsCount; i++)
         {
             VendorItem vendorItem = new();
@@ -112,10 +120,34 @@ public partial class WorldClient
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
                 vendorItem.ExtendedCostID = packet.ReadInt32();
             GetSession().GameState.SetItemBuyCount(vendorItem.Item.ItemID, vendorItem.StackCount);
+            if (vendorItem.Quantity == 0)
+                soldOutCount++;
             vendor.Items.Add(vendorItem);
+
+            // Diagnostic: dump every item's stock state at vendor open so we can
+            // see whether the legacy server is dynamically decrementing Quantity
+            // for sold-out slots (mangos convention: Quantity == 0 means out;
+            // Quantity == -1/0xFFFFFFFF means unlimited).
+            Log.Event("vendor.item", new
+            {
+                vendor_guid_low = vendor.VendorGUID.GetCounter(),
+                slot = vendorItem.Slot,
+                item_id = vendorItem.Item.ItemID,
+                quantity = vendorItem.Quantity,
+                stack_count = vendorItem.StackCount,
+                price = vendorItem.Price,
+                extended_cost = vendorItem.ExtendedCostID,
+            });
         }
 
         SendPacketToClient(vendor);
+
+        Log.Event("vendor.list.received", new
+        {
+            vendor_guid_low = vendor.VendorGUID.GetCounter(),
+            item_count = (int)itemsCount,
+            sold_out_count = soldOutCount,
+        });
     }
 
     [PacketHandler(Opcode.SMSG_SHOW_BANK)]


### PR DESCRIPTION
…tics

Tester mammouth reports sold-out vendor items not visually greyed on 1.14 Classic client. Confirmed parity break: 1.12 native client greys these reliably; modern 1.14 Classic doesn't, even though buy-block fires correctly server-side.

Tester JSONL (20260513-044049, 20260513-044704) walks through the investigation. Liferoot (item 3357) at Maria Lumere ships from vmangos with Quantity=0 in SMSG_LIST_INVENTORY both at vendor open AND on every buy-failed refresh. Two wire-side experiments to flip the grey state both confirmed delivered but ignored by the modern client:
  - Quantity=0 alone — no grey.
  - VendorItem.PlayerConditionFailed=1 on sold-out slots — no grey.

The 1.14 Classic Era client's icon-grey gate for vendor slots lives somewhere we can't reach from the wire on this build. But GetMerchantItemInfo's numAvailable return DOES expose the correct value (0 = sold out) in Lua-land, so we can apply the desaturate ourselves.

Changes:

1. JimsPlus TooltipFix.lua — FixMerchantUsability now reads numAvailable alongside the existing usability check. On sold-out slots: - icon texture SetDesaturated(true) - icon/name/border tint 0.65 grey (chosen by user; lighter than the 0.45 first pass, matches the 1.12 native client's dim) - name text 0.65 grey, overriding the quality-color path Non-sold-out slots restore desaturate=false so a button reused for a different slot doesn't carry stale grey. Core.lua build bumps 18 -> 19.

2. ItemHandler.cs HandleBuyFailed/HandleBuySucceeded — proxy-issue CMSG_LIST_INVENTORY when: - BuyFailed reason in {ItemSoldOut, ItemAlreadySold, CantFindItem} (Twinstar sends ItemAlreadySold=1, not the canonical ItemSoldOut=7, so we widen the gate) - BuySucceeded.NewQuantity == 0 The fresh SMSG_VENDOR_INVENTORY triggers MerchantFrame_Update on the modern client, which fires the addon's grey logic with up-to-date numAvailable. Without this, a player buying the last stack or hitting a slot another player drained mid-session wouldn't see the grey update until they closed and reopened the vendor.

3. NPCHandler.cs HandleVendorInventory — diagnostic Log.Event per VendorItem (slot, item_id, quantity, stack_count, price, extended_cost) and a sold_out_count summary. Confirms wire state for any future "vendor behaves wrong" report without re-instrumenting.

All 502 tests pass.