### PR TITLE
Fix/zep stuck low latency race

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -56,6 +56,18 @@ public sealed class TradeSession
     public uint ServerStateIndex = 1; // incremented by any trade action
 }
 
+// JimsProxy (zep-stuck-low-latency-race 2026-05-17): which deferred-synth path
+// armed the PendingDeferredTransportSynth flag. NewWorld defers + conditionally
+// skips when destination has player on transport (natural NEW_WORLD load already
+// unlocks the client). Login always fires the synth because there's no loading
+// screen at login to unlock the modern client's turn-input gate.
+public enum DeferredTransportSynthMode
+{
+    None = 0,
+    NewWorld = 1,
+    Login = 2,
+}
+
 public sealed class GameSessionData
 {
     public bool HasWsgHordeFlagCarrier;
@@ -111,6 +123,31 @@ public sealed class GameSessionData
     // TransportGuid across UpdateObject reads so the diagnostic in
     // UpdateHandler.ReadMovementUpdateBlock fires only on state transitions.
     public WowGuid128? DiagLastObservedPlayerTransportGuid;
+
+    // JimsProxy (zep-stuck-low-latency-race 2026-05-17): deferred-synth mode.
+    // HandleNewWorld / HandleLoginVerifyWorld set this and defer the transport-
+    // clear MoveTeleport synth until the player's first post-NEW_WORLD (or
+    // post-login) UpdateObject is processed in UpdateHandler. Two reasons to
+    // defer:
+    //   1. NewWorld path — at low latency (~35ms) the inline synth fired
+    //      BEFORE the destination map's COMPRESSED_UPDATE_OBJECT arrived; the
+    //      server's subsequent natural player-update re-attached
+    //      MOVEMENTFLAG_ONTRANSPORT (player landed on destination zep tower /
+    //      boat deck), and the rapid clear→re-attach wedged the modern client.
+    //      Deferred path skips the synth entirely when the destination's
+    //      player UpdateObject confirms the player is on a destination
+    //      transport (no synth needed — the natural NEW_WORLD flow already
+    //      unlocks the client's movement state on map load).
+    //   2. Login path — when the client logs in already on a transport, the
+    //      modern client gates turn-input (CMSG_MOVE_SET_FACING / START_TURN_*)
+    //      and never sends them until something resets its movement state.
+    //      There's no loading screen at login, so the natural NEW_WORLD reset
+    //      doesn't fire. Synthesizing the transport-clear MoveTeleport gives
+    //      the gate the kick it needs to release. Login path ALWAYS synths
+    //      regardless of transport state.
+    // Cleared by the deferred path in UpdateHandler.ReadMovementUpdateBlock
+    // once it fires or skips.
+    public DeferredTransportSynthMode PendingDeferredTransportSynth;
 
     public bool IsFirstEnterWorld;
     public bool IsConnectedToInstance;

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -309,6 +309,20 @@ public partial class WorldClient
             map_id = verify.MapID,
         });
 
+        // JimsProxy (zep-stuck-login-turn-gate 2026-05-17): when the player logs
+        // in already on a transport (zep/boat in flight), the modern 1.14 client
+        // gates turn-input — CMSG_MOVE_SET_FACING / START_TURN_* never fire until
+        // the client receives a teleport-tier movement reset. World transfers
+        // (NEW_WORLD) provide that reset naturally via the map-load. Plain login
+        // doesn't. Arm the deferred-synth path with mode=Login so the synth
+        // fires AFTER the player's first UpdateObject lands (and so we have
+        // current transport state to attach to). The synth body uses
+        // TransportGUID=default; the server's natural player-update re-attaches
+        // the legitimate transport right after, but the brief off-transport
+        // pulse is what releases the client's turn-input gate.
+        GetSession().GameState.PendingDeferredTransportSynth =
+            DeferredTransportSynthMode.Login;
+
         LoadCUFProfiles cuf = new();
         cuf.Data = GetSession().AccountDataMgr.LoadCUFProfiles();
         SendPacketToClient(cuf);

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -294,65 +294,21 @@ public partial class WorldClient
 
             SendPacketToClient(teleport);
 
