### PR TITLE
Fix swim animation for NPCs (Rotgrip, Desolace naga)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -527,6 +527,13 @@ public sealed class GameSessionData
     // packets for it get the hover override regardless of HOVERHEIGHT.
     public HashSet<WowGuid128> KnownHoveringMobs = [];
 
+    // MIRASU (swim-mob basketball-bounce 2026-05-23): mobs we've observed with
+    // MovementFlag.Swimming set (Rotgrip in Maraudon, naga in Desolace, etc.).
+    // Modern 1.14 client expects UNIT_BYTES_1.AnimTier = Swim and spline flags
+    // without SmoothGroundPath for these — vanilla doesn't carry AnimTier so we
+    // synthesize it. Same shape as KnownHoveringMobs above.
+    public HashSet<WowGuid128> KnownSwimmingMobs = [];
+
     // JimsProxy (Tallstrider-Fix): per-GUID last-known facing orientation, populated from
     // any MovementInfo we observe (spawn, heartbeat, ObjectUpdate movement block). Used by
     // MovementHandler.HandleMonsterMove to compare the creature's current facing against

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -636,7 +636,7 @@ public partial class WorldClient
                 // and basketball-bounces between flight legs.
                 if (IsHoveringMob(guid))
                 {
-                    moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierSwim | SplineFlagModern.AnimTierHover;
+                    moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierHover;
                     Framework.Logging.Log.Event("hover.spline_stop_override", new
                     {
                         guid = guid.ToString(),
@@ -709,7 +709,7 @@ public partial class WorldClient
             if (IsHoveringMob(guid))
             {
                 moveSpline.SplineFlags &= ~(SplineFlagModern.Unknown5 | SplineFlagModern.Falling | SplineFlagModern.FallingSlow | SplineFlagModern.SmoothGroundPath | SplineFlagModern.CatmullRom);
-                moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierSwim | SplineFlagModern.AnimTierHover;
+                moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierHover;
                 Framework.Logging.Log.Event("hover.spline_override", new
                 {
                     guid = guid.ToString(),
@@ -905,7 +905,7 @@ public partial class WorldClient
 
             // Spline flags + catmull-rom endpoint apply to every taxi spline (first leg
             // and follow-ons alike) so the client renders continuous flight movement.
-            moveSpline.SplineFlags = SplineFlagModern.Flying | SplineFlagModern.AnimTierSwim |
+            moveSpline.SplineFlags = SplineFlagModern.Flying |
                                      SplineFlagModern.CatmullRom |
                                      SplineFlagModern.CanSwim |
                                      SplineFlagModern.UncompressedPath |

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -20,6 +20,13 @@ public partial class WorldClient
         return GetSession().GameState.GetLegacyFieldValueFloat(guid, UnitField.UNIT_FIELD_HOVERHEIGHT) > 0.0f;
     }
 
+    // MIRASU (swim-mob basketball-bounce 2026-05-23): true if we've seen this mob
+    // with MovementFlag.Swimming. Seeded in UpdateHandler.ReadMovementUpdateBlock.
+    private bool IsSwimmingMob(WowGuid128 guid)
+    {
+        return GetSession().GameState.KnownSwimmingMobs.Contains(guid);
+    }
+
     // Strips Falling/FallingFar and forces DisableGravity on a hovering mob's movement
     // flags. Call BEFORE casting WotLK flags to Modern. Vanilla servers don't have
     // AnimTier/HoverHeight in their movement protocol, so hovering mobs bleed Falling
@@ -31,6 +38,38 @@ public partial class WorldClient
             return false;
 
         moveInfo.Flags &= ~(uint)(MovementFlagWotLK.Falling | MovementFlagWotLK.FallingFar);
+        moveInfo.Flags |= (uint)MovementFlagWotLK.DisableGravity;
+        moveInfo.FallTime = 0;
+        moveInfo.JumpVerticalSpeed = 0.0f;
+        moveInfo.JumpHorizontalSpeed = 0.0f;
+        return true;
+    }
+
+    // MIRASU (swim-mob basketball-bounce 2026-05-23): the flag bit positions differ
+    // between WotLK (the proxy's internal storage format after Vanilla→WotLK cast)
+    // and Modern. Specifically:
+    //   WotLK.Swimming      = 0x200000  (bit 21)
+    //   Modern.Swimming     = 0x100000  (bit 20)
+    //   Modern bit 21       = Ascending
+    // The proxy writes info.Flags raw to the modern wire (no name-based conversion),
+    // so a swimming NPC ends up with the modern Ascending flag set — the 1.14 client
+    // then renders it as continuously ascending = visible up/down bouncing on the
+    // water surface with walk anim. This mirrors the workaround the hover override
+    // uses: explicitly strip the wrong bits and set the right modern ones.
+    // Also strip Falling/FallingFar so the client doesn't try to ground-snap.
+    private bool ApplySwimOverrideIfNeeded(WowGuid128 guid, MovementInfo moveInfo)
+    {
+        if (!IsSwimmingMob(guid))
+            return false;
+
+        // Clear WotLK's Swimming bit position (which would show up as Ascending on modern)
+        // and clear falling flags. Set modern Swimming bit (0x100000) directly.
+        moveInfo.Flags &= ~(uint)(MovementFlagWotLK.Swimming | MovementFlagWotLK.Falling | MovementFlagWotLK.FallingFar);
+        moveInfo.Flags |= (uint)MovementFlagModern.Swimming;
+        // MIRASU (swim moving anim 2026-05-23): DisableGravity is the anti-gravity bit
+        // that doesn't force a flight anim (unlike SplineFlagModern.Flying). Pairs with
+        // UnitFlags.CanSwim on UNIT_FIELD_FLAGS so the client renders swim moving anim
+        // instead of bouncing the unit on the water surface.
         moveInfo.Flags |= (uint)MovementFlagWotLK.DisableGravity;
         moveInfo.FallTime = 0;
         moveInfo.JumpVerticalSpeed = 0.0f;
@@ -597,8 +636,21 @@ public partial class WorldClient
                 // and basketball-bounces between flight legs.
                 if (IsHoveringMob(guid))
                 {
-                    moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierHover;
+                    moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierSwim | SplineFlagModern.AnimTierHover;
                     Framework.Logging.Log.Event("hover.spline_stop_override", new
+                    {
+                        guid = guid.ToString(),
+                    });
+                }
+                // MIRASU (swim-mob basketball-bounce 2026-05-23): same pattern as hover
+                // but for swimming mobs. Without AnimTierSwim on stop, the modern client
+                // reverts to ground anim and ground-snaps Z, causing big up-down hops on
+                // swimming bosses (Rotgrip) and patrolling water mobs.
+                else if (IsSwimmingMob(guid))
+                {
+                    moveSpline.SplineFlags &= ~SplineFlagModern.Flying;
+                    moveSpline.SplineFlags |= SplineFlagModern.AnimTierSwim | SplineFlagModern.CanSwim;
+                    Framework.Logging.Log.Event("swim.spline_stop_override", new
                     {
                         guid = guid.ToString(),
                     });
@@ -657,8 +709,29 @@ public partial class WorldClient
             if (IsHoveringMob(guid))
             {
                 moveSpline.SplineFlags &= ~(SplineFlagModern.Unknown5 | SplineFlagModern.Falling | SplineFlagModern.FallingSlow | SplineFlagModern.SmoothGroundPath | SplineFlagModern.CatmullRom);
-                moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierHover;
+                moveSpline.SplineFlags |= SplineFlagModern.Flying | SplineFlagModern.AnimTierSwim | SplineFlagModern.AnimTierHover;
                 Framework.Logging.Log.Event("hover.spline_override", new
+                {
+                    guid = guid.ToString(),
+                    spline_type = moveSpline.SplineType.ToString(),
+                });
+            }
+            // MIRASU (swim-mob basketball-bounce 2026-05-23): same shape as hover override
+            // but for swimming mobs. Strip ground-snapping / falling flags so the modern
+            // client doesn't yank the mob's Z to ground level each spline tick. Add Flying
+            // (means "moves freely in 3D, don't ground-follow") + AnimTierSwim. Without
+            // Flying, the client still ground-snaps and warps between waypoints because
+            // the smooth-3D path mode isn't enabled.
+            else if (IsSwimmingMob(guid))
+            {
+                moveSpline.SplineFlags &= ~(SplineFlagModern.Unknown5 | SplineFlagModern.Falling | SplineFlagModern.FallingSlow | SplineFlagModern.SmoothGroundPath | SplineFlagModern.Flying);
+                // MIRASU (swim moving anim 2026-05-23): Flying spline flag forced the
+                // client to play flight glide. With UnitFlags.CanSwim now on
+                // UNIT_FIELD_FLAGS (synthesized in UpdateHandler), the client treats
+                // the unit as a swimmer for both physics and anim selection — Flying
+                // is no longer needed and was actually preventing the swim moving anim.
+                moveSpline.SplineFlags |= SplineFlagModern.AnimTierSwim | SplineFlagModern.CanSwim;
+                Framework.Logging.Log.Event("swim.spline_override", new
                 {
                     guid = guid.ToString(),
                     spline_type = moveSpline.SplineType.ToString(),
@@ -832,7 +905,7 @@ public partial class WorldClient
 
             // Spline flags + catmull-rom endpoint apply to every taxi spline (first leg
             // and follow-ons alike) so the client renders continuous flight movement.
-            moveSpline.SplineFlags = SplineFlagModern.Flying |
+            moveSpline.SplineFlags = SplineFlagModern.Flying | SplineFlagModern.AnimTierSwim |
                                      SplineFlagModern.CatmullRom |
                                      SplineFlagModern.CanSwim |
                                      SplineFlagModern.UncompressedPath |

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1066,7 +1066,38 @@ public partial class WorldClient
                 }
             }
 
+            // MIRASU (swim-mob basketball-bounce 2026-05-23): vanilla NPCs in water
+            // carry MovementFlagVanilla.Swimming on their MovementInfo. Modern 1.14 client
+            // wants UNIT_BYTES_1.AnimTier=Swim, spline flags without SmoothGroundPath, and
+            // the modern Swimming bit (0x100000) instead of WotLK's Swimming bit (0x200000)
+            // — otherwise it ground-snaps to the water surface, plays walk anim, and
+            // basketball-bounces (Rotgrip in Maraudon, naga in Desolace). Seed the swim
+            // registry from this flag — same shape as the hover seed above. The actual
+            // flag-bit fixup is in ApplySwimOverrideIfNeeded called below. The detection
+            // checks the WotLK-format flag (post-CastFlags) since info.Flags has already
+            // been normalized to WotLK by ReadMovementInfoLegacy.
+            // MIRASU (swim debug 2026-05-23): restrict to creatures only so that
+            // other players, pets, and tamed mobs aren't permanently flagged as
+            // swimming after a single observation. Hunter pets and other players
+            // legitimately transition between water and land — applying persistent
+            // swim overrides to them would make them visually float on land.
+            // Stationary aquatic creatures (Rotgrip, naga) remain in water so the
+            // one-shot Add is still correct for them.
+            if (((MovementFlagWotLK)moveInfo.Flags).HasAnyFlag(MovementFlagWotLK.Swimming) &&
+                guid.GetHighType() == HighGuidType.Creature)
+            {
+                if (GetSession().GameState.KnownSwimmingMobs.Add(guid))
+                {
+                    Framework.Logging.Log.Event("swim.detect_swimming_flag", new
+                    {
+                        guid = guid.ToString(),
+                        z = moveInfo.Position.Z,
+                    });
+                }
+            }
+
             ApplyHoverOverrideIfNeeded(guid, moveInfo);
+            ApplySwimOverrideIfNeeded(guid, moveInfo);
 
             // JimsProxy (zep-relog-diag 2026-05-15): emit a diagnostic on the
             // player's own UpdateObject only when transport state transitions
@@ -2291,6 +2322,18 @@ public partial class WorldClient
                     updateData.UnitData.Flags = updates[UNIT_FIELD_FLAGS].UInt32Value;
                 }
 
+                // MIRASU (swim animation 2026-05-23): vmangos source confirms
+                // UNIT_FLAG_USE_SWIM_ANIMATION (0x00008000, = UnitFlags.CanSwim)
+                // is THE bit that tells the client to play swim anim — the comment
+                // reads "Without it units walk on the sea floor instead of swimming."
+                // Twinstar / some vanilla servers don't set CREATURE_STATIC_FLAG_CAN_SWIM
+                // on aquatic creatures (Rotgrip, Desolace naga), so this bit never
+                // reaches the modern client and the mob ground-walks underwater.
+                // When we've registered the mob as swimming via MovementFlag.Swimming,
+                // force the bit on so the client picks the swim animation.
+                if (Session.GameState.KnownSwimmingMobs.Contains(guid))
+                    updateData.UnitData.Flags |= (uint)UnitFlags.CanSwim;
+
                 // Here because of this bullshit in cmangos:
                 // https://github.com/cmangos/mangos-tbc/blob/fd093b33071b546545cc5973608304bccc5a041b/src/game/Entities/Object.cpp#L544
                 if (updateData.UnitData.Flags.HasAnyFlag(UnitFlags.ServerControlled) && isCreate &&
@@ -2474,6 +2517,14 @@ public partial class WorldClient
                     updateData.UnitData.AnimTier = 2;
                     if (hoverHeight > 0.0f)
                         updateData.UnitData.HoverHeight = hoverHeight;
+                }
+                // MIRASU (swim-mob basketball-bounce 2026-05-23): mirror the hover synth —
+                // when we've registered this mob as swimming (MovementFlag.Swimming on
+                // its MovementInfo), set AnimTier=Swim so the modern client plays the
+                // swim animation and stops ground-snapping the unit.
+                else if (Session.GameState.KnownSwimmingMobs.Contains(guid))
+                {
+                    updateData.UnitData.AnimTier = 1; // AnimTier.Swim
                 }
             }
             int UNIT_FIELD_PETNUMBER = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_PETNUMBER);


### PR DESCRIPTION
## Summary

Aquatic creatures (Rotgrip in Maraudon, Desolace naga, etc.) ground-walked and basketball-bounced on the water surface instead of swimming on Twinstar.

Three signals must all align for the modern client to render the swim moving animation. Vanilla servers send none of them for creatures missing `CREATURE_STATIC_FLAG_CAN_SWIM` in their `creature_template`. The proxy now infers them from observed `MovementFlag.Swimming`:

1. **`UNIT_FIELD_FLAGS` gets `UnitFlags.CanSwim` (0x8000) OR'd in.** This is `UNIT_FLAG_USE_SWIM_ANIMATION` per vmangos `UnitDefines.h:560` — comment reads *"Without it units walk on the sea floor instead of swimming."*
2. **Movement info gets `MovementFlagWotLK.DisableGravity`.** Provides anti-gravity without the fly-glide that `SplineFlagModern.Flying` would force.
3. **Monster-move splines get `SplineFlagModern.AnimTierSwim | CanSwim`.** `Flying` is stripped — it overrode the swim anim selection.

Without (1) the client picks walk anim. Without (2) the client ground-snaps the unit to the liquid surface between waypoints (the basketball bounce). Without (3) the spline plays the glide animation.

Detection is restricted to `HighGuidType.Creature` so other players, hunter pets, and tamed mobs aren't permanently flagged as swimming after a single observation (they legitimately transition water↔land).

## Test plan

- [x] Rotgrip in Maraudon — swims with leg motion, no bounce, smooth Z
- [x] Desolace naga — swims correctly while patrolling
- [x] Other-player swimming → walking transitions render normally (excluded from registry)
- [x] No regression on existing hover-mob fix (separate code path, same `DisableGravity` pattern)
- [x] Build clean, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)