### PR TITLE
Pet: per-Model M_native ratio compensates 1.12-vs-1.14 mesh shrink

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -459,9 +459,17 @@ public partial class WorldClient
             float? familyTableK = (familyId > 0)
                 ? GameData.GetPetFamilyScale(familyId)
                 : (float?)null;
-            float k = vanillaCmsK
-                ?? familyTableK
-                ?? (p.IsWarlockPet ? 0.75f : 1.5f);
+            // Mirror UpdateHandler's isLocalPet branch: per-ModelId M_native
+            // multiplier on vanilla CMS_v (see M2NativeRatio).
+            int modelIdForRatio = p.DisplayId > 0
+                ? (int)GameData.GetDisplayInfo(p.DisplayId).ModelId
+                : 0;
+            bool modelRatioApplied = modelIdForRatio > 0
+                                     && vanillaCmsK.HasValue
+                                     && WorldClient.M2NativeRatio.TryGetValue(modelIdForRatio, out var mRatio);
+            float k = modelRatioApplied
+                ? vanillaCmsK!.Value * WorldClient.M2NativeRatio[modelIdForRatio]
+                : (vanillaCmsK ?? familyTableK ?? (p.IsWarlockPet ? 0.75f : 1.5f));
 
             float emit = (p.Cms > 0)
                 ? (p.RawScale / p.Cms) * k
@@ -481,7 +489,8 @@ public partial class WorldClient
                 display_id = p.DisplayId,
                 family_id = familyId,
                 k = k,
-                k_source = vanillaCmsK.HasValue ? "vanilla-dbc"
+                k_source = modelRatioApplied ? "model-native-ratio"
+                           : vanillaCmsK.HasValue ? "vanilla-dbc"
                            : familyTableK.HasValue ? "family-table"
                            : (p.IsWarlockPet ? "k-warlock-fallback" : "k-hunter-fallback"),
                 raw_scale = p.RawScale,

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -34,6 +34,27 @@ public partial class WorldClient
         18223,  // Dreadsteed
     }.ToFrozenSet();
 
+    // Per-ModelId M_native ratio — multiplier applied to vanilla CMS_v when a
+    // model's 1.12 M2 intrinsic ModelScale differs from modern Classic's same-
+    // numbered M2 file. Multiplying CMS_v by this ratio preserves the per-
+    // DisplayID size relationships baked into the vanilla DBC (e.g., one bat
+    // skin meant to render at 0.15 stays half the size of one meant for 0.3),
+    // while compensating for the modern M2 mesh shrink.
+    //
+    // Validated 2026-05-18 on model 411 (FelBat) via two tames same session:
+    //   Ressan (displayId 9750, CMS_v=0.3): K=0.3×2.33≈0.7 → render parity 1.12.
+    //   Greater Duskbat (displayId 4734, CMS_v=0.15): expected K=0.35, renders
+    //     at half Ressan's size matching vanilla intent.
+    // Ratio derivation: see project_flying_pets_open memory.
+    //
+    // A universal family-table-MaxScale floor was tried first and rejected —
+    // it collapsed every low-CMS_v bat to the same K=0.7, erasing the vanilla
+    // intent that different bat skins are different sizes.
+    internal static readonly FrozenDictionary<int, float> M2NativeRatio = new Dictionary<int, float>
+    {
+        { 411, 2.33f },  // FelBat — 1.12 intrinsic ≈ 2.33× modern's (Ressan-validated)
+    }.ToFrozenDictionary();
+
     // Per-ModelId render-time compensation for divergences invisible to DBC/M2 files.
     // Confirmed 2026-05-12 via same-server 1.12 vs 1.14 parity (static-prop reference
     // proves equal camera): vertex positions, bone hierarchy by key_bone_id, CMS, and
@@ -4332,9 +4353,18 @@ public partial class WorldClient
                 float? vanillaCmsK = (displayId > 0 && GameData.VanillaCreatureModelScales.TryGetValue((uint)displayId, out var vCms))
                     ? vCms
                     : (float?)null;
