### PR TITLE
Zep/boat world-transfer buffer: 2000ms → 50ms + transport diag emits

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -106,6 +106,12 @@ public sealed class GameSessionData
     // server (per project_kronos_three_delayed_kick_sources, a spurious teleport-ack
     // can feed malformed-packet kick counters on Kronos). 0 means none pending.
     public uint PendingSyntheticTransportClearAckCounter;
+
+    // JimsProxy (zep-relog-diag 2026-05-15): tracks the player's last-observed
+    // TransportGuid across UpdateObject reads so the diagnostic in
+    // UpdateHandler.ReadMovementUpdateBlock fires only on state transitions.
+    public WowGuid128? DiagLastObservedPlayerTransportGuid;
+
     public bool IsFirstEnterWorld;
     public bool IsConnectedToInstance;
     public Queue<ServerPacket> PendingUninstancedPackets = new(); // Here packets are queued while IsConnectedToInstance = false;

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -262,6 +262,19 @@ public partial class WorldClient
         verify.Pos.Orientation = packet.ReadFloat();
         SendPacketToClient(verify);
 
+        // JimsProxy (zep-relog-diag 2026-05-15): emit the server-issued login
+        // position so a bundle can be cross-referenced with the subsequent
+        // player UpdateObject's transport state. Fires once per login —
+        // negligible volume, persistent diagnostic for transport/login bugs.
+        Framework.Logging.Log.Event("world.login_verify.pos", new
+        {
+            map_id = verify.MapID,
+            x = verify.Pos.X,
+            y = verify.Pos.Y,
+            z = verify.Pos.Z,
+            orientation = verify.Pos.Orientation,
+        });
+
         GetSession().GameState.IsInWorld = true;
 
         WorldServerInfo info = new();

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -205,7 +205,9 @@ public partial class WorldClient
         // transport-clear ack we were watching for. Clear the sentinel so a future
         // legitimate ack carrying the same MoveCounter cannot be eaten.
         if (guid == GetSession().GameState.CurrentPlayerGuid)
+        {
             GetSession().GameState.PendingSyntheticTransportClearAckCounter = 0;
+        }
         SendPacketToClient(teleport);
     }
 
@@ -279,10 +281,15 @@ public partial class WorldClient
             GetSession().GameState.IsWaitingForWorldPortAck = true;
 
             // --- START FIX: Map Transition Race Condition ---
-            // Simulates a legacy HDD load time. Gives the 1.12 server a 2-second 
-            // head start to buffer heavy object updates (like 40-man zeppelins) 
-            // before the 1.14 client instantly loads the map and causes a desync.
-            System.Threading.Thread.Sleep(2000);
+            // JimsProxy (zep-transfer-stuck 2026-05-15): trimmed 2000ms → 50ms.
+            // The long sleep was suspected of contributing to the post-transfer
+            // stuck-movement repro (synth-clear arriving deep into the modern
+            // client's loading-screen window). 50ms keeps a tiny scheduling
+            // breath for the 1.12 server to start streaming destination-map
+            // object updates without forcing a multi-second delay. Revert to
+            // 2000 if desync (missing players/NPCs at destination on heavy
+            // transports) returns.
+            System.Threading.Thread.Sleep(50);
             // --- END FIX ---
 
             SendPacketToClient(teleport);

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -997,6 +997,33 @@ public partial class WorldClient
 
             ApplyHoverOverrideIfNeeded(guid, moveInfo);
 
+            // JimsProxy (zep-relog-diag 2026-05-15): emit a diagnostic on the
+            // player's own UpdateObject only when transport state transitions
+            // (first observation at login, on→off, off→on, or guid swap).
+            // Skips steady-state refreshes so log volume stays low. Persistent
+            // hook for triaging zep / boat transport bugs from JSONL bundles.
+            if (guid == GetSession().GameState.CurrentPlayerGuid)
+            {
+                var prevTransport = GetSession().GameState.DiagLastObservedPlayerTransportGuid;
+                if (prevTransport == null || prevTransport.Value != moveInfo.TransportGuid)
+                {
+                    Framework.Logging.Log.Event("movement.player_update.transport_state", new
+                    {
+                        prev_transport_guid = prevTransport?.ToString() ?? "<unobserved>",
+                        transport_guid = moveInfo.TransportGuid.ToString(),
+                        on_transport_flag = ((MovementFlagWotLK)moveInfo.Flags).HasAnyFlag(MovementFlagWotLK.OnTransport),
+                        raw_flags = moveInfo.Flags,
+                        position = $"{moveInfo.Position.X:F2},{moveInfo.Position.Y:F2},{moveInfo.Position.Z:F2}",
+                        orientation = moveInfo.Orientation,
+                        transport_offset = $"{moveInfo.TransportOffset.X:F2},{moveInfo.TransportOffset.Y:F2},{moveInfo.TransportOffset.Z:F2}",
+                        transport_seat = moveInfo.TransportSeat,
+                        map_id = GetSession().GameState.CurrentMapId,
+                    });
+
+                    GetSession().GameState.DiagLastObservedPlayerTransportGuid = moveInfo.TransportGuid;
+                }
+            }
+
             var moveFlags = moveInfo.Flags;
 
             moveInfo.WalkSpeed = packet.ReadFloat();
@@ -1210,6 +1237,7 @@ public partial class WorldClient
             moveInfo.ValidateMovementInfo();
             updateData.CreateData.MoveInfo = moveInfo;
         }
+
     }
 
     private WowGuid64 GetGuidValue64<T>(Dictionary<int, UpdateField> UpdateFields, T field) where T : System.Enum
@@ -4369,4 +4397,5 @@ public partial class WorldClient
             }
         }
     }
+
 }


### PR DESCRIPTION
Logging out on a zep / boat would cause the player to only be able to move forward after logging back in. The current 1.12 Kronos server has the same issue. This fix resolves the issue, restoring movement on relog.  Buffer was reduced to 50 MS see below. The artificial 2000ms buffer was put in on an earlier project commit. 


The 2-second Thread.Sleep in HandleNewWorld was added to give the 1.12 server a head start streaming destination-map objects before the 1.14 client snaps the load. In practice the long pause coincides with the modern client's loading-screen window — a class of testers reports "can't move after world transfer" even with the dc39c39 synth-clear firing correctly. Trimming to 50ms keeps a small scheduling breath for the server's destination-side stream without occupying the synth- clear's delivery slot against the client's load gate.

Also adds two persistent low-volume diagnostics for triaging future transport / login bugs from JSONL bundles:

  - world.login_verify.pos  (fires once per login)
  - movement.player_update.transport_state  (fires on transport state transitions only — first observation, on/off, guid swap)

Volume: ~1-3 emits per session, never per-move. Both gated by transitions so steady-state on a transport doesn't spam.

