### PR TITLE
Fix gather nodes stuck after the first tick

### DIFF
--- a/HermesProxy.Tests/World/WatchdogEvictionTests.cs
+++ b/HermesProxy.Tests/World/WatchdogEvictionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using HermesProxy;
 using HermesProxy.Enums;
 using HermesProxy.World;
@@ -173,24 +174,26 @@ public class WatchdogEvictionTests
     }
 
     [Fact]
-    public void DrainPendingCastsForDestroyedTarget_Match_EvictsNotStartedOnly()
+    public void DrainPendingCastsForDestroyedTarget_Match_EvictsAllExceptStartedChannels()
     {
+        // Started NON-channeled casts (Frostbolt-style) are still evicted so the
+        // proxy keeps emitting instant BadTargets feedback on combat-on-dying-mob.
+        // Only started CHANNELS are kept for the server's real resolution.
         var session = NewSession();
-        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, Creature(1), hasStarted: true)); // started — kept
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, Creature(1), hasStarted: true)); // started, non-channeled — evicted
         session.PendingNormalCasts.Enqueue(MakeCastWithTarget(200, Creature(2)));                   // other target — kept
         session.PendingNormalCasts.Enqueue(MakeCastWithTarget(300, Creature(1)));                   // not started, matches — evicted
 
         session.DrainPendingCastsForDestroyedTarget(Creature(1),
             out var normal, out var pet);
 
-        // Only the not-yet-started cast aimed at the destroyed target is evicted.
-        Assert.Single(normal);
-        Assert.Equal(300u, normal[0].SpellId);
+        // Both casts aimed at the destroyed target are evicted; the started one
+        // because it's not a channel, the not-started one as before.
+        Assert.Equal(2, normal.Count);
+        Assert.Contains(normal, c => c.SpellId == 100);
+        Assert.Contains(normal, c => c.SpellId == 300);
         Assert.Empty(pet);
-        // The started cast aimed at the destroyed target stays queued so the
-        // legacy server's real SPELL_GO / SPELL_FAILURE can resolve it.
-        Assert.Equal(2, session.PendingNormalCasts.Count);
-        Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 100);
+        Assert.Single(session.PendingNormalCasts);
         Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 200);
     }
 
@@ -228,25 +231,44 @@ public class WatchdogEvictionTests
     }
 
     [Fact]
-    public void DrainPendingCastsForDestroyedTarget_StartedCast_KeptForServerResolution()
+    public void DrainPendingCastsForDestroyedTarget_StartedChannel_KeptForServerResolution()
     {
         // Regression guard (gather "node does nothing after the first tick"):
-        // a cast the legacy server has already started must NOT be evicted when
-        // its target is destroyed. The server owns it and sends a real
-        // SMSG_SPELL_GO / SMSG_SPELL_FAILURE; HandleSpellFailure arms the
-        // watchdog as the leak backstop. Evicting it here raced that resolution
-        // and emitted SMSG_CAST_FAILED, which cannot tear down an already-started
-        // cast/channel bar — stranding the modern client until it moved away.
-        var session = NewSession();
-        var dyingMob = Creature(1);
-        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, dyingMob, hasStarted: true));
+        // a CHANNELED cast the legacy server has already started must NOT be
+        // evicted when its target is destroyed. The server owns it and sends a
+        // real SMSG_SPELL_FAILURE; HandleSpellFailure arms the watchdog as the
+        // leak backstop. Evicting it here raced that resolution and emitted
+        // SMSG_CAST_FAILED, which cannot tear down an already-started channel
+        // bar — stranding the modern client until it moved away.
+        //
+        // Non-channeled started casts (e.g. Frostbolt) DO still get evicted —
+        // that's covered by DrainPendingCastsForDestroyedTarget_Match_*. The
+        // narrowing here matches Jim's review feedback: scope the kept-cast
+        // exemption to channels specifically so combat instant-feedback isn't
+        // regressed.
+        var prevChanneled = GameData.ChanneledSpells;
+        try
+        {
+            const uint channeledSpellId = 2575; // Mining (vanilla 1.12, real channel)
+            GameData.ChanneledSpells = new System.Collections.Generic.HashSet<uint> { channeledSpellId }
+                .ToFrozenSet();
+            Assert.True(GameData.IsChanneledSpell(channeledSpellId));
 
-        session.DrainPendingCastsForDestroyedTarget(dyingMob, out var normal, out var pet);
+            var session = NewSession();
+            var dyingMob = Creature(1);
+            session.PendingNormalCasts.Enqueue(MakeCastWithTarget(channeledSpellId, dyingMob, hasStarted: true));
 
-        Assert.Empty(normal);
-        Assert.Empty(pet);
-        Assert.Single(session.PendingNormalCasts);
-        Assert.True(session.HasStartedNormalCast());
+            session.DrainPendingCastsForDestroyedTarget(dyingMob, out var normal, out var pet);
+
+            Assert.Empty(normal);
+            Assert.Empty(pet);
+            Assert.Single(session.PendingNormalCasts);
+            Assert.True(session.HasStartedNormalCast());
+        }
+        finally
+        {
+            GameData.ChanneledSpells = prevChanneled;
+        }
     }
 
     // ---- Movement preemption tests ----

