### PR TITLE
Fix: clear cast state on world transfer (BG-entry total-casting-lockout)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -319,6 +319,33 @@ public partial class WorldClient
             GetSession().GameState.IsWaitingForNewWorld = false;
             GetSession().GameState.IsWaitingForWorldPortAck = true;
 
+            // JimsProxy (zone-transfer cast-state cleanup): the source map's server
+            // state is torn down on transition (BG entry, instance change, zep arrival,
+            // GM teleport). Any CMSG_CAST_SPELL we forwarded just before NEW_WORLD
+            // will not get its SPELL_START / SPELL_GO / CAST_FAILED reply, or the
+            // reply will be keyed to a guid that no longer matches the destination
+            // map's bookkeeping. Without sweeping these orphans, a !HasStarted entry
+            // survives the transition and HasForwardedPendingCast() returns true on
+            // the destination map — the OUTER hold path at Server/SpellHandler.cs:443
+            // then swallows every subsequent cast for the rest of the session
+            // (warlock BG-entry total lockout observed 2026-05-24, 6h session).
+            // Same cleanup that ResetInFlightCastState does for the unplanned-
+            // reconnect path; held-slot drops mirror CancelGcdHold's silent drop on
+            // OnDisconnect / HandleLogoutComplete (no ack to modern client — the
+            // loading screen resets visible button state anyway).
+            var clearedCounts = GetSession().GameState.ResetInFlightCastState();
+            var droppedGcdHold = GetSession().GameState.CancelGcdHold();
+            var droppedCastTimeHold = GetSession().GameState.ClearHeldCastTimeCast();
+            Log.Event("session.world_transfer.cast_state_cleared", new
+            {
+                new_map_id = teleport.MapID,
+                normal_casts_cleared = clearedCounts.normalCasts,
+                pet_casts_cleared = clearedCounts.petCasts,
+                other_caster_ids_cleared = clearedCounts.otherCasterIds,
+                gcd_hold_dropped_spell_id = droppedGcdHold?.SpellId ?? 0,
+                cast_time_hold_dropped_spell_id = droppedCastTimeHold?.SpellId ?? 0,
+            });
+
             // --- START FIX: Map Transition Race Condition ---
             // JimsProxy (zep-transfer-stuck 2026-05-15): trimmed 2000ms → 50ms.
             // The long sleep was suspected of contributing to the post-transfer


### PR DESCRIPTION
## Summary

`HandleNewWorld` confirms a real world transition via `IsWaitingForNewWorld` but never sweeps the cast queues. Any `!HasStarted` entry in `PendingNormalCasts` that was forwarded just before the transition becomes an orphan — the source map's server state is torn down, so the SPELL_START / SPELL_GO / CAST_FAILED reply never arrives, or arrives keyed to a guid that no longer matches the destination map's bookkeeping.

Once one orphan exists on the destination map, `HasForwardedPendingCast()` returns true forever and the OUTER hold path at `Server/SpellHandler.cs:443` swallows every subsequent `CMSG_CAST_SPELL` — total casting lockout until session ends.

## Evidence

Warlock BG session 2026-05-24 (`jimsproxy-20260524-151611.jsonl`, 6 hours, 36 NEW_WORLD transitions). Hold queue worked fine pre-BG-entry; after the first NEW_WORLD into a BG, the hold queue never released another cast for the entire session. User-visible symptoms:

- "i summon my pet, nothing happens"
- "i make a healthstone says i cant do that yet"
- "cant cast any spells"
- "mounted now but theres no horse"

All downstream symptoms of the wedged cast queue. 12 `spell.held_pending`, 3 `spell.held_cancel`, zero `spell.held_fire` in the 45 s post-NEW_WORLD window.

## Fix

In `HandleNewWorld`, inside the existing `if (IsWaitingForNewWorld)` block (so only real cross-map transfers trigger it), call:

- `GameState.ResetInFlightCastState()` — clears `PendingNormalCasts`, `PendingPetCasts`, `OtherCasterActiveCastIds`, `PetAutoCastActiveCastIds`, melee/auto-repeat trackers (existing function, was only called from unplanned-reconnect path before)
- `GameState.CancelGcdHold()` — drops `_heldGcdCast` + GCD timer
- `GameState.ClearHeldCastTimeCast()` — drops `_heldCastTimeCast`

Held-slot drops are silent to the modern client (same pattern as `OnDisconnect` / `HandleLogoutComplete` — the loading screen resets visible button state).

Emits one structured event (`session.world_transfer.cast_state_cleared`) under default `StructuredLog` so the cleanup is auditable in beta-tester bundles without needing `DebugOutput=true`.

## Gating safety

The cleanup only runs when both:

1. `SMSG_NEW_WORLD` fires (real world-server handover; same-map teleports use `MSG_MOVE_TELEPORT` and don't fire this opcode)
2. `IsWaitingForNewWorld` is true (only set by preceding `HandleTransferPending` — the canonical "server is about to transfer you" warning)

Same-map teleports (Blink, Spirit Healer rez within map), first-login, and transfer-aborted paths all skip the cleanup.

## Test plan

- Enter and exit a BG several times. After each entry, cast a spell within the first second. Should always work; should never require `/reload`.
- Verify `session.world_transfer.cast_state_cleared` event fires once per NEW_WORLD with non-zero `normal_casts_cleared` when there was a pending cast at transition time.
- Dungeon enter/exit, zeppelin/boat transfers, GM teleport (cross-map) — all should clear cleanly without affecting in-flight casts that the player intentionally completed pre-transfer.

## What this does NOT touch

- Same-map teleports — they don't fire NEW_WORLD, untouched.
- First login from char select — `IsFirstEnterWorld` path, untouched.
- The OUTER hold path itself — still exists, just no longer wedges on zone-transfer orphans.