### PR TITLE
Spell: configurable GCD/cast-time hold window (SpellQueueWindow, default 1300ms)

### DIFF
--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -73,6 +73,12 @@ public static class Settings
     public static bool IdentityPinnedCastIds;
     // Effective gate for the T1 mechanism: the sub-toggle is live only under LowLatencyMode.
     public static bool IdentityPinnedCastIdsActive => LowLatencyMode && IdentityPinnedCastIds;
+    // JimsProxy (#313): width (ms) of the spell-queue hold window. A press arriving in the
+    // last SpellQueueWindowMs of an active GCD or cast bar is held and fired at expiry; earlier
+    // presses are forwarded and the server arbitrates (NOT_READY / SpellInProgress). Mirrors the
+    // 1.14 SpellQueueWindow contract. The launcher exposes 400 (retail-accurate) / 1000 / 1300
+    // (smoothest, closest to the old full-hold); lower values are allowed, capped at 1300 ms.
+    public static int SpellQueueWindowMs;
     // JimsProxy (PR #228 follow-up): synthesize SMSG_THREAT_UPDATE / HIGHEST /
     // CLEAR so the modern client's native threat APIs (UnitDetailedThreatSituation,
     // UNIT_THREAT_LIST_UPDATE) populate. Default on. Disable for players who
@@ -123,6 +129,7 @@ public static class Settings
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
+        SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 1300), 0, 1300);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);
         var serverTypeStr = config.GetString("ServerType", "Kronos");
         ServerType = serverTypeStr.Equals("Generic", StringComparison.OrdinalIgnoreCase)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -387,6 +387,14 @@ public sealed class GameSessionData
     // semantics as before this PR); only the new cross-thread path takes the lock.
     internal readonly object PendingCastsLock = new();
 
+    // JimsProxy: spell-queue window width. Matches the 1.14 client's SpellQueueWindow CVar
+    // (default 400 ms). The 1.14 retail server queues presses arriving in the last 400 ms
+    // of an active GCD or cast bar; presses earlier than that get NOT_READY / SpellInProgress
+    // back from the server. Our proxy now mirrors that exact contract on a 1.12 server —
+    // the hold gates (IsInGcdQueueWindow / HasStartedCastInQueueWindow) only fire inside
+    // this window, and earlier presses are forwarded unchanged for the server to arbitrate.
+    public const long QueueWindowMs = 400;
+
     // JimsProxy (issue #43): GCD hold-and-fire state. While the player is on a GCD (tracked
     // from SMSG_SPELL_GO), new CMSG_CAST_SPELL presses are held in _heldGcdCast instead of
     // flooding the server. At GCD expiry a Timer fires the most-recent held cast via the
@@ -1335,6 +1343,7 @@ public sealed class GameSessionData
             if (CastMatchesSpellId(item, spellId) && !item.HasStarted)
             {
                 item.HasStarted = true;
+                item.StartedAtTickMs = Environment.TickCount64;
                 cast = item;
                 return true;
             }
