### PR TITLE
Threat: skip AddThreat for non-creature victims (MC lag fix)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -265,6 +265,20 @@ public sealed class GameSessionData
     // as the base so we can synthesize ModRangedHaste = resting / current. Written from
     // the WorldClient handler thread; ConcurrentDictionary keeps it torn-state safe.
     public ConcurrentDictionary<WowGuid128, uint> RestingRangedAttackTime = new();
+    // JimsProxy (#320): defer mid-swing UNIT_FIELD_BASEATTACKTIME field changes for the
+    // local player until the next SMSG_ATTACKER_STATE_UPDATE. Vanilla server's
+    // m_attackTimer is frozen at swing-start cadence (vmangos Unit.cpp ResetAttackTimer
+    // fires only on swing-out, NOT when a ModMeleeHaste aura applies/removes mid-swing),
+    // so the in-flight swing finishes at the OLD speed while the BASEATTACKTIME field
+    // jumps to the new speed immediately. WeaponSwingTimer / Quartz / ClassicSwingTimer
+    // all rescale the remaining swing-bar by (new/old) on UnitAttackSpeed change, landing
+    // the bar at 0 BEFORE the actual swing fires — the "bar ends early then snaps" /
+    // "0 hang" symptom. Slot 0=MH, 1=OH; ranged has its own RestingRangedAttackTime path
+    // (PR #287) that operates on a different mechanism (animation engine, not addon API).
+    public uint[] LastSentBaseAttackTime = new uint[2];
+    public uint[] PendingBaseAttackTime = new uint[2];
+    public bool[] HasPendingBaseAttackTime = new bool[2];
+    public long[] LastAttackerStateUpdateMs = new long[2];
     // JimsProxy: pet creature family cache. SMSG_PET_SPELLS_MESSAGE on pre-3.1
     // servers doesn't carry the family on the wire — we derive it from the
     // creature template via GetItemId(petGuid). For quest-tame pets the

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -138,9 +138,43 @@ public partial class WorldClient
 
         SendPacketToClient(attack);
 
+        // JimsProxy (#320): on a real swing for the local player, record the swing time
+        // and flush any deferred BASEATTACKTIME so the speed change reaches the addon at
+        // the moment the new server-side cadence becomes effective. The HitInfo.OffHand
+        // bit picks the right slot.
+        if (attack.AttackerGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            int slot = (hitInfo & (uint)HitInfo.OffHand) != 0 ? 1 : 0;
+            FlushDeferredBaseAttackTime(slot);
+        }
+
         // Threat translation: feed melee swing damage into the threat tracker.
         // Vanilla damage threat is 1.0 × raw damage, no school weighting.
         GetSession().ThreatTracker.OnDamage(attack.AttackerGUID, attack.VictimGUID, attack.Damage);
