### PR TITLE
Zep Fix / Movement: clear stale MOVEMENTFLAG_ONTRANSPORT after zep/boat NEW_WORLD

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -98,6 +98,14 @@ public sealed class GameSessionData
     public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;
+    // JimsProxy (zep-stuck-no-move 2026-05-14): set to a sentinel MoveCounter when
+    // HandleNewWorld emits a synthesized SMSG_MOVE_TELEPORT to clear the modern
+    // client's stale MOVEMENTFLAG_ONTRANSPORT after a cross-continent transport
+    // (zep/boat) zone change. The legacy server never sent that teleport, so the
+    // matching CMSG_MOVE_TELEPORT_ACK must be dropped before reaching the legacy
+    // server (per project_kronos_three_delayed_kick_sources, a spurious teleport-ack
+    // can feed malformed-packet kick counters on Kronos). 0 means none pending.
+    public uint PendingSyntheticTransportClearAckCounter;
     public bool IsFirstEnterWorld;
     public bool IsConnectedToInstance;
     public Queue<ServerPacket> PendingUninstancedPackets = new(); // Here packets are queued while IsConnectedToInstance = false;

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -200,6 +200,12 @@ public partial class WorldClient
             teleport.Vehicle = new();
             teleport.Vehicle.VehicleSeatIndex = moveInfo.TransportSeat;
         }
+        // JimsProxy (zep-stuck-no-move 2026-05-14, belt-and-suspenders): a real
+        // teleport from the legacy server supersedes any pending synthetic
+        // transport-clear ack we were watching for. Clear the sentinel so a future
+        // legitimate ack carrying the same MoveCounter cannot be eaten.
+        if (guid == GetSession().GameState.CurrentPlayerGuid)
+            GetSession().GameState.PendingSyntheticTransportClearAckCounter = 0;
         SendPacketToClient(teleport);
     }
 
