### PR TITLE
Cleanup: trim historical narrative in inline comments

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -519,31 +519,11 @@ public partial class WorldClient
             string[] inner = raw.Length > 0 && raw[0] == ':'
                 ? raw.Substring(1).Split(':')
                 : raw.Split(':');
-            // JimsProxy (chat-link-suffix 2026-05-07): WoW Classic Era 1.14 itemString fields
-            // after itemID, verified empirically against bundle jimsproxy-20260507-183921:
-            //   [0] enchantID     [1-4] gem1-4              [5] suffixID
-            //   [6] uniqueID      [7] linkLevel             [8..] specID/upgrade/etc.
-            // (matches the Wowpedia public docs after the leading-colon Substring(1) fix.)
+            // 1.14 itemString fields after itemID: [0] enchantID, [1-4] gems, [5] suffixID.
             int enchant = inner.Length > 0 && int.TryParse(inner[0], out var e) ? e : 0;
             int suffix  = inner.Length > 5 && int.TryParse(inner[5], out var s) ? s : 0;
-            // JimsProxy (chat-link-suffix-vanilla 2026-05-19): vanilla 1.12 servers only have
-            // ItemRandomProperties.dbc — there is no ItemRandomSuffix.dbc in 1.12 (that table
-            // was added in TBC/WotLK). All vanilla item suffixes ("of Power", "of Strength",
-            // "of Stamina", etc.) are ItemRandomProperties rows referenced by POSITIVE IDs on
-            // the wire. The earlier 2026-05-07 version of this code unconditionally negated
-            // the modern client's positive suffix at position 5, on the assumption that
-            // ItemRandomSuffix was the dominant case — but that assumption is inverted: in
-            // vanilla content, every linkable random-suffix item is ItemRandomProperty, and
-            // sending vmangos/Twinstar a negative ID makes them look up a non-existent
-            // ItemRandomSuffix row → suffix dropped from the broadcast → 1.12 client viewers
-            // see "Notched Shortsword" instead of "Notched Shortsword of Power".
-            //
-            // Pass the suffix through with its sign preserved. Modern Classic 1.14 only ever
-            // emits positive at position 5 for vanilla-content items, so this is effectively
-            // "no transform" for the common case. The negative branch is left undisturbed
-            // for forward compatibility — if a future Twinstar build adds ItemRandomSuffix
-            // backports and the modern client somehow encodes it negatively, we already pass
-            // it through correctly.
+            // 1.12 has no ItemRandomSuffix.dbc — all vanilla suffixes are positive
+            // ItemRandomProperty IDs. Pass the sign through; don't negate.
             Framework.Logging.Log.Event("chat.item_link.translated", new
             {
                 item_id = itemId,

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -34,22 +34,8 @@ public partial class WorldClient
         18223,  // Dreadsteed
     }.ToFrozenSet();
 
-    // Per-ModelId M_native ratio — multiplier applied to vanilla CMS_v when a
-    // model's 1.12 M2 intrinsic ModelScale differs from modern Classic's same-
-    // numbered M2 file. Multiplying CMS_v by this ratio preserves the per-
-    // DisplayID size relationships baked into the vanilla DBC (e.g., one bat
-    // skin meant to render at 0.15 stays half the size of one meant for 0.3),
-    // while compensating for the modern M2 mesh shrink.
-    //
-    // Validated 2026-05-18 on model 411 (FelBat) via two tames same session:
-    //   Ressan (displayId 9750, CMS_v=0.3): K=0.3×2.33≈0.7 → render parity 1.12.
-    //   Greater Duskbat (displayId 4734, CMS_v=0.15): expected K=0.35, renders
-    //     at half Ressan's size matching vanilla intent.
-    // Ratio derivation: see project_flying_pets_open memory.
-    //
-    // A universal family-table-MaxScale floor was tried first and rejected —
-    // it collapsed every low-CMS_v bat to the same K=0.7, erasing the vanilla
-    // intent that different bat skins are different sizes.
+    // Per-ModelId M_native ratio multiplier on vanilla CMS_v, compensating for
+    // 1.12-vs-1.14 M2 intrinsic ModelScale divergence on the same model file.
     internal static readonly FrozenDictionary<int, float> M2NativeRatio = new Dictionary<int, float>
     {
         { 411, 2.33f },  // FelBat — 1.12 intrinsic ≈ 2.33× modern's (Ressan-validated)
@@ -3051,17 +3037,7 @@ public partial class WorldClient
                     if (updateMaskArray[itemIdIndex] || updateMaskArray[permEnchantIndex] || updateMaskArray[tempEnchantIndex])
                     {
                         int itemId = updates.ContainsKey(itemIdIndex) ? updates[itemIdIndex].Int32Value : 0;
-                        // Permanent enchants take visual priority over temporary — matches
-                        // 1.12 native client behavior (parity-confirmed: Crusader / Fiery /
-                        // Lifestealing / etc. wins over an applied poison or shaman imbue
-                        // on the same weapon). PR #22 originally inverted this to surface
-                        // shaman imbues / rogue poisons after the proxy was only reading
-                        // the perm slot, but over-corrected — perm visuals now disappeared
-                        // whenever a poison was on the same weapon. The fallback chain
-                        // still picks up the temp visual when perm has no glow (e.g.
-                        // +stat enchants like Crusader's lower-tier replacements, or no
-                        // perm at all), so shaman/rogue users without a glowy perm still
-                        // see their imbue/poison visual.
+                        // Perm takes visual priority; fall back to temp only when perm has no glow.
                         ushort itemVisual = 0;
                         if (updates.ContainsKey(permEnchantIndex))
                             itemVisual = (ushort)GameData.GetItemEnchantVisual(updates[permEnchantIndex].UInt32Value);

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -4115,19 +4115,9 @@ public static partial class GameData
         if (ItemEffectSlotMismatchExclusions.Contains(item.Entry))
             return null;
 
-        // Mana gems: only skip mutation when the legacy server's spell id for this slot
-        // doesn't match any CSV record we have for the item — i.e., the path below
-        // would either rewrite an existing record's SpellID (effect != null branch) or
-        // create a fresh ItemEffect bound to a legacy SpellID the modern client's
-        // SpellDB can't resolve (new-record branch). In both cases the Use: line is
-        // stripped because 10053/10054 mean "Conjure Citrine/Ruby" in the modern client.
-        //
-        // When the server already serves the modern id (e.g. Twinstar's Citrine has
-        // spellid_1=10057), the slot-relocation path is safe and necessary: it preserves
-        // SpellID and only moves LegacySlotIndex so the client's DB2 record (slot 1)
-        // lines up with the server's placement (slot 0). Skipping it here leaves the
-        // record at LegacySlotIndex=1, the client doesn't find an effect at slot 0
-        // (where the server says the on-use lives), and the Use: line vanishes.
+        // Mana gems: skip mutation only when the server's slot SpellID doesn't match
+        // any CSV record we have — otherwise the rewrite/new-record path binds the
+        // legacy SpellID (10053/10054) and the modern client strips the Use: line.
         if (ManaGemItemEntries.Contains(item.Entry) &&
             item.TriggeredSpellIds[slot] > 0 &&
             (effect == null || effect.SpellID != item.TriggeredSpellIds[slot]) &&


### PR DESCRIPTION
Closes #275.

## Change

Trimmed verbose historical comments at four sites cited in the issue, replacing 10-18 line PR-history narratives with one-line summaries that keep only the non-obvious *why*. PR-history context lives in commit messages and PR descriptions, not the source.

Sites:
- **#261** (`UpdateHandler.cs`): M2NativeRatio dict header — 15 lines → 2 lines
- **#270** (`GameData.cs`): mana gem skip condition — 13 lines → 3 lines
- **#273** (`UpdateHandler.cs`): perm/temp enchant priority — 11 lines → 1 line
- **#274** (`ChatHandler.cs`): suffix sign-preservation — 23 lines (two adjacent blocks) → 4 lines

Net: -54 lines.

## Verification

Behavior identical — full test suite 452/452 passes.