### PR TITLE
Fix bow shoot animation freezing during ranged haste

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -254,6 +254,13 @@ public sealed class GameSessionData
     // source is UNIT_FIELD_HEALTH / UNIT_FIELD_MAXHEALTH from SMSG_UPDATE_OBJECT;
     // we also bump current HP forward on heal events to stay accurate between pushes.
     public ConcurrentDictionary<WowGuid128, (int Hp, int MaxHp)> UnitHealthCache = new();
+    // JimsProxy: per-unit resting (un-hasted) ranged attack time. Vanilla bakes ranged
+    // haste straight into UNIT_FIELD_RANGEDATTACKTIME, but the modern client treats its
+    // RangedAttackRoundBaseTime as the *base* and time-scales the bow draw/release
+    // animation by ModRangedHaste. We track the slowest RANGEDATTACKTIME seen per unit
+    // as the base so we can synthesize ModRangedHaste = resting / current. Written from
+    // the WorldClient handler thread; ConcurrentDictionary keeps it torn-state safe.
+    public ConcurrentDictionary<WowGuid128, uint> RestingRangedAttackTime = new();
     // JimsProxy: pet creature family cache. SMSG_PET_SPELLS_MESSAGE on pre-3.1
     // servers doesn't carry the family on the wire — we derive it from the
     // creature template via GetItemId(petGuid). For quest-tame pets the

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2323,7 +2323,37 @@ public partial class WorldClient
             int UNIT_FIELD_RANGEDATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_RANGEDATTACKTIME);
             if (UNIT_FIELD_RANGEDATTACKTIME >= 0 && updateMaskArray[UNIT_FIELD_RANGEDATTACKTIME])
             {
-                updateData.UnitData.RangedAttackRoundBaseTime = updates[UNIT_FIELD_RANGEDATTACKTIME].UInt32Value;
+                uint rangedAttackTime = updates[UNIT_FIELD_RANGEDATTACKTIME].UInt32Value;
+                updateData.UnitData.RangedAttackRoundBaseTime = rangedAttackTime;
+
+                // JimsProxy: vanilla bakes ranged haste straight into RANGEDATTACKTIME, but the
+                // modern client treats RangedAttackRoundBaseTime as the *un-hasted* base and
+                // time-scales the bow draw/release animation by ModRangedHaste. With no haste
+                // multiplier the bow animation can't keep up with hasted Auto Shot (Rapid Fire /
+                // Quick Shots) and freezes in the drawn pose until it catches up. Track the
+                // slowest (resting) RANGEDATTACKTIME seen for this unit as the base and send
+                // ModRangedHaste = resting / current so the client scales the animation. Note:
+                // a mid-session swap to a *faster* ranged weapon leaves the cached resting
+                // stale-high until a slower value is seen again — the failure mode there is a
+                // mildly fast animation, far less jarring than the freeze, so it degrades well.
+                if (rangedAttackTime > 0)
+                {
+                    WowGuid128 rangedUnitGuid = guid.To128(GetSession().GameState);
+                    uint restingRangedAttackTime = GetSession().GameState.RestingRangedAttackTime.AddOrUpdate(
+                        rangedUnitGuid, rangedAttackTime,
+                        (_, prev) => Math.Max(prev, rangedAttackTime));
+                    float modRangedHaste = (float)restingRangedAttackTime / rangedAttackTime;
+                    updateData.UnitData.RangedAttackRoundBaseTime = restingRangedAttackTime;
+                    updateData.UnitData.ModRangedHaste = modRangedHaste;
+                    if (modRangedHaste > 1.0f)
+                        Log.Event("ranged.haste.synth", new
+                        {
+                            guid = rangedUnitGuid.ToString(),
+                            resting_ms = restingRangedAttackTime,
+                            current_ms = rangedAttackTime,
+                            mod_ranged_haste = modRangedHaste,
+                        });
+                }
             }
             int UNIT_FIELD_BOUNDINGRADIUS = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_BOUNDINGRADIUS);
             if (UNIT_FIELD_BOUNDINGRADIUS >= 0 && updateMaskArray[UNIT_FIELD_BOUNDINGRADIUS])


### PR DESCRIPTION
Hunters report the bow shoot animation freezing in the drawn pose during a ranged-haste proc (Rapid Fire / Quick Shots) — it keeps up as long as it can, then holds a full shot before snapping to catch up. The shots themselves fire on the correct hasted cadence; only the animation lags.

**Root cause:** Vanilla 1.12 bakes ranged haste straight into `UNIT_FIELD_RANGEDATTACKTIME` — the server sends the already-shortened value. The proxy copied that hasted value verbatim into the modern client's `RangedAttackRoundBaseTime`, so the shot *timer* sped up correctly. But the modern client treats `RangedAttackRoundBaseTime` as the *un-hasted base* and time-scales the bow draw/release animation by `ModRangedHaste` — which the proxy never sets (`UpdatePackets.cs` only ever defaults it, and `ModHaste`/`ModHasteRegen`/`ModTimeRate`, to `1`). Pinned at 1, the animation stays locked to base duration and can't fit a hasted shot interval.

**Fix:** In the `UNIT_FIELD_RANGEDATTACKTIME` handler, track the slowest (resting) ranged attack time seen per unit in a new `GameSessionData.RestingRangedAttackTime` (`ConcurrentDictionary<WowGuid128, uint>`), then send `RangedAttackRoundBaseTime = resting` and `ModRangedHaste = resting / current`. The client's effective speed (`base / ModRangedHaste`) is unchanged, so the swing timer is unaffected — only the missing animation scalar is added. Emits a `ranged.haste.synth` JSONL event when haste is active.

Known limitation (documented inline): a mid-session swap to a *faster* ranged weapon, or reconnecting while already hasted, leaves the cached resting stale until a slower value is seen — the failure mode is a mildly fast animation rather than the freeze, and `max()`-tracking self-corrects it upward. Scoped to ranged only; melee `ModHaste` has the same dead-default but discrete per-swing animations make it far less visible.

**Testing:** Build clean, 452/452 tests pass. Field-tested on a 1.14 client through Rapid Fire / quiver stacking — animation now tracks the proc, shot cadence unchanged. JSONL confirmed clean multipliers (1.10-1.58).