### PR TITLE
Fix auto-attack stuck when server rejects swing

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -43,6 +43,9 @@ public partial class WorldClient
             }
             else if (!state.WaitingForAttackStart)
             {
+                // Server-initiated stop without our SWING: Gouge / Cheap Shot / Blind /
+                // Feign Death / stealth / Vanish. Must clear CurrentAttackTarget here or
+                // the next CMSG_ATTACK_SWING gets eaten by the dedupe guard at Server/CombatHandler.cs:16.
                 state.CurrentAttackTarget = default;
             }
             else if (rawVictim == state.CurrentAttackTarget)

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -27,13 +27,13 @@ public partial class WorldClient
     {
         SAttackStop attack = new();
         attack.Attacker = packet.ReadPackedGuid().To128(GetSession().GameState);
-        attack.Victim = packet.ReadPackedGuid().To128(GetSession().GameState);
+        var rawVictim = packet.ReadPackedGuid();
+        attack.Victim = rawVictim.To128(GetSession().GameState);
         attack.NowDead = packet.ReadUInt32() != 0;
 
         var state = GetSession().GameState;
         if (attack.Attacker == state.CurrentPlayerGuid)
         {
-            // If the client wanted to stop and we deferred it, now flush it
             if (state.DeferredAttackStop)
             {
                 state.DeferredAttackStop = false;
@@ -41,26 +41,20 @@ public partial class WorldClient
                 WorldPacket stopPacket = new WorldPacket(Opcode.CMSG_ATTACK_STOP);
                 SendPacketToServer(stopPacket, Opcode.MSG_NULL_ACTION);
             }
-            //MIRASU: Server-initiated SMSG_ATTACK_STOP — Gouge, Cheap Shot, Blind, Feign Death,
-            //MIRASU: stealth, Vanish, and similar incapacitate/stealth effects all cause Kronos/TC-1.12
-            //MIRASU: to push SMSG_ATTACK_STOP (attacker=self) without a prior CMSG_ATTACK_STOP from the
-            //MIRASU: client. WaitingForAttackStart is false (our prior SWING was already ack'd by
-            //MIRASU: SMSG_ATTACK_START long ago) and DeferredAttackStop is false (client never asked).
-            //MIRASU: We MUST clear CurrentAttackTarget here: otherwise the modern client's next
-            //MIRASU: CMSG_ATTACK_SWING (issued when the debuff wears off / stealth breaks / target is
-            //MIRASU: right-clicked / /startattack macro fires) hits the (target == CurrentAttackTarget)
-            //MIRASU: de-dupe guard in the server-side CMSG_ATTACK_SWING handler and gets swallowed —
-            //MIRASU: server never learns the player wants to resume, so no white-swings, no animation,
-            //MIRASU: until the user clicks the action-bar Attack button which bypasses the guard.
-            //MIRASU: The WaitingForAttackStart==true case below remains untouched: that's the
-            //MIRASU: client-driven target-switch sequence (CMSG_SWING(new) → SMSG_STOP(old) → SMSG_START(new))
-            //MIRASU: where the new CurrentAttackTarget is already set and must be preserved.
             else if (!state.WaitingForAttackStart)
             {
                 state.CurrentAttackTarget = default;
             }
-            // If WaitingForAttackStart is true with no deferred stop, we're switching targets —
-            // don't clear the attack target, the new SWING already set it
+            else if (rawVictim == state.CurrentAttackTarget)
+            {
+                // Server rejected our SWING with ATTACK_STOP (no prior ATTACK_START):
+                // target died or became invalid between our SWING and server processing.
+                // Clear the state so the de-dupe guard doesn't eat future attacks.
+                state.WaitingForAttackStart = false;
+                state.CurrentAttackTarget = default;
+            }
+            // else: WaitingForAttackStart is true but victim != CurrentAttackTarget —
+            // target-switch sequence, the new SWING already set CurrentAttackTarget.
         }
 
         SendPacketToClient(attack);


### PR DESCRIPTION
## Summary

- Fixes ~30-second auto-attack lockout where right-click, action bar button, and /startattack macro all fail to start auto-attack
- Root cause: `WaitingForAttackStart` stays true when the server responds to `CMSG_ATTACK_SWING` with `SMSG_ATTACK_STOP` instead of `SMSG_ATTACK_START` (target died in the ~100ms round-trip window), leaving `CurrentAttackTarget` stuck and the de-dupe guard eating every subsequent attack on that target

## Bug path

1. Player sends `CMSG_ATTACK_SWING` -> proxy sets `CurrentAttackTarget = victim`, `WaitingForAttackStart = true`
2. Target dies before server processes the swing -> server sends `SMSG_ATTACK_STOP` (no `SMSG_ATTACK_START`)
3. `WaitingForAttackStart` stays true -> `SMSG_ATTACK_STOP` handler skips clearing `CurrentAttackTarget`
4. Player tries to re-attack same target -> de-dupe guard (`CurrentAttackTarget == victim`) silently drops the command
5. All attack methods fail until something else resets the state

## Fix

When `SMSG_ATTACK_STOP` arrives while `WaitingForAttackStart` is true, compare the stop's victim GUID against `CurrentAttackTarget`:
- **Matches** -> server rejected our swing, clear both `WaitingForAttackStart` and `CurrentAttackTarget`
- **Doesn't match** -> target-switch sequence (stop for old target), preserve `CurrentAttackTarget` (existing behavior)

## Evidence

Diagnosed from JSONL diagnostic log (`jimsproxy-20260525-203540`). The last `CMSG_ATTACK_SWING` in the session (L34840) received `SMSG_ATTACK_STOP` without `SMSG_ATTACK_START`, confirming the bug path. Player report: rogue class, auto-attack completely unresponsive for ~30 seconds mid-fight.

## Test plan

- [ ] Attack a mob normally, verify auto-attack works
- [ ] Kill a mob mid-swing (have it die from DOT/other damage while you press attack), verify you can immediately attack the next target
- [ ] Target-switch: attack Mob A, then click Mob B mid-fight, verify smooth switch
- [ ] Stealth -> opener -> verify auto-attack starts correctly
- [ ] Verify no regression with Gouge/Cheap Shot/Blind server-initiated stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)