### PR TITLE
Fix: preserve all started casts on destroy-hook eviction (mining stuck-animation)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1319,24 +1319,31 @@ public sealed class GameSessionData
 
     /// <summary>
     /// JimsProxy (PR #161 follow-up — destroy-hook fast path): walks pending
-    /// queues and dequeues any cast whose TargetGuid matches the destroyed
-    /// unit, except started channels (see below). Returns evicted entries
-    /// for the caller to emit synthetic CastFailed packets with a more
-    /// accurate reason (BadTargets) than the watchdog's DontReport, since
-    /// we know exactly why the cast can't proceed: the target was destroyed.
+    /// queues and dequeues any !HasStarted cast whose TargetGuid matches the
+    /// destroyed unit. Returns evicted entries for the caller to emit synthetic
+    /// CastFailed packets with a more accurate reason (BadTargets) than the
+    /// watchdog's DontReport, since we know exactly why the cast can't proceed:
+    /// the target was destroyed.
     ///
-    /// Started CHANNELS specifically are left in the queue. The legacy server
-    /// owns the channel — it sends a real SMSG_SPELL_FAILURE that
-    /// HandleSpellFailure routes to the client and arms the watchdog as a
-    /// leak backstop. Evicting a started channel here is wrong twice over:
-    /// it races that real resolution, and synthetic SMSG_CAST_FAILED cannot
-    /// tear down a channel bar — only SMSG_SPELL_FAILURE can. That stranded
-    /// gathering: a queued second mining/herb tick would get started by the
-    /// server, then evicted when the depleted node despawned, leaving a
-    /// phantom channel — the node "did nothing" until the player moved away
-    /// and back. Started non-channeled casts (Frostbolt etc.) still get
-    /// evicted so the instant BadTargets feedback is preserved for normal
-    /// combat-on-dying-mob.
+    /// Started casts (HasStarted=true) are intentionally LEFT in the queue.
+    /// The legacy server owns them — it sends a real SMSG_SPELL_GO or
+    /// SMSG_SPELL_FAILURE whose CastID/reason the proxy routes back to the
+    /// client. Evicting a started cast here races that resolution and produces
+    /// the wrong outcome:
+    ///
+    ///   - Channels (mining, herbalism, Drain Soul): a queued second tick gets
+    ///     started by the server, then evicted when the depleted node despawns,
+    ///     leaving a phantom channel — the node "did nothing" until the player
+    ///     moves away and back. Synthetic SMSG_CAST_FAILED cannot tear down a
+    ///     channel bar; only SMSG_SPELL_FAILURE can.
+    ///   - Cast-time spells (Frostbolt etc.) mid-cast on a dying mob: the
+    ///     server will send SMSG_SPELL_FAILURE → SMSG_CAST_FAILED. Evicting
+    ///     here races those packets and corrupts queue alignment for later
+    ///     same-spell presses (the burst-flood scenario seen in May 2026 logs).
+    ///
+    /// Trade: BadTargets feedback for combat-on-dying-mob is now driven by the
+    /// server response (~RTT-bound) instead of the instant client-side synthesis.
+    /// Worth it to eliminate the preemptive-removal-of-started-cast class of bugs.
     /// </summary>
     public void DrainPendingCastsForDestroyedTarget(WowGuid128 destroyedGuid,
         out List<ClientCastRequest> normalEvicted,
@@ -1350,8 +1357,7 @@ public sealed class GameSessionData
         var keepNormal = new List<ClientCastRequest>();
         while (PendingNormalCasts.TryDequeue(out var cast))
         {
-            bool isStartedChannel = cast.HasStarted && GameData.IsChanneledSpell(cast.SpellId);
-            if (!isStartedChannel && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
                 normalEvicted.Add(cast);
             else
                 keepNormal.Add(cast);
@@ -1362,8 +1368,7 @@ public sealed class GameSessionData
         var keepPet = new List<ClientCastRequest>();
         while (PendingPetCasts.TryDequeue(out var cast))
         {
-            bool isStartedChannel = cast.HasStarted && GameData.IsChanneledSpell(cast.SpellId);
-            if (!isStartedChannel && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
                 petEvicted.Add(cast);
             else
                 keepPet.Add(cast);


### PR DESCRIPTION
## Summary

`DrainPendingCastsForDestroyedTarget` was evicting started cast-time spells (e.g., mining a node) whose target was destroyed, only sparing started channels. When a mining node depleted mid-cast, the entry got evicted; the trailing server `SMSG_SPELL_FAILURE` then found an empty queue, fell through to the non-local-caster branch, was forwarded with a wrong deterministic CastID, and the `casterIsLocalPlayer && wasStarted` gate for `CancelSpellVisual` was missed — animation stuck until movement.

## Evidence

Warrior mining Tin in Loch Modan (2026-05-23 session, log lines 129633 and 129660). Mining spell 2576 is cast-time (3200ms), not a channel. Two nodes compared in the same log:

| Field | Node 637487 (clean) | Node 637484 (bugged) |
|---|---|---|
| `had_started` | false | true |
| Evicted? | Yes | Yes |
| SPELL_START sent to client? | No | Yes |
| Animation stuck? | No | Yes — until movement |
| Failure dequeued in proxy? | n/a | No (queue already gone) |
| `sentCancelVisual` | n/a | false |

## Fix

Narrow the eviction condition to `!cast.HasStarted` only, regardless of whether the spell is a channel. Started casts (channels AND cast-time) are intentionally left in the queue for the server's real SPELL_GO/SPELL_FAILURE to resolve. Updated the doc comment to capture both rationales (gathering channels AND cast-time-on-dying-mob).

## Tradeoff

BadTargets feedback for combat-on-dying-mob shifts from instant client-side synthesis to server-driven (~RTT-bound). Worth it to eliminate the preemptive-removal-of-started-cast class of bugs. The 2.5s SPELL_FAILURE-peek watchdog remains as a leak backstop.

## Test plan

- Loch Modan: mine a cluster of Tin nodes; allow some to deplete mid-cast (other player or natural). Animation should cancel cleanly every time (no stuck animation requiring movement).
- Combat on dying mob: cast Frostbolt on a low-HP mob, have it die mid-cast. Cast bar should dismiss cleanly and the next press should fire normally.

## JSONL signature (with companion diagnostics PR shipped + `DebugOutput=true`)

- `cast.destroy_eviction` events should only show `had_started: false`
- `cast.unmatched_failure_forwarded` count for matching spell IDs should drop to zero