### PR TITLE
Fix: cast animation freeze after Cannibalize (suppress channel SPELL_START/GO)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1320,6 +1320,23 @@ public partial class WorldClient
             return;
         }
 
+        // Cannibalize channel (20578): the 1.12 server triggers this as a
+        // sub-spell of wrapper 20577. No CMSG_CAST_SPELL was sent for 20578,
+        // so the pending-cast queue has no entry — SPELL_START arrives at the
+        // client with an unmapped CastID (no SpellPrepare), corrupting the
+        // animation dispatcher for all subsequent cast-time spells.
+        // Channel functionality is preserved via MSG_CHANNEL_START +
+        // UNIT_CHANNEL_SPELL; SPELL_GO 20577 still drives the GCD synth.
+        if (spell.Cast.SpellID == 20578 && (casterIsLocalPlayer || casterIsLocalPet))
+        {
+            Log.Event("spell.start.suppressed_cannibalize_channel", new
+            {
+                spell_id = spell.Cast.SpellID,
+                spell_visual_id = spell.Cast.SpellXSpellVisualID,
+            });
+            return;
+        }
+
         SendPacketToClient(spell);
 
         // JimsProxy HealComm bridge: when local player begins a resurrection
@@ -1369,6 +1386,20 @@ public partial class WorldClient
             // contents so the next hit gives us bytes to fix the parser.
             LogSpellStartGoParseFailure(packet, e, isSpellGo: true);
             DrainOrphanedStartedNormalCastsOnParseFailure(isSpellGo: true);
+            return;
+        }
+
+        // Cannibalize channel (20578): matching the SPELL_START suppression.
+        // No pending-cast entry exists for 20578, so all dequeue/GCD paths
+        // below are no-ops. GCD is driven by SPELL_GO 20577 (the wrapper).
+        if (spell.Cast.SpellID == 20578 &&
+            (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit ||
+             GetSession().GameState.CurrentPetGuid == spell.Cast.CasterUnit))
+        {
+            Log.Event("spell.go.suppressed_cannibalize_channel", new
+            {
+                spell_id = spell.Cast.SpellID,
+            });
             return;
         }
 


### PR DESCRIPTION
## Summary

- Undead Cannibalize corrupts the 1.14.2 client's cast-animation dispatcher — every subsequent cast-time spell skips its pre-cast build-up animation until relog
- **Root cause:** the 1.12 server splits Cannibalize into wrapper 20577 (instant) and channel 20578 (real effect). The client only sends CMSG_CAST_SPELL for 20577, so the pending-cast queue has no entry for 20578. When SPELL_START 20578 arrives with caster=self, its CastID has no matching SpellPrepare, corrupting the animation dispatcher
- **Fix:** suppress SPELL_START and SPELL_GO for spell 20578 when caster is local player/pet. Channel still works via MSG_CHANNEL_START + UNIT_CHANNEL_SPELL + UNIT_FIELD_AURA. Wrapper 20577 flows normally (SpellPrepare, button state, GCD synth all intact)

## Why this differs from the reverted PR #302

PR #302 suppressed the **wrapper** (20577). That broke button state ("ability not ready", stuck lit) because the client needed 20577's SPELL_START to correlate with its SpellPrepare. It also didn't address the actual corruption vector — the unmapped CastID on 20578 was still reaching the client.

This PR suppresses the **channel sub-spell** (20578), which is the packet that carries the unmapped CastID. The wrapper 20577 still forwards normally with correct CastID from SpellPrepare.

## Evidence

The prior investigation tested 5 approaches — all failed because none addressed the CastID mismatch:

| # | Prior approach | Result | Why it failed |
|---|---|---|---|
| 1 | Suppress SPELL_START 20577 | Broken + button stuck | Client needs 20577 for SpellPrepare correlation |
| 3 | Override visual 0→247577 | Broken | Visual was never the cause; CastID was |
| 4 | Suppress 20577 + rewrite 20578→20577 | Broken | CastID still deterministic hash, not from SpellPrepare |

This fix targets the actual corruption vector: SPELL_START 20578 with unmapped CastID.

## Test plan

- [x] Undead character: cast Cannibalize, then cast Fireball — pre-cast build-up animation plays
- [x] Cast a second cast-time spell — animation still plays (dispatcher not wedged)
- [x] Cannibalize kneeling/eating animation plays (driven by MSG_CHANNEL_START + UNIT_CHANNEL_SPELL)
- [ ] GCD on Cannibalize works (SPELL_GO 20577 → cooldown synth)
- [ ] Sanity: Shadowmeld (NE), Berserking (Troll) unaffected (different spells entirely)
- [ ] Other players' Cannibalize animation visible (suppression is local-player only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)