### PR TITLE
Defer mid-swing BASEATTACKTIME changes until next swing fires (#320)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -265,6 +265,20 @@ public sealed class GameSessionData
     // as the base so we can synthesize ModRangedHaste = resting / current. Written from
     // the WorldClient handler thread; ConcurrentDictionary keeps it torn-state safe.
     public ConcurrentDictionary<WowGuid128, uint> RestingRangedAttackTime = new();
+    // JimsProxy (#320): defer mid-swing UNIT_FIELD_BASEATTACKTIME field changes for the
+    // local player until the next SMSG_ATTACKER_STATE_UPDATE. Vanilla server's
+    // m_attackTimer is frozen at swing-start cadence (vmangos Unit.cpp ResetAttackTimer
+    // fires only on swing-out, NOT when a ModMeleeHaste aura applies/removes mid-swing),
+    // so the in-flight swing finishes at the OLD speed while the BASEATTACKTIME field
+    // jumps to the new speed immediately. WeaponSwingTimer / Quartz / ClassicSwingTimer
+    // all rescale the remaining swing-bar by (new/old) on UnitAttackSpeed change, landing
+    // the bar at 0 BEFORE the actual swing fires — the "bar ends early then snaps" /
+    // "0 hang" symptom. Slot 0=MH, 1=OH; ranged has its own RestingRangedAttackTime path
+    // (PR #287) that operates on a different mechanism (animation engine, not addon API).
+    public uint[] LastSentBaseAttackTime = new uint[2];
+    public uint[] PendingBaseAttackTime = new uint[2];
+    public bool[] HasPendingBaseAttackTime = new bool[2];
+    public long[] LastAttackerStateUpdateMs = new long[2];
     // JimsProxy: pet creature family cache. SMSG_PET_SPELLS_MESSAGE on pre-3.1
     // servers doesn't carry the family on the wire — we derive it from the
     // creature template via GetItemId(petGuid). For quest-tame pets the

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -138,9 +138,43 @@ public partial class WorldClient
 
         SendPacketToClient(attack);
 
+        // JimsProxy (#320): on a real swing for the local player, record the swing time
+        // and flush any deferred BASEATTACKTIME so the speed change reaches the addon at
+        // the moment the new server-side cadence becomes effective. The HitInfo.OffHand
+        // bit picks the right slot.
+        if (attack.AttackerGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            int slot = (hitInfo & (uint)HitInfo.OffHand) != 0 ? 1 : 0;
+            FlushDeferredBaseAttackTime(slot);
+        }
+
         // Threat translation: feed melee swing damage into the threat tracker.
         // Vanilla damage threat is 1.0 × raw damage, no school weighting.
         GetSession().ThreatTracker.OnDamage(attack.AttackerGUID, attack.VictimGUID, attack.Damage);
+    }
+
+    // JimsProxy (#320): record the swing timestamp and, if a BASEATTACKTIME change was
+    // deferred while the in-flight swing was running, synthesize a values-update carrying
+    // just the new AttackRoundBaseTime so addons re-poll UnitAttackSpeed with the correct
+    // post-swing value. Called from HandleAttackerStateUpdate (slot per HitInfo.OffHand)
+    // and from the combat-exit / attack-stop paths (both slots) so a pending value never
+    // outlives the swing window.
+    void FlushDeferredBaseAttackTime(int slot)
+    {
+        var state = GetSession().GameState;
+        state.LastAttackerStateUpdateMs[slot] = Environment.TickCount64;
+        if (!state.HasPendingBaseAttackTime[slot])
+            return;
+
+        uint pending = state.PendingBaseAttackTime[slot];
+        UpdateObject updateObject = new UpdateObject(state);
+        ObjectUpdate update = new ObjectUpdate(state.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
+        update.UnitData.AttackRoundBaseTime[slot] = pending;
+        updateObject.ObjectUpdates.Add(update);
+        SendPacketToClient(updateObject);
+
+        state.LastSentBaseAttackTime[slot] = pending;
+        state.HasPendingBaseAttackTime[slot] = false;
     }
     [PacketHandler(Opcode.SMSG_ATTACKSWING_NOTINRANGE)]
     void HandleAttackSwingNotInRange(WorldPacket packet)
@@ -178,6 +212,11 @@ public partial class WorldClient
         GetSession().GameState.DeferredAttackStop = false;
         CancelCombat combat = new();
         SendPacketToClient(combat);
+
+        // JimsProxy (#320): combat ended — flush any deferred BASEATTACKTIME for both slots
+        // so a SnD/buff applied just before combat exit doesn't sit pending forever.
+        FlushDeferredBaseAttackTime(0);
+        FlushDeferredBaseAttackTime(1);
 
         // Drop every mob's threat list — vanilla 1.12 doesn't emit a
         // "threat ended" signal, so without this the modern client retains

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2373,10 +2373,53 @@ public partial class WorldClient
             int UNIT_FIELD_BASEATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_BASEATTACKTIME);
             if (UNIT_FIELD_BASEATTACKTIME >= 0)
             {
+                bool isLocalPlayer = guid == GetSession().GameState.CurrentPlayerGuid;
                 for (int i = 0; i < 2; i++)
                 {
-                    if (updateMaskArray[UNIT_FIELD_BASEATTACKTIME + i])
-                        updateData.UnitData.AttackRoundBaseTime[i] = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
+                    if (!updateMaskArray[UNIT_FIELD_BASEATTACKTIME + i])
+                        continue;
+
+                    uint raw = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
+
+                    // JimsProxy (#320): for the local player, defer mid-swing speed changes
+                    // until the next SMSG_ATTACKER_STATE_UPDATE flushes them. See the comment
+                    // on LastSentBaseAttackTime in GlobalSessionData for full rationale — the
+                    // vanilla server doesn't recalculate m_attackTimer mid-swing, so the
+                    // BASEATTACKTIME field changing immediately while the in-flight swing
+                    // finishes at the OLD cadence breaks swing-timer addons' rescale math.
+                    bool deferred = false;
+                    if (isLocalPlayer && raw > 0)
+                    {
+                        var state = GetSession().GameState;
+                        uint lastSent = state.LastSentBaseAttackTime[i];
+                        long lastSwingMs = state.LastAttackerStateUpdateMs[i];
+                        long nowMs = Environment.TickCount64;
+                        // Defer only when the player is actively in an attack cycle. If they
+                        // /stopattacked mid-swing then cast SnD before combat times out, we
+                        // want the haste change to surface immediately rather than hang
+                        // until SMSG_CANCEL_COMBAT — they're not visibly swinging, so the
+                        // addon's "rescale on speed change" math can't go wrong.
+                        bool isAttacking = state.CurrentAttackTarget != default;
+                        bool inFlight = isAttacking &&
+                                        lastSent > 0 && lastSwingMs > 0 &&
+                                        (nowMs - lastSwingMs) < lastSent;
+
+                        if (inFlight && raw != lastSent)
+                        {
+                            state.PendingBaseAttackTime[i] = raw;
+                            state.HasPendingBaseAttackTime[i] = true;
+                            updateData.UnitData.AttackRoundBaseTime[i] = lastSent;
+                            deferred = true;
+                        }
+                        else
+                        {
+                            state.LastSentBaseAttackTime[i] = raw;
+                            state.HasPendingBaseAttackTime[i] = false;
+                        }
+                    }
+
+                    if (!deferred)
+                        updateData.UnitData.AttackRoundBaseTime[i] = raw;
                 }
             }
             int UNIT_FIELD_RANGEDATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_RANGEDATTACKTIME);