+    }
+
+    // JimsProxy (#320): record the swing timestamp and, if a BASEATTACKTIME change was
+    // deferred while the in-flight swing was running, synthesize a values-update carrying
+    // just the new AttackRoundBaseTime so addons re-poll UnitAttackSpeed with the correct
+    // post-swing value. Called from HandleAttackerStateUpdate (slot per HitInfo.OffHand)
+    // and from the combat-exit / attack-stop paths (both slots) so a pending value never
+    // outlives the swing window.
+    void FlushDeferredBaseAttackTime(int slot)
+    {
+        var state = GetSession().GameState;
+        state.LastAttackerStateUpdateMs[slot] = Environment.TickCount64;
+        if (!state.HasPendingBaseAttackTime[slot])
+            return;
+
+        uint pending = state.PendingBaseAttackTime[slot];
+        UpdateObject updateObject = new UpdateObject(state);
+        ObjectUpdate update = new ObjectUpdate(state.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
+        update.UnitData.AttackRoundBaseTime[slot] = pending;
+        updateObject.ObjectUpdates.Add(update);
+        SendPacketToClient(updateObject);
+
+        state.LastSentBaseAttackTime[slot] = pending;
+        state.HasPendingBaseAttackTime[slot] = false;
     }
     [PacketHandler(Opcode.SMSG_ATTACKSWING_NOTINRANGE)]
     void HandleAttackSwingNotInRange(WorldPacket packet)
@@ -178,6 +212,11 @@ public partial class WorldClient
         GetSession().GameState.DeferredAttackStop = false;
         CancelCombat combat = new();
         SendPacketToClient(combat);
+
+        // JimsProxy (#320): combat ended — flush any deferred BASEATTACKTIME for both slots
+        // so a SnD/buff applied just before combat exit doesn't sit pending forever.
+        FlushDeferredBaseAttackTime(0);
+        FlushDeferredBaseAttackTime(1);
 
         // Drop every mob's threat list — vanilla 1.12 doesn't emit a
         // "threat ended" signal, so without this the modern client retains

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2373,10 +2373,53 @@ public partial class WorldClient
             int UNIT_FIELD_BASEATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_BASEATTACKTIME);
             if (UNIT_FIELD_BASEATTACKTIME >= 0)
             {
+                bool isLocalPlayer = guid == GetSession().GameState.CurrentPlayerGuid;
                 for (int i = 0; i < 2; i++)
                 {
-                    if (updateMaskArray[UNIT_FIELD_BASEATTACKTIME + i])
-                        updateData.UnitData.AttackRoundBaseTime[i] = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
+                    if (!updateMaskArray[UNIT_FIELD_BASEATTACKTIME + i])
+                        continue;
+
+                    uint raw = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
+
+                    // JimsProxy (#320): for the local player, defer mid-swing speed changes
+                    // until the next SMSG_ATTACKER_STATE_UPDATE flushes them. See the comment
+                    // on LastSentBaseAttackTime in GlobalSessionData for full rationale — the
+                    // vanilla server doesn't recalculate m_attackTimer mid-swing, so the
+                    // BASEATTACKTIME field changing immediately while the in-flight swing
+                    // finishes at the OLD cadence breaks swing-timer addons' rescale math.
+                    bool deferred = false;
+                    if (isLocalPlayer && raw > 0)
+                    {
+                        var state = GetSession().GameState;
+                        uint lastSent = state.LastSentBaseAttackTime[i];
+                        long lastSwingMs = state.LastAttackerStateUpdateMs[i];
+                        long nowMs = Environment.TickCount64;
+                        // Defer only when the player is actively in an attack cycle. If they
+                        // /stopattacked mid-swing then cast SnD before combat times out, we
+                        // want the haste change to surface immediately rather than hang
+                        // until SMSG_CANCEL_COMBAT — they're not visibly swinging, so the
+                        // addon's "rescale on speed change" math can't go wrong.
+                        bool isAttacking = state.CurrentAttackTarget != default;
+                        bool inFlight = isAttacking &&
+                                        lastSent > 0 && lastSwingMs > 0 &&
+                                        (nowMs - lastSwingMs) < lastSent;
+
+                        if (inFlight && raw != lastSent)
+                        {
+                            state.PendingBaseAttackTime[i] = raw;
+                            state.HasPendingBaseAttackTime[i] = true;
+                            updateData.UnitData.AttackRoundBaseTime[i] = lastSent;
+                            deferred = true;
+                        }
+                        else
+                        {
+                            state.LastSentBaseAttackTime[i] = raw;
+                            state.HasPendingBaseAttackTime[i] = false;
+                        }
+                    }
+
+                    if (!deferred)
+                        updateData.UnitData.AttackRoundBaseTime[i] = raw;
                 }
             }
             int UNIT_FIELD_RANGEDATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_RANGEDATTACKTIME);

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -497,6 +497,15 @@ public sealed class ThreatTracker
         }
         if (victim == default) return;
 
+        // JimsProxy: vanilla threat is creature-only. If the victim isn't a creature
+        // (e.g., an ally Mind-Controlled by an enemy mob, an enemy player in PvP, a
+        // friendly hunter pet caught in AoE), don't register them as a fake "mob"
+        // — doing so emits an SMSG_THREAT_UPDATE per damage event for a unit that
+        // can't actually hold threat, which cascades to every group member's proxy
+        // and addon (Plater, Details, TinyThreat) and shows up as a damage-tick-
+        // synchronized lag spike. Reported repeatedly against MC scenarios in BGs.
+        if (victim.GetHighType() != HighGuidType.Creature) return;
+
         double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);
         double passiveModifier = GetPassiveModifier(attacker);
         double talentMultiplier = GetSpellTalentMultiplier(attacker, spellId);


### PR DESCRIPTION
## Symptom