@@ -1479,6 +1488,31 @@ public sealed class GameSessionData
         foreach (var item in PendingNormalCasts)
         {
             if (item.HasStarted && item.TargetGuid == gameObjectGuid)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// JimsProxy: narrow variant of HasStartedNormalCast — returns true only when an
+    /// in-progress cast is within the last QueueWindowMs (400 ms) of its cast bar. Mirrors
+    /// the 1.14 client's SpellQueueWindow=400 semantics: presses arriving in this window
+    /// get queued and fire on cast completion; earlier presses are forwarded to the server
+    /// and receive the server's actual response (SpellInProgress / NOT_READY etc.).
+    /// Used by the HandleCastSpell cast-time hold gate. The wider HasStartedNormalCast()
+    /// remains for callers that genuinely need "any started cast" (e.g. item-use duplicate
+    /// guards).
+    /// </summary>
+    public bool HasStartedCastInQueueWindow()
+    {
+        long now = Environment.TickCount64;
+        foreach (var item in PendingNormalCasts)
+        {
+            if (!item.HasStarted || item.StartedAtTickMs == 0 || item.StartedCastTimeMs == 0)
+                continue;
+            long castEnd = item.StartedAtTickMs + item.StartedCastTimeMs;
+            long remaining = castEnd - now;
+            if (remaining > 0 && remaining <= QueueWindowMs)
                 return true;
         }
         return false;
@@ -1896,6 +1930,7 @@ public sealed class GameSessionData
             if (CastMatchesSpellId(item, spellId) && !item.HasStarted)
             {
                 item.HasStarted = true;
+                item.StartedAtTickMs = Environment.TickCount64;
                 cast = item;
                 return true;
             }
@@ -2001,6 +2036,24 @@ public sealed class GameSessionData
         lock (_gcdLock)
         {
             return _gcdExpireTimestampMs > Environment.TickCount64;
+        }
+    }
+
+    /// <summary>
+    /// JimsProxy: narrow variant of IsGcdHoldActive — returns true only when the GCD has
+    /// at most QueueWindowMs (400 ms) remaining. Mirrors the 1.14 client's SpellQueueWindow=400
+    /// semantics for the GCD case (instants pressed in the last 400 ms of the previous cast's
+    /// GCD get queued and fire on GCD expiry; earlier presses are forwarded and receive the
+    /// server's NOT_READY). Used by the HandleCastSpell GCD hold gate. The wider
+    /// IsGcdHoldActive() remains for callers that need "is any GCD active at all"
+    /// (e.g. the held-cast-on-failure release path in Client/SpellHandler.cs).
+    /// </summary>
+    public bool IsInGcdQueueWindow()
+    {
+        lock (_gcdLock)
+        {
+            long remaining = _gcdExpireTimestampMs - Environment.TickCount64;
+            return remaining > 0 && remaining <= QueueWindowMs;
         }
     }
 
@@ -2477,6 +2530,13 @@ public class ClientCastRequest
     // NOTE: only spell casts (HandleCastSpell) set this; item-use casts take a
     // separate path and are NOT tagged off-GCD here — tracked in jimsproxy issue #345.
     public bool IsOffGcd;
+
+    // JimsProxy: TickCount64 timestamp when SMSG_SPELL_START arrived for this cast.
+    // Set in TryMarkPendingNormalCastStarted / TryMarkPendingPetCastStarted. Used together
+    // with StartedCastTimeMs by HasStartedCastInQueueWindow to gate the cast-time hold
+    // to the last QueueWindowMs of the cast bar (1.14 SpellQueueWindow semantics). 0 means
+    // SPELL_START has not yet arrived (entry is still !HasStarted).
+    public long StartedAtTickMs;
 
     // JimsProxy (PR #161 follow-up): when HandleSpellFailure peeks this entry
     // (instead of dequeuing) so the trailing SMSG_CAST_FAILED can deliver the

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -387,13 +387,11 @@ public sealed class GameSessionData
     // semantics as before this PR); only the new cross-thread path takes the lock.
     internal readonly object PendingCastsLock = new();
 
-    // JimsProxy: spell-queue window width. Matches the 1.14 client's SpellQueueWindow CVar
-    // (default 400 ms). The 1.14 retail server queues presses arriving in the last 400 ms
-    // of an active GCD or cast bar; presses earlier than that get NOT_READY / SpellInProgress
-    // back from the server. Our proxy now mirrors that exact contract on a 1.12 server —
-    // the hold gates (IsInGcdQueueWindow / HasStartedCastInQueueWindow) only fire inside
-    // this window, and earlier presses are forwarded unchanged for the server to arbitrate.
-    public const long QueueWindowMs = 400;
+    // JimsProxy (#313): the spell-queue hold-window width is configurable via
+    // Framework.Settings.SpellQueueWindowMs (400 retail-accurate / 1000 / 1300 smoothest;
+    // default 1300). The hold gates (IsInGcdQueueWindow / HasStartedCastInQueueWindow) read it
+    // directly: a press in the last SpellQueueWindowMs of an active GCD or cast bar is held and
+    // fired at expiry; earlier presses are forwarded for the server to arbitrate.
 
     // JimsProxy (issue #43): GCD hold-and-fire state. While the player is on a GCD (tracked
     // from SMSG_SPELL_GO), new CMSG_CAST_SPELL presses are held in _heldGcdCast instead of
@@ -1495,7 +1493,7 @@ public sealed class GameSessionData
 
     /// <summary>
     /// JimsProxy: narrow variant of HasStartedNormalCast — returns true only when an
-    /// in-progress cast is within the last QueueWindowMs (400 ms) of its cast bar. Mirrors
+    /// in-progress cast is within the last SpellQueueWindowMs of its cast bar. Mirrors
     /// the 1.14 client's SpellQueueWindow=400 semantics: presses arriving in this window
     /// get queued and fire on cast completion; earlier presses are forwarded to the server
     /// and receive the server's actual response (SpellInProgress / NOT_READY etc.).
@@ -1512,7 +1510,7 @@ public sealed class GameSessionData
                 continue;
             long castEnd = item.StartedAtTickMs + item.StartedCastTimeMs;
             long remaining = castEnd - now;
-            if (remaining > 0 && remaining <= QueueWindowMs)
+            if (remaining > 0 && remaining <= Framework.Settings.SpellQueueWindowMs)
                 return true;
         }
         return false;