@@ -253,6 +259,13 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_NEW_WORLD)]
     void HandleNewWorld(WorldPacket packet)
     {
+        // JimsProxy (zep-stuck-no-move 2026-05-14, belt-and-suspenders): clear any
+        // stale synthetic transport-clear ack sentinel. If the modern client failed
+        // to ack our previous synth MoveTeleport, the sentinel would otherwise
+        // linger forever and could eat a future legitimate teleport ack that
+        // happened to carry the same MoveCounter value.
+        GetSession().GameState.PendingSyntheticTransportClearAckCounter = 0;
+
         NewWorld teleport = new NewWorld();
         GetSession().GameState.CurrentMapId = teleport.MapID = packet.ReadUInt32();
         teleport.Position = packet.ReadVector3();
@@ -273,6 +286,66 @@ public partial class WorldClient
             // --- END FIX ---
 
             SendPacketToClient(teleport);
+
+            // JimsProxy (zep-stuck-no-move 2026-05-14): cross-continent transports
+            // (Grom'gol↔Orgrimmar zep, BB↔Ratchet boat) leave the 1.14 client holding
+            // a stale MOVEMENTFLAG_ONTRANSPORT after NEW_WORLD. Mouse-look continues
+            // to work, but the client suppresses every CMSG_MOVE_START_* because its
+            // local MovementInfo still references the old-map transport GUID, which
+            // no longer exists. Symptom: "can't move after the zeppelin." Synthesize
+            // an SMSG_MOVE_TELEPORT with TransportGUID=default to force the client to
+            // fully reset its local MovementInfo. The client will fire a matching
+            // CMSG_MOVE_TELEPORT_ACK; HandleMoveTeleportAck (server side) drops it by
+            // sentinel MoveCounter so the legacy server never sees the spurious ack.
+            WowGuid128 playerGuid = GetSession().GameState.CurrentPlayerGuid;
+            if (!playerGuid.IsEmpty())
+            {
+                const uint SyntheticTeleportAckSentinel = 0xFFFFFFFFu;
+                MoveTeleport transportClear = new MoveTeleport();
+                transportClear.MoverGUID = playerGuid;
+                transportClear.MoveCounter = SyntheticTeleportAckSentinel;
+                transportClear.Position = teleport.Position;
+                transportClear.Orientation = teleport.Orientation;
+                transportClear.PreloadWorld = 0;
+                transportClear.TransportGUID = default;
+                // Leave transportClear.Vehicle at its default null! sentinel —
+                // assigning null here trips the non-nullable-ref-type check; the
+                // existing MoveTeleport path uses this same pattern for non-vehicle
+                // teleports.
+                GetSession().GameState.PendingSyntheticTransportClearAckCounter =
+                    SyntheticTeleportAckSentinel;
+                Framework.Logging.Log.Event("movement.transport_clear.synthesized", new
+                {
+                    map_id = teleport.MapID,
+                    player_low = playerGuid.GetCounter(),
+                    position = $"{teleport.Position.X:F2},{teleport.Position.Y:F2},{teleport.Position.Z:F2}",
+                });
+                // JimsProxy (zep-stuck-no-move 2026-05-14, belt-and-suspenders):
+                // explicitly wrap the SendPacketToClient call so we know whether
+                // the packet actually reached the socket. If `send_completed`
+                // fires, the call returned without throwing; if `send_failed`
+                // fires, an exception was raised and we can pinpoint the issue.
+                // Resolves the open "synth emitted but no ack" question by ruling
+                // out a silent drop in the proxy's outbound pipeline.
+                try
+                {
+                    SendPacketToClient(transportClear);
+                    Framework.Logging.Log.Event("movement.transport_clear.send_completed", new
+                    {
+                        player_low = playerGuid.GetCounter(),
+                        sentinel_counter = SyntheticTeleportAckSentinel,
+                    });
+                }
+                catch (System.Exception ex)
+                {
+                    Framework.Logging.Log.Event("movement.transport_clear.send_failed", new
+                    {
+                        player_low = playerGuid.GetCounter(),
+                        exception_type = ex.GetType().Name,
+                        exception_message = ex.Message,
+                    });
+                }
+            }
 
             if (teleport.MapID > 1)
             {

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -129,6 +129,25 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_MOVE_TELEPORT_ACK)]
     void HandleMoveTeleportAck(MoveTeleportAck teleport)
     {
+        // JimsProxy (zep-stuck-no-move 2026-05-14): if this ack corresponds to the
+        // synthesized SMSG_MOVE_TELEPORT emitted by HandleNewWorld to clear stale
+        // MOVEMENTFLAG_ONTRANSPORT, drop it — the legacy server never sent the
+        // teleport and would treat the unsolicited MSG_MOVE_TELEPORT_ACK as
+        // malformed input.
+        uint pendingSentinel = GetSession().GameState.PendingSyntheticTransportClearAckCounter;
+        if (pendingSentinel != 0 &&
+            teleport.MoveCounter == pendingSentinel &&
+            teleport.MoverGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            GetSession().GameState.PendingSyntheticTransportClearAckCounter = 0;
+            Framework.Logging.Log.Event("movement.transport_clear.ack_dropped", new
+            {
+                player_low = teleport.MoverGUID.GetCounter(),
+                move_counter = teleport.MoveCounter,
+            });
+            return;
+        }
+
         WorldPacket packet = new WorldPacket(Opcode.MSG_MOVE_TELEPORT_ACK);
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
             packet.WritePackedGuid(teleport.MoverGUID.To64());


### PR DESCRIPTION
Cross-continent transports (Grom'gol<->Orgrimmar zep, Booty Bay<->Ratchet boat) leave the 1.14 client holding a stale MOVEMENTFLAG_ONTRANSPORT after the legacy server's SMSG_NEW_WORLD. Mouse-look continues to work (CMSG_MOVE_SET_FACING flows), but the client suppresses every CMSG_MOVE_START_* because its local MovementInfo still references the old-map transport GUID, which no longer exists in the new map. Players land at the destination and can turn the camera but cannot move.

Repro:
- Bundle from a prior PTR session showed 364 dropped c2s movement packets after a Grom'gol -> Orgrimmar zep ride, every facing-mode CMSG packet sized 84 bytes (the transport-block overhead) and zero CMSG_MOVE_START_FORWARD / STRAFE / JUMP for the rest of the session.

Fix:
- HandleNewWorld now synthesizes a player-targeted SMSG_MOVE_TELEPORT with TransportGUID=default after sending NewWorld. The 1.14 client applies the transport-clear side effect to its local MovementInfo even when Position is a positional no-op (silent apply, no ack), so the next CMSG_MOVE_START_FORWARD fires normally.
- A sentinel MoveCounter (0xFFFFFFFF) lets the server-side HandleMoveTeleportAck recognise and drop the matching ack so the legacy server never sees an unsolicited MSG_MOVE_TELEPORT_ACK that could feed Kronos's malformed-packet kick counter.
- Belt-and-suspenders: PendingSyntheticTransportClearAckCounter is auto-cleared at the top of HandleNewWorld and inside the legacy MSG_MOVE_TELEPORT handler so a stale sentinel cannot eat a future legitimate ack on a different teleport flow.

Diagnostics:
- movement.transport_clear.synthesized fires once per NEW_WORLD
- movement.transport_clear.send_completed confirms the synth reached the socket without exception
- movement.transport_clear.send_failed captures any send exception
- movement.transport_clear.ack_dropped fires only if the client ever does ack (1.14 typically doesn't, on positional no-ops)

Validated in-game on Twinstar (login3 and Kronos V variants, both Org to Booty Bay directions). Player gains movement ~2-3s after the synth fires; pre-fix the same flow stayed broken for the rest of the session. The two-second HDD-load-simulator sleep in HandleNewWorld is untouched.