### PR TITLE
Fix/trainer buy predecessor defense

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -228,6 +228,27 @@ public sealed class GameSessionData
     // a real ban. On explicit SMSG_TRAINER_BUY_FAILED we restore the predecessor.
     public uint PendingTrainerBuySpellId;
     public uint PendingTrainerBuyRemovedPredecessor;
+    // JimsProxy: real spell ids that the most recent SMSG_TRAINER_LIST marked
+    // with TrainerSpellState=Known. Authoritative server view of "this spell
+    // is effectively learned by you" — covers both direct ownership (HasSpell)
+    // and supersede-chain ownership (HasSpell on any higher rank). Without this
+    // we can't intercept stale-click buys for spells that were just removed
+    // from CurrentPlayerKnownSpells by a SMSG_SUPERCEDED_SPELLS for the new
+    // rank: e.g., learn Apprentice Riding, then Journeyman, then click stale
+    // Apprentice in the UI — Apprentice is gone from KnownSpells but the
+    // server still treats it as effectively-known and rejects the buy with
+    // FAILED. Repopulated on every new SMSG_TRAINER_LIST so this set always
+    // reflects the latest server view.
+    public System.Collections.Generic.HashSet<uint> LastTrainerListKnownSpells = new();
+    // JimsProxy: in-flight trainer-buy tracking. Set on every forwarded
+    // CMSG_TRAINER_BUY_SPELL, cleared on the response (LEARNED, SUPERCEDED, FAILED,
+    // or a fresh trainer-list refresh). Used to drop rapid same-spell double-clicks
+    // where the second CMSG races with the first's response — both reach the
+    // server, the first succeeds, the second gets FAILED. Distinct from
+    // PendingTrainerBuy* (which only tracks buys that triggered speculative
+    // predecessor removal for the ban defense).
+    public uint InFlightTrainerBuySpellId;
+    public long InFlightTrainerBuyTickMs;
     // JimsProxy: per-unit HP cache used to compute overhealing on legacy servers
     // that don't include OverHeal in SMSG_SPELL_HEAL_LOG (1.12 vanilla). Authoritative
     // source is UNIT_FIELD_HEALTH / UNIT_FIELD_MAXHEALTH from SMSG_UPDATE_OBJECT;

--- a/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
@@ -168,6 +168,14 @@ public partial class WorldClient
         trainer.TrainerID = trainer.TrainerGUID.GetEntry();
         trainer.TrainerType = packet.ReadInt32();
         int count = packet.ReadInt32();
+        int filteredKnown = 0;
+        // JimsProxy: reset the authoritative-Known set for this fresh trainer
+        // list, then repopulate as we walk the entries. The intercept in
+        // HandleTrainerBuySpell consults this set to catch stale UI clicks for
+        // spells that the server considers Known via supersede chain (and so
+        // are absent from CurrentPlayerKnownSpells).
+        var lastKnownSet = GetSession().GameState.LastTrainerListKnownSpells;
+        lastKnownSet.Clear();
         for (int i = 0; i < count; ++i)
         {
             TrainerListSpell spell = new();
@@ -197,7 +205,44 @@ public partial class WorldClient
             spell.ReqAbility[0] = packet.ReadUInt32();
             spell.ReqAbility[1] = packet.ReadUInt32();
             spell.ReqAbility[2] = packet.ReadUInt32();
+            // JimsProxy: filter already-learned spells out of the trainer list
+            // before forwarding to the modern client. Empirically the modern
+            // Classic 1.14 trainer UI does not visually differentiate Known from
+            // Available based on the state byte — both render as a clickable
+            // green row with an enabled Train button. Clicking a Known spell
+            // sends CMSG_TRAINER_BUY_SPELL, the server replies with FAILED
+            // (Reason 2), and the player sees an unhelpful "Failed to learn"
+            // chat message for a spell they already have. Filtering server-side
+            // keeps the trainer UI clean and matches user expectation that
+            // learned spells "drop off" the list (the original UX complaint
+            // that motivated the trainer-list-refresh work).
+            // Note: we still call StoreRealSpell + read all packet fields above
+            // so the mapping stays available if the spell is bought via any
+            // other code path, and so the reader cursor stays aligned with the
+            // legacy packet body regardless of filtering.
+            if (stateOld == TrainerSpellStateLegacy.Known)
+            {
+                // Normalize to the real spell id regardless of whether the version
+                // condition above replaced `spellId` (modern→legacy across expansion
+                // boundary) or left it as the legacy learn-wrapper (1.14→1.12, both
+                // expansion 1). The intercept in HandleTrainerBuySpell looks up the
+                // real id via GameData.GetRealSpell, so storing the real id here
+                // makes Contains() match in both versioning regimes.
+                lastKnownSet.Add(GameData.GetRealSpell(spellId));
+                filteredKnown++;
+                continue;
+            }
             trainer.Spells.Add(spell);
+        }
+        if (filteredKnown > 0)
+        {
+            Log.Event("spell.trainer_list.known_filtered", new
+            {
+                trainer_id = trainer.TrainerID,
+                listed = trainer.Spells.Count,
+                filtered_known = filteredKnown,
+                total_received = count,
+            });
         }
         trainer.Greeting = packet.ReadCString();
         SendPacketToClient(trainer);