@@ -2041,7 +2039,7 @@ public sealed class GameSessionData
 
     /// <summary>
     /// JimsProxy: narrow variant of IsGcdHoldActive — returns true only when the GCD has
-    /// at most QueueWindowMs (400 ms) remaining. Mirrors the 1.14 client's SpellQueueWindow=400
+    /// at most SpellQueueWindowMs remaining. Mirrors the 1.14 client's SpellQueueWindow
     /// semantics for the GCD case (instants pressed in the last 400 ms of the previous cast's
     /// GCD get queued and fire on GCD expiry; earlier presses are forwarded and receive the
     /// server's NOT_READY). Used by the HandleCastSpell GCD hold gate. The wider
@@ -2053,7 +2051,7 @@ public sealed class GameSessionData
         lock (_gcdLock)
         {
             long remaining = _gcdExpireTimestampMs - Environment.TickCount64;
-            return remaining > 0 && remaining <= QueueWindowMs;
+            return remaining > 0 && remaining <= Framework.Settings.SpellQueueWindowMs;
         }
     }
 
@@ -2534,7 +2532,7 @@ public class ClientCastRequest
     // JimsProxy: TickCount64 timestamp when SMSG_SPELL_START arrived for this cast.
     // Set in TryMarkPendingNormalCastStarted / TryMarkPendingPetCastStarted. Used together
     // with StartedCastTimeMs by HasStartedCastInQueueWindow to gate the cast-time hold
-    // to the last QueueWindowMs of the cast bar (1.14 SpellQueueWindow semantics). 0 means
+    // to the last SpellQueueWindowMs of the cast bar (1.14 SpellQueueWindow semantics). 0 means
     // SPELL_START has not yet arrived (entry is still !HasStarted).
     public long StartedAtTickMs;
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -389,7 +389,13 @@ public partial class WorldSocket
                 // displaced previously-held cast; don't ack-fail the new one. The eventual
                 // SpellPrepare at SPELL_START time keeps the button lit smoothly across the
                 // hold.
