### PR TITLE
Fix infinite spin on fast character switch

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2123,6 +2123,7 @@ public class GlobalSessionData
     // the same WorldClient and needs it alive until the user picks a char.
     // Cleared after the recreate succeeds.
     public volatile bool WorldClientNeedsRecreateOnNextLogin;
+    public volatile bool IsInCharacterSelect;
     public SniffFile ModernSniff = null!;
 
     public Dictionary<string, WowGuid128> GuildsByName = [];

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -434,6 +434,7 @@ public partial class WorldClient
         // 20260505-130649 reproduced exactly that regression. The flag is
         // cleared in WorldSocket.HandlePlayerLogin after the recreate.
         GetSession().WorldClientNeedsRecreateOnNextLogin = true;
+        GetSession().IsInCharacterSelect = true;
         Log.Event("session.logout_complete.worldclient_recreate_marked", new
         {
             had_world_client = GetSession().WorldClient != null,

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -485,6 +485,11 @@ public partial class WorldClient
             // block these packets until connected to instance
             while (GetSession().InstanceSocket == null)
             {
+                if (GetSession().IsInCharacterSelect)
+                {
+                    Log.PrintNet(LogType.Debug, LogNetDir.P2C, $"Dropping {packet.GetUniversalOpcode()} — session is at character select.");
+                    return;
+                }
                 Log.PrintNet(LogType.Network, LogNetDir.P2C, $"Waiting to send {packet.GetUniversalOpcode()} ({packet.GetOpcode()}).");
                 System.Threading.Thread.Sleep(200);
             }

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -262,6 +262,7 @@ public partial class WorldSocket
             }
             GetSession().WorldClientNeedsRecreateOnNextLogin = false;
         }
+        GetSession().IsInCharacterSelect = false;
 
         if (!GetSession().GameState.CachedPlayers.TryGetValue(playerLogin.Guid, out var selectedChar))
         {


### PR DESCRIPTION
## Summary
- Switching characters quickly causes the proxy to freeze with `Waiting to send SMSG_SPELL_GO` repeating forever
- The old WorldClient receive thread tries to forward stale packets after `SMSG_LOGOUT_COMPLETE` nulled `InstanceSocket`
- The `while (InstanceSocket == null)` spin loop in `SendPacketToClientDirect` has no exit condition

## Fix
- `IsInCharacterSelect` flag on `GlobalSessionData`: set on `SMSG_LOGOUT_COMPLETE`, cleared on `CMSG_PLAYER_LOGIN`
- The spin loop checks the flag and drops instance-bound packets instead of blocking — they're stale from the old character

## Test plan
- [ ] Log in, switch characters quickly (spam click) — should no longer freeze
- [ ] Normal character switch (wait for logout timer) still works
- [ ] First login of session unaffected (flag starts false)
- [ ] Verify connection log shows "Dropping SMSG_SPELL_GO — session is at character select" instead of infinite "Waiting to send"

🤖 Generated with [Claude Code](https://claude.com/claude-code)