@@ -241,6 +286,14 @@ public partial class WorldClient
 
         // Ban defense: server explicitly rejected the buy, so the predecessor
         // was NOT removed server-side. Restore it to keep proxy state in sync.
+        // Also clear in-flight tracking so a legitimate retry (e.g., player
+        // came back with more money) isn't dropped as a stale duplicate.
+        if (GetSession().GameState.InFlightTrainerBuySpellId != 0)
+        {
+            GetSession().GameState.InFlightTrainerBuySpellId = 0u;
+            GetSession().GameState.InFlightTrainerBuyTickMs = 0;
+        }
+
         uint pendingSpellId = GetSession().GameState.PendingTrainerBuySpellId;
         uint removedPredecessor = GetSession().GameState.PendingTrainerBuyRemovedPredecessor;
         if (pendingSpellId != 0 && removedPredecessor != 0)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -140,6 +140,14 @@ public partial class WorldClient
             GetSession().GameState.PendingTrainerBuySpellId = 0u;
             GetSession().GameState.PendingTrainerBuyRemovedPredecessor = 0u;
         }
+        // Clear in-flight trainer-buy on rank-upgrade response too — match on either
+        // the new or the superseded id so we don't strand stale in-flight state.
+        if (GetSession().GameState.InFlightTrainerBuySpellId == spellId
+            || GetSession().GameState.InFlightTrainerBuySpellId == supercededId)
+        {
+            GetSession().GameState.InFlightTrainerBuySpellId = 0u;
+            GetSession().GameState.InFlightTrainerBuyTickMs = 0;
+        }
         SendPacketToClient(spells);
         ReconcileTalentRankInjection();
     }
@@ -159,6 +167,13 @@ public partial class WorldClient
         {
             GetSession().GameState.PendingTrainerBuySpellId = 0u;
             GetSession().GameState.PendingTrainerBuyRemovedPredecessor = 0u;
+        }
+        // Clear in-flight trainer-buy on confirmed learn so the next CMSG
+        // for the same spell isn't dropped as a stale duplicate.
+        if (GetSession().GameState.InFlightTrainerBuySpellId == spellId)
+        {
+            GetSession().GameState.InFlightTrainerBuySpellId = 0u;
+            GetSession().GameState.InFlightTrainerBuyTickMs = 0;
         }
         SendPacketToClient(spells);
         ReconcileTalentRankInjection();

