### PR TITLE
Spell: fix double-tap stuck button — prefer non-started dequeue

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -987,13 +987,18 @@ public sealed class GameSessionData
 
     /// <summary>
     /// Try to find and dequeue a pending cast by SpellId.
-    /// Uses FIFO order since TCP guarantees packet ordering.
+    /// Prefers non-started entries when multiple entries match the same spell.
+    /// A started entry (HasStarted=true) is being tracked by the SPELL_START →
+    /// SPELL_GO lifecycle; CAST_FAILED for a rapid same-spell duplicate should
+    /// consume the non-started entry (the rejected cast) rather than the started
+    /// one (whose SPELL_GO is still in flight).
     /// </summary>
     public bool TryDequeuePendingNormalCast(uint spellId, out ClientCastRequest? cast)
     {
-        // Since TCP preserves order, the first matching SpellId is the correct one
         var pending = new List<ClientCastRequest>();
         cast = null;
+        ClientCastRequest? startedFallback = null;
+        int startedFallbackIndex = -1;
 
         lock (PendingCastsLock)
         {
@@ -1001,7 +1006,20 @@ public sealed class GameSessionData
             {
                 if (cast == null && CastMatchesSpellId(current, spellId))
                 {
-                    cast = current;
+                    if (!current.HasStarted)
+                    {
+                        cast = current;
+                    }
+                    else if (startedFallback == null)
+                    {
+                        startedFallback = current;
+                        startedFallbackIndex = pending.Count;
+                        pending.Add(current);
+                    }
+                    else
+                    {
+                        pending.Add(current);
+                    }
                 }
                 else
                 {
@@ -1009,7 +1027,13 @@ public sealed class GameSessionData
                 }
             }
 
-            // Re-enqueue non-matching casts
+            // No non-started match found — fall back to the first started entry
+            if (cast == null && startedFallback != null)
+            {
+                cast = startedFallback;
+                pending.RemoveAt(startedFallbackIndex);
+            }
+
             foreach (var item in pending)
             {
                 PendingNormalCasts.Enqueue(item);


### PR DESCRIPTION
## Summary
- `TryDequeuePendingNormalCast` now prefers non-started entries when multiple entries match the same spell
- Fixes permanently stuck action buttons caused by rapid same-spell double-taps (Bloodrage, First Aid bandages, etc.)
- Root cause: FIFO dequeue consumed the wrong pending entry — a started cast's entry was taken by the rejected duplicate's CAST_FAILED, then SPELL_GO consumed the duplicate's entry, leaving SPELL_FAILURE with no matching SpellPrepare

## Root cause (JSONL-confirmed)
1. Player double-taps Bloodrage (204ms apart) → two PendingNormalCasts entries
2. SPELL_START for cast#1 → peeks entry, sets HasStarted=true
3. CAST_FAILED for cast#2 (rejected) → FIFO dequeue takes cast#1 (wrong!)
4. SPELL_GO for cast#1 → dequeues cast#2 (wrong!)
5. SPELL_FAILURE for cast#2 → queue empty → `foundActiveCastId:false` → orphaned SpellPrepare → stuck button

## Fix
Prefer non-started entries: a started entry is tracked by SPELL_START → SPELL_GO and shouldn't be consumed by CAST_FAILED. Falls back to started entries when no non-started match exists (normal single-cast failure path unchanged).

## Test plan
- [x] All 452 existing tests pass
- [ ] Double-tap Bloodrage during GCD — button should not stick
- [ ] Double-click First Aid bandage — channel should not leave button stuck
- [ ] Normal casting flow unchanged (single casts, GCD holds, cast-time holds)
- [ ] Interrupt mid-cast (movement, Counterspell) still clears cast bar


🤖 Generated with [Claude Code](https://claude.com/claude-code)