### PR TITLE
Fix: cast animation freeze after Cannibalize (suppress wrapper SPELL_START)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1320,6 +1320,43 @@ public partial class WorldClient
             return;
         }
 
+        // JimsProxy (cannibalize-animation-break): suppress SMSG_SPELL_START for
+        // spell 20577 (Cannibalize wrapper) cast by the local player/pet.
+        // Processing this packet — which carries SpellXSpellVisualID=0 because the
+        // 1.14.2 client's DBC has no SpellXSpellVisual entry for 20577 — corrupts
+        // the modern client's cast-animation dispatcher. Symptom: ALL subsequent
+        // cast-time spells skip the pre-cast build-up animation (cast bar fills,
+        // projectile fires, but the model never plays the casting pose), persists
+        // until /reload. Reproduced on PTR; bundle jimsproxy-20260522-211006.jsonl
+        // captures two repros (Undead rogue + Undead mage), both showing
+        // SPELL_START 20577 visual=0 immediately followed (~0ms) by SPELL_START
+        // 20578 visual=247577 (the real channel).
+        //
+        // 20577 is the action-bar wrapper; the legacy server fires it followed
+        // by SPELL_START 20578 (the real channeled effect, kneeling/eating
+        // visual). 20578 plays Cannibalize's actual animation, so dropping the
+        // wrapper SPELL_START loses nothing visible: SPELL_GO 20577 still
+        // forwards (drives the GCD synth), 20578's START still plays the
+        // kneeling visual, and CAST_FAILED routing is unaffected.
+        //
+        // Whitelist (not a broader "SpellXSpellVisualID==0" guard) because some
+        // 1.14 cast animations are baked into the model and triggered by
+        // SPELL_START regardless of SpellXSpellVisualID. A broad visual==0 guard
+        // would risk regressing Shadowmeld (743) and other racials whose
+        // visual-less SPELL_START currently drives built-in animations. If
+        // another wrapper-channel pair surfaces with the same symptom, add it
+        // here explicitly rather than widening the condition.
+        if (spell.Cast.SpellID == 20577 && (casterIsLocalPlayer || casterIsLocalPet))
+        {
+            Log.Event("spell.start.suppressed_cannibalize_wrapper", new
+            {
+                spell_id = spell.Cast.SpellID,
+                caster_is_player = casterIsLocalPlayer,
+                caster_is_pet = casterIsLocalPet,
+            });
+            return;
+        }
+
         SendPacketToClient(spell);
 
         // JimsProxy HealComm bridge: when local player begins a resurrection


### PR DESCRIPTION
## Summary

- Undead Cannibalize corrupts the modern client's cast-animation dispatcher; every subsequent cast-time spell skips its pre-cast build-up animation until `/reload`
- Root cause: the legacy server fires `SPELL_START 20577` (the action-bar wrapper) with `visual=0` immediately followed by `SPELL_START 20578` (the real channel) with `visual=247577`. The 1.14.2 client's DBC has no SpellXSpellVisual entry for 20577, so the wrapper packet's visual is 0, which wedges the dispatcher
- Fix: suppress the wrapper `SPELL_START 20577` for local-player/pet casts. The 20578 START still plays Cannibalize's kneeling visual; `SPELL_GO 20577` still drives the GCD synth; `CAST_FAILED` routing is unaffected

## Why a whitelist (20577 only) instead of `SpellXSpellVisualID == 0`

Some 1.14 cast animations are baked into the model and triggered by `SPELL_START` regardless of visual ID (per Mirasu's earlier Shadowmeld work). A broad `visual==0` guard would risk regressing Shadowmeld (743), Berserking (20554), Blood Fury (20572), Find Herbs (2383), Find Minerals (2580), etc. — all racials/professions whose visual-less SPELL_START currently drives built-in animations.

If another wrapper-channel pair surfaces with the same symptom, add it to the list explicitly rather than widening the guard.

## Evidence

- PTR log: `jimsproxy-20260522-211006.jsonl` captures two repros (Undead rogue → Stealth, Undead mage → Fireball). In both, `SPELL_START 20577 visual=0` precedes `SPELL_START 20578 visual=247577` by 0ms
- DBC verified via wago.tools (build 1.14.2.42597): `SpellXSpellVisual` table has 0 entries for 20577, 1 entry for 20578
- Audit confirms 20577 is the only player-castable instant wrapper-channel pair in the empirical log; First Aid bandages (the other DBC name-collision pair) are cast-time, not instant, and have valid visuals

## Test plan

- [ ] Undead character: cast Cannibalize on a corpse, channel for ~5s, interrupt by casting Frostbolt/Fireball — verify pre-cast build-up animation plays
- [ ] Cast a second cast-time spell after the first — verify animation still plays (i.e. dispatcher not wedged)
- [ ] Verify Cannibalize itself still plays the kneeling/eating animation (the 20578 channel)
- [ ] Sanity check Shadowmeld (NE), Berserking (Troll), Blood Fury (Orc) — these spells are unaffected by the change (whitelist scope) and should behave exactly as before
- [ ] GCD on Cannibalize still works (SPELL_GO 20577 → `gcd.begin` → cooldown synth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)