--- a/HermesProxy/World/Server/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/NPCHandler.cs
@@ -54,6 +54,50 @@ public partial class WorldSocket
     {
         uint realSpellId = GameData.GetRealSpell(buy.SpellID);
 
+        // Intercept stale-click and duplicate-click trainer buys. The 1.14 trainer
+        // panel doesn't honor mid-interaction SMSG_TRAINER_LIST refreshes — once
+        // open, the spell list is rendered from the initial open. Stale entries
+        // can still be clicked, producing useless "Failed to learn Spell X"
+        // round-trips. Three predicates cover the common cases:
+        //   * inKnownSpells       — player has the spell directly
+        //   * inTrainerKnownSet   — server's last trainer list marked it Known
+        //                           (catches supersede case where the spell was
+        //                           removed from CurrentPlayerKnownSpells by
+        //                           SMSG_SUPERCEDED but the trainer still treats
+        //                           the lower rank as effectively-known)
+        //   * isInFlightDuplicate — same-spell second click within ~2.5s, before
+        //                           the first buy's response had a chance to
+        //                           update either set above (rapid double-click)
+        // When any fires, send a friendly chat message and close the gossip
+        // panel; the player has to reopen, which yields a fresh trainer list
+        // with HandleTrainerList's initial Known filter applied cleanly.
+        bool inKnownSpells = GetSession().GameState.CurrentPlayerKnownSpells.Contains(realSpellId);
+        bool inTrainerKnownSet = GetSession().GameState.LastTrainerListKnownSpells.Contains(realSpellId);
+        long nowMs = System.Environment.TickCount64;
+        long sinceInFlightMs = nowMs - GetSession().GameState.InFlightTrainerBuyTickMs;
+        bool isInFlightDuplicate = GetSession().GameState.InFlightTrainerBuySpellId == realSpellId
+            && sinceInFlightMs >= 0 && sinceInFlightMs < 2500;
+        if (LegacyVersion.ExpansionVersion <= 1 && (inKnownSpells || inTrainerKnownSet || isInFlightDuplicate))
+        {
+            Log.Event("spell.trainer_buy.intercepted_already_known", new
+            {
+                real_spell_id = realSpellId,
+                learn_spell_id = buy.SpellID,
+                in_known_spells = inKnownSpells,
+                in_trainer_known_set = inTrainerKnownSet,
+                is_in_flight_duplicate = isInFlightDuplicate,
+                in_flight_age_ms = sinceInFlightMs,
+                known_count = GetSession().GameState.CurrentPlayerKnownSpells.Count,
+            });
+            ChatPkt chat = new ChatPkt(GetSession(), ChatMessageTypeModern.System,
+                "You already know that spell. The trainer list has been refreshed.");
+            SendPacket(chat);
+            GossipComplete gossipClose = new GossipComplete();
+            SendPacket(gossipClose);
+            return;
+        }
+
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_TRAINER_BUY_SPELL);
         packet.WriteGuid(buy.TrainerGUID.To64());
         if (ModernVersion.ExpansionVersion > 1 &&
@@ -63,6 +107,11 @@ public partial class WorldSocket
         }
         packet.WriteUInt32(buy.SpellID);
         SendPacketToServer(packet);
+
+        // Track in-flight buy so rapid same-spell double-clicks can be dropped
+        // before the response lands (see intercept block above).
+        GetSession().GameState.InFlightTrainerBuySpellId = realSpellId;
+        GetSession().GameState.InFlightTrainerBuyTickMs = nowMs;
 
         // Ban defense: speculatively remove predecessor rank from known spells.
         // Kronos calls RemoveSpell(prev) unconditionally but gates the
@@ -82,8 +131,10 @@ public partial class WorldSocket
             Log.Event("spell.trainer_buy.predecessor_speculatively_removed", new
             {
                 real_spell_id = realSpellId,
+                learn_spell_id = buy.SpellID,
                 predecessor_spell_id = predecessor,
                 was_in_known_set = removed,
+                known_count = known.Count,
             });
         }
         else


