### PR TITLE
Mana gems: narrow slot-mismatch exclusion to SpellID-mismatch only

### DIFF
--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -3992,6 +3992,17 @@ public static partial class GameData
         (99320u, 9421),
     };
 
+    // Mage mana gems: subject to a *narrowed* slot-mismatch skip — see the call site
+    // in GenerateItemEffectUpdateIfNeeded. On servers that already serve the modern
+    // spell id (e.g. Twinstar's Citrine has spellid_1=10057), the slot-relocation
+    // hotfix is safe and necessary; only the case where the server's spell id has
+    // no matching CSV record (vanilla 10053/10054 → would create a record bound to
+    // a legacy id the modern client can't resolve) is skipped.
+    //
+    // Agate (5514) and Jade (5513) have CSV records (97663/97664).
+    // Citrine (8007) and Ruby (8008) have modern DB2 records (98334/98355).
+    internal static readonly HashSet<uint> ManaGemItemEntries = new() { 5513u, 5514u, 8007u, 8008u };
+
     // Items where PR #196's slot-mismatch ItemEffect hotfix breaks the modern
     // client's "Use:" tooltip + on-use action, because the vanilla SpellID
     // doesn't exist in the modern Classic Era SpellDB. The hotfix relocates
@@ -4001,34 +4012,21 @@ public static partial class GameData
     // working behaviour where right-click consume goes to the legacy server
     // for handling.
     //
-    //   Mana gems — vanilla "Restore Mana" spell IDs were reshuffled in the
-    //   modern client. Vanilla 10053/10054 ("Restore Mana" R3/R4) became
-    //   "Conjure Mana Citrine/Ruby" in 1.14; the modern equivalents are
-    //   10057/10058. Items 5513/5514 have ItemEffect CSV records
-    //   (97663/97664) that trip the slot-mismatch path; Citrine (8007) /
-    //   Ruby (8008) have modern DB2 records (98334/98355) with the correct
-    //   spells (10057/10058) that the hotfix would overwrite with the wrong
-    //   vanilla IDs.
-    //
     //   Warlock Spellstone — base rank (5522) has both a slot-0 vanilla record
     //   (97949) and a slot-1 retail record (97950) carrying spell 32793, a
     //   modern-only id that strips the "Use:" line when relocated. Greater /
     //   Major (13456 / 13457) only have slot-0 records so they shouldn't hit
     //   this path, but listing them defensively guards against server data
     //   variance.
+    //
+    //   Orb of Soran'ruk — item has 3 CSV records (97771 OnEquip Shadow
+    //   Resistance, 97772 OnEquip spell damage, 97773 OnUse spell 18956).
+    //   Excluding it leaves the client's cached retail record intact.
     internal static readonly HashSet<uint> ItemEffectSlotMismatchExclusions = new()
     {
-        // Mage mana gems (Agate=5514, Jade=5513, Citrine=8007, Ruby=8008)
-        5513u, 5514u, 8007u, 8008u,
         // Warlock spellstones
         5522u, 13456u, 13457u,
-        // Orb of Soran'ruk — hypothesis-A local-only test for PTR. Item has 3
-        // CSV records (97771 OnEquip Shadow Resistance, 97772 OnEquip spell
-        // damage, 97773 OnUse spell 18956). If PR #196's slot-mismatch
-        // mutation is what's breaking the item, excluding it leaves the
-        // client's cached retail record intact. NOT COMMITTED until PTR
-        // confirms — revert if force-push of 97773 turns out to be the real
-        // fix instead.
+        // Orb of Soran'ruk
         6898u,
     };
 
@@ -4069,14 +4067,33 @@ public static partial class GameData
 
     public static Server.Packets.HotFixMessage? GenerateItemEffectUpdateIfNeeded(ItemTemplate item, byte slot)
     {
-        // Mana gems & warlock spellstones: leave the client's cached retail ItemEffect
-        // record untouched. Any mutation pushed via hotfix binds the record to a vanilla
-        // SpellID the modern client's SpellDB doesn't know, stripping the Use: line and
-        // making the item inert. See ItemEffectSlotMismatchExclusions above for details.
+        ItemEffect? effect = GetItemEffectByItemId(item.Entry, slot);
+
+        // Warlock spellstones + Orb of Soran'ruk: blanket skip — the modern client's
+        // retail ItemEffect record carries an id the SpellDB can't resolve once
+        // relocated. See ItemEffectSlotMismatchExclusions above for details.
         if (ItemEffectSlotMismatchExclusions.Contains(item.Entry))
             return null;
 
-        ItemEffect? effect = GetItemEffectByItemId(item.Entry, slot);
+        // Mana gems: only skip mutation when the legacy server's spell id for this slot
+        // doesn't match any CSV record we have for the item — i.e., the path below
+        // would either rewrite an existing record's SpellID (effect != null branch) or
+        // create a fresh ItemEffect bound to a legacy SpellID the modern client's
+        // SpellDB can't resolve (new-record branch). In both cases the Use: line is
+        // stripped because 10053/10054 mean "Conjure Citrine/Ruby" in the modern client.
+        //
+        // When the server already serves the modern id (e.g. Twinstar's Citrine has
+        // spellid_1=10057), the slot-relocation path is safe and necessary: it preserves
+        // SpellID and only moves LegacySlotIndex so the client's DB2 record (slot 1)
+        // lines up with the server's placement (slot 0). Skipping it here leaves the
+        // record at LegacySlotIndex=1, the client doesn't find an effect at slot 0
+        // (where the server says the on-use lives), and the Use: line vanishes.
+        if (ManaGemItemEntries.Contains(item.Entry) &&
+            item.TriggeredSpellIds[slot] > 0 &&
+            (effect == null || effect.SpellID != item.TriggeredSpellIds[slot]) &&
+            FindItemEffectBySpellId(item.Entry, item.TriggeredSpellIds[slot], slot) == null)
+            return null;
+
         if (effect != null)
         {
             // Relocated CSV records: leave alone on subsequent queries as long as the


### PR DESCRIPTION
The previous unconditional `return null` for items in ItemEffectSlotMismatchExclusions also blocked the slot-relocation hotfix that Citrine/Ruby need on servers that already serve the modern spell id. On Twinstar, item 8007 (Mana Citrine) has spellid_1=10057 — same as our CSV record 98334. The slot-relocation path was the only thing aligning the client's DB2 record (LegacySlotIndex=1) with the server's placement (slot 0); skipping it leaves the client unable to find an effect at slot 0 and strips the "Use:" tooltip line.

Split the exclusion into two sets:
- ManaGemItemEntries (5513/5514/8007/8008): narrowed skip — only fires when the server's spell id for this slot has no matching CSV record for the item (i.e., the mutation would create/rewrite a record bound to a legacy id the modern client's SpellDB can't resolve).
- ItemEffectSlotMismatchExclusions (5522/13456/13457/6898): warlock spellstones + Orb of Soran'ruk keep the blanket skip — their CSV records carry modern-only spell ids that strip the Use: line when relocated regardless of server data.

For Twinstar's Citrine: condition fails (CSV has 10057 at slot 1, matching server) → fall through to slot-relocation, hotfix pushed, Use: line returns. For a hypothetical server serving 10053 for Citrine: condition holds (no CSV record has 10053 for item 8007) → skip mutation, client keeps untouched DB2.