### PR TITLE
Character: guard delete/create response against client freeze

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -147,7 +147,14 @@ public partial class WorldClient
 
         CreateChar createChar = new CreateChar();
         createChar.Guid = new WowGuid128();
-        createChar.Code = ModernVersion.ConvertResponseCodesValue(result);
+        try
+        {
+            createChar.Code = ModernVersion.ConvertResponseCodesValue(result);
+        }
+        catch
+        {
+            createChar.Code = (byte)V1_14_1_40688.ResponseCodes.CharCreateError;
+        }
         SendPacketToClient(createChar);
     }
 
@@ -157,7 +164,14 @@ public partial class WorldClient
         byte result = packet.ReadUInt8();
 
         DeleteChar deleteChar = new DeleteChar();
-        deleteChar.Code = ModernVersion.ConvertResponseCodesValue(result);
+        try
+        {
+            deleteChar.Code = ModernVersion.ConvertResponseCodesValue(result);
+        }
+        catch
+        {
+            deleteChar.Code = (byte)V1_14_1_40688.ResponseCodes.CharDeleteFailed;
+        }
         SendPacketToClient(deleteChar);
     }
 


### PR DESCRIPTION
## Summary
- If `ConvertResponseCodesValue` throws on an unmapped Kronos response code, the handler died and `SendPacketToClient` never ran — client waited forever for `SMSG_DELETE_CHAR` that never came
- Now falls back to `CharDeleteFailed` / `CharCreateError` so the client shows an error message instead of freezing
- Also guards `SMSG_CREATE_CHAR` handler with the same pattern

## Test plan
- [ ] Delete a character with mail in mailbox — should show error, not freeze
- [ ] Delete a normal character — should succeed as before
- [ ] Create a character — should succeed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)