### PR TITLE
Fix WSG disconnect: drop CMSG_MOVE_CHANGE_TRANSPORT on legacy servers

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -89,6 +89,22 @@ public partial class WorldSocket
             GetSession().GameState.LastLoopingEmoteId = 0;
         }
 
+        // JimsProxy (wsg-change-transport-dc 2026-05-22): drop CMSG_MOVE_CHANGE_TRANSPORT.
+        // It's a TBC+ opcode with no legacy equivalent, so the opcode==0 fallback below
+        // would mis-forward it as MSG_MOVE_SET_FACING still carrying its OnTransport block —
+        // a "set facing" packet claiming a transport absent on the current map, which
+        // vmangos/Kronos kicks for (the ~8-min WSG "header" disconnect). Safe to drop:
+        // transport state rides in every ordinary movement packet; 1.12 has no such opcode.
+        if (movement.GetUniversalOpcode() == Opcode.CMSG_MOVE_CHANGE_TRANSPORT)
+        {
+            Framework.Logging.Log.Event("movement.change_transport.dropped", new
+            {
+                server_build = Framework.Settings.ServerBuild.ToString(),
+                on_transport = !movement.MoveInfo.TransportGuid.IsEmpty(),
+            });
+            return;
+        }
+
         string opcodeName = movement.GetUniversalOpcode().ToString();
         opcodeName = opcodeName.Replace("CMSG", "MSG");
         uint opcode = Opcodes.GetOpcodeValueForVersion(opcodeName, Framework.Settings.ServerBuild);


### PR DESCRIPTION
## Problem

A tester repeatedly disconnects ~8 minutes into Warsong Gulch. The proxy logs `session.ondisconnect.suppressed` with `disconnect_reason: "header"` — the legacy server (Kronos V / Twinstar, vmangos 1.12) cleanly closes the world socket. RTT was a stable 47 ms right up to the close, so it is a deliberate server-side kick, not a network blip.

## Root cause

`CMSG_MOVE_CHANGE_TRANSPORT` is a TBC+ opcode. `HandlePlayerMove` registers it among the movement opcodes and resolves the legacy opcode by replacing `CMSG`→`MSG` and looking it up — but `MSG_MOVE_CHANGE_TRANSPORT` exists in no legacy enum (`V1_12_1_5875`, `V2_4_3_8606`, `V3_3_5_12340` define only the `CMSG_` form). The lookup returns 0 and the `opcode == 0` fallback re-labels the packet `MSG_MOVE_SET_FACING`.

The modern body still carries an `OnTransport` block (these packets are ~24 bytes larger than a plain facing update), so the legacy server receives a "set facing" packet asserting the player is on a transport. Inside WSG — entered straight off a zeppelin — that transport does not exist on the BG map. vmangos/Kronos treats the sustained fake-transport movement as invalid input and issues a delayed socket close.

Bundle `jimsproxy-20260522-071453`: 6× `CMSG_MOVE_CHANGE_TRANSPORT` during the WSG match (0 in the preceding 60 min of on-foot play; the 3 earlier ones in the session were legit boat/zeppelin rides), the last one ~8s before the kick.

Other suspects were ruled out from the same bundle: the keepalive ping is a clean 1/30s (no m_OverSpeedPings), `SMSG_WARDEN_DATA` is never answered, and the PR #259 `CMSG_PVP_LOG_DATA` throttle is live and holding well under threshold.

## Fix

Drop `CMSG_MOVE_CHANGE_TRANSPORT` in `HandlePlayerMove` — never forward it. A dedicated change-transport packet is redundant: transport state rides inside every ordinary movement packet's `MovementInfo`, so the next heartbeat conveys it. A native 1.12 client has no `CHANGE_TRANSPORT` opcode at all, so this is exact parity. Emits a `movement.change_transport.dropped` diagnostic.

Legit transport rides (boats / zeppelins / elevators) are unaffected — the surrounding regular movement packets still carry the transport state.

## Risk / testing

- **Beta-first** — touches a packet handler.
- Build clean; 452 tests pass.
- Blast radius is one opcode: the guard is `if (opcode == CMSG_MOVE_CHANGE_TRANSPORT)`; the other 30 movement opcodes sharing `HandlePlayerMove` are byte-identical.
- **In-game repro:** enter WSG straight off a zeppelin/boat and play a full match. Before this change the session DCs with a "header" disconnect mid-match; after, `movement.change_transport.dropped` events appear in the bundle and the session holds.
