### PR TITLE
Chat-link suffix: stop negating on vanilla path (preserve ItemRandomP…

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -526,14 +526,24 @@ public partial class WorldClient
             // (matches the Wowpedia public docs after the leading-colon Substring(1) fix.)
             int enchant = inner.Length > 0 && int.TryParse(inner[0], out var e) ? e : 0;
             int suffix  = inner.Length > 5 && int.TryParse(inner[5], out var s) ? s : 0;
-            // JimsProxy (chat-link-suffix 2026-05-07): vanilla wire chat-link convention is
-            // signed — negative randomProperty → ItemRandomSuffix.dbc lookup (variable-stat
-            // "of the Bear"), positive → ItemRandomProperties.dbc (fixed bonuses).
-            // Modern Classic 1.14 stores both as positive at position 5; assume ItemRandomSuffix
-            // (the dominant case for "of the X" suffix items) and negate. If a value is already
-            // negative we leave it alone — modern client may pre-sign it.
-            if (suffix > 0)
-                suffix = -suffix;
+            // JimsProxy (chat-link-suffix-vanilla 2026-05-19): vanilla 1.12 servers only have
+            // ItemRandomProperties.dbc — there is no ItemRandomSuffix.dbc in 1.12 (that table
+            // was added in TBC/WotLK). All vanilla item suffixes ("of Power", "of Strength",
+            // "of Stamina", etc.) are ItemRandomProperties rows referenced by POSITIVE IDs on
+            // the wire. The earlier 2026-05-07 version of this code unconditionally negated
+            // the modern client's positive suffix at position 5, on the assumption that
+            // ItemRandomSuffix was the dominant case — but that assumption is inverted: in
+            // vanilla content, every linkable random-suffix item is ItemRandomProperty, and
+            // sending vmangos/Twinstar a negative ID makes them look up a non-existent
+            // ItemRandomSuffix row → suffix dropped from the broadcast → 1.12 client viewers
+            // see "Notched Shortsword" instead of "Notched Shortsword of Power".
+            //
+            // Pass the suffix through with its sign preserved. Modern Classic 1.14 only ever
+            // emits positive at position 5 for vanilla-content items, so this is effectively
+            // "no transform" for the common case. The negative branch is left undisturbed
+            // for forward compatibility — if a future Twinstar build adds ItemRandomSuffix
+            // backports and the modern client somehow encodes it negatively, we already pass
+            // it through correctly.
             Framework.Logging.Log.Event("chat.item_link.translated", new
             {
                 item_id = itemId,


### PR DESCRIPTION
…roperty)

The 2026-05-07 chat-link fix (commit referenced as f667118 in the comment) unconditionally negated the modern client's positive suffix ID at position 5 before forwarding to the vanilla server. The author's note assumed ItemRandomSuffix was the dominant case ("of the X" variable-stat items) and negation would map modern→vanilla correctly.

Inverted assumption: vanilla 1.12 servers only have ItemRandomProperties.dbc — ItemRandomSuffix.dbc was added in TBC/WotLK. Every linkable vanilla suffix ("of Power", "of Strength", "of Stamina", "of Intellect", etc.) is an ItemRandomProperty row referenced by a POSITIVE ID. Sending vmangos/Twinstar a negative ID makes them look up a non-existent suffix → broadcast drops the suffix text → 1.12 client viewers see "Notched Shortsword" instead of "Notched Shortsword of Power".

Repro from user log jimsproxy-20260519-192640.jsonl: "Notched Shortsword of Strength" linked → chat.item_link.translated event shows suffix_id=-6 after the negation; 1.12 native viewer received the link with the suffix field stripped.

Fix: drop the unconditional negate. Pass the modern client's positive suffix ID through with its sign preserved. Modern Classic 1.14 only emits positive at position 5 for vanilla-content items so this is "no transform" for the common case. Negative-on-the-wire input (if any future build adds it) still passes through correctly.