### PR TITLE
Move structured logging off the packet thread (fixes movement rubberbanding)

### DIFF
--- a/Framework/Logging/Log.cs
+++ b/Framework/Logging/Log.cs
@@ -67,6 +67,15 @@ public static class Log
     private static StreamWriter? _jsonlWriter;
     private static readonly object _jsonlLock = new();
     private static string? _jsonlPath;
+    // JimsProxy: structured-log writes run on a dedicated background thread so a
+    // slow disk flush can never block a packet-handling thread (per-event
+    // synchronous flushing here was the cause of in-game rubberbanding under
+    // load). Event() only serializes + enqueues; the writer thread owns all
+    // file I/O. Bounded so a wedged disk drops lines instead of growing memory
+    // unbounded — and TryAdd means the hot path never blocks even when full.
+    private static readonly BlockingCollection<string> _jsonlQueue = new(boundedCapacity: 1 << 18);
+    private static Thread? _jsonlWriterThread;
+    private static long _jsonlDroppedCount;
     private static readonly JsonSerializerOptions _jsonOpts = new()
     {
         WriteIndented = false,
@@ -98,7 +107,10 @@ public static class Log
             _jsonlPath = Path.Combine(logsDir, $"jimsproxy-{stamp}.jsonl");
             _jsonlWriter = new StreamWriter(new FileStream(_jsonlPath, FileMode.Create, FileAccess.Write, FileShare.Read))
             {
-                AutoFlush = true
+                // AutoFlush off: the background writer thread (JsonlWriterLoop) flushes
+                // explicitly. Per-event flushing was synchronous disk I/O on the
+                // packet-handling thread — the cause of in-game rubberbanding under load.
+                AutoFlush = false
             };
         }
         catch (Exception ex)
@@ -117,11 +129,21 @@ public static class Log
     /// </summary>
     public static void StartStructuredLog()
     {
-        if (!StructuredLogEnabled || _jsonlWriter != null)
+        if (!StructuredLogEnabled || _jsonlWriterThread != null)
             return;
         lock (_jsonlLock)
         {
+            if (_jsonlWriterThread != null)
+                return;
             EnsureJsonlOpen();
+            if (_jsonlWriter == null)
+                return; // open failed; EnsureJsonlOpen already disabled structured logging
+            _jsonlWriterThread = new Thread(JsonlWriterLoop)
+            {
+                IsBackground = true,
+                Name = "jsonl-writer",
+            };
+            _jsonlWriterThread.Start();
         }
     }
 
@@ -158,20 +180,63 @@ public static class Log
             });
         }
 
-        lock (_jsonlLock)
+        // Hand off to the background writer thread; never touch the disk here.
+        // TryAdd is non-blocking — if the queue is full (disk wedged) drop the
+        // line rather than stall a packet-handling thread. Once logging has been
+        // shut down (CompleteAdding) TryAdd throws InvalidOperationException;
+        // swallow it so a late Event() during teardown never propagates out.
+        try
         {
-            EnsureJsonlOpen();
-            if (_jsonlWriter == null)
-                return;
+            if (!_jsonlQueue.TryAdd(line))
+                Interlocked.Increment(ref _jsonlDroppedCount);
+        }
+        catch (InvalidOperationException)
+        {
+            // structured logging already closed — drop silently
+        }
+    }
+
+    /// <summary>
+    /// Background pump: drains the structured-log queue and writes to disk.
+    /// Flushes when the queue momentarily empties (so data lands promptly) and
+    /// at least every 1000 lines (so a sustained burst can't defer a flush
+    /// indefinitely). All structured-log file I/O happens here, off the
+    /// packet-handling threads.
+    /// </summary>
+    private static void JsonlWriterLoop()
+    {
+        var sinceFlush = Stopwatch.StartNew();
+        bool writeFailed = false;
+        foreach (var line in _jsonlQueue.GetConsumingEnumerable())
+        {
+            if (_jsonlWriter == null || writeFailed)
+                continue;
             try
             {
                 _jsonlWriter.WriteLine(line);
+                // Flush when the queue momentarily drains, or at least every
+                // 200ms during a sustained burst — bounds how much is lost if
+                // the process is hard-killed before the shutdown hooks run.
+                if (_jsonlQueue.Count == 0 || sinceFlush.ElapsedMilliseconds >= 200)
+                {
+                    _jsonlWriter.Flush();
+                    sinceFlush.Restart();
+                }
             }
             catch (Exception ex)
             {
+                // Stop writing after the first failure — a wedged/full disk fails
+                // every subsequent line, and we don't want one Console.Error line
+                // per queued event. Keep draining the queue so producers' TryAdd
+                // never blocks; the lines are simply discarded.
+                writeFailed = true;
                 StructuredLogEnabled = false;
                 Console.Error.WriteLine($"[JimsProxy] Structured log write failed, disabling: {ex.Message}");
             }
+        }
+        if (!writeFailed)
+        {
+            try { _jsonlWriter?.Flush(); } catch { /* ignore */ }
         }
     }
 
