### PR TITLE
Restore targeted /spit emote

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -349,6 +349,7 @@ public sealed class GameSessionData
     public DateTime AuctionReplicateStartTime;
     public uint LastWhoRequestId;
     public WowGuid128 CurrentPetGuid;
+    public WowGuid128 CurrentSelection;
     public WowGuid64 CurrentAttackTarget;        // active CMSG_ATTACK_SWING victim, cleared on ATTACK_STOP/CANCEL_COMBAT
     public bool WaitingForAttackStart;           // true between CMSG_ATTACK_SWING and SMSG_ATTACK_START
     public bool DeferredAttackStop;              // CMSG_ATTACK_STOP received while waiting for SMSG_ATTACK_START

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -2410,6 +2410,7 @@ public static partial class GameData
     // on top of the universal hotfix at startup when Settings.ServerType names
     // a known emulator. Distinct ID range so it doesn't collide with the
     // universal HotfixItemSparseBegin block.
+    public const uint HotfixEmotesTextDataBegin = 310000;
     public const uint HotfixItemSparseEmulatorBegin = 300000;
     public static Dictionary<uint, HotfixRecord> Hotfixes = [];
     public static void LoadHotfixes()
@@ -2438,6 +2439,7 @@ public static partial class GameData
         LoadCreatureDisplayInfoHotfixes();
         LoadCreatureDisplayInfoExtraHotfixes();
         LoadCreatureDisplayInfoOptionHotfixes();
+        LoadEmotesTextDataHotfixes();
     }
 
     public static void LoadAreaTriggerHotfixes()
@@ -5070,6 +5072,34 @@ public static partial class GameData
             Hotfixes.Add(record.HotfixId, record);
         }
     }
+    public static void LoadEmotesTextDataHotfixes()
+    {
+        // Blizzard changed /spit in the modern client (post-2019) to always
+        // display "spits on the ground" even when targeting a player. Restore
+        // the original vanilla targeted text so proxy players see it properly.
+        ReadOnlySpan<(uint id, string text)> spitFixes =
+        [
+            (458, "%s spits on %s."),
+            (459, "%s spits on you."),
+            (460, "You spit on %s."),
+        ];
+        uint counter = 0;
+        foreach (var (id, text) in spitFixes)
+        {
+            counter++;
+            HotfixRecord record = new()
+            {
+                TableHash = DB2Hash.EmotesTextData,
+                HotfixId = HotfixEmotesTextDataBegin + counter,
+                Status = HotfixStatus.Valid,
+                RecordId = id,
+            };
+            record.UniqueId = record.HotfixId;
+            record.HotfixContent.WriteCString(text);
+            Hotfixes.Add(record.HotfixId, record);
+        }
+    }
+
     public static void LoadItemEffectHotfixes()
     {
         var path = Path.Combine("CSV", "Hotfix", $"ItemEffect{ModernVersion.ExpansionVersion}.csv");

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -5077,14 +5077,18 @@ public static partial class GameData
         // Blizzard changed /spit in the modern client (post-2019) to always
         // display "spits on the ground" even when targeting a player. Restore
         // the original vanilla targeted text so proxy players see it properly.
-        ReadOnlySpan<(uint id, string text)> spitFixes =
+        // Inline payload is Text_lang (CString) + RelationshipFlags (u8). EmotesTextID
+        // is a non-inline relation field and is NOT written to the hotfix record.
+        // RelationshipFlags selects the perspective: 0 = third party, 1 = you are the
+        // target, 2 = you are the source.
+        ReadOnlySpan<(uint id, string text, byte relationshipFlags)> spitFixes =
         [
-            (458, "%s spits on %s."),
-            (459, "%s spits on you."),
-            (460, "You spit on %s."),
+            (458, "%s spits on %s.", 0),
+            (459, "%s spits on you.", 1),
+            (460, "You spit on %s.", 2),
         ];
         uint counter = 0;
-        foreach (var (id, text) in spitFixes)
+        foreach (var (id, text, relationshipFlags) in spitFixes)
         {
             counter++;
             HotfixRecord record = new()
@@ -5096,6 +5100,7 @@ public static partial class GameData
             };
             record.UniqueId = record.HotfixId;
             record.HotfixContent.WriteCString(text);
+            record.HotfixContent.WriteUInt8(relationshipFlags);
             Hotfixes.Add(record.HotfixId, record);
         }
     }

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -332,13 +332,24 @@ public partial class WorldSocket
         }
     }
 
+    const int TEXTEMOTE_SPIT = 89;
+
     [PacketHandler(Opcode.CMSG_SEND_TEXT_EMOTE)]
     void HandleSendTextEmote(CTextEmote emote)
     {
+        var target = emote.Target;
+
+        if (emote.EmoteID == TEXTEMOTE_SPIT && target.IsEmpty())
+        {
+            var selection = GetSession().GameState.CurrentSelection;
+            if (!selection.IsEmpty())
+                target = selection;
+        }
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SEND_TEXT_EMOTE);
         packet.WriteInt32(emote.EmoteID);
         packet.WriteInt32(emote.SoundIndex);
-        packet.WriteGuid(emote.Target.To64());
+        packet.WriteGuid(target.To64());
         SendPacketToServer(packet);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/MiscHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MiscHandler.cs
@@ -39,6 +39,7 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SET_SELECTION)]
     void HandleSetSelection(SetSelection selection)
     {
+        GetSession().GameState.CurrentSelection = selection.TargetGUID;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SET_SELECTION);
         packet.WriteGuid(selection.TargetGUID.To64());
         SendPacketToServer(packet);


### PR DESCRIPTION
## Summary

Blizzard modified the modern 1.14 client's `EmotesTextData` DB2 table (post-2019) to replace all targeted `/spit` text variants with "spits on the ground" — effectively neutering the emote even when targeting another player.

- **DB2 hotfix**: Pushes corrected `EmotesTextData` records at login to restore the original vanilla strings (`"%s spits on %s."`, `"%s spits on you."`, `"You spit on %s."`) for the three targeted relationship flags
- **Target injection**: Caches the player's current selection from `CMSG_SET_SELECTION` in `GameState.CurrentSelection`, and injects it into `CMSG_SEND_TEXT_EMOTE` when emote 89 (spit) arrives with an empty target GUID — safety net in case the client also strips the target, not just the display text

## Test plan

- [ ] Target a player, `/spit` — verify chat shows "You spit on PlayerName." (not "on the ground")
- [ ] Other player sees "YourName spits on you." in their chat
- [ ] Nearby players see "YourName spits on PlayerName."
- [ ] `/spit` with no target — still shows "You spit on the ground." (untargeted path unchanged)
- [ ] Other emotes (`/wave`, `/dance`, `/rude`) still work correctly with targets
- [ ] Verify hotfix loads at login (check proxy log for EmotesTextData hotfix records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)