--- a/HermesProxy.Tests/World/WatchdogEvictionTests.cs
+++ b/HermesProxy.Tests/World/WatchdogEvictionTests.cs
@@ -173,21 +173,25 @@ public class WatchdogEvictionTests
     }
 
     [Fact]
-    public void DrainPendingCastsForDestroyedTarget_Match_EvictsOnly()
+    public void DrainPendingCastsForDestroyedTarget_Match_EvictsNotStartedOnly()
     {
         var session = NewSession();
-        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, Creature(1), hasStarted: true));
-        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(200, Creature(2)));
-        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(300, Creature(1))); // also targets evicted unit
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, Creature(1), hasStarted: true)); // started — kept
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(200, Creature(2)));                   // other target — kept
+        session.PendingNormalCasts.Enqueue(MakeCastWithTarget(300, Creature(1)));                   // not started, matches — evicted
 
         session.DrainPendingCastsForDestroyedTarget(Creature(1),
             out var normal, out var pet);
 
-        Assert.Equal(2, normal.Count);
-        Assert.Contains(normal, c => c.SpellId == 100);
-        Assert.Contains(normal, c => c.SpellId == 300);
-        Assert.Single(session.PendingNormalCasts);
+        // Only the not-yet-started cast aimed at the destroyed target is evicted.
+        Assert.Single(normal);
+        Assert.Equal(300u, normal[0].SpellId);
         Assert.Empty(pet);
+        // The started cast aimed at the destroyed target stays queued so the
+        // legacy server's real SPELL_GO / SPELL_FAILURE can resolve it.
+        Assert.Equal(2, session.PendingNormalCasts.Count);
+        Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 100);
+        Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 200);
     }
 
     [Fact]
@@ -224,21 +228,25 @@ public class WatchdogEvictionTests
     }
 
     [Fact]
-    public void DrainPendingCastsForDestroyedTarget_HasStartedNormalCast_FalseAfterEviction()
+    public void DrainPendingCastsForDestroyedTarget_StartedCast_KeptForServerResolution()
     {
-        // The end-to-end symptom: cast-time spell on a target, target dies, server
-        // sends only SMSG_SPELL_FAILURE (no trailing CAST_FAILED on Kronos). Without
-        // the destroy hook the entry leaks. With the hook, SMSG_DESTROY_OBJECT for
-        // the target evicts it immediately and HasStartedNormalCast returns false.
+        // Regression guard (gather "node does nothing after the first tick"):
+        // a cast the legacy server has already started must NOT be evicted when
+        // its target is destroyed. The server owns it and sends a real
+        // SMSG_SPELL_GO / SMSG_SPELL_FAILURE; HandleSpellFailure arms the
+        // watchdog as the leak backstop. Evicting it here raced that resolution
+        // and emitted SMSG_CAST_FAILED, which cannot tear down an already-started
+        // cast/channel bar — stranding the modern client until it moved away.
         var session = NewSession();
         var dyingMob = Creature(1);
         session.PendingNormalCasts.Enqueue(MakeCastWithTarget(100, dyingMob, hasStarted: true));
 
+        session.DrainPendingCastsForDestroyedTarget(dyingMob, out var normal, out var pet);
+
+        Assert.Empty(normal);
+        Assert.Empty(pet);
+        Assert.Single(session.PendingNormalCasts);
         Assert.True(session.HasStartedNormalCast());
-
-        session.DrainPendingCastsForDestroyedTarget(dyingMob, out var _, out var _);
-
-        Assert.False(session.HasStartedNormalCast());
     }
 
     // ---- Movement preemption tests ----

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1261,22 +1261,24 @@ public sealed class GameSessionData
 
     /// <summary>
     /// JimsProxy (PR #161 follow-up — destroy-hook fast path): walks pending
