### PR TITLE
Fix Kronos ByteBufferException on ticket, AH list, and AUTH_SESSION CMSGs

### DIFF
--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -804,6 +804,17 @@ public partial class WorldClient
         byte[] addonBytes = AuthSessionAddons.BuildAddonAuthSection(flagBytes);
         packet.WriteBytes(addonBytes);
 
+        // MIRASU (Kronos parser 2026-05-23): Kronos's _HandleAuthSession reads
+        // one byte past the addon section (locale or similar trailing field).
+        // Without it, every login produces a server-side ByteBufferException
+        // "pos N size N value with size: 1" — non-fatal (auth still succeeds)
+        // but spams the server log. vmangos's parser stops at the digest read
+        // and never touches the addon section in WorldSocket, so the extra
+        // trailing byte is unread leftover and ignored. Vanilla-path only;
+        // TBC+ already writes its own trailing fields.
+        if (Settings.ServerBuild < ClientVersionBuild.V2_0_1_6180)
+            packet.WriteUInt8(0);
+
         Log.Event("auth.addon_section.sent", new
         {
             flags_uint32 = BitConverter.ToUInt32(flagBytes, 0),

--- a/HermesProxy/World/Server/PacketHandlers/AuctionHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/AuctionHandler.cs
@@ -227,6 +227,15 @@ public partial class WorldSocket
         packet.WriteInt32(auction.Quality);
         packet.WriteBool(auction.OnlyUsable);
 
+        // MIRASU (Kronos AH parser 2026-05-23): the 1.12.1 patch added a trailing
+        // uint8 `getAll` flag to CMSG_AUCTION_LIST_ITEMS. Some 1.12 forks (vmangos)
+        // never read it; Kronos's parser does, and threw a ByteBufferException at
+        // "pos N size N value with size: 1" on every query. Write 0 (= don't
+        // request getAll). Older 1.12 builds that don't read the byte leave it as
+        // unread trailing data in the recv buffer.
+        if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+            packet.WriteUInt8(0);
+
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
             packet.WriteBool(auction.ExactMatch);

--- a/HermesProxy/World/Server/PacketHandlers/SupportTicketHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SupportTicketHandler.cs
@@ -42,7 +42,15 @@ public partial class WorldSocket
             packet.WriteUInt32(complaint.Header.SelfPlayerMapId);
             packet.WriteVector3(complaint.Header.SelfPlayerPos);
             packet.WriteCString(ticketText);
-            packet.WriteCString(""); // Not used
+            // MIRASU (Kronos ticket parser 2026-05-23): Kronos's CMSG_GM_TICKET_CREATE
+            // expects a trailing uint32 after the ticket text (likely the
+            // "need_response_from_gm" flag that the TBC+ branch already writes).
+            // The proxy previously wrote an empty cstring here, which is 1 byte
+            // where Kronos wants 4 — the server logged a ByteBufferException on
+            // every ticket submit. vmangos's parser reads `reservedForFutureUse`
+            // as a cstring-until-null; the first zero byte of uint32(0) satisfies
+            // that terminator and the remaining 3 bytes are ignored.
+            packet.WriteUInt32(0);
         }
         else
         {


### PR DESCRIPTION
## Summary

Three CMSGs the proxy was writing slightly short of what Kronos's parsers expect. Each fix appends the trailing field Kronos reads but vmangos (and similar 1.12 forks) ignore. All 1.12-path only.

### CMSG_GM_TICKET_CREATE (opcode 517)
Kronos's parser reads `cstring(ticketText) + uint32(...)`. The proxy wrote `cstring(ticketText) + cstring(\"\")` — a single null byte where Kronos wants 4. Switched the trailing empty cstring to \`WriteUInt32(0)\` — equivalent to the \"no GM response needed\" flag the TBC+ branch in the same handler already writes. vmangos reads the first zero byte as the cstring terminator for \`reservedForFutureUse\`.

### CMSG_AUCTION_LIST_ITEMS (opcode 600)
1.12.1 added a trailing \`uint8 getAll\` flag. Some 1.12 forks (vmangos) never read it; Kronos's parser does. Now writing \`WriteUInt8(0)\` (= don't request getAll, matches modern client behavior).

### CMSG_AUTH_SESSION (opcode 493)
Kronos's \`_HandleAuthSession\` reads one byte past the addon section (parser snippet shared by the server dev shows the prefix-read but declares a \`ByteBuffer addonInfo\` whose final-byte read isn't visible to us — landing at \`pos N size N value with size: 1\`). Append \`WriteUInt8(0)\` after the addon section to satisfy that read. vmangos's WorldSocket parser stops at the digest read and never touches the addon section, so the trailing byte is unread leftover and ignored.

Auth still succeeded before this change (the exception is non-fatal), but it spammed the server log on every reconnect (~every 20 min per session).

## Test plan

- [x] Build clean, no warnings
- [ ] In-game on Kronos: file a ticket, run an AH search, log out and log back in. Verify no opcode 517 / 600 / 493 ByteBufferException in server log.
- [ ] In-game on vmangos / Twinstar PTR: same actions to confirm no regression (extra trailing bytes are unread by these forks' parsers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)