### PR TITLE
Fix: respond to CMSG_QUERY_REALM_NAME (trailing dash in player names)

### DIFF
--- a/HermesProxy/World/Server/Packets/AuthenticationPackets.cs
+++ b/HermesProxy/World/Server/Packets/AuthenticationPackets.cs
@@ -492,7 +492,7 @@ public class AuthWaitInfo
     public bool HasFCM; // true if the account has a forced character migration pending. @todo implement
 }
 
-struct VirtualRealmNameInfo
+public struct VirtualRealmNameInfo
 {
     public VirtualRealmNameInfo(bool isHomeRealm, bool isInternalRealm, string realmNameActual, string realmNameNormalized)
     {
@@ -537,4 +537,21 @@ struct VirtualRealmInfo
 
     public uint RealmAddress;             // the virtual address of this realm, constructed as RealmHandle::Region << 24 | RealmHandle::Battlegroup << 16 | RealmHandle::Index
     public VirtualRealmNameInfo RealmNameInfo;
+}
+
+public class RealmQueryResponse : ServerPacket
+{
+    public RealmQueryResponse() : base(Opcode.SMSG_REALM_QUERY_RESPONSE) { }
+
+    public override void Write()
+    {
+        _worldPacket.WriteUInt32(VirtualRealmAddress);
+        _worldPacket.WriteUInt8(LookupState);
+        if (LookupState == 0)
+            NameInfo.Write(_worldPacket);
+    }
+
+    public uint VirtualRealmAddress;
+    public byte LookupState;
+    public VirtualRealmNameInfo NameInfo;
 }

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -281,7 +281,8 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                                 opcode == Opcode.CMSG_ENABLE_NAGLE ||
                                 opcode == Opcode.CMSG_CONNECT_TO_FAILED ||
                                 opcode == Opcode.CMSG_ENTER_ENCRYPTED_MODE_ACK ||
-                                opcode == Opcode.CMSG_SERVER_TIME_OFFSET_REQUEST;
+                                opcode == Opcode.CMSG_SERVER_TIME_OFFSET_REQUEST ||
+                                opcode == Opcode.CMSG_QUERY_REALM_NAME;
         Log.Event("packet.in", new
         {
             direction = "c2s",
@@ -362,6 +363,9 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 break;
             case Opcode.CMSG_SERVER_TIME_OFFSET_REQUEST:
                 SendServerTimeOffset();
+                break;
+            case Opcode.CMSG_QUERY_REALM_NAME:
+                HandleQueryRealmName(packet);
                 break;
             default:
                 HandlePacket(packet);
@@ -1265,6 +1269,30 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
     {
         ServerTimeOffset response = new();
         response.Time = Time.UnixTime;
+        SendPacket(response);
+    }
+
+    void HandleQueryRealmName(WorldPacket packet)
+    {
+        uint realmAddress = packet.ReadUInt32();
+        var realm = GetSession().RealmManager.GetRealm(new Framework.Realm.RealmId(realmAddress));
+
+        RealmQueryResponse response = new();
+        response.VirtualRealmAddress = realmAddress;
+        if (realm != null)
+        {
+            response.LookupState = 0; // success
+            response.NameInfo = new VirtualRealmNameInfo(
+                realmAddress == GetSession().RealmId.GetAddress(),
+                false,
+                realm.Name,
+                realm.NormalizedName);
+        }
+        else
+        {
+            response.LookupState = 1; // failure
+            response.NameInfo = new VirtualRealmNameInfo(false, false, "", "");
+        }
         SendPacket(response);
     }
 


### PR DESCRIPTION
## Summary

- The 1.14 client sends `CMSG_QUERY_REALM_NAME` to resolve a VirtualRealmAddress into a realm name for player link formatting (whisper targets, mail recipients, AH seller names)
- The proxy had no handler — the query went unanswered, client resolved empty realm name → "Name-" with trailing dash
- On base HermesProxy (ashenwow) this affected every name. Our fork partially fixed it by keeping more names cached from the auth response, but any name resolved through a path triggering this query still showed the dash
- Implement `HandleQueryRealmName`: responds with `SMSG_REALM_QUERY_RESPONSE` carrying the realm name and `IsLocal=true` so the client strips the suffix entirely

## Test plan

- [ ] Right-click a player name in chat → Whisper — should NOT have trailing "-"
- [ ] Reply to mail — recipient should NOT have trailing "-"
- [ ] Check AH seller names — should NOT show "(*)"
- [ ] `/w Playername message` — should work without the dash
- [ ] Verify the "No handler for opcode CMSG_QUERY_REALM_NAME" warning is gone from logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)