### PR TITLE
Quest query throttle: cache + dedupe + token-bucket

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -245,6 +245,28 @@ public sealed class GameSessionData
     public Dictionary<uint, WowGuid128> CachedPetNumbers = new();
     // Tracks quest ids the proxy has issued its own CMSG_QUERY_QUEST_INFO for.
     public HashSet<uint> ProxyIssuedQuestInfoQueries = new();
+    // JimsProxy: client-originated CMSG_QUERY_QUEST_INFO gating. Questie's filter-toggle
+    // SmoothReset iterates ~10k quest IDs and fires GetQuestTagInfo on each, generating
+    // thousands of CMSG_QUERY_QUEST_INFO in a single burst. Without dedupe, Kronos's
+    // anti-flood drops the connection. InFlight tracks queries already forwarded so
+    // duplicates within the round-trip window are dropped (one modern SMSG response
+    // satisfies all client-side waiters for the same quest). Negative cache tracks
+    // quest IDs the legacy server returned masked-entry on — typically TBC/Wrath
+    // quests in Questie's DB that the 1.12 server has never heard of.
+    public HashSet<uint> InFlightClientQuestInfoQueries = new();
+    public HashSet<uint> NegativeQuestInfoCache = new();
+    // JimsProxy: token-bucket rate limiter for CMSG_QUERY_QUEST_INFO. Questie's
+    // cold-start scan bursts ~1500 UNIQUE quest IDs in ~700ms (so in-flight dedupe
+    // does nothing on the first pass); this lands at >2000/sec, well past Kronos's
+    // ~80-100/sec WorldPacketLimit, and the connection gets dropped. The bucket
+    // smooths the burst to a sustained 10/sec with a 20-token initial allowance.
+    // PendingQuestQueryQueue holds IDs awaiting a token; QuestQueryDrainerRunning
+    // is a 0/1 CAS flag so at most one async drainer pumps the queue per session.
+    public System.Collections.Concurrent.ConcurrentQueue<uint> PendingQuestQueryQueue = new();
+    public double QuestQueryTokens = 20.0;
+    public long QuestQueryLastRefillMs = 0;
+    public int QuestQueryDrainerRunning = 0;
+    public readonly object QuestQueryBucketLock = new();
     // JimsProxy (pet-scale-resolve-race): Pet GUIDs whose first SCALE_X arrived
     // before SMSG_QUERY_CREATURE_RESPONSE landed.
     public Dictionary<WowGuid128, PendingPetScale> PetScaleResolvePending = new();

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -253,8 +253,11 @@ public sealed class GameSessionData
     // satisfies all client-side waiters for the same quest). Negative cache tracks
     // quest IDs the legacy server returned masked-entry on — typically TBC/Wrath
     // quests in Questie's DB that the 1.12 server has never heard of.
-    public HashSet<uint> InFlightClientQuestInfoQueries = new();
-    public HashSet<uint> NegativeQuestInfoCache = new();
+    // ConcurrentDictionary (not HashSet) — written from WorldServer handler thread (Add),
+    // WorldClient handler thread (Remove/Add), and the drainer Task thread (Remove).
+    // Plain HashSet under concurrent Add/Remove tears its bucket array.
+    public ConcurrentDictionary<uint, byte> InFlightClientQuestInfoQueries = new();
+    public ConcurrentDictionary<uint, byte> NegativeQuestInfoCache = new();
     // JimsProxy: token-bucket rate limiter for CMSG_QUERY_QUEST_INFO. Questie's
     // cold-start scan bursts ~1500 UNIQUE quest IDs in ~700ms (so in-flight dedupe
     // does nothing on the first pass); this lands at >2000/sec, well past Kronos's

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -28,8 +28,14 @@ public partial class WorldClient
         QueryQuestInfoResponse response = new QueryQuestInfoResponse();
         var id = packet.ReadEntry();
         response.QuestID = (uint)id.Key;