-            // JimsProxy (zep-stuck-no-move 2026-05-14): cross-continent transports
-            // (Grom'gol↔Orgrimmar zep, BB↔Ratchet boat) leave the 1.14 client holding
-            // a stale MOVEMENTFLAG_ONTRANSPORT after NEW_WORLD. Mouse-look continues
-            // to work, but the client suppresses every CMSG_MOVE_START_* because its
-            // local MovementInfo still references the old-map transport GUID, which
-            // no longer exists. Symptom: "can't move after the zeppelin." Synthesize
-            // an SMSG_MOVE_TELEPORT with TransportGUID=default to force the client to
-            // fully reset its local MovementInfo. The client will fire a matching
-            // CMSG_MOVE_TELEPORT_ACK; HandleMoveTeleportAck (server side) drops it by
-            // sentinel MoveCounter so the legacy server never sees the spurious ack.
-            WowGuid128 playerGuid = GetSession().GameState.CurrentPlayerGuid;
-            if (!playerGuid.IsEmpty())
-            {
-                const uint SyntheticTeleportAckSentinel = 0xFFFFFFFFu;
-                MoveTeleport transportClear = new MoveTeleport();
-                transportClear.MoverGUID = playerGuid;
-                transportClear.MoveCounter = SyntheticTeleportAckSentinel;
-                transportClear.Position = teleport.Position;
-                transportClear.Orientation = teleport.Orientation;
-                transportClear.PreloadWorld = 0;
-                transportClear.TransportGUID = default;
-                // Leave transportClear.Vehicle at its default null! sentinel —
-                // assigning null here trips the non-nullable-ref-type check; the
-                // existing MoveTeleport path uses this same pattern for non-vehicle
-                // teleports.
-                GetSession().GameState.PendingSyntheticTransportClearAckCounter =
-                    SyntheticTeleportAckSentinel;
-                Framework.Logging.Log.Event("movement.transport_clear.synthesized", new
-                {
-                    map_id = teleport.MapID,
-                    player_low = playerGuid.GetCounter(),
-                    position = $"{teleport.Position.X:F2},{teleport.Position.Y:F2},{teleport.Position.Z:F2}",
-                });
-                // JimsProxy (zep-stuck-no-move 2026-05-14, belt-and-suspenders):
-                // explicitly wrap the SendPacketToClient call so we know whether
-                // the packet actually reached the socket. If `send_completed`
-                // fires, the call returned without throwing; if `send_failed`
-                // fires, an exception was raised and we can pinpoint the issue.
-                // Resolves the open "synth emitted but no ack" question by ruling
-                // out a silent drop in the proxy's outbound pipeline.
-                try
-                {
-                    SendPacketToClient(transportClear);
-                    Framework.Logging.Log.Event("movement.transport_clear.send_completed", new
-                    {
-                        player_low = playerGuid.GetCounter(),
-                        sentinel_counter = SyntheticTeleportAckSentinel,
-                    });
-                }
-                catch (System.Exception ex)
-                {
-                    Framework.Logging.Log.Event("movement.transport_clear.send_failed", new
-                    {
-                        player_low = playerGuid.GetCounter(),
-                        exception_type = ex.GetType().Name,
-                        exception_message = ex.Message,
-                    });
-                }
-            }
+            // JimsProxy (zep-stuck-low-latency-race 2026-05-17): defer the
+            // transport-clear synth until the player's first post-NEW_WORLD
+            // UpdateObject lands. Firing inline here at NEW_WORLD time worked at
+            // ~150ms latency (synth happened to arrive at the modern client AFTER
+            // the destination COMPRESSED_UPDATE_OBJECT) but raced at ~35ms (synth
+            // arrived BEFORE the destination state, the server's subsequent
+            // player-update re-attached the transport flag, and the rapid
+            // clear→re-attach wedged the modern client into a no-MOVE_START_*
+            // state when the destination position was on a transport — Grom'gol
+            // zep tower platform, Ratchet boat deck). The deferred path in
+            // UpdateHandler.ReadMovementUpdateBlock inspects moveInfo.TransportGuid
+            // and only synths when the destination has the player OFF a transport,
+            // preserving the dc39c39 original use case (cross-continent land
+            // destinations) without breaking the on-transport destinations.
+            GetSession().GameState.PendingDeferredTransportSynth = DeferredTransportSynthMode.NewWorld;
 
             if (teleport.MapID > 1)
             {
@@ -368,6 +324,62 @@ public partial class WorldClient
                 resume.Reason = 1;
                 SendPacketToClient(resume);
             }
