### PR TITLE
Fix Kronos CMSG_GM_TICKET_CREATE wire format (supersedes PR #301 ticket fix)

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/SupportTicketHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SupportTicketHandler.cs
@@ -38,19 +38,25 @@ public partial class WorldSocket
 
         if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
-            packet.WriteUInt8(2); // GMTICKET_BEHAVIOR_HARASSMENT
+            // MIRASU (Kronos ticket parser 2026-05-23 — REVISED): Kronos's
+            // CMSG_GM_TICKET_CREATE handler reads:
+            //   uint32 map; float x; float y; float z;
+            //   cstring ticketText;
+            //   uint32 unk1 (= 0);
+            //   uint32 unk2 (= 1);
+            //   uint32 unk3 (= 0);
+            // No leading category byte. Three trailing uint32s. The prior
+            // shape (uint8 category + cstring "" trailer) was the older
+            // mangos-zero layout; PR #301 corrected the 1-byte trailer to
+            // 4 bytes but the leading category byte still threw the offsets
+            // off by 1, and Kronos wants 3 trailing words not 1. This
+            // matches the parser snippet shared by Kronos directly.
             packet.WriteUInt32(complaint.Header.SelfPlayerMapId);
             packet.WriteVector3(complaint.Header.SelfPlayerPos);
             packet.WriteCString(ticketText);
-            // MIRASU (Kronos ticket parser 2026-05-23): Kronos's CMSG_GM_TICKET_CREATE
-            // expects a trailing uint32 after the ticket text (likely the
-            // "need_response_from_gm" flag that the TBC+ branch already writes).
-            // The proxy previously wrote an empty cstring here, which is 1 byte
-            // where Kronos wants 4 — the server logged a ByteBufferException on
-            // every ticket submit. vmangos's parser reads `reservedForFutureUse`
-            // as a cstring-until-null; the first zero byte of uint32(0) satisfies
-            // that terminator and the remaining 3 bytes are ignored.
-            packet.WriteUInt32(0);
+            packet.WriteUInt32(0); // unk1
+            packet.WriteUInt32(1); // unk2 (server-side comment says expected = 1)
+            packet.WriteUInt32(0); // unk3
         }
         else
         {


### PR DESCRIPTION
## Summary

The \`CMSG_GM_TICKET_CREATE\` shape from PR #301 was wrong. Kronos's parser actually reads:

\`\`\`cpp
uint32 map;
float x, y, z;
cstring ticketText;
uint32 unk1 (= 0);
uint32 unk2 (= 1);
uint32 unk3 (= 0);
\`\`\`

**No leading category byte. Three trailing uint32s.**

PR #301 kept the leading \`uint8(2)\` (older mangos-zero layout) and only added a single trailing \`uint32\`. That shifted every field after the type byte by 1 *and* left the parser 8 bytes short of EOF, so Kronos still threw \`ByteBufferException\` on every ticket submit.

This PR replaces the prior PR #301 ticket fix with the correct shape (confirmed against Kronos's server-side parser snippet). TBC+ branch unchanged.

### Note on PR #301
PR #301 also fixed AH list trailing \`getAll\` byte and AUTH_SESSION trailing byte — those are independent and remain correct. Only the ticket portion needs this replacement.

If Jim merges PR #301 first, this PR should still apply cleanly (it modifies the same lines further). If Jim merges this first, PR #301's ticket commit will conflict and should be dropped during merge.

## Test plan

- [x] Build clean, no warnings
- [x] In-game on Kronos: right-click player → Report Player → submit. Server log shows no opcode 517 ByteBufferException; ticket lands in Kronos's GM queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)