+        // JimsProxy: pair with the CMSG_QUERY_QUEST_INFO dedupe gate in WorldSocket.
+        // Clear in-flight so subsequent CMSGs for this id (after addon retries, etc.)
+        // can re-query if needed; cache the negative response so we don't ever ask
+        // the legacy server about this id again this session.
+        GetSession().GameState.InFlightClientQuestInfoQueries.Remove(response.QuestID);
         if (id.Value) // entry is masked
         {
+            GetSession().GameState.NegativeQuestInfoCache.Add(response.QuestID);
             response.Allow = false;
             SendPacketToClient(response);
             return;

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -32,10 +32,10 @@ public partial class WorldClient
         // Clear in-flight so subsequent CMSGs for this id (after addon retries, etc.)
         // can re-query if needed; cache the negative response so we don't ever ask
         // the legacy server about this id again this session.
-        GetSession().GameState.InFlightClientQuestInfoQueries.Remove(response.QuestID);
+        GetSession().GameState.InFlightClientQuestInfoQueries.TryRemove(response.QuestID, out _);
         if (id.Value) // entry is masked
         {
-            GetSession().GameState.NegativeQuestInfoCache.Add(response.QuestID);
+            GetSession().GameState.NegativeQuestInfoCache.TryAdd(response.QuestID, 0);
             response.Allow = false;
             SendPacketToClient(response);
             return;

--- a/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
@@ -41,7 +41,7 @@ public partial class WorldSocket
             return;
         }
 
-        if (state.NegativeQuestInfoCache.Contains(questId))
+        if (state.NegativeQuestInfoCache.ContainsKey(questId))
         {
             QueryQuestInfoResponse negResponse = new QueryQuestInfoResponse();
             negResponse.QuestID = questId;
@@ -51,7 +51,7 @@ public partial class WorldSocket
             return;
         }
 
-        if (!state.InFlightClientQuestInfoQueries.Add(questId))
+        if (!state.InFlightClientQuestInfoQueries.TryAdd(questId, 0))
         {
             Framework.Logging.Log.Event("quest.query.in_flight_drop", new { quest_id = questId });
             return;
@@ -129,13 +129,14 @@ public partial class WorldSocket
                     break;
                 // Cache may have been populated by a parallel proxy-issued query
                 // while this id was waiting; skip a redundant outbound send if so.
-                if (GameData.GetQuestTemplate(questId) != null)
+                QuestTemplate? warmTemplate = GameData.GetQuestTemplate(questId);
+                if (warmTemplate != null)
                 {
-                    state.InFlightClientQuestInfoQueries.Remove(questId);
+                    state.InFlightClientQuestInfoQueries.TryRemove(questId, out _);
                     QueryQuestInfoResponse warm = new QueryQuestInfoResponse();
                     warm.QuestID = questId;
                     warm.Allow = true;
-                    warm.Info = GameData.GetQuestTemplate(questId)!;
+                    warm.Info = warmTemplate;
                     SendPacket(warm);
                     Framework.Logging.Log.Event("quest.query.bucket_drain_cache_hit", new { quest_id = questId });
                     continue;
@@ -155,6 +156,12 @@ public partial class WorldSocket
                     queue_depth = state.PendingQuestQueryQueue.Count,
                 });
             }