+        }
+    }
+
+    // JimsProxy (zep-stuck-low-latency-race 2026-05-17): synthesizes a player-targeted
+    // SMSG_MOVE_TELEPORT with TransportGUID=default to force the modern client to clear
+    // any stale MOVEMENTFLAG_ONTRANSPORT carried across from the source map's transport.
+    // Fired from the deferred path in UpdateHandler.ReadMovementUpdateBlock only when the
+    // destination's player UpdateObject confirms the player is NOT on a transport (zep
+    // tower / boat deck) at the destination. The MoveCounter sentinel is dropped by the
+    // server-side HandleMoveTeleportAck so the legacy server never sees the spurious ack.
+    internal void FireDeferredTransportClearSynth(WowGuid128 playerGuid, Vector3 position, float orientation, string mode)
+    {
+        if (playerGuid.IsEmpty())
+            return;
+
+        const uint SyntheticTeleportAckSentinel = 0xFFFFFFFFu;
+        MoveTeleport transportClear = new MoveTeleport();
+        transportClear.MoverGUID = playerGuid;
+        transportClear.MoveCounter = SyntheticTeleportAckSentinel;
+        transportClear.Position = position;
+        transportClear.Orientation = orientation;
+        transportClear.PreloadWorld = 0;
+        transportClear.TransportGUID = default;
+        // Leave transportClear.Vehicle at its default null! sentinel — assigning
+        // null trips the non-nullable-ref-type check; the existing MoveTeleport
+        // path uses this same pattern for non-vehicle teleports.
+
+        GetSession().GameState.PendingSyntheticTransportClearAckCounter =
+            SyntheticTeleportAckSentinel;
+
+        Framework.Logging.Log.Event("movement.transport_clear.synthesized", new
+        {
+            map_id = GetSession().GameState.CurrentMapId,
+            player_low = playerGuid.GetCounter(),
+            position = $"{position.X:F2},{position.Y:F2},{position.Z:F2}",
+            deferred = true,
+            mode = mode,
+        });
+
+        try
+        {
+            SendPacketToClient(transportClear);
+            Framework.Logging.Log.Event("movement.transport_clear.send_completed", new
+            {
+                player_low = playerGuid.GetCounter(),
+                sentinel_counter = SyntheticTeleportAckSentinel,
+            });
+        }
+        catch (System.Exception ex)
+        {
+            Framework.Logging.Log.Event("movement.transport_clear.send_failed", new
+            {
+                player_low = playerGuid.GetCounter(),
+                exception_type = ex.GetType().Name,
+                exception_message = ex.Message,
+            });
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1022,6 +1022,52 @@ public partial class WorldClient
 
                     GetSession().GameState.DiagLastObservedPlayerTransportGuid = moveInfo.TransportGuid;
                 }
+
+                // JimsProxy (zep-stuck-low-latency-race 2026-05-17): deferred
+                // transport-clear synth dispatcher. Both arming paths SKIP the
+                // synth when the player's destination UpdateObject confirms
+                // they are legitimately on a transport (zep tower / boat deck /
+                // mid-flight zep). Reasons differ but the action is the same:
+                //
+                //   - NewWorld + on transport: the natural NEW_WORLD load
+                //     already unlocked the client's movement state on map
+                //     load; firing the synth would risk re-wedging.
+                //   - Login + on transport: SMSG_MOVE_TELEPORT with
+                //     TransportGUID=empty would dump the player off the
+                //     transport into mid-air / ocean (validated 2026-05-17,
+                //     log jimsproxy-20260517-102517.jsonl — tester fell into
+                //     ocean at Silithus). MoveTeleport semantics don't allow
+                //     a no-op "state-refresh" with TransportGUID preserved;
+                //     the client treats any MoveTeleport as a real teleport.
+                //     Accept the temporary turn-input gate; the next natural
+                //     world transition (zep docking) releases it.
+                //
+                // Synth fires only when destination is NOT on a transport —
+                // the dc39c39 stale-flag-clear use case (player rode through
+                // a portal mid-zep, or the legacy server's UpdateObject lost
+                // the transport attach by destination). Same payload for
+                // both NewWorld and Login paths in this branch.
+                var pendingMode = GetSession().GameState.PendingDeferredTransportSynth;
+                if (pendingMode != DeferredTransportSynthMode.None)
+                {
+                    GetSession().GameState.PendingDeferredTransportSynth = DeferredTransportSynthMode.None;
+                    bool destinationOnTransport = !moveInfo.TransportGuid.IsEmpty();
+                    if (destinationOnTransport)
+                    {
+                        Framework.Logging.Log.Event("movement.transport_clear.deferred_skipped", new
+                        {
+                            map_id = GetSession().GameState.CurrentMapId,
+                            player_low = guid.GetCounter(),
+                            destination_transport_guid = moveInfo.TransportGuid.ToString(),
+                            mode = pendingMode.ToString(),
+                            reason = "destination_on_transport",
+                        });
+                    }
+                    else
+                    {
+                        FireDeferredTransportClearSynth(guid, moveInfo.Position, moveInfo.Orientation, pendingMode.ToString());
+                    }
+                }
             }
 
             var moveFlags = moveInfo.Flags;

