### PR TITLE
Battleground: throttle CMSG_PVP_LOG_DATA to 10s per session

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -60,6 +60,18 @@ public sealed class GameSessionData
 {
     public bool HasWsgHordeFlagCarrier;
     public bool HasWsgAllyFlagCarrier;
+
+    // JimsProxy (pvp-log-data-throttle 2026-05-17): tick of the most recent
+    // CMSG_PVP_LOG_DATA we forwarded to the legacy server. Used by
+    // BattlegroundHandler.HandlePvPLogData to drop requests inside the throttle
+    // window (10s). Kronos / vanilla-emu servers treat sustained
+    // CMSG_PVP_LOG_DATA above ~10/min as a spam-bot signal and silently queue
+    // a kick — addons like BattlegroundEnemies (2s ticker) and enemyFrames
+    // (every-frame OnUpdate) can blow past that threshold per-addon. The
+    // proxy throttle is the universal defense: covers any current or future
+    // misbehaving PvP-scoreboard addon with zero per-addon work. 0 means we
+    // haven't forwarded one yet this session — first request always passes.
+    public long LastForwardedPvpLogDataTickMs;
     public bool JimsPlusSideband;
     public bool ChannelDisplayList;
     public bool ShowPlayedTime;

--- a/HermesProxy/World/Server/PacketHandlers/BattlegroundHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/BattlegroundHandler.cs
@@ -56,6 +56,33 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_PVP_LOG_DATA)]
     void HandlePvPLogData(PVPLogDataRequest log)
     {
+        // JimsProxy (pvp-log-data-throttle 2026-05-17): forward at most once
+        // per 10 seconds per session. Kronos / vanilla-emu servers treat
+        // sustained CMSG_PVP_LOG_DATA above ~10/min as a spam-bot signal and
+        // silently queue a kick (observed BG-exit DC, log
+        // jimsproxy-20260516-...-BGDC.jsonl). Common BG-addons hammer this:
+        // BattlegroundEnemies' default 2s OnUpdate ticker = ~30/min;
+        // enemyFrames calls RequestBattlefieldScoreData() every frame from
+        // OnUpdate = ~3600/min at 60fps. Throttling proxy-side covers every
+        // current and future misbehaving addon. Side effect for dropped
+        // requests: the client won't fire UPDATE_BATTLEFIELD_SCORE for THIS
+        // drop, but the last forwarded request's response still populated
+        // the cache — 10s staleness is fine for BG scoreboards.
+        const long ThrottleWindowMs = 10_000;
+        long now = Environment.TickCount64;
+        long last = GetSession().GameState.LastForwardedPvpLogDataTickMs;
+        long deltaMs = last == 0 ? long.MaxValue : now - last;
+        if (deltaMs < ThrottleWindowMs)
+        {
+            Log.Event("battleground.pvp_log_data.throttle_dropped", new
+            {
+                ms_since_last_forward = deltaMs,
+                throttle_window_ms = ThrottleWindowMs,
+            });
+            return;
+        }
+
+        GetSession().GameState.LastForwardedPvpLogDataTickMs = now;
         WorldPacket packet = new WorldPacket(Opcode.MSG_PVP_LOG_DATA);
         SendPacketToServer(packet);
     }


### PR DESCRIPTION
Kronos / vanilla-emu servers treat sustained CMSG_PVP_LOG_DATA above ~10/min as a spam-bot signal and silently queue a kick (observed BG-exit DC, tester's log jimsproxy-20260516 BGDC bundle). Multiple PvP-scoreboard addons on the modern 1.14 client side hammer the request:

- BattlegroundEnemies default OnUpdate ticker: 2s → ~30/min per session.
- enemyFrames-master OnUpdate calls RequestBattlefieldScoreData() every frame with no throttle → ~3600/min at 60fps.
- Likely others — vanilla-era addons assume the request is free.

A per-addon patch (e.g. bumping BGE's UpdatePeroid to 10s) helps only that one addon and only for users running the patched copy. The proxy- side throttle is the universal defense: covers any current or future misbehaving addon with zero per-addon work.

Implementation:

- New GameSessionData.LastForwardedPvpLogDataTickMs (long, ms tick).
- BattlegroundHandler.HandlePvPLogData checks Environment.TickCount64 - LastForwardedPvpLogDataTickMs; drops if inside 10s window, otherwise forwards MSG_PVP_LOG_DATA and updates the tick.
- 0 sentinel means "never forwarded this session" — first request always passes through.
- Dropped requests emit battleground.pvp_log_data.throttle_dropped with ms_since_last_forward + window for triage.

Max forward rate: 6/min, well under Kronos's ~10/min threshold.

Side effect for dropped requests: the modern client won't fire UPDATE_BATTLEFIELD_SCORE for the dropped call, but the most recent forwarded request's response still populated the addon's score cache — 10s staleness is fine for BG scoreboards. Validated separately via the BattlegroundEnemies addon patch (same 10s window) — tester stopped DC'ing after the addon throttle alone. Proxy throttle layers on top as defense-in-depth.