### PR TITLE
Enchant visual: perm wins over temp (matches 1.12 client)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -3030,12 +3030,22 @@ public partial class WorldClient
                     if (updateMaskArray[itemIdIndex] || updateMaskArray[permEnchantIndex] || updateMaskArray[tempEnchantIndex])
                     {
                         int itemId = updates.ContainsKey(itemIdIndex) ? updates[itemIdIndex].Int32Value : 0;
-                        // Temporary enchants (shaman imbues, poisons) take visual priority over permanent
+                        // Permanent enchants take visual priority over temporary — matches
+                        // 1.12 native client behavior (parity-confirmed: Crusader / Fiery /
+                        // Lifestealing / etc. wins over an applied poison or shaman imbue
+                        // on the same weapon). PR #22 originally inverted this to surface
+                        // shaman imbues / rogue poisons after the proxy was only reading
+                        // the perm slot, but over-corrected — perm visuals now disappeared
+                        // whenever a poison was on the same weapon. The fallback chain
+                        // still picks up the temp visual when perm has no glow (e.g.
+                        // +stat enchants like Crusader's lower-tier replacements, or no
+                        // perm at all), so shaman/rogue users without a glowy perm still
+                        // see their imbue/poison visual.
                         ushort itemVisual = 0;
-                        if (updates.ContainsKey(tempEnchantIndex))
-                            itemVisual = (ushort)GameData.GetItemEnchantVisual(updates[tempEnchantIndex].UInt32Value);
-                        if (itemVisual == 0 && updates.ContainsKey(permEnchantIndex))
+                        if (updates.ContainsKey(permEnchantIndex))
                             itemVisual = (ushort)GameData.GetItemEnchantVisual(updates[permEnchantIndex].UInt32Value);
+                        if (itemVisual == 0 && updates.ContainsKey(tempEnchantIndex))
+                            itemVisual = (ushort)GameData.GetItemEnchantVisual(updates[tempEnchantIndex].UInt32Value);
 
                         // Cache permanent enchant for inspect display
                         if (updates.ContainsKey(permEnchantIndex))


### PR DESCRIPTION
PR #22 (d0ed02d) originally added the temp enchant slot read to PLAYER_VISIBLE_ITEM after the proxy was only reading the perm slot — shaman imbues / rogue poisons had no glow at all. It made temp take visual priority over perm, but that over-corrected: a Crusader-enchanted weapon with poison applied loses its blue glow and shows the green poison glow instead, which doesn't match the native 1.12 client.

User parity-tested on 1.12 native (2026-05-19): perm enchant wins, the poison glow only renders if no perm visual is set.

Swap the priority order:
  - Read perm first
  - Fall back to temp only when perm has no visual (e.g. +stat enchants that don't glow, or no perm at all)

Shaman/rogue users without a glowy perm still see their imbue/poison visual, preserving the original PR #22 win. Perm visuals are no longer hidden by poisons.