### PR TITLE
Fix skill-gated trainer spells rendering green-clickable (#305)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2077,6 +2077,46 @@ public sealed class GameSessionData
         return 0;
     }
 
+    // JimsProxy (issue #305): return player's skill rank for skillLine, 0 if absent; see memory.
+    public ushort GetPlayerSkillRank(uint skillLine)
+    {
+        if (skillLine == 0) return 0;
+        int baseField = LegacyVersion.GetUpdateField(PlayerField.PLAYER_SKILL_INFO_1_1);
+        if (baseField < 0) return 0;
+        var fields = GetCachedObjectFieldsLegacy(CurrentPlayerGuid);
+        if (fields == null) return 0;
+        for (int i = 0; i < 128; i++)
+        {
+            int idIdx = baseField + i * 3;
+            if (!fields.TryGetValue(idIdx, out var idField)) continue;
+            ushort id = (ushort)(idField.UInt32Value & 0xFFFF);
+            if (id != skillLine) continue;
+            if (!fields.TryGetValue(idIdx + 1, out var valField)) return 0;
+            ushort rank = (ushort)(valField.UInt32Value & 0xFFFF);
+            ushort perm = 0;
+            if (fields.TryGetValue(idIdx + 2, out var bonusField))
+                perm = (ushort)((bonusField.UInt32Value >> 16) & 0xFFFF);
+            return (ushort)(rank + perm);
+        }
+        return 0;
+    }
+
+    // JimsProxy (issue #305): true if any skill slot is populated; guards pre-UpdateObject race; see memory.
+    public bool HasPopulatedSkillBlock()
+    {
+        int baseField = LegacyVersion.GetUpdateField(PlayerField.PLAYER_SKILL_INFO_1_1);
+        if (baseField < 0) return false;
+        var fields = GetCachedObjectFieldsLegacy(CurrentPlayerGuid);
+        if (fields == null) return false;
+        for (int i = 0; i < 128; i++)
+        {
+            int idIdx = baseField + i * 3;
+            if (fields.TryGetValue(idIdx, out var idField) && (idField.UInt32Value & 0xFFFF) != 0)
+                return true;
+        }
+        return false;
+    }
+
     public Dictionary<int, UpdateField>? GetCachedObjectFieldsLegacy(WowGuid128 guid)
     {
         lock (ObjectCacheLock)

--- a/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
@@ -195,13 +195,30 @@ public partial class WorldClient
             spell.SpellID = spellId;
             TrainerSpellStateLegacy stateOld = (TrainerSpellStateLegacy)packet.ReadUInt8();
             TrainerSpellStateModern stateNew = stateOld.CastEnum<TrainerSpellStateModern>();
-            spell.Usable = stateNew;
             spell.MoneyCost = packet.ReadUInt32();
             packet.ReadInt32(); // Profession Dialog
             packet.ReadInt32(); // Profession Button
             spell.ReqLevel = packet.ReadUInt8();
             spell.ReqSkillLine = packet.ReadUInt32();
             spell.ReqSkillRank = packet.ReadUInt32();
+            // JimsProxy (issue #305): override Available→Unavailable when player skill rank < ReqSkillRank; see memory.
+            if (stateNew == TrainerSpellStateModern.Available && spell.ReqSkillLine != 0 && spell.ReqSkillRank > 0)
+            {
+                var gs = GetSession().GameState;
+                if (gs.HasPopulatedSkillBlock() && gs.GetPlayerSkillRank(spell.ReqSkillLine) < spell.ReqSkillRank)
+                {
+                    stateNew = TrainerSpellStateModern.Unavailable;
+                    Log.Event("spell.trainer_list.skill_gated_override", new
+                    {
+                        trainer_id = trainer.TrainerID,
+                        spell_id = spellId,
+                        req_skill_line = spell.ReqSkillLine,
+                        req_skill_rank = spell.ReqSkillRank,
+                        player_skill_rank = gs.GetPlayerSkillRank(spell.ReqSkillLine),
+                    });
+                }
+            }
+            spell.Usable = stateNew;
             spell.ReqAbility[0] = packet.ReadUInt32();
             spell.ReqAbility[1] = packet.ReadUInt32();
             spell.ReqAbility[2] = packet.ReadUInt32();


### PR DESCRIPTION
Fixes #305.

## Summary

The 1.14 client doesn't recompute trainer-list row color from `ReqSkillLine`/`ReqSkillRank` — only the `Usable` state byte drives the green/red decision. Vanilla servers can report skill-gated spells as `Available` in the trainer list while the buy code rejects them. Rogue poisons before completing the rogue poison quest are the canonical case (Crippling Poison spell 3422 → green-clickable → BUY_FAILED Reason 2 = `TRAIN_FAIL_NOT_ENOUGH_SKILL` → "Failed to learn Spell 3422" chat error).

## Fix

Proactively override `Available`→`Unavailable` in `HandleTrainerList` when the player's actual skill rank (read from the cached `PLAYER_SKILL_INFO_1_1` legacy fields) falls below the spell's `ReqSkillRank`. Wire-byte 2 (`Unavailable`) renders red in the 1.14 client — validated empirically by an initial-state test where pre-skill-grant rogue poisons rendered red, then turned green only after the server granted the Poisons skill.

## Why this works

- **Proactive, not feedback-loop**: every player sees the correct red state on first trainer open. No "click and fail" required per user.
- **Self-correcting**: when the player completes the prereq quest, the next `SMSG_UPDATE_OBJECT` updates `PLAYER_SKILL_INFO`, and the next trainer open naturally passes the gate → spell renders green.
- **No regressions to legitimately-Available spells**: the override only fires when `stateNew == Available` AND `ReqSkillLine != 0` AND `ReqSkillRank > 0` AND the player's actual rank is below it. Sinister Strike, Pick Lock, etc. pass through untouched.

## Safety gates

- `HasPopulatedSkillBlock()` guards the pre-`UpdateObject` race (just-zoned player, skill block not yet populated, every rank reads 0). Without this, every skill-gated spell would mass-mark Unavailable.
- Skill value computed as `base rank + perm bonus` (matches typical `GetSkillValue`). Temp bonus excluded (rare in vanilla, signed-short edge cases).

## Diagnostic

Adds `spell.trainer_list.skill_gated_override` JSONL event on each override, with `trainer_id`, `spell_id`, `req_skill_line`, `req_skill_rank`, `player_skill_rank` — so future bundles can confirm the gate fired (or didn't) for a given report.

## Test plan

- [x] Rogue without poison quest opens rogue trainer → rank-1 poisons render RED (validated in-game 2026-05-24)
- [x] Rogue with Poisons skill grants → rank-1 poisons render GREEN (validated in PTR initial-state test)
- [ ] Profession trainers: cooking/first-aid recipes requiring higher skill than player has → render red (no false-positive learnable spells)
- [x] No regression on Available rogue spells (Sinister Strike, Kick, Sprint etc.) — stay green