### PR TITLE
Fix: clear cast state on transfer abort

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -314,6 +314,24 @@ public partial class WorldClient
 
         SendPacketToClient(transfer);
         GetSession().GameState.IsWaitingForNewWorld = false;
+
+        var clearedCounts = GetSession().GameState.ResetInFlightCastState();
+        var droppedGcdHold = GetSession().GameState.CancelGcdHold();
+        var droppedCastTimeHold = GetSession().GameState.ClearHeldCastTimeCast();
+        if (clearedCounts.normalCasts > 0 || clearedCounts.petCasts > 0 ||
+            droppedGcdHold != null || droppedCastTimeHold != null)
+        {
+            Log.Event("session.transfer_aborted.cast_state_cleared", new
+            {
+                aborted_map_id = transfer.MapID,
+                reason = transfer.Reason.ToString(),
+                normal_casts_cleared = clearedCounts.normalCasts,
+                pet_casts_cleared = clearedCounts.petCasts,
+                other_caster_ids_cleared = clearedCounts.otherCasterIds,
+                gcd_hold_dropped_spell_id = droppedGcdHold?.SpellId ?? 0,
+                cast_time_hold_dropped_spell_id = droppedCastTimeHold?.SpellId ?? 0,
+            });
+        }
     }
 
     [PacketHandler(Opcode.SMSG_NEW_WORLD)]


### PR DESCRIPTION
## Summary

`HandleTransferAborted` clears `IsWaitingForNewWorld` but never swept the cast queues. Any `CMSG_CAST_SPELL` forwarded between `TransferPending` and `TransferAborted` becomes an orphan — `HasForwardedPendingCast()` returns true permanently and the OUTER hold path blocks all subsequent casts for the rest of the session.

Found during an audit of all state transitions after shipping #312 (the NEW_WORLD equivalent of this fix).

## Triggers

- Instance full (raid at capacity)
- Level too low for instance
- Transfer cancelled by server for any reason

## Fix

Same three-line cleanup as `HandleNewWorld` (#312): `ResetInFlightCastState` + `CancelGcdHold` + `ClearHeldCastTimeCast`. Diagnostic event only fires when state was actually cleared.

## Test plan

- [x] `dotnet build` clean
- [ ] Attempt to enter a full instance → transfer aborted → verify casting still works