--- a/MOVEMENT_SYNTH_PATTERN.md
+++ b/MOVEMENT_SYNTH_PATTERN.md
@@ -1,0 +1,177 @@
+# Movement-state synth race trap & deferred-synth pattern
+
+Quick reference for anyone (human or AI) adding a proxy → client synthesized
+`SMSG_MOVE_TELEPORT` (or similar movement-state reset) to unlock a wedged
+modern client. Background and rationale are in commits `dc39c39`, `fc86903`,
+`a3e763a`, `f414896`.
+
+## TL;DR
+
+If you're synthesizing a movement-state packet after the proxy receives
+`SMSG_NEW_WORLD` or `SMSG_LOGIN_VERIFY_WORLD`, **do not fire the synth
+inline** in the handler. **Defer it** to the player's first post-arming
+`SMSG_UPDATE_OBJECT`. Otherwise you will introduce a latency-dependent race
+that NA testers (~150ms) can't repro but EU testers (~35ms) hit consistently.
+
+## The trap
+
+```
+t+0      proxy receives SMSG_NEW_WORLD from legacy server
+         forwards NEW_WORLD to modern client
+         INLINE synth fires here  ← TRAP
+t+50ms   proxy receives small UPDATE_OBJECT (transport object header)
+t+1.37s  proxy receives SMSG_COMPRESSED_UPDATE_OBJECT (destination map state)
+t+1.38s  player UpdateObject inside the compressed packet re-attaches
+         transport (e.g., player lands on a destination zep tower)
+```
+
+At ~150ms latency, the inline synth happens to land at the modern client
+AFTER the destination's `COMPRESSED_UPDATE_OBJECT` — synth clears stale
+state, server re-attaches via the natural flow, everything works.
+
+At ~35ms latency, the synth lands BEFORE the destination state. Server's
+subsequent natural re-attach then conflicts with the just-cleared client
+state, and the modern client wedges into one of two failure modes:
+
+- **Linear-movement wedge** (forward/back/strafe all blocked) — observed
+  on post-zep transit landing on a destination transport.
+- **Turn-input gate** (forward/back/strafe work, rotation blocked) —
+  observed on login already on a transport.
+
+## The pattern
+
+Use the existing infrastructure in `HermesProxy/GlobalSessionData.cs`:
+
+```csharp
+public enum DeferredTransportSynthMode { None, NewWorld, Login }
+public DeferredTransportSynthMode PendingDeferredTransportSynth;
+```
+
+### Arming (handler side)
+
+In `MovementHandler.HandleNewWorld` (and now `CharacterHandler.HandleLoginVerifyWorld`):
+
+```csharp
+GetSession().GameState.PendingDeferredTransportSynth =
+    DeferredTransportSynthMode.NewWorld;  // or .Login
+```
+
+Don't fire the synth inline. Just arm.
+
+### Dispatching (deferred firing)
+
+In `UpdateHandler.ReadMovementUpdateBlock`, inside the existing
+`if (guid == GetSession().GameState.CurrentPlayerGuid)` block (right after
+the `movement.player_update.transport_state` diagnostic):
+
+```csharp
+var pendingMode = GetSession().GameState.PendingDeferredTransportSynth;
+if (pendingMode != DeferredTransportSynthMode.None)
+{
+    GetSession().GameState.PendingDeferredTransportSynth = DeferredTransportSynthMode.None;
+    bool destinationOnTransport = !moveInfo.TransportGuid.IsEmpty();
+    bool alwaysFire = pendingMode == DeferredTransportSynthMode.Login;
+    if (!alwaysFire && destinationOnTransport)
+    {
+        // NewWorld + on destination transport: SKIP. Natural NEW_WORLD load
+        // already unlocked the client; firing here risks re-wedging.
+        Log.Event("movement.transport_clear.deferred_skipped", ...);
+    }
+    else
+    {
+        FireDeferredTransportClearSynth(guid, moveInfo.Position, moveInfo.Orientation, pendingMode.ToString());
+    }
+}
+```
+
+### Wire ordering caveat
+
+The dispatcher runs INSIDE `ReadMovementUpdateBlock`, which runs WHILE
+`HandleUpdateObject` is parsing the legacy COMPRESSED_UPDATE_OBJECT. The
+modern UpdateObject isn't actually sent to the client until line ~419's
+`SendPacketToClient(updateObject)` at the end of the handler. So if the
+dispatcher fires the synth inline, the wire order to the client is:
+
+  1. synth (fires from within ReadMovementUpdateBlock at proxy time T)
+  2. modern UpdateObject (fires at end of handler, T+~50ms)
+
+The synth lands FIRST, then the UpdateObject. Whether this matters
+depends on the synth payload:
+
+- **For clear-stale-flag synths** (TransportGUID=empty when player is NOT
+  on a destination transport): the trailing UpdateObject also has no
+  transport attach, so it doesn't conflict. Inline order works.
+- **For state-refresh synths** (where you wanted the synth to land AFTER
+  the UpdateObject so it could "fix up" something): this pattern does
+  NOT give you that. Validated 2026-05-17: stashing the synth payload
+  and firing it after `SendPacketToClient(updateObject)` did make the
+  wire order "updateObject → synth" — but for the transport-clear case
+  this caused worse behavior (synth dismounted player from transport →
+  fall into ocean). The fix was to SKIP the synth entirely when the
+  destination shows the player on a transport.
+
+If you genuinely need "synth lands after destination state with no race",
+stash + fire after `SendPacketToClient(updateObject)` works at the wire
+level. Make sure your synth payload is correct for that ordering.
+
+## Why Login is no longer special-cased
+
+Earlier drafts of this pattern always-fired the Login synth, including
+when the player was on a transport. Bad idea — validated 2026-05-17
+(log jimsproxy-20260517-102517.jsonl): tester logged in mid-flight on a
+zep, synth fired with TransportGUID=empty, modern client teleported them
+off the zep into mid-air, fell into the ocean at Silithus.
+
+`SMSG_MOVE_TELEPORT` semantically means "teleport to this world position
+[and attach to this transport]". The packet has no transport-offset
+field and no "state refresh" flag. A TransportGUID-preserving synth
+still tells the client "teleport you onto this transport at this world
+point" — visual snap, possible re-detach. There is no known no-op
+flavor of MoveTeleport.
+
+So when the player is legitimately on a transport at login, we SKIP the
+synth. The trade-off: the modern client's turn-input gate stays engaged
+(player can strafe / move forward+back but can't rotate) until the next
+natural world transition (zep docking) releases it. That's a worse UX
+than rotation-works-immediately, but VASTLY better than falling into
+ocean. If a future client-state-reset opcode is discovered that releases
+the gate without dismount, revisit.
+
+For non-transport logins, the synth is a harmless no-op (clearing a
+transport flag that wasn't set) — fires safely.
+
+## Diagnostic events to grep when triaging
+
+- `movement.transport_clear.synthesized` — the synth fired. Includes
+  `deferred: true` and `mode` (NewWorld | Login).
+- `movement.transport_clear.deferred_skipped` — dispatcher skipped the
+  synth because the destination has the player legitimately on a
+  transport. `mode` field tells you which path armed (NewWorld | Login).
+- `movement.transport_clear.send_completed` / `send_failed` — outbound
+  send wrapper diagnostics.
+- `movement.player_update.transport_state` — fires once per
+  transport-state transition on the player. Useful for confirming the
+  destination's attachment state.
+
+## When NOT to use this pattern
+
+- For pure proxy → client packets that don't depend on the modern
+  client's movement-state machine (chat synthesis, aura updates, etc.).
+- For synths that need to fire BEFORE the destination state is processed
+  (rare — if you find one, you almost certainly have a different
+  architectural problem).
+
+## Future synth patterns to vet against this
+
+- Mount/dismount stuck states
+- AFK timeout re-entry
+- Instance entry / vehicle entry
+- Resurrection at graveyards
+
+If you add a new client-state-reset synth, ask yourself:
+
+1. Does the destination state arrive in a separate later packet?
+2. Could the synth land at the client before that state?
+3. If yes to both, use the deferred-dispatcher pattern. Add a new enum
+   variant to `DeferredTransportSynthMode` if the conditional skip logic
+   differs.


### PR DESCRIPTION
 ## Summary

  Two-pronged fix for transport-related movement stuck states on the modern 1.14 client, both root-caused via JSONL
  bundles on Twinstar/Kronos V at build 5.1.3-beta.6:

  ### 1. Post-NEW_WORLD stuck at low latency (~35ms EU testers)

  `fc86903` dropped `HandleNewWorld`'s HDD-simulator sleep 2000ms → 50ms, unmasking a race the original `dc39c39` inline
   synth never had to handle:

  t+0      SMSG_NEW_WORLD
  t+58ms   movement.transport_clear.synthesized  ← inline synth fires
  t+1.37s  SMSG_COMPRESSED_UPDATE_OBJECT (destination state)
  t+1.38s  player update re-attaches transport (zep tower at destination)
  t+2.3s   client wedged — no CMSG_MOVE_START_* for 30+ seconds

  At ~150ms latency (NA testers) the synth happened to arrive AFTER the destination state, so the wedge never fired —
  bug only repros at ≤ ~50ms RTT.

  ### 2. Login-on-transport turn-input gate

  Logging in already on a transport (zep mid-flight) leaves the modern client gating turn-input — `CMSG_MOVE_SET_FACING`
   / `START_TURN_*` never fire until the client receives a teleport-tier movement reset. World transfers provide that
  reset naturally via the map-load loading screen. Plain login doesn't. Linear movement (forward/back/strafe) works,
  **only rotation is gated**.

  ## Fix

  - New `DeferredTransportSynthMode` enum (`None` / `NewWorld` / `Login`) replaces the previous bool flag.
  - `HandleNewWorld` arms with `mode=NewWorld` (no longer fires inline synth).
  - `HandleLoginVerifyWorld` arms with `mode=Login`.
  - Deferred dispatcher lives in `UpdateHandler.ReadMovementUpdateBlock`'s existing player-UpdateObject hook (fires once
   the first post-arming UpdateObject is processed, guaranteeing destination state has been seen):
    - **NewWorld + on destination transport** → SKIP synth (natural NEW_WORLD load already unlocked client; firing risks
   re-wedging).
    - **NewWorld + off destination transport** → fire synth with `TransportGUID=default` (dc39c39 original use case —
  clears stale flag).
    - **Login** → ALWAYS fire synth (no loading screen at login, so the synth is the only thing that releases the
  turn-input gate). No-op on non-transport logins (`TransportGUID=default` is a noop if not on transport already).
  - Same `MoveCounter` sentinel (`0xFFFFFFFF`) so server-side `HandleMoveTeleportAck` still drops the spurious ack.
  - New `mode` field on `movement.transport_clear.synthesized` / `deferred_skipped` diagnostics distinguishes NewWorld
  vs Login paths.

  ## Race analysis

  TCP byte ordering + serialized `SendPacketToClient` calls guarantee the synth lands at the client AFTER the
  destination state — eliminates the `fc86903` race window for this synth. Doesn't affect unrelated packet-ordering
  paths.

  ## Test plan

  - [x] `dotnet build HermesProxy` clean (0 warnings, 0 errors)
  - [x] `dotnet test HermesProxy.Tests` — 452/452 passing
  - [x] Local test (Mirasu, NA 150ms): logged in mid-zep, turn was gated; world-transfer unlocked turn ✓
  - [x] Local test (after fix): logged in mid-zep, turn unlocked immediately via login-mode synth ✓
  - [ ] EU low-latency tester to verify the original transit-stuck repro is gone via the deferred timing