Reports from BG players: every time a party member gets Mind-Controlled (Gnomish Mind Control Cap, enemy mob MCs, etc.) and takes damage, the rest of the group experiences a damage-tick-synchronized lag spike. Visible on the wearer-of-cap repro but the underlying bug fires for any Mind Control source.

## Root cause

`ThreatTracker.OnDamage` was unconditionally calling `AddThreat(victim, attacker, ...)` whenever the attacker passed `IsRelevantThreater`. There's no guard that the *victim* is actually a unit type that can hold threat. In vanilla, threat is a creature-only mechanic — players (including MC'd allies), player pets, and enemy players in PvP can't hold threat.

When an MC'd ally takes damage from a fellow party member trying to break the MC:
- `attacker` = ally player → passes `IsRelevantThreater` (since Phase 6.0 widened to full party).
- `victim` = MC'd ally → still a player GUID, no special handling.
- `AddThreat(MC'd_ally, ally, scaled_threat)` → registers the MC'd ally in `_threatLists` as a fake "mob".
- `EmitDirty()` → synthesizes `SMSG_THREAT_UPDATE` (and possibly `SMSG_HIGHEST_THREAT_UPDATE`) for that ghost mob.

Every party member's proxy independently produces this cascade on every damage tick. Client-side threat addons (Plater nameplates, Details TinyThreat, ThreatPlates) redraw per spurious threat event, multiplying the cost. Net effect: one MC + a few party members attacking it = a flood of synthetic threat traffic synchronized with damage ticks → the reported lag spike.

## Timing of the regression

| Date | Commit | Behavior |
|---|---|---|
| Pre-2026-05-04 | (no threat engine) | No `SMSG_THREAT_UPDATE` synthesis possible. |
| 2026-05-04 | `8272cba` "Threat Phase 2" | Bug introduced but scoped — only local player's damage on an MC'd ally tripped it. Low volume. |
| **2026-05-10** | `fff0f5a` "Threat Phase 6.0+6.1: full-party threat" | `IsRelevantThreater` widened to full party/raid. **Now every party member's damage** to an MC'd ally fires `AddThreat`. Bug volume scales with group size. |

Phase 6.0 widened the *attacker* filter correctly (group threat is the right design), but didn't add the matching *victim* type constraint.

## Fix

Single guard in `OnDamage` after the existing `victim == default` check:

```csharp
if (victim.GetHighType() != HighGuidType.Creature) return;
```

Other `AddThreat` call sites are already naturally constrained:
- `OnHeal` only iterates mobs that are already in `_threatLists` (and our guard prevents non-creatures from getting in there in the first place).
- `OnEnergize`'s `AddThreatToAllMobs` walks existing mobs.
- `ThreatNPCModules` entries are gated on `(npcEntry, spellId)` table lookups — never hit for player/pet entries.
- `OnSpellCast` routes through `ThreatModules` / `ThreatNPCModules` — same gating.

So the single victim-type guard in `OnDamage` is the only place that needed it.

## Side notes

- **PvP scenarios were also silently wrong** — `AddThreat(enemy_player, ally, ...)` was generating phantom threat updates for any allied damage on enemy players. Fix covers this case implicitly.
- **Stale threat entries** from before the fix decay naturally via existing cleanup paths (`OnLocalPlayerLeftCombat`, `OnUnitDestroyed`, `ClearMob` on `SMSG_PARTY_KILL_LOG`). No proactive purge needed.

## DC reports

Players also report DCs in the same MC scenarios. From the bundle reviewed (`jimsproxy-20260526-143828.jsonl`), no DC was traceable to the threat-emit path — the one DC in the log was on a stale secondary connection (`was_active_world_client: false`, last opcode `SMSG_UPDATE_OBJECT`). The threat-update synthesis doesn't throw or emit malformed packets. The DC reports are likely a separate bug — possibly `SMSG_PET_SPELLS_MESSAGE` for an MC'd "pet" carrying player-class spell IDs in a shape the modern client doesn't expect — and will need a fresh bundle from someone who actually DC'd to investigate.

This PR ships the lag fix only.

## Test plan

- [x] Code review confirms only OnDamage was missing the guard.
- [ ] In-game: have someone get MC'd in a BG, allies attack to break, watch proxy SMSG_THREAT_UPDATE rate (should drop to baseline) and party member lag spike reports (should stop).
- [ ] Watch DC reports — if they persist after this fix lands, the DC is a separate bug.