-                float k = vanillaCmsK
-                    ?? familyTableK
-                    ?? (isWarlockPet ? K_warlock : K_hunter);
+                // Per-ModelId M_native compensation: multiply vanilla CMS_v by the
+                // model's 1.12-vs-1.14 intrinsic ratio when listed (see M2NativeRatio).
+                // Preserves per-DisplayID size relationships from vanilla DBC.
+                int modelIdForRatio = displayId > 0
+                    ? (int)GameData.GetDisplayInfo((uint)displayId).ModelId
+                    : 0;
+                bool modelRatioApplied = modelIdForRatio > 0
+                                         && vanillaCmsK.HasValue
+                                         && M2NativeRatio.TryGetValue(modelIdForRatio, out var mRatio);
+                float k = modelRatioApplied
+                    ? vanillaCmsK!.Value * M2NativeRatio[modelIdForRatio]
+                    : (vanillaCmsK ?? familyTableK ?? (isWarlockPet ? K_warlock : K_hunter));
 
                 // First-sight race: if CreatureTemplate isn't cached yet (creature
                 // query hasn't round-tripped), record the pet's data so the next
@@ -4382,7 +4412,8 @@ public partial class WorldClient
                     family = familyName ?? (isWarlockPet ? "warlock" : "hunter"),
                     family_id = familyId,
                     pet_entry = petEntry,
-                    k_source = vanillaCmsK.HasValue ? "vanilla-dbc"
+                    k_source = modelRatioApplied ? "model-native-ratio"
+                               : vanillaCmsK.HasValue ? "vanilla-dbc"
                                : familyTableK.HasValue ? "family-table"
                                : (isWarlockPet ? "k-warlock-fallback" : "k-hunter-fallback"),
                     raw_scale = rawScale,


### PR DESCRIPTION
Tamed bats render dramatically smaller in 1.14 vs 1.12 native against the same Kronos server. JSONL traced it to the bat M2 (model 411, FelBat) having a smaller intrinsic mesh in modern Classic than vanilla 1.12 — the per-DisplayID CMS_v compensation that worked for vanilla now under-shrinks instead. Two side-by-side data points:

  Ressan the Needler (displayId 9750, CMS_v=0.3, rawScale=0.45):
    Untouched: emit=0.45 -> 0.135 * MS_1.14 (visibly tiny)
    Target:    emit=1.05 -> 0.315 * MS_1.14 (vanilla-parity, validated)

  Greater Duskbat (displayId 4734, CMS_v=0.15, rawScale=0.43):
    Untouched: emit=0.43 -> 0.065 * MS_1.14 (visibly super-tiny)
    Target:    emit=1.00 -> 0.150 * MS_1.14 (half of Ressan, as in 1.12)

Both require the same multiplier: K_target = CMS_v * 2.33, where 2.33 is the 1.12-vs-1.14 intrinsic ratio for FelBat. Multiplying preserves the per-DisplayID size relationships baked into vanilla DBC (different bat skins are different sizes) instead of collapsing everything to a flat per-family floor.

Two earlier approaches were tried and rejected in-session:
  - Per-DisplayID K override (only Ressan): left other low-CMS bat skins (Greater Duskbat etc.) at vanilla CMS_v, still under-shrunk.
  - Family-table MaxScale floor: collapsed all low-CMS bat skins to K=0.7, erasing the half-size-of-Ressan intent for Greater Duskbat.

Fix: M2NativeRatio FrozenDictionary keyed on ModelId, checked ahead of vanilla CMS_v in both UpdateHandler isLocalPet branch and the QueryHandler ResolvePendingPetScalesForEntry resolver. When the DisplayID's ModelId is in the table, K = vanilla_CMS_v * ratio.

Currently only model 411 (FelBat) entered with ratio 2.33. Other families that have the same M2 intrinsic delta will get their own entries as testers report — the table is one-line-per-model to extend.