### PR TITLE
Fix proxy DC on short SMSG_LOOT_RESPONSE (Stratholme trap crates)

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -282,6 +282,11 @@ public class ByteBuffer : IDisposable
         return _position < _length;
     }
 
+    public bool CanRead(int count)
+    {
+        return _position + count <= _length;
+    }
+
     public uint ReadPackedTime()
     {
         return (uint)Time.GetUnixTimeFromPackedTime(ReadUInt32());

--- a/HermesProxy/World/Client/PacketHandlers/LootHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LootHandler.cs
@@ -23,7 +23,8 @@ public partial class WorldClient
         loot.AcquireReason = (LootType)packet.ReadUInt8();
         if (loot.AcquireReason == LootType.None)
         {
-            loot.FailureReason = (LootError)packet.ReadUInt8(); //MIRASU
+            if (packet.CanRead())
+                loot.FailureReason = (LootError)packet.ReadUInt8(); //MIRASU
             loot.Acquired = false;                               //MIRASU - client gates red chat line on !Acquired
             SendPacketToClient(loot);                            //MIRASU - was missing: failure never reached client, loot cursor hung
             return;
@@ -31,12 +32,26 @@ public partial class WorldClient
         GetSession().GameState.LastLootTargetGuid = targetGuid;  //MIRASU - only commit on success so failures don't poison subsequent LastLootTargetGuid consumers (LOOT_REMOVED / LOOT_CLEAR_MONEY / LOOT_MONEY_NOTIFY)
         loot.LootMethod = GetSession().GameState.GetCurrentLootMethod();
 
-        loot.Coins = packet.ReadUInt32();
+        // Bounded reads past the fixed guid+type header. A booby-trapped Stratholme
+        // crate (GO 175537) sends a short SMSG_LOOT_RESPONSE the full-structure parse
+        // overran — an IndexOutOfRangeException in the receive loop DC'd the session.
+        // A malformed/short loot packet must degrade to an empty loot window, never a DC.
+        loot.Coins = packet.CanRead(4) ? packet.ReadUInt32() : 0;
         GetSession().GameState.CurrentLootCoins = loot.Coins; //MIRASU - stash for synthesizing SMSG_LOOT_MONEY_NOTIFY on pickup (Kronos/TC-1.12 doesn't send it)
 
-        var itemsCount = packet.ReadUInt8();
+        var itemsCount = packet.CanRead() ? packet.ReadUInt8() : (byte)0;
         for (var i = 0; i < itemsCount; ++i)
         {
+            if (!packet.CanRead(LootItemWireSize))
+            {
+                Framework.Logging.Log.Event("loot.response.truncated", new
+                {
+                    owner_guid_low = targetGuid.GetLowValue(),
+                    declared_items = itemsCount,
+                    parsed_items = i,
+                });
+                break;
+            }
             LootItemData lootItem = new();
             lootItem.LootListID = packet.ReadUInt8();
             lootItem.Loot.ItemID = packet.ReadUInt32();
@@ -51,6 +66,10 @@ public partial class WorldClient
         SendMasterLootListIfApplicable();
         SendPacketToClient(loot);
     }
+
+    // Per-item wire size in SMSG_LOOT_RESPONSE: slot(1) + itemId(4) + quantity(4)
+    // + displayId(4) + randomSeed(4) + randomPropId(4) + slotType(1).
+    private const int LootItemWireSize = 22;
 
     [PacketHandler(Opcode.SMSG_LOOT_RELEASE)]
     void HandleLootRelease(WorldPacket packet)


### PR DESCRIPTION
## Problem

Opening a booby-trapped Stratholme crate (GameObject `175537`) disconnects the player. The crate is destroyed on open and the server sends a short 15-byte `SMSG_LOOT_RESPONSE`. `HandleLootResponse` read the full loot structure — 4-byte coins, 1-byte item count, then 22 bytes per item — unconditionally, overran the buffer, and threw `IndexOutOfRangeException` in the `WorldClient` receive loop, tearing down the whole session.

```
SMSG_LOOT_RESPONSE (size 15) → IndexOutOfRangeException at ByteBuffer.ReadUInt8() → session DC
```

## Fix

A malformed/short loot packet must degrade to an empty loot window, never a disconnect. `HandleLootResponse` now bounds every read past the fixed guid+type header:

- `LootType.None` failure-reason read guarded with `CanRead()`
- coins / item-count guarded — default to 0 if absent
- the item loop stops (and logs `loot.response.truncated`) when fewer than 22 bytes remain

Adds `ByteBuffer.CanRead(int count)` for the multi-byte guard.

## Verification

- Build clean, full test suite 452/452 passes
- In-game on Kronos PTR: opened multiple booby-trapped Stratholme crates — each now produces a clean 15-byte `SMSG_LOOT_RESPONSE` parse (empty loot, correct for a trap crate), no `packet.error`, no DC. Session continued normally afterward.