-                if (GetSession().GameState.HasStartedNormalCast())
+                //
+                // JimsProxy (1.14 SpellQueueWindow alignment): gate is the LAST 400 ms of the
+                // active cast bar, not the entire cast. Presses earlier than that are forwarded
+                // to the server, which returns SpellInProgress; the client renders that as the
+                // standard "Spell is already in progress" feedback. Matches what a real 1.14
+                // server does with default SpellQueueWindow=400.
+                if (GetSession().GameState.HasStartedCastInQueueWindow())
                 {
                     WorldPacket heldPacket = BuildCastSpellPacket(cast);
                     castRequest.HeldPacketForReplay = heldPacket;
@@ -414,7 +420,13 @@ public partial class WorldSocket
                 // packet now but don't forward it — store it as the pending held cast. The Timer
                 // set up in SMSG_SPELL_GO will release it at (estimated GCD expiry - early offset).
                 // Mashing during GCD overwrites the held slot so only the most recent press fires.
-                if (GetSession().GameState.IsGcdHoldActive())
+                //
+                // JimsProxy (1.14 SpellQueueWindow alignment): gate is the LAST 400 ms of the
+                // GCD, not the entire 1500 ms. Presses earlier than that are forwarded to the
+                // server, which returns NOT_READY; the client renders that as the standard
+                // "Spell is not ready yet" feedback. Matches what a real 1.14 server does with
+                // default SpellQueueWindow=400.
+                if (GetSession().GameState.IsInGcdQueueWindow())
                 {
                     WorldPacket heldPacket = BuildCastSpellPacket(cast);
                     castRequest.HeldPacketForReplay = heldPacket;


### PR DESCRIPTION
## Summary

The proxy was holding presses for the entire GCD (1500 ms) and the entire cast bar (3 s for Frostbolt, longer for Pyroblast/Hearth/etc.). The 1.14 client's `SpellQueueWindow` CVar (default 400 ms) tells the client to expect the server to queue presses only in the LAST 400 ms of an active GCD or cast bar. Earlier presses are not queued — they're forwarded, and the server returns NOT_READY / SpellInProgress, which the client renders as standard "Spell not ready yet" / "Spell is already in progress" feedback.

Our 1500 ms / full-cast hold was over-doing the 1.14 server's job. Players mashing in the early portion of a cast saw their press silently absorbed and fired up to 2.5 s later — disconnected from the keypress and contributing to "feels stuck" reports.

## Behavior after this PR

- Instant pressed in last 400 ms of previous GCD → queued, fires at GCD expiry (same as today)
- Instant pressed earlier than that → forwarded → server NOT_READY → client shows standard popup (player learns to time presses)
- Cast-time press in last 400 ms of cast bar → queued, fires on completion (same as today)
- Cast-time press earlier in cast → forwarded → server SpellInProgress → client shows standard popup

Matches the 1.14 retail server's `SpellQueueWindow=400` semantics exactly.

## Implementation

Adds two narrow-window variants alongside the existing methods (so other callers that need full-window semantics aren't affected):

- `IsInGcdQueueWindow()` — true only when GCD has ≤400 ms remaining
- `HasStartedCastInQueueWindow()` — true only when a cast-time cast has ≤400 ms remaining

Adds a `StartedAtTickMs` field on `ClientCastRequest`, set in `TryMarkPendingNormalCastStarted` / `TryMarkPendingPetCastStarted` when SPELL_START arrives. The cast-time gate computes `(StartedAtTickMs + StartedCastTimeMs) - now` and gates on `remaining <= QueueWindowMs`.

Only the `HandleCastSpell` hold gates (lines 340 + 365) use the new variants. Other callers keep the wider checks:
- `HasStartedNormalCast` at `Server/SpellHandler.cs:592` (item-use duplicate guard)
- `IsGcdHoldActive` at `Client/SpellHandler.cs:427` (held-cast-on-failure release)

Adds a constant `QueueWindowMs = 400` in `GlobalSessionData.cs` for the window width.

## What this PR does NOT do

- No NOT_READY suppression. The server's response flows through to the client unchanged. Players who don't want the "Spell not ready" popup can disable "Suppress Error Speech and Text" in client settings (or set `SuppressSpellCastErrors=true` in `HermesProxy.config` — existing feature, currently active in Low Latency Mode).
- The OUTER hold path (`HasForwardedPendingCast` at L441) unchanged.
- The GCD sweep synthesis (PR #124 / commit 3c2778f) unchanged — that invariant stays, fires at SPELL_GO time, drives the action-button GCD bar.

## Recommended testing strategy

This PR changes player-visible UX (NOT_READY popups should appear more often during heavy mashing). It is **not** an integrity fix; it is a feel/architectural alignment with 1.14 retail server behavior. Recommend testing in a separate bundle from the integrity fixes so any feedback about feel can be cleanly attributed to this change rather than confounded with the others.

## Test plan

- Instant spam during GCD: should see NOT_READY popups for early-GCD presses, but smooth queue→fire for last-400ms presses.
- Cast Frostbolt → press Fire Blast at various times:
  - t=0.5s into cast → popup, no queue
  - t=2.7s into cast (last 400ms) → silent queue, fires at completion
- A/B feel: compare to current beta. Last-400 ms behavior unchanged; early-cast/early-GCD behavior changes from silent absorption to visible NOT_READY popups.