### PR TITLE
[Linux] Fix crash on flight-path landing against Vanilla/TBC servers

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -216,14 +216,27 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_MOVE_WATER_WALK_ACK)]
     void HandleMoveForceAck1(MovementAckMessage movementAck)
     {
-        WorldPacket packet = new WorldPacket(movementAck.GetUniversalOpcode());
+        var universalOpcode = movementAck.GetUniversalOpcode();
+        uint legacyOpcode = LegacyVersion.GetCurrentOpcode(universalOpcode);
+        if (legacyOpcode == 0)
+        {
+            // The modern client acks proxy-synthesized state changes (e.g. the
+            // SMSG_MOVE_UNSET_CAN_FLY sent at the end of a taxi flight) with
+            // CMSG_MOVE_SET_CAN_FLY_ACK, which doesn't exist on Vanilla legacy
+            // servers. The legacy server never sent the change and expects no ack,
+            // so discard it instead of crashing in the WorldPacket(Opcode) assert.
+            Log.Event("movement.ack_discarded", new { opcode = universalOpcode.ToString() });
+            return;
+        }
+
+        WorldPacket packet = new WorldPacket(legacyOpcode);
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
             packet.WritePackedGuid(movementAck.MoverGUID.To64());
         else
             packet.WriteGuid(movementAck.MoverGUID.To64());
         packet.WriteUInt32(movementAck.Ack.MoveCounter);
         movementAck.Ack.MoveInfo.WriteMovementInfoLegacy(packet);
-        packet.WriteInt32(movementAck.Ack.MoveInfo.Flags.HasAnyFlag(GetFlagForAckOpcode(movementAck.GetUniversalOpcode())) ? 1 : 0);
+        packet.WriteInt32(movementAck.Ack.MoveInfo.Flags.HasAnyFlag(GetFlagForAckOpcode(universalOpcode)) ? 1 : 0);
         SendPacketToServer(packet);
     }
 
@@ -234,7 +247,21 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_MOVE_GRAVITY_ENABLE_ACK)]
     void HandleMoveForceAck2(MovementAckMessage movementAck)
     {
-        WorldPacket packet = new WorldPacket(movementAck.GetUniversalOpcode());
+        var universalOpcode = movementAck.GetUniversalOpcode();
+        uint legacyOpcode = LegacyVersion.GetCurrentOpcode(universalOpcode);
+        if (legacyOpcode == 0)
+        {
+            // CMSG_MOVE_GRAVITY_ENABLE_ACK / CMSG_MOVE_GRAVITY_DISABLE_ACK don't
+            // exist on Vanilla/TBC legacy servers. The modern client sends them in
+            // response to proxy-synthesized SMSG_MOVE_ENABLE_GRAVITY (e.g. at the
+            // end of a taxi flight). The legacy server never sent a gravity packet
+            // and expects no ack, so discard it instead of crashing in the
+            // WorldPacket(Opcode) constructor's assert.
+            Log.Event("movement.ack_discarded", new { opcode = universalOpcode.ToString() });
+            return;
+        }
+
+        WorldPacket packet = new WorldPacket(legacyOpcode);
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
             packet.WritePackedGuid(movementAck.MoverGUID.To64());
         else


### PR DESCRIPTION
At the end of a taxi flight the dismount routine sends SMSG_MOVE_ENABLE_GRAVITY and SMSG_MOVE_UNSET_CAN_FLY to the modern client to restore its post-flight state. The client acks these with CMSG_MOVE_GRAVITY_ENABLE_ACK and CMSG_MOVE_SET_CAN_FLY_ACK, neither of which exists on Vanilla legacy servers (gravity acks are also absent on TBC).

HandleMoveForceAck1/2 relayed those acks via new WorldPacket(Opcode), whose constructor maps the universal opcode to the legacy opcode and asserts it is non-zero. With no legacy equivalent the mapping returns 0 and the assert fires. Trace.Assert is compiled into Release builds and aborts the process on Linux ("Aborted (core dumped)"); on Windows it surfaces an assertion dialog or sends a malformed opcode-0 packet to the server. Either way the proxy is broken for vanilla flight paths.

Resolve the legacy opcode first; if it is 0 the legacy server never sent the state change and expects no ack, so discard it (matching the existing CMSG_MOVE_SET_COLLISION_HEIGHT_ACK handler) and emit a movement.ack_discarded diagnostic. Opcodes that do map are forwarded byte-for-byte as before.