### PR TITLE
Fix: ResponseCodes unbox cast crash on char create/delete/rename

### DIFF
--- a/HermesProxy/VersionChecker.cs
+++ b/HermesProxy/VersionChecker.cs
@@ -1055,8 +1055,11 @@ public static class ModernVersion
     public static byte ConvertResponseCodesValue(byte legacyValue)
     {
         string legacyName = Enum.ToObject(LegacyVersion.GetResponseCodesEnum()!, legacyValue).ToString()!;
+        // Enum.TryParse returns a boxed enum whose underlying type is byte.
+        // CLR unboxing requires the exact type — (int) fails on a byte-backed
+        // enum, so cast directly to the underlying type.
         if (Enum.TryParse(GetResponseCodesEnum()!, legacyName, out object? modern))
-            return (byte)(int)modern;
+            return (byte)modern;
         Framework.Logging.Log.Print(Framework.Logging.LogType.Error,
             $"Unmapped ResponseCode: legacy byte {legacyValue} name '{legacyName}'");
         return legacyValue;


### PR DESCRIPTION
## Summary

- Commit 5de747c introduced `(byte)(int)modern` in `ConvertResponseCodesValue`, but both ResponseCodes enums are `: byte` — CLR can't unbox a byte-backed enum via `(int)`, throws `InvalidCastException`
- Every character create, delete, and rename on beta crashes with "Specified cast is not valid"
- Fix: `(byte)modern` — cast directly to the underlying type, matching the pattern the original `Enum.Parse` version used
- TryParse fallback for unmapped Kronos codes (the goal of 5de747c) is preserved

## Test plan

- [ ] Create a new character on beta — should succeed
- [ ] Delete a character on beta — should succeed
- [ ] Verify unmapped response codes still log + pass through (no freeze)

🤖 Generated with [Claude Code](https://claude.com/claude-code)