### PR TITLE
Fix: disconnect on fast character switch (lingering instance socket)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2132,6 +2132,7 @@ public class GlobalSessionData
 
     public WorldSocket RealmSocket = null!;
     public WorldSocket InstanceSocket = null!;
+    public volatile WorldSocket? LingeringInstanceSocket;
     public AuthClient AuthClient = null!;
     public WorldClient? WorldClient;
     // JimsProxy: set true on SMSG_LOGOUT_COMPLETE so the next CMSG_PLAYER_LOGIN

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -450,6 +450,7 @@ public partial class WorldClient
         // gated on a clean socket lifetime through the char-select transition.
         var lingeringSocket = GetSession().InstanceSocket;
         GetSession().InstanceSocket = null!;
+        GetSession().LingeringInstanceSocket = lingeringSocket;
         var holdStart = DateTime.UtcNow;
         Log.Event("session.logout_complete.socket_hold_started", new
         {
@@ -471,6 +472,7 @@ public partial class WorldClient
                 {
                     if (lingeringSocket == null || !lingeringSocket.IsOpen())
                     {
+                        GetSession().LingeringInstanceSocket = null;
                         var elapsed = (long)(DateTime.UtcNow - holdStart).TotalMilliseconds;
                         Log.Event("session.logout_complete.client_closed_first", new
                         {
@@ -484,6 +486,7 @@ public partial class WorldClient
                 if (lingeringSocket != null && lingeringSocket.IsOpen())
                 {
                     lingeringSocket.CloseSocket();
+                    GetSession().LingeringInstanceSocket = null;
                     Log.Event("session.logout_complete.safety_net_closed", new
                     {
                         elapsed_ms = LogoutCompleteSocketHoldMs,

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -282,6 +282,19 @@ public partial class WorldSocket
         if (GetSession().AuthClient != null)
             GetSession().AuthClient.Disconnect();
 
+        // Close lingering instance socket from the previous logout's safety-net
+        // hold before sending ConnectTo. The WTF flush is done by now (user spent
+        // ≥2s at char select), but the 3s safety-net may not have fired yet. If
+        // the old socket is still alive when ConnectTo arrives, the modern client
+        // sees two instance connections and disconnects with reason 3.
+        var lingering = GetSession().LingeringInstanceSocket;
+        if (lingering != null)
+        {
+            if (lingering.IsOpen())
+                lingering.CloseSocket();
+            GetSession().LingeringInstanceSocket = null;
+        }
+
         SendConnectToInstance(ConnectToSerial.WorldAttempt1);
         GetSession().GameState.IsConnectedToInstance = true;
         GetSession().GameState.IsFirstEnterWorld = true;


### PR DESCRIPTION
## Summary

- When switching characters quickly twice in a row, the second switch disconnects with reason 3
- Root cause: the 3000ms WTF-flush safety-net holds the old instance socket alive. If the user reaches `SendConnectToInstance` before 3000ms elapse (typical: ~2.7s), the modern client sees two live instance connections and rejects the second one
- Fix: store the lingering socket on the session (`LingeringInstanceSocket`), close it explicitly in `HandlePlayerLogin` before sending `ConnectTo`. The WTF flush is already done by then (user spent ≥2s at char select)
- The safety-net task clears `LingeringInstanceSocket` when it fires or when the client closes first, so no double-close

## Evidence

From JSONL `jimsproxy-20260521-152302.jsonl`:
- First switch: 3110ms between LOGOUT_COMPLETE and ConnectTo — safety-net (3000ms) already closed. Works.
- Second switch: 2767ms between LOGOUT_COMPLETE and ConnectTo — safety-net hasn't fired yet (233ms remaining). Old socket alive → client disconnects.

## What's NOT affected

- First login (no lingering socket exists)
- First character switch (safety-net has time to close naturally in most cases)
- Slow switches (3s+ at char select — safety-net already fired)
- WTF flush (still protected — the safety-net hold remains for its full 3s, this fix only force-closes when the user has already committed to a new login)

## Related

- `3e2a96a` fixed the proxy-side infinite spin on fast switch (different bug, same trigger)
- This fixes the client-side disconnection (reason 3) on back-to-back fast switches

## Test plan

- [ ] Switch characters quickly twice in a row (click within 2s of reaching char select both times) — should no longer disconnect
- [ ] Switch characters slowly (wait 5s at char select) — should still work
- [ ] First login from char select — should be unaffected
- [ ] Verify WTF settings (keybinds, macros) persist after a fast switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)