### PR TITLE
Spell: revert SpellPrepare-at-hold-accept (#214) — restore GCD sync

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -332,20 +332,9 @@ public partial class WorldSocket
                     });
                     if (displaced != null)
                         SendCastFailedWithoutPrepare(displaced);
-                    // Send SpellPrepare immediately on hold-accept so the client has a
-                    // ClientCastID → ServerCastID mapping to match any future SMSG_SPELL_FAILURE
-                    // for this cast. Mirrors the off-GCD path below — see that comment for the
-                    // underlying contract. Without this, server rejections (LoS / range /
-                    // out-of-mana race) arriving for the eventually-fired held cast leave the
-                    // action button permanently lit because SpellFailure has no SpellPrepare
-                    // to match against. Symptom is most prevalent on low-ping (~50ms) clients
-                    // in populated zones, where the proxy's hold delay + SMSG backlog from
-                    // other casters extends the time the client spends in queued-press state.
-                    SpellPrepare prepare = new SpellPrepare();
-                    prepare.ClientCastID = castRequest.ClientGUID;
-                    prepare.ServerCastID = castRequest.ServerGUID;
-                    SendPacket(prepare);
-                    castRequest.HasSentPrepare = true;
+                    // Don't ack-fail castRequest — keep the modern client's action-button GCD
+                    // anticipation lit until SpellPrepare arrives at SPELL_START time for the
+                    // refired cast. Matches the smooth feel of native 1.14.
                     return;
                 }
 
@@ -398,21 +387,9 @@ public partial class WorldSocket
                             SendCastFailedWithoutPrepare(displaced);
                         }
 
-                        // Send SpellPrepare immediately on hold-accept so the client has a
-                        // ClientCastID → ServerCastID mapping to match any future
-                        // SMSG_SPELL_FAILURE for this cast. Mirrors the off-GCD path below —
-                        // see that comment for the underlying contract. Without this, server
-                        // rejections (LoS / range / cooldown race) for the eventually-fired
-                        // held cast leave the action button permanently lit because
-                        // SpellFailure has no SpellPrepare to match against. Symptom is most
-                        // prevalent on low-ping (~50ms) clients in populated zones, where
-                        // the proxy's hold delay + SMSG backlog from other casters extends
-                        // the time the client spends in queued-press state.
-                        SpellPrepare prepare = new SpellPrepare();
-                        prepare.ClientCastID = castRequest.ClientGUID;
-                        prepare.ServerCastID = castRequest.ServerGUID;
-                        SendPacket(prepare);
-                        castRequest.HasSentPrepare = true;
+                        // Don't send SpellPrepare here — hide the queue from the client.
+                        // SpellPrepare will be sent at SPELL_START time (Client/SpellHandler.cs)
+                        // so button, animation, and GCD sweep all start together.
                         return;
                     }
                     // Else: GCD expired between IsGcdHoldActive() and TryHoldCastDuringGcd() —
@@ -455,15 +432,7 @@ public partial class WorldSocket
                     });
                     if (displaced != null)
                         SendCastFailedWithoutPrepare(displaced);
-                    // Send SpellPrepare on hold-accept so the client has a SpellPrepare to
-                    // match against any future SMSG_SPELL_FAILURE for this cast. Same
-                    // reasoning as the cast-time and GCD hold paths above — see the off-GCD
-                    // comment below (~line 460) for the underlying contract.
-                    SpellPrepare prepare = new SpellPrepare();
-                    prepare.ClientCastID = castRequest.ClientGUID;
-                    prepare.ServerCastID = castRequest.ServerGUID;
-                    SendPacket(prepare);
-                    castRequest.HasSentPrepare = true;
+                    // Don't send SpellPrepare for the NEW hold — hide the queue from the client.
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- Reverts the three SpellPrepare sends added in #214 (`5e67b92`) for cast-time hold, GCD hold, and forwarded-pending hold paths
- SpellPrepare deferred back to SPELL_START/SPELL_GO time so button-light, cast-bar, and GCD sweep fire atomically
- Keeps the `HasSentPrepare` guard in HandleSpellStart (independently valuable for off-GCD dedup)

## Why
#214 solved a rare stuck-button edge case (server rejects held cast without SMSG_CAST_FAILED) by sending SpellPrepare at hold-accept time. This broke the hidden-queue timing contract — button lights up at hold-accept, GCD sweep fires at SPELL_GO — creating a visible lag gap on every queued cast. Low-latency players were disproportionately affected.

User reports confirm the stuck button self-heals on the next keypress (watchdog eviction path). The tradeoff — universal casting lag to fix a rare one-extra-press edge case — is not justified.

## Test plan
- [ ] Spam instants (Arcane Explosion, Counterspell) — verify GCD sweep is crisp with no visual gap between press and GCD animation
- [ ] Cast-time → instant spam (Frostbolt → Fire Blast → Frostbolt) — verify smooth transitions
- [ ] Compare first→second cast feel vs pre-#214 (should match the crisp feel from before the regression)
- [ ] Target-dies-mid-cast scenario — verify stuck button clears on second press (existing behavior, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)