### PR DESCRIPTION
Fixes #320.

## Root cause

Vanilla 1.12's server-side `m_attackTimer` is **frozen at swing-start cadence** — `Unit::ResetAttackTimer` (vmangos `Unit.cpp:509`) is called only when a swing fires, not when a `ModMeleeHaste` aura applies or removes. So the server's BASEATTACKTIME field jumps to the new haste-baked value immediately, but the in-flight swing finishes at the OLD cadence. Server fires the next swing at `last_swing + old_speed`, then resets to the new speed for the swing after that.

WeaponSwingTimer / Quartz / ClassicSwingTimer all detect speed changes via `UnitAttackSpeed("player")` poll and rescale the remaining swing-bar by `new/old`. With the server's frozen timer, the rescaled bar lands at 0 *before* the actual swing fires — the "bar ends early then snaps to new timer" / "0 hang briefly" symptom in the issue.

Why the proposed PR #287-style decomposition didn't work: on 1.14 Classic Era specifically, the Lua `UnitAttackSpeed` API returns raw `AttackRoundBaseTime / 1000` and does NOT divide by `UNIT_FIELD_MOD_HASTE` (vanilla-faithful behavior preserved in Classic Era; retail / Wrath Classic / Cata Classic clients DO divide). So a constant base + scalar `ModHaste` would be invisible to the addon API surface that drives the bug.

