### PR TITLE
Fix oversized engineering-pet scale (Battle Chicken, Dragonling)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -471,9 +471,23 @@ public partial class WorldClient
                 ? vanillaCmsK!.Value * WorldClient.M2NativeRatio[modelIdForRatio]
                 : (vanillaCmsK ?? familyTableK ?? (p.IsWarlockPet ? 0.75f : 1.5f));
 
+            // Server-pre-scaled summons (engineering trinket pets): strip the
+            // pre-baked wire scale, mirroring UpdateHandler's pet branch — without
+            // this, the creature-query resolver re-emits the oversized value
+            // 200-300ms after summon and overrides the corrected first emit.
+            // Gate on wire > 1.0 — see the matching comment in UpdateHandler's pet
+            // branch. Small pets (wire < 1.0) keep their M2NativeRatio/family logic.
+            float effectiveWire = p.RawScale;
+            bool wirePreScaled = vanillaCmsK.HasValue
+                && p.RawScale > 1.01f
+                && p.RawScale >= vanillaCmsK.Value - 0.01f
+                && p.RawScale < vanillaCmsK.Value * 1.5f;
+            if (wirePreScaled)
+                effectiveWire = 1.0f;
+
             float emit = (p.Cms > 0)
-                ? (p.RawScale / p.Cms) * k
-                : p.RawScale * k;
+                ? (effectiveWire / p.Cms) * k
+                : effectiveWire * k;
 
             // Synthesize a values-update carrying just OBJECT_FIELD_SCALE_X.
             UpdateObject updateObject = new UpdateObject(GetSession().GameState);
@@ -494,6 +508,8 @@ public partial class WorldClient
                            : familyTableK.HasValue ? "family-table"
                            : (p.IsWarlockPet ? "k-warlock-fallback" : "k-hunter-fallback"),
                 raw_scale = p.RawScale,
+                wire_pre_scaled = wirePreScaled,
+                effective_wire = effectiveWire,
                 emitted_scale = emit,
             });
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -4404,12 +4404,35 @@ public partial class WorldClient
                     }
                 }
 
+                // Server-pre-scaled summons: engineering trinket pets (Mechanical
+                // Battle Chicken display 6909, Mithril Dragonling 7908, etc.) have
+                // creature_template.display_scale set to CMS_v, so the legacy server
+                // sends wire == CMS_v. The 1.12 client renders wire × ModelScale; the
+                // 1.14 client *also* applies CreatureModelScale → wire × CMS × ModelScale
+                // = CMS_v² — visibly oversized (3×3 chicken). Mirror the NPC path's
+                // wire-pre-scaled strip: when wire ≈ CMS_v (and isn't the server-default
+                // 1.0), drop wire to 1.0 so the client lands at vanilla baseline.
+                // Real hunter/warlock pets are unaffected — their wire is the server-
+                // default 1.0, which the `!= 1.0` guard excludes.
+                // Gate strictly on wire > 1.0: the double-application bug only renders
+                // a creature OVERSIZED when the server pre-scales above 1.0 (chicken 3,
+                // dragonling 1.15). Small pets legitimately carry wire < 1.0 (voidwalker
+                // 0.8, tamed bats 0.43) and must keep the M2NativeRatio / family-table
+                // logic — stripping them to 1.0 wrongly inflates them.
+                float effectivePetWire = rawScale;
+                bool petWirePreScaled = vanillaCmsK.HasValue
+                    && rawScale > 1.01f
+                    && rawScale >= vanillaCmsK.Value - 0.01f
+                    && rawScale < vanillaCmsK.Value * 1.5f;
+                if (petWirePreScaled)
+                    effectivePetWire = 1.0f;
+
                 // Skip normalization if CMS data is missing/invalid — fall back to a flat
                 // K multiply so the pet still gets a size bump rather than passing through
                 // un-modified (and rendering small).
                 float emit = (cms > 0)
-                    ? (rawScale / cms) * k
-                    : rawScale * k;
+                    ? (effectivePetWire / cms) * k
+                    : effectivePetWire * k;
 
                 updateData.ObjectData.Scale = emit;
 
@@ -4427,6 +4450,8 @@ public partial class WorldClient
                                : familyTableK.HasValue ? "family-table"
                                : (isWarlockPet ? "k-warlock-fallback" : "k-hunter-fallback"),
                     raw_scale = rawScale,
+                    wire_pre_scaled = petWirePreScaled,
+                    effective_wire = effectivePetWire,
                     emitted_scale = emit,
                     matched_via = (currentPetGuid != default && guid == currentPetGuid) ? "current_pet_guid" : "summoned_by",
                     cms_fallback = cms <= 0,


### PR DESCRIPTION
## Problem

Engineering trinket summons — Mechanical Battle Chicken, Mithril Dragonling, etc. — render oversized on the 1.14 client. The Battle Chicken comes out at **3×** size; the Dragonling slightly large.

## Root cause

vmangos/Kronos `creature_template.display_scale` for these entries is set to `CMS_v` (Battle Chicken entry 8836 → `display_scale1 = 3.0`), so the legacy server sends `OBJECT_FIELD_SCALE_X == CMS_v` on the wire.

- **1.12 client** renders `wire × ModelScale`
- **1.14 client** *additionally* applies `CreatureDisplayInfo.CreatureModelScale` → `wire × CMS × ModelScale` = `CMS_v²` (3 × 3 = 9× the mesh)

Verified against DBC data: `CreatureModelScale` and `CreatureModelData.ModelScale` are **identical** in vanilla 1.12 and modern 1.14.2 — so a native 1.14 client renders these correctly. Only the proxy's pet path forwarded the pre-scaled wire value straight through.

## Fix

The NPC scale path already strips this (wire-pre-scaled heuristic). The two pet emit paths didn't — now both do:
- `UpdateHandler` pet branch (first emit on summon)
- `QueryHandler.ResolvePendingPetScalesForEntry` (re-emit ~200ms later, after the creature-query response)

Gated strictly on `wire > 1.0`: the double-application only renders a creature **oversized** when the server pre-scales above 1.0. Small pets legitimately carry `wire < 1.0` — Voidwalker 0.8, tamed bats 0.43, FelBat 0.45 — and keep their existing `M2NativeRatio` / family-table scaling untouched. The detection is per-creature (its own wire vs its own `CMS_v`), not per-model, so creatures sharing a model are unaffected.

## Verification

- Build clean, full suite 452/452
- In-game on Kronos PTR: Battle Chicken + Mithril Dragonling now render correct size; `unit.pet_scale.applied` and `unit.pet_scale.resolved_after_template` both emit ~1.0. Voidwalker / tamed bats / FelBat confirmed `wire_pre_scaled:false` — unchanged.