### PR DESCRIPTION
## Summary

 **Unlearned spell defense**: legacy server's trainer-buy supersede path calls `RemoveSpell(prev)` unconditionally but gates the
  `SMSG_SUPERCEDED_SPELL` send on `m_session->IsInWorld()`. When that gate is briefly false (server-side transient), the
   predecessor disappears from the spellbook silently. The next `CMSG_CAST_SPELL` for the predecessor rank slips past
  the existing cast-block-unknown-spells guard and trips an autoban. Repro'd 2026-05-18 on a rogue training Stealth R3 —
   server log: `HandleCastSpellOpcode: Player ... casts spell 1785 which he shouldn't have`. Proxy now mirrors the
  server-side removal locally so the cast-block guard catches the post-buy cast attempt and converts it into a
  `CastFailed` instead of a real ban.
  - **Trainer list refreshes after a buy**: vanilla server sends `SMSG_TRAINER_BUY_SUCCEEDED` (1.12-only opcode the
  modern client has no slot for), then nothing else. The modern client never refreshes its trainer panel from
  `SMSG_LEARNED_SPELL` alone. Proxy now intercepts the legacy opcode and emits a fresh `CMSG_TRAINER_LIST` back to the
  legacy server (same pattern AuctionHandler uses post-operation).
  - **Filter + intercept already-known buys**: empirically the modern Classic 1.14 trainer panel does NOT visually
  differentiate Known from Available via the state byte alone, and does NOT honor mid-interaction `SMSG_TRAINER_LIST`
  refreshes (panel renders from the initial open). Two complementary fixes — initial list filters Known entries before
  forwarding; the buy handler intercepts clicks on already-known entries (direct, supersede-known, and rapid
  double-click races) and force-closes the gossip panel so reopening produces a clean list.

  ## Changes

  | File | What |
  |---|---|
  | `HermesProxy/CSV/SpellRankChain.csv` (new) | 3140 `spell_id,prev_spell` pairs derived from 1.12.1 Spell.dbc
  Name+Rank grouping |
  | `HermesProxy/World/GameData.cs` | `SpellRankPredecessor` FrozenDictionary + `LoadSpellRankChain` loader |
  | `HermesProxy/GlobalSessionData.cs` | `PendingTrainerBuy*` (ban defense state), `LastTrainerListKnownSpells`
  (supersede-known cache), `InFlightTrainerBuy*` (duplicate-detection state) |
  | `HermesProxy/World/Server/PacketHandlers/NPCHandler.cs` | `HandleTrainerBuySpell`: stale-click/duplicate-click
  intercept + speculative predecessor removal |
  | `HermesProxy/World/Client/PacketHandlers/NPCHandler.cs` | `HandleTrainerList`: filter Known + populate Known cache;
  `HandleTrainerBuySucceeded`: re-request fresh list; `HandleTrainerBuyFailed`: restore predecessor on explicit fail |
  | `HermesProxy/World/Client/PacketHandlers/SpellHandler.cs` | clear ban-defense + in-flight state on
  `SMSG_LEARNED_SPELL` / `SMSG_SUPERCEDED_SPELLS` |
  | `HermesProxy/World/KnownBenignOpcodes.cs` | remove `SMSG_TRAINER_BUY_SUCCEEDED` (now has a real handler) |

  ## Diagnostics added (all low-volume)

  - `spell.trainer_buy.predecessor_speculatively_removed` — ban defense fired
  - `spell.trainer_buy.predecessor_restored_on_failed` — ban defense reverted on explicit fail
  - `spell.trainer_buy.refresh_list_requested` — fresh trainer list re-requested
  - `spell.trainer_list.known_filtered` — count of hidden Known spells per list
  - `spell.trainer_buy.intercepted_already_known` — stale/duplicate click caught with `in_known_spells` /
  `in_trainer_known_set` / `is_in_flight_duplicate` flags

  ## Test plan

  - [x] `dotnet build` clean
  - [x] `dotnet test` 452/452 pass (talent-rank-injection tests still green)
  - [x] In-game: trainer flow with all four scenarios validated 2026-05-18
    - [x] Normal multi-spell training (60+ buys in one session) — no false intercepts
    - [x] Stealth chain train (R1→R2→R3→R4) — ban defense fires per rank-up, predecessor speculatively removed,
  server-side state matched
    - [x] Apprentice → Journeyman riding train, then click stale Apprentice — intercept fires with
  `in_trainer_known_set: true`, panel closes
    - [x] Rapid double-click same spell — intercept fires with `is_in_flight_duplicate: true`
  - [x] No regression: existing `cast-block-unknown-spells` guard still catches removed predecessors