+        }
+        catch (System.Exception ex)
+        {
+            // Drainer runs on a fire-and-forget Task; if the session disconnects mid-drain,
+            // SendPacketToServer throws and the exception would otherwise go unobserved.
+            Framework.Logging.Log.Event("quest.query.bucket_drain_error", new { error = ex.ToString() });
         }
         finally
         {

--- a/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
@@ -3,6 +3,8 @@ using HermesProxy.World;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace HermesProxy.World.Server;
 
@@ -18,9 +20,153 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_QUERY_QUEST_INFO)]
     void HandleQueryQuestInfo(QueryQuestInfo queryQuest)
     {
-        WorldPacket packet = new WorldPacket(Opcode.CMSG_QUERY_QUEST_INFO);
-        packet.WriteUInt32(queryQuest.QuestID);
-        SendPacketToServer(packet);
+        // JimsProxy: cache-first + dedupe + negative-cache.
+        // Questie's filter-toggle reset (and any other addon that iterates the quest DB)
+        // bursts thousands of CMSG_QUERY_QUEST_INFO in seconds — Kronos's anti-flood drops
+        // the connection if these all reach the server. The modern client's quest-info
+        // cache is keyed by quest id only, so a single SMSG response satisfies any number
+        // of outstanding client-side requests for that id.
+        uint questId = queryQuest.QuestID;
+        var state = GetSession().GameState;
+
+        QuestTemplate? cached = GameData.GetQuestTemplate(questId);
+        if (cached != null)
+        {
+            QueryQuestInfoResponse cachedResponse = new QueryQuestInfoResponse();
+            cachedResponse.QuestID = questId;
+            cachedResponse.Allow = true;
+            cachedResponse.Info = cached;
+            SendPacket(cachedResponse);
+            Framework.Logging.Log.Event("quest.query.cache_hit", new { quest_id = questId });
+            return;
+        }
+
+        if (state.NegativeQuestInfoCache.Contains(questId))
+        {
+            QueryQuestInfoResponse negResponse = new QueryQuestInfoResponse();
+            negResponse.QuestID = questId;
+            negResponse.Allow = false;
+            SendPacket(negResponse);
+            Framework.Logging.Log.Event("quest.query.negative_cache_hit", new { quest_id = questId });
+            return;
+        }
+
+        if (!state.InFlightClientQuestInfoQueries.Add(questId))
+        {
+            Framework.Logging.Log.Event("quest.query.in_flight_drop", new { quest_id = questId });
+            return;
+        }
+
+        // Token bucket: forward immediately if a token is available; otherwise
+        // enqueue and let the (single, per-session) async drainer pump at rate.
+        if (TryConsumeQuestQueryToken(state))
+        {
+            WorldPacket packet = new WorldPacket(Opcode.CMSG_QUERY_QUEST_INFO);
+            packet.WriteUInt32(questId);
+            SendPacketToServer(packet);
+            return;
+        }
+
+        state.PendingQuestQueryQueue.Enqueue(questId);
+        Framework.Logging.Log.Event("quest.query.bucket_enqueue", new
+        {
+            quest_id = questId,
+            queue_depth = state.PendingQuestQueryQueue.Count,
+        });
+        if (Interlocked.CompareExchange(ref state.QuestQueryDrainerRunning, 1, 0) == 0)
+            _ = Task.Run(DrainQuestQueryBucketAsync);
+    }
+
+    private const double QuestQueryTokensPerSec = 10.0;
+    private const double QuestQueryBurstCapacity = 20.0;
+
+    private static bool TryConsumeQuestQueryToken(GameSessionData state)
+    {
+        lock (state.QuestQueryBucketLock)
+        {
+            long now = System.Environment.TickCount64;
+            if (state.QuestQueryLastRefillMs == 0) state.QuestQueryLastRefillMs = now;
+            double elapsedSec = (now - state.QuestQueryLastRefillMs) / 1000.0;
+            state.QuestQueryTokens = System.Math.Min(
+                QuestQueryBurstCapacity,
+                state.QuestQueryTokens + elapsedSec * QuestQueryTokensPerSec);
+            state.QuestQueryLastRefillMs = now;
+            if (state.QuestQueryTokens >= 1.0)
+            {
+                state.QuestQueryTokens -= 1.0;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    // Returns ms until the next whole token is available (0 if available now).
+    private static int MsUntilNextQuestQueryToken(GameSessionData state)
+    {
+        lock (state.QuestQueryBucketLock)
+        {
+            long now = System.Environment.TickCount64;
+            double elapsedSec = (now - state.QuestQueryLastRefillMs) / 1000.0;
+            double tokensNow = System.Math.Min(
+                QuestQueryBurstCapacity,
+                state.QuestQueryTokens + elapsedSec * QuestQueryTokensPerSec);
+            if (tokensNow >= 1.0) return 0;
+            double needed = 1.0 - tokensNow;
+            return (int)System.Math.Ceiling(needed * 1000.0 / QuestQueryTokensPerSec);
+        }
+    }
+
+    private async Task DrainQuestQueryBucketAsync()
+    {
+        var state = GetSession().GameState;
+        try
+        {
+            while (state.PendingQuestQueryQueue.TryPeek(out _))
+            {
+                int waitMs = MsUntilNextQuestQueryToken(state);
+                if (waitMs > 0) await Task.Delay(waitMs).ConfigureAwait(false);
+                if (!state.PendingQuestQueryQueue.TryDequeue(out uint questId))
+                    break;
+                // Cache may have been populated by a parallel proxy-issued query
+                // while this id was waiting; skip a redundant outbound send if so.
+                if (GameData.GetQuestTemplate(questId) != null)
+                {
+                    state.InFlightClientQuestInfoQueries.Remove(questId);
+                    QueryQuestInfoResponse warm = new QueryQuestInfoResponse();
+                    warm.QuestID = questId;
+                    warm.Allow = true;
+                    warm.Info = GameData.GetQuestTemplate(questId)!;
+                    SendPacket(warm);
+                    Framework.Logging.Log.Event("quest.query.bucket_drain_cache_hit", new { quest_id = questId });
+                    continue;
+                }
+                if (!TryConsumeQuestQueryToken(state))
+                {
+                    // Lost a race; re-enqueue and loop (wait will recompute).
+                    state.PendingQuestQueryQueue.Enqueue(questId);
+                    continue;
+                }
+                WorldPacket packet = new WorldPacket(Opcode.CMSG_QUERY_QUEST_INFO);
+                packet.WriteUInt32(questId);
+                SendPacketToServer(packet);
+                Framework.Logging.Log.Event("quest.query.bucket_drain_send", new
+                {
+                    quest_id = questId,
+                    queue_depth = state.PendingQuestQueryQueue.Count,
+                });
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref state.QuestQueryDrainerRunning, 0);
+            // Race: an enqueue could have happened between the empty-check and
+            // releasing the flag. Re-check and restart if needed.
+            if (!state.PendingQuestQueryQueue.IsEmpty &&
+                Interlocked.CompareExchange(ref state.QuestQueryDrainerRunning, 1, 0) == 0)
+            {
+                _ = Task.Run(DrainQuestQueryBucketAsync);
+            }
+        }
     }
     [PacketHandler(Opcode.CMSG_QUERY_CREATURE)]
     void HandleQueryCreature(QueryCreature queryCreature)


### PR DESCRIPTION
Questie's filter-toggle SmoothReset bursts ~1500 unique CMSG_QUERY_QUEST_INFO in under a second when re-evaluating quest tags across its DB. Kronos's anti-flood (~80-100 packets/sec) drops the connection mid-burst. Field test captured 1427 unique CMSGs in ~700ms (>2000/sec) before SocketException.

Triages each incoming CMSG_QUERY_QUEST_INFO before forwarding:
- Cache hit (GameData.QuestTemplates already has it): synthesize the modern SMSG locally from the cached QuestTemplate. QueryQuestInfoResponse.Write() already serializes from a QuestTemplate so no new wire path is needed.
- Negative cache (legacy server returned masked-entry for this id earlier): reply Allow=false locally. Covers TBC/Wrath quest ids that Questie's DB includes but the 1.12 server has never heard of.
- In-flight dedupe: a CMSG for the same id is already pending. The modern client's quest cache is keyed by id, so one SMSG satisfies all waiters.
- Otherwise gate through a per-session token bucket: 10/sec sustained, 20-token initial burst. Excess goes onto a FIFO queue drained by a single async pump (CAS-gated, restarts on tail enqueues). The drain re-checks the cache on dequeue so any id that got warmed by a parallel proxy-issued query skips the redundant server round-trip.

Response handler clears the in-flight bit and seeds the negative cache on masked-entry replies, so the gating self-heals across the session.

JSONL events for tuning: quest.query.cache_hit / negative_cache_hit / in_flight_drop / bucket_enqueue / bucket_drain_send / bucket_drain_cache_hit.

Field-tested: connection survives a full Questie PvP-icon toggle burst.