### PR TITLE
Cleanup: drop redundant M2NativeRatio re-index

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -464,11 +464,12 @@ public partial class WorldClient
             int modelIdForRatio = p.DisplayId > 0
                 ? (int)GameData.GetDisplayInfo(p.DisplayId).ModelId
                 : 0;
+            float mRatio = 1f;
             bool modelRatioApplied = modelIdForRatio > 0
                                      && vanillaCmsK.HasValue
-                                     && WorldClient.M2NativeRatio.TryGetValue(modelIdForRatio, out var mRatio);
+                                     && WorldClient.M2NativeRatio.TryGetValue(modelIdForRatio, out mRatio);
             float k = modelRatioApplied
-                ? vanillaCmsK!.Value * WorldClient.M2NativeRatio[modelIdForRatio]
+                ? vanillaCmsK!.Value * mRatio
                 : (vanillaCmsK ?? familyTableK ?? (p.IsWarlockPet ? 0.75f : 1.5f));
 
             float emit = (p.Cms > 0)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -4369,11 +4369,12 @@ public partial class WorldClient
                 int modelIdForRatio = displayId > 0
                     ? (int)GameData.GetDisplayInfo((uint)displayId).ModelId
                     : 0;
+                float mRatio = 1f;
                 bool modelRatioApplied = modelIdForRatio > 0
                                          && vanillaCmsK.HasValue
-                                         && M2NativeRatio.TryGetValue(modelIdForRatio, out var mRatio);
+                                         && M2NativeRatio.TryGetValue(modelIdForRatio, out mRatio);
                 float k = modelRatioApplied
-                    ? vanillaCmsK!.Value * M2NativeRatio[modelIdForRatio]
+                    ? vanillaCmsK!.Value * mRatio
                     : (vanillaCmsK ?? familyTableK ?? (isWarlockPet ? K_warlock : K_hunter));
 
                 // First-sight race: if CreatureTemplate isn't cached yet (creature


### PR DESCRIPTION
Closes #276 (partially — see note on the second item).

## Change

Both pet-scale call sites used `TryGetValue` to capture `mRatio` but then re-indexed `M2NativeRatio[modelIdForRatio]` in the multiplication. Now they use the captured `mRatio` directly.

`mRatio` is pre-declared with a `1f` default because the `TryGetValue` lives inside a short-circuiting `&&` chain — without a definite-assignment fallback the compiler rejects the use in the ternary. The default value is unreachable in practice (the ternary branch only fires when `modelRatioApplied` is true, which requires `TryGetValue` to have succeeded), but the explicit `1f` is also the identity multiplier so any future restructure stays safe.

Two files touched:
- `UpdateHandler.cs` — isLocalPet branch
- `QueryHandler.cs` — `ResolvePendingPetScalesForEntry`

## Note on the second item in #276

The issue also mentions a potential NRE on `GetDisplayInfo((uint)displayId).ModelId` if the DisplayID has no entry. After checking `GetDisplayInfo` (GameData.cs:547), this isn't reachable:

\`\`\`csharp
public static CreatureDisplayInfo GetDisplayInfo(uint displayId)
{
    if (CreatureDisplayInfos.TryGetValue(displayId, out var info))
        return info;
    return new CreatureDisplayInfo(0, 1.0f);
}
\`\`\`

It returns a non-null fallback record with `ModelId = 0`, and the existing `modelIdForRatio > 0` guard catches the missing-entry case. No defensive null-check needed.

## Verification

Behavior identical — full test suite 452/452 passes.