### PR TITLE
WorldClient: CompareExchange before Disconnect() — fixes BG-exit stuc…

### DIFF
--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -251,8 +251,20 @@ public partial class WorldClient
         }
         else
         {
-            Disconnect();
-            // JimsProxy realm-swap fix: previously called GetSession().OnDisconnect()
+            // CompareExchange MUST run before Disconnect(). Disconnect() also nulls
+            // session.WorldClient at line ~184 (if (GetSession().WorldClient == this)
+            // GetSession().WorldClient = null;), so calling Disconnect() first leaves
+            // CompareExchange comparing against a null field and reporting
+            // wasActiveWorldClient=false even when this WorldClient WAS the active one.
+            // The bug: legacy server closes a healthy connection → HandleDisconnect runs
+            // → Disconnect() nulls the field → CompareExchange sees null → suppresses the
+            // reconnect → modern client stays connected but every CMSG drops via the
+            // c2s.dropped_during_disconnect path until the client surrenders ~50s later.
+            // Issue #229 (BG-exit DC repro on Kronos V). The silent-stall watchdog at
+            // SendKeepAlivePing already uses the correct order — this brings the
+            // FIN/RST paths into consistency.
+            //
+            // JimsProxy realm-swap context: previously called GetSession().OnDisconnect()
             // here, which tore down the entire BNet session including any newly-created
             // WorldClient for a different realm during a swap. Now: only null our slot
             // if it's still pointing at us (a fresh swap may have already replaced it
@@ -266,6 +278,7 @@ public partial class WorldClient
                 var prior = Interlocked.CompareExchange(ref session.WorldClient, null, this);
                 wasActiveWorldClient = ReferenceEquals(prior, this);
             }
+            Disconnect();
             Log.Event("session.ondisconnect.suppressed", new
             {
                 reason = "worldclient_legacy_disconnect",
@@ -343,8 +356,10 @@ public partial class WorldClient
                 _isSuccessful = false;
             else
             {
-                Disconnect();
-                // JimsProxy realm-swap fix: see WorldClient.HandleDisconnect.
+                // Same ordering rule as HandleDisconnect: CompareExchange before
+                // Disconnect() so Disconnect's internal null-assignment doesn't
+                // falsely set wasActiveWorldClient=false. See HandleDisconnect's
+                // comment for the full rationale (issue #229).
                 var session = GetSession();
                 bool wasActiveWorldClient = false;
                 if (session != null)
@@ -352,6 +367,7 @@ public partial class WorldClient
                     var prior = Interlocked.CompareExchange(ref session.WorldClient, null, this);
                     wasActiveWorldClient = ReferenceEquals(prior, this);
                 }
+                Disconnect();
                 Log.Event("session.ondisconnect.suppressed", new
                 {
                     reason = "worldclient_receive_loop_exception",


### PR DESCRIPTION
…k DC (#229)

Issue #229: rogue leaves BG → game freezes → DC. Tester JSONL shows the legacy server closed the WorldClient connection cleanly (reason "header"), the proxy logged session.ondisconnect.suppressed with was_active_world_client=false, no reconnect was triggered, and the modern client kept sending CMSGs (~75 packets over 50s — movement, cancels, casts, logout) all dropped via c2s.dropped_during_disconnect until the client surrendered.

The issue author guessed the BG-exit transition was creating a new WorldClient before the old one tore down. That's plausible but wrong: the only places that reassign session.WorldClient are the realm-swap auth path and HandlePlayerLogin's recreate branch, neither of which fires on a BG exit. The real bug is internal to HandleDisconnect and the ReceiveLoop catch:

  // OLD (buggy):
  Disconnect();   // <-- ALSO nulls session.WorldClient at line 184-185
  var prior = Interlocked.CompareExchange(ref session.WorldClient, null, this);
  wasActiveWorldClient = ReferenceEquals(prior, this);  // false — already null

Disconnect()'s own null-assignment runs before the CompareExchange tries to detect "am I still the active WorldClient", so the comparison sees a null field even when this connection WAS the active one moments earlier. The wasActiveWorldClient gate then suppresses the reconnect, modern client gets stranded.

The silent-stall watchdog at SendKeepAlivePing:947-971 already uses the correct order — this brings the FIN/RST paths into consistency.

Fix: in HandleDisconnect and the ReceiveLoop catch, do the CompareExchange BEFORE calling Disconnect(). Disconnect()'s internal null-assignment then becomes a clean no-op (the field is already null), and wasActiveWorldClient accurately reflects whether this WorldClient owned the session slot when the legacy side closed.

Audited side effects, all safe:
- External callers of Disconnect() (intentional logout, realm-swap orphan, stale-recreate, session cleanup) don't enter HandleDisconnect and are unchanged.
- TryUnplannedReconnectAndPropagate's comment explicitly says it expects session.WorldClient to be null when invoked (it assigns the new instance after auth), and has its own CAS for idempotency.
- The new tiny window between CompareExchange and StopKeepAliveTimer (which Disconnect calls) is harmless: SendKeepAlivePing guards on IsConnected/_isSuccessful and the silent-stall path has its own CAS that no-ops on the already-null field.
- Modern client CMSG drop path triggers a few microseconds earlier; no user-visible behavior change.

All 502 tests pass.

Side observations from issue #229 (deferred, not part of this fix):
- 10 SpellExecuteLog parse failures earlier in the session for shaman totems 6390/6363/2484 with effect types 87/88. Separate issue.