## Fix

Hold the BASEATTACKTIME field change for the local player when it arrives mid-swing. Flush via a synthetic UPDATE_OBJECT carrying just the new `AttackRoundBaseTime[slot]` on the next `SMSG_ATTACKER_STATE_UPDATE` (slot picked by `HitInfo.OffHand`). This way the speed change reaches the addon at the exact moment the new server-side cadence becomes effective — the addon's `rescale-remaining-by-ratio` math then produces a correct timer because the rescale happens on the swing-reset boundary, not mid-swing.

Mid-swing is detected as: `CurrentAttackTarget != default && lastSent > 0 && lastSwingMs > 0 && (now - lastSwingMs) < lastSent`. The `CurrentAttackTarget` gate avoids deferring at-rest SnD casts (e.g., build CPs, /stopattack, cast SnD — the haste should surface immediately on the paperdoll, not hang until SMSG_CANCEL_COMBAT).

Scoped to the local player — remote units don't have addons watching their swing timing and we lack the swing timestamp anyway. Falls through to existing pass-through behavior for non-player units and for the local player when not mid-swing.

## Files

- `HermesProxy/GlobalSessionData.cs`: 4 new arrays per slot (LastSent, Pending, HasPending, LastAttackerStateUpdateMs).
- `HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs`: intercept BASEATTACKTIME field, defer mid-swing.
- `HermesProxy/World/Client/PacketHandlers/CombatHandler.cs`: helper `FlushDeferredBaseAttackTime` synthesizes the UPDATE_OBJECT; called per slot on swing and on both slots on SMSG_CANCEL_COMBAT.

## Side effects (vanilla-faithful, intentional)

- SnD's haste visually applies one swing late on the swing bar when cast mid-swing. Matches what a native 1.12 client connected to a 1.12 server would render — the server's `m_attackTimer` only re-resets at the next swing fire.
- Paperdoll "Attack Speed" line lags by one swing for the same reason in the mid-swing case. At-rest casts surface immediately.

## Test plan

- [x] Rogue SnD R1 apply mid-swing on a target dummy — bar continues at old cadence until swing fires, snaps to new speed (no "0 hang").
- [x] Warrior Thunder Clap (-15% melee haste) applied mid-swing — same smooth pattern, both MH and OH slots tracked independently.
- [x] Stacked haste/slow transitions (TClap + SnD overlap, fade orders): all defer/flush pairs match the actual server-side swing reset boundaries.
- [x] SnD cast at-rest (build CPs → /stopattack → SnD before combat times out) — `CurrentAttackTarget == default` skips defer, paperdoll "Attack Speed" updates instantly.
- [x] Re-engage after at-rest SnD — first swing at new (hasted) cadence, no double-application.