@@ -180,10 +245,31 @@ public static class Log
     /// </summary>
     public static void FlushAndCloseStructuredLog()
     {
+        // Stop accepting new events and let the writer thread drain what's queued.
+        try { _jsonlQueue.CompleteAdding(); } catch { /* already completed */ }
+        bool drained = _jsonlWriterThread == null || _jsonlWriterThread.Join(5000);
+
         lock (_jsonlLock)
         {
-            if (_jsonlWriter != null)
+            // Only dispose once the writer thread has actually finished. If a
+            // wedged disk kept it past the Join timeout, disposing here would
+            // fault it mid-write; leave the handle for the OS to reclaim on exit.
+            if (_jsonlWriter != null && drained)
             {
+                long dropped = Interlocked.Read(ref _jsonlDroppedCount);
+                if (dropped > 0)
+                {
+                    try
+                    {
+                        _jsonlWriter.WriteLine(JsonSerializer.Serialize(new
+                        {
+                            timestamp_ms = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                            eventType = "log.dropped",
+                            payload = new { dropped_lines = dropped },
+                        }, _jsonOpts));
+                    }
+                    catch { /* ignore */ }
+                }
                 try { _jsonlWriter.Flush(); _jsonlWriter.Dispose(); } catch { /* ignore */ }
                 _jsonlWriter = null;
             }

--- a/HermesProxy/HermesProxy.csproj
+++ b/HermesProxy/HermesProxy.csproj
@@ -13,6 +13,12 @@
     <Copyright>Copyright © WowLegacyCore 2023; Fork © jameopotato 2026</Copyright>
     <Authors>WowLegacyCore; jameopotato</Authors>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- JimsProxy: Server GC (per-core heaps + background collection) keeps
+         stop-the-world pauses short under the proxy's high allocation rate.
+         Default Workstation GC produced long pauses that froze packet
+         forwarding and showed up in-game as movement rubberbanding. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UsePublishBuildSettings)' == 'true'">


### PR DESCRIPTION
Testers reported heavy in-game movement rubberbanding on dungeon runs. A 22-minute JSONL capture showed the proxy process freezing **459 times for >150ms** (~20/min), plus three freezes of 1.2-2.4s — with network RTT flat at 63-93ms the whole session, so it was not latency.

**Root cause:** `Log.Event` ran entirely on the calling thread (a packet-handling thread). It reflection-serialized the payload, took a global lock, and `WriteLine`d to a `StreamWriter` with `AutoFlush = true` — a synchronous disk flush on every event. That session logged ~170k events (155k of them `packet.in` / `packet.translated`, one pair per packet). Whenever a flushed write blocked (large file, OS buffer flush, AV scan) the packet thread blocked with it: client movement packets queued, the legacy server's view of the player froze, and on unblock everything flushed at once — server authority and client prediction diverged into a rubberband.

**Fix:**
- `Log.Event` now only serializes and enqueues to a bounded `BlockingCollection` via non-blocking `TryAdd`. A dedicated background thread (`JsonlWriterLoop`) owns all file I/O — no disk on the hot path.
- `StreamWriter` `AutoFlush` disabled; the writer thread flushes when the queue drains and at least every 200ms (bounds hard-crash loss).
- Queue is bounded (262144); a wedged disk drops lines (counted, reported as a `log.dropped` event at close) rather than ever blocking a producer or growing memory unbounded.
- `TryAdd` after shutdown (`CompleteAdding`) is caught, so a late `Event()` during teardown never throws.
- HermesProxy: enable Server GC + concurrent GC — the ~170k reflection-JSON serializations drove heavy allocation, and default Workstation GC's longer stop-the-world pauses compounded the freezes.

**Testing:** build clean, 452/452 tests pass. A follow-up capture on the fixed build handled a 326 packet/sec burst with no internal stalls (max translation 5ms) and zero dropped lines.