### PR TITLE
Fix run speed stuck at base after fear or BG-end while mounted

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -103,6 +103,10 @@ public sealed class GameSessionData
     // by hardcoding 7.0f. Default true: a player who has never been CC'd is
     // always in control, so the natural login state is "has control already."
     public bool LastObservedHasControl = true;
+    // JimsProxy (speed-stuck-after-fear-while-mounted): cached for reassert; see memory.
+    public float LastKnownPlayerRunSpeed = 7.0f;
+    // JimsProxy (speed-stuck-after-bg-end-while-mounted): deferred reassert flag; see memory.
+    public bool PendingPostTeleportRunSpeedReassert;
     // JimsProxy (taxi-flight-robustness): when set, signals a pending taxi-dismount Task
     // scheduled to fire at TaxiDismountFiresAtTickMs. The CTS is cancelled+disposed on
     // (a) clean session disconnect, (b) early landing CMSG, (c) a fresh taxi spline

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -197,10 +197,11 @@ public partial class WorldClient
 
         if (isLocalPlayer && justRegainedControl)
         {
+            // JimsProxy (speed-stuck-after-fear-while-mounted): reassert cached speed, not 7.0f; see memory.
             MoveSetSpeed runFix = new MoveSetSpeed(Opcode.SMSG_MOVE_SET_RUN_SPEED);
             runFix.MoverGUID = control.Guid;
             runFix.MoveCounter = 0;
-            runFix.Speed = 7.0f; // Default WoW running speed
+            runFix.Speed = GetSession().GameState.LastKnownPlayerRunSpeed;
             SendPacketToClient(runFix);
         }
     }
@@ -468,6 +469,13 @@ public partial class WorldClient
 
         speed.Speed = packet.ReadFloat();
         SendPacketToClient(speed);
+
+        // JimsProxy (speed-stuck-after-fear-while-mounted): cache for CC-end reassert.
+        if (universalOpcode == Opcode.SMSG_MOVE_SET_RUN_SPEED &&
+            speed.MoverGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            GetSession().GameState.LastKnownPlayerRunSpeed = speed.Speed;
+        }
 
         // Convenience in vanilla to use SwimSpeed as FlySpeed
         if (universalOpcode is Opcode.SMSG_MOVE_SET_SWIM_SPEED

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1177,6 +1177,20 @@ public partial class WorldClient
 
             moveInfo.WalkSpeed = packet.ReadFloat();
             moveInfo.RunSpeed = packet.ReadFloat();
+            // JimsProxy (speed-stuck-{fear,bg-end}-while-mounted): seed cache + fire BG-end reassert if armed.
+            if (guid == GetSession().GameState.CurrentPlayerGuid && moveInfo.RunSpeed > 0)
+            {
+                GetSession().GameState.LastKnownPlayerRunSpeed = moveInfo.RunSpeed;
+                if (GetSession().GameState.PendingPostTeleportRunSpeedReassert)
+                {
+                    GetSession().GameState.PendingPostTeleportRunSpeedReassert = false;
+                    MoveSetSpeed reassert = new MoveSetSpeed(Opcode.SMSG_MOVE_SET_RUN_SPEED);
+                    reassert.MoverGUID = guid;
+                    reassert.MoveCounter = 0;
+                    reassert.Speed = moveInfo.RunSpeed;
+                    SendPacketToClient(reassert);
+                }
+            }
             moveInfo.RunBackSpeed = packet.ReadFloat();
             moveInfo.SwimSpeed = packet.ReadFloat();
             moveInfo.SwimBackSpeed = packet.ReadFloat();

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -178,6 +178,8 @@ public partial class WorldSocket
     void HandleWorldPortResponse(WorldPortResponse teleport)
     {
         GetSession().GameState.IsWaitingForWorldPortAck = false;
+        // JimsProxy (speed-stuck-after-bg-end-while-mounted): arm post-teleport reassert; see memory.
+        GetSession().GameState.PendingPostTeleportRunSpeedReassert = true;
         WorldPacket packet = new WorldPacket(Opcode.MSG_MOVE_WORLDPORT_ACK);
         SendPacketToServer(packet);
     }


### PR DESCRIPTION
## Summary

Mounted player gets feared (or teleported out of a BG) → mount visual persists but run speed drops to base 7.0 and never recovers. Two distinct triggers, same root cause: a proxy-side synthetic `SMSG_MOVE_SET_RUN_SPEED` clobbers the active speed buff, and the legacy server doesn't re-emit a speed-change packet because (a) fear is movement-flag based — server-side run-speed never actually changed, and (b) cross-map teleport doesn't trigger a speed change either.

### Fix 1 — fear-end

`HandleControlUpdate` (`Client/PacketHandlers/MovementHandler.cs:200`) — the RP-walk fix was hardcoding `Speed = 7.0f` on every false→true control transition. The pre-existing `LastObservedHasControl` gate already prevents this from firing on login/reload, but a real fear-end transition still goes through it.

Changed to reassert `GameState.LastKnownPlayerRunSpeed` instead. Same fix automatically covers sprint, aspect of cheetah, druid travel form, and any other active speed buff.

### Fix 2 — cross-map teleport (BG end, instance port, GM teleport)

`HandleWorldPortResponse` (`Server/PacketHandlers/MovementHandler.cs:180`) arms `PendingPostTeleportRunSpeedReassert`. `ReadMovementUpdateBlock` (`Client/PacketHandlers/UpdateHandler.cs:1180`) fires `SMSG_MOVE_SET_RUN_SPEED` on the player's first post-teleport `UpdateObject`, using the freshly-observed `RunSpeed` from the movement block.

Self-correcting: if the speed was already right, the reassert is a no-op. Piggybacks on the same "fire on first post-teleport UpdateObject" pattern already used by `FireDeferredTransportClearSynth`.

### Cache seeding

`LastKnownPlayerRunSpeed` is updated from:
- `SMSG_FORCE_RUN_SPEED_CHANGE` forwarding (the player's authoritative speed-change packet)
- The player's `UpdateObject` movement block (login, full updates, post-teleport)

## Test plan

- [x] Mount → get feared → fear ends → mount speed restored (validated in-game on Twinstar/Kronos PTR with local stacked build)
- [ ] Mount in BG staging → BG ends → ported home → mount speed restored (speculative fix, same shape)
- [ ] Sprint → get feared → fear ends → sprint speed intact
- [ ] Cheetah → get feared → fear ends → cheetah speed intact
- [ ] Login mounted (no regression vs prior RP-walk fix)