-    /// queues and dequeues any NOT-YET-STARTED cast whose TargetGuid matches
-    /// the destroyed unit. Returns evicted entries for the caller to emit
-    /// synthetic CastFailed packets with a more accurate reason (BadTargets)
-    /// than the watchdog's DontReport, since we know exactly why the cast
-    /// can't proceed: the target was destroyed.
+    /// queues and dequeues any cast whose TargetGuid matches the destroyed
+    /// unit, except started channels (see below). Returns evicted entries
+    /// for the caller to emit synthetic CastFailed packets with a more
+    /// accurate reason (BadTargets) than the watchdog's DontReport, since
+    /// we know exactly why the cast can't proceed: the target was destroyed.
     ///
-    /// Casts the legacy server has already started (HasStarted) are deliberately
-    /// left in the queue. The server owns them and sends a real SMSG_SPELL_GO
-    /// or SMSG_SPELL_FAILURE that HandleSpellGo / HandleSpellFailure route to
-    /// the client; HandleSpellFailure also arms the watchdog as a leak backstop.
-    /// Evicting a started cast here is wrong twice over: it races that real
-    /// resolution, and the synthetic SMSG_CAST_FAILED cannot tear down a cast
-    /// the client has already shown a cast/channel bar for — only SMSG_SPELL_FAILURE
-    /// can. That stranded gathering: a queued second mining/herb tick would get
-    /// started, then evicted when the depleted node despawned, leaving a phantom
-    /// channel — the node "did nothing" until the player moved away and back.
+    /// Started CHANNELS specifically are left in the queue. The legacy server
+    /// owns the channel — it sends a real SMSG_SPELL_FAILURE that
+    /// HandleSpellFailure routes to the client and arms the watchdog as a
+    /// leak backstop. Evicting a started channel here is wrong twice over:
+    /// it races that real resolution, and synthetic SMSG_CAST_FAILED cannot
+    /// tear down a channel bar — only SMSG_SPELL_FAILURE can. That stranded
+    /// gathering: a queued second mining/herb tick would get started by the
+    /// server, then evicted when the depleted node despawned, leaving a
+    /// phantom channel — the node "did nothing" until the player moved away
+    /// and back. Started non-channeled casts (Frostbolt etc.) still get
+    /// evicted so the instant BadTargets feedback is preserved for normal
+    /// combat-on-dying-mob.
     /// </summary>
     public void DrainPendingCastsForDestroyedTarget(WowGuid128 destroyedGuid,
         out List<ClientCastRequest> normalEvicted,
@@ -1290,7 +1292,8 @@ public sealed class GameSessionData
         var keepNormal = new List<ClientCastRequest>();
         while (PendingNormalCasts.TryDequeue(out var cast))
         {
-            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            bool isStartedChannel = cast.HasStarted && GameData.IsChanneledSpell(cast.SpellId);
+            if (!isStartedChannel && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
                 normalEvicted.Add(cast);
             else
                 keepNormal.Add(cast);
@@ -1301,7 +1304,8 @@ public sealed class GameSessionData
         var keepPet = new List<ClientCastRequest>();
         while (PendingPetCasts.TryDequeue(out var cast))
         {
-            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            bool isStartedChannel = cast.HasStarted && GameData.IsChanneledSpell(cast.SpellId);
+            if (!isStartedChannel && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
                 petEvicted.Add(cast);
             else
                 keepPet.Add(cast);

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1261,11 +1261,22 @@ public sealed class GameSessionData
 
     /// <summary>
     /// JimsProxy (PR #161 follow-up — destroy-hook fast path): walks pending
-    /// queues and dequeues any cast whose TargetGuid matches the destroyed
-    /// unit. Returns evicted entries for the caller to emit synthetic
-    /// CastFailed packets with a more accurate reason (BadTargets) than the
-    /// watchdog's DontReport, since we know exactly why the cast can't
-    /// proceed: the target was destroyed.
+    /// queues and dequeues any NOT-YET-STARTED cast whose TargetGuid matches
+    /// the destroyed unit. Returns evicted entries for the caller to emit
+    /// synthetic CastFailed packets with a more accurate reason (BadTargets)
+    /// than the watchdog's DontReport, since we know exactly why the cast
+    /// can't proceed: the target was destroyed.
+    ///
+    /// Casts the legacy server has already started (HasStarted) are deliberately
+    /// left in the queue. The server owns them and sends a real SMSG_SPELL_GO
+    /// or SMSG_SPELL_FAILURE that HandleSpellGo / HandleSpellFailure route to
+    /// the client; HandleSpellFailure also arms the watchdog as a leak backstop.
+    /// Evicting a started cast here is wrong twice over: it races that real
+    /// resolution, and the synthetic SMSG_CAST_FAILED cannot tear down a cast
+    /// the client has already shown a cast/channel bar for — only SMSG_SPELL_FAILURE
+    /// can. That stranded gathering: a queued second mining/herb tick would get
+    /// started, then evicted when the depleted node despawned, leaving a phantom
+    /// channel — the node "did nothing" until the player moved away and back.
     /// </summary>
     public void DrainPendingCastsForDestroyedTarget(WowGuid128 destroyedGuid,
         out List<ClientCastRequest> normalEvicted,
@@ -1279,7 +1290,7 @@ public sealed class GameSessionData
         var keepNormal = new List<ClientCastRequest>();
         while (PendingNormalCasts.TryDequeue(out var cast))
         {
-            if (!cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
                 normalEvicted.Add(cast);
             else
                 keepNormal.Add(cast);
@@ -1290,7 +1301,7 @@ public sealed class GameSessionData
         var keepPet = new List<ClientCastRequest>();
         while (PendingPetCasts.TryDequeue(out var cast))
         {
-            if (!cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
                 petEvicted.Add(cast);
             else
                 keepPet.Add(cast);
@@ -2178,11 +2189,13 @@ public class GlobalSessionData
 
     /// <summary>
     /// JimsProxy (PR #161 follow-up — destroy-hook fast path): when
-    /// SMSG_DESTROY_OBJECT arrives for a unit, evict any pending casts aimed
-    /// at it. Reason=BadTargets because we know exactly why the cast can't
-    /// proceed (target was destroyed) and the modern client renders the
-    /// correct popup ("Invalid target"). Faster than the 2.5s watchdog —
-    /// fires within ~RTT of the destroy packet.
+    /// SMSG_DESTROY_OBJECT arrives for a unit, evict any not-yet-started
+    /// pending casts aimed at it. Reason=BadTargets because we know exactly
+    /// why the cast can't proceed (target was destroyed) and the modern
+    /// client renders the correct popup ("Invalid target"). Faster than the
+    /// 2.5s watchdog — fires within ~RTT of the destroy packet. Started casts
+    /// are left for the server's real SPELL_GO/SPELL_FAILURE (see
+    /// DrainPendingCastsForDestroyedTarget).
     /// </summary>
     public void EvictPendingCastsForDestroyedTarget(WowGuid128 destroyedGuid)
     {


### PR DESCRIPTION
## Problem

Mining/herb nodes "do nothing" after the first successful gather — the player has to run out of range and back before the node works again.

## Cause

Gathering a node casts the gather spell at the node GameObject. Clicking again while the first tick is still casting queues a second cast. When the first tick completes the depleted node despawns and the legacy server sends `SMSG_DESTROY_OBJECT` for it. The destroy-hook fast path (`DrainPendingCastsForDestroyedTarget`) then evicts the queued second cast — which the legacy server had **already started** (`SMSG_SPELL_START` sent, client showing a channel bar) — and sends the client `SMSG_CAST_FAILED`.

`SMSG_CAST_FAILED` cannot tear down an already-started cast/channel bar; only `SMSG_SPELL_FAILURE` can. The client is left with a phantom gather channel and refuses to gather again until `SMSG_DESTROY_OBJECT` for the node resets its state client-side — i.e. the player runs away and back.

The destroy-hook fast path exists to fast-fail casts that have **not started yet**, replacing the slow 2.5s watchdog with a precise `BadTargets` reason. It should never touch a cast the legacy server has already started: the server owns those and sends a real `SMSG_SPELL_GO` / `SMSG_SPELL_FAILURE` that `HandleSpellGo` / `HandleSpellFailure` route to the client, and `HandleSpellFailure` arms the watchdog as a leak backstop.

Verified against a capture: the server reliably sends `SMSG_SPELL_FAILURE` + `SMSG_CAST_FAILED` ~600–970ms after `SMSG_SPELL_START` for the interrupted gather; the old eviction at ~+50ms raced and discarded the cast so that real resolution matched nothing.

## Fix

`DrainPendingCastsForDestroyedTarget` now evicts only not-yet-started casts (normal and pet queues). Started casts stay queued for the server's authoritative resolution.

## Testing

- `dotnet test` — 502/502 pass; updated two destroy-hook tests that encoded the old behavior and added a regression guard.
