### PR TITLE
Fix/jimsplus tooltipfix quest rewards shirts

### DIFF
--- a/Addons/JimsPlus/TooltipFix.lua
+++ b/Addons/JimsPlus/TooltipFix.lua
@@ -376,6 +376,12 @@ local function PlayerCanUse(itemClassId, itemSubClassId)
     local _, classFile = UnitClass("player")
 
     if itemClassId == ITEM_CLASS_ARMOR then
+        -- Subclass 0 (Miscellaneous) — shirts, tabards, cloaks, necklaces,
+        -- rings, trinkets. None require any proficiency / training; any class
+        -- can equip them. Must short-circuit before the trainedArmorSubs
+        -- check (which would return false since these aren't in any class's
+        -- skill book).
+        if itemSubClassId == 0 then return true end
         -- Relic types: paladin librams, druid idols, shaman totems. These
         -- aren't trained — they're hard class-locked.
         if itemSubClassId == ARMOR_SUB.LIBRAM then return classFile == "PALADIN" end

--- a/Addons/JimsPlus/TooltipFix.lua
+++ b/Addons/JimsPlus/TooltipFix.lua
@@ -670,7 +670,15 @@ local function FixQuestRewardUsability()
                     else            r, g, b = 0.9, 0.0, 0.0 end
 
                     if SetItemButtonTextureVertexColor       then SetItemButtonTextureVertexColor(button, r, g, b)       end
-                    if SetItemButtonNormalTextureVertexColor then SetItemButtonNormalTextureVertexColor(button, r, g, b) end
+                    -- pcall both FrameXML helpers — they index _G[name.."NormalTexture"] /
+                    -- _G[name.."SlotTexture"] which the modern Classic client doesn't always
+                    -- expose for quest-reward buttons (QuestInfoRewardsFrameQuestInfoItem1
+                    -- etc.). Use member access first when available, fall back to the helper.
+                    if button.NormalTexture and button.NormalTexture.SetVertexColor then
+                        button.NormalTexture:SetVertexColor(r, g, b)
+                    elseif SetItemButtonNormalTextureVertexColor then
+                        pcall(SetItemButtonNormalTextureVertexColor, button, r, g, b)
+                    end
                     if SetItemButtonSlotVertexColor then
                         pcall(SetItemButtonSlotVertexColor, button, r, g, b)
                     end


### PR DESCRIPTION
Summary

  Two small fixes to Addons/JimsPlus/TooltipFix.lua, both surfaced from in-game testing today.

  1. Quest-reward NormalTexture nil guard (3b291ed)

  FrameXML's SetItemButtonNormalTextureVertexColor does _G[name.."NormalTexture"]:SetVertexColor(...). On modern Classic
   1.14.2, QuestInfoRewardsFrameQuestInfoItem1NormalTexture (and siblings) aren't exposed as globals, so the _G[...]
  lookup returns nil and indexing it triggers a Lua error popup (174x: attempt to index field '?' (a nil value)) every
  time a quest frame opens.

  Mirror the existing pcall(SetItemButtonSlotVertexColor, ...) guard on the line above: prefer
  button.NormalTexture:SetVertexColor member access when available, fall back to a pcall'd FrameXML helper. The other
  tints in FixQuestRewardUsability (texture, IconBorder, IconOverlay, region sweep) continue to apply, so the red "you
  can't use this" coloring on wrong-class rewards still renders — we just stop the error spam.

  2. Subclass-0 armor exemption (7718a87)

  Shirts were rendering with the wrong-class red tint in tooltips and quest-reward icons. Root cause: PlayerCanUse for
  ITEM_CLASS_ARMOR consulted trainedArmorSubs (built from the Skills tab — Cloth/Leather/Mail/Plate/Shield). Subclass 0
  (MISCELLANEOUS) is never trained, so the lookup returned false and downstream callers painted these items red.

  Subclass 0 also covers tabards, cloaks, necklaces, rings, and trinkets — none require any proficiency. Short-circuit
  subclass 0 to return true before the trainedArmorSubs lookup. Libram / Idol / Totem class-locks still apply for their
  respective relic subclasses; cloth-through-plate proficiency unchanged.
