### PR TITLE
Aura quad: don't phantom-refresh non-stackable adjacent slots

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -265,6 +265,20 @@ public sealed class GameSessionData
     // as the base so we can synthesize ModRangedHaste = resting / current. Written from
     // the WorldClient handler thread; ConcurrentDictionary keeps it torn-state safe.
     public ConcurrentDictionary<WowGuid128, uint> RestingRangedAttackTime = new();
+    // JimsProxy (#320): defer mid-swing UNIT_FIELD_BASEATTACKTIME field changes for the
+    // local player until the next SMSG_ATTACKER_STATE_UPDATE. Vanilla server's
+    // m_attackTimer is frozen at swing-start cadence (vmangos Unit.cpp ResetAttackTimer
+    // fires only on swing-out, NOT when a ModMeleeHaste aura applies/removes mid-swing),
+    // so the in-flight swing finishes at the OLD speed while the BASEATTACKTIME field
+    // jumps to the new speed immediately. WeaponSwingTimer / Quartz / ClassicSwingTimer
+    // all rescale the remaining swing-bar by (new/old) on UnitAttackSpeed change, landing
+    // the bar at 0 BEFORE the actual swing fires — the "bar ends early then snaps" /
+    // "0 hang" symptom. Slot 0=MH, 1=OH; ranged has its own RestingRangedAttackTime path
+    // (PR #287) that operates on a different mechanism (animation engine, not addon API).
+    public uint[] LastSentBaseAttackTime = new uint[2];
+    public uint[] PendingBaseAttackTime = new uint[2];
+    public bool[] HasPendingBaseAttackTime = new bool[2];
+    public long[] LastAttackerStateUpdateMs = new long[2];
     // JimsProxy: pet creature family cache. SMSG_PET_SPELLS_MESSAGE on pre-3.1
     // servers doesn't carry the family on the wire — we derive it from the
     // creature template via GetItemId(petGuid). For quest-tame pets the

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -138,9 +138,43 @@ public partial class WorldClient
 
         SendPacketToClient(attack);
 
+        // JimsProxy (#320): on a real swing for the local player, record the swing time
+        // and flush any deferred BASEATTACKTIME so the speed change reaches the addon at
+        // the moment the new server-side cadence becomes effective. The HitInfo.OffHand
+        // bit picks the right slot.
+        if (attack.AttackerGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            int slot = (hitInfo & (uint)HitInfo.OffHand) != 0 ? 1 : 0;
+            FlushDeferredBaseAttackTime(slot);
+        }
+
         // Threat translation: feed melee swing damage into the threat tracker.
         // Vanilla damage threat is 1.0 × raw damage, no school weighting.
         GetSession().ThreatTracker.OnDamage(attack.AttackerGUID, attack.VictimGUID, attack.Damage);
+    }
+
+    // JimsProxy (#320): record the swing timestamp and, if a BASEATTACKTIME change was
+    // deferred while the in-flight swing was running, synthesize a values-update carrying
+    // just the new AttackRoundBaseTime so addons re-poll UnitAttackSpeed with the correct
+    // post-swing value. Called from HandleAttackerStateUpdate (slot per HitInfo.OffHand)
+    // and from the combat-exit / attack-stop paths (both slots) so a pending value never
+    // outlives the swing window.
+    void FlushDeferredBaseAttackTime(int slot)
+    {
+        var state = GetSession().GameState;
+        state.LastAttackerStateUpdateMs[slot] = Environment.TickCount64;
+        if (!state.HasPendingBaseAttackTime[slot])
+            return;
+
+        uint pending = state.PendingBaseAttackTime[slot];
+        UpdateObject updateObject = new UpdateObject(state);
+        ObjectUpdate update = new ObjectUpdate(state.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
+        update.UnitData.AttackRoundBaseTime[slot] = pending;
+        updateObject.ObjectUpdates.Add(update);
+        SendPacketToClient(updateObject);
+
+        state.LastSentBaseAttackTime[slot] = pending;
+        state.HasPendingBaseAttackTime[slot] = false;
     }
     [PacketHandler(Opcode.SMSG_ATTACKSWING_NOTINRANGE)]
     void HandleAttackSwingNotInRange(WorldPacket packet)
@@ -178,6 +212,11 @@ public partial class WorldClient
         GetSession().GameState.DeferredAttackStop = false;
         CancelCombat combat = new();
         SendPacketToClient(combat);
+
+        // JimsProxy (#320): combat ended — flush any deferred BASEATTACKTIME for both slots
+        // so a SnD/buff applied just before combat exit doesn't sit pending forever.
+        FlushDeferredBaseAttackTime(0);
+        FlushDeferredBaseAttackTime(1);
 
         // Drop every mob's threat list — vanilla 1.12 doesn't emit a
         // "threat ended" signal, so without this the modern client retains

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2373,10 +2373,53 @@ public partial class WorldClient
             int UNIT_FIELD_BASEATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_BASEATTACKTIME);
             if (UNIT_FIELD_BASEATTACKTIME >= 0)
             {
+                bool isLocalPlayer = guid == GetSession().GameState.CurrentPlayerGuid;
                 for (int i = 0; i < 2; i++)
                 {
-                    if (updateMaskArray[UNIT_FIELD_BASEATTACKTIME + i])
-                        updateData.UnitData.AttackRoundBaseTime[i] = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
+                    if (!updateMaskArray[UNIT_FIELD_BASEATTACKTIME + i])
+                        continue;
+
+                    uint raw = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
+
+                    // JimsProxy (#320): for the local player, defer mid-swing speed changes
+                    // until the next SMSG_ATTACKER_STATE_UPDATE flushes them. See the comment
+                    // on LastSentBaseAttackTime in GlobalSessionData for full rationale — the
+                    // vanilla server doesn't recalculate m_attackTimer mid-swing, so the
+                    // BASEATTACKTIME field changing immediately while the in-flight swing
+                    // finishes at the OLD cadence breaks swing-timer addons' rescale math.
+                    bool deferred = false;
+                    if (isLocalPlayer && raw > 0)
+                    {
+                        var state = GetSession().GameState;
+                        uint lastSent = state.LastSentBaseAttackTime[i];
+                        long lastSwingMs = state.LastAttackerStateUpdateMs[i];
+                        long nowMs = Environment.TickCount64;
+                        // Defer only when the player is actively in an attack cycle. If they
+                        // /stopattacked mid-swing then cast SnD before combat times out, we
+                        // want the haste change to surface immediately rather than hang
+                        // until SMSG_CANCEL_COMBAT — they're not visibly swinging, so the
+                        // addon's "rescale on speed change" math can't go wrong.
+                        bool isAttacking = state.CurrentAttackTarget != default;
+                        bool inFlight = isAttacking &&
+                                        lastSent > 0 && lastSwingMs > 0 &&
+                                        (nowMs - lastSwingMs) < lastSent;
+
+                        if (inFlight && raw != lastSent)
+                        {
+                            state.PendingBaseAttackTime[i] = raw;
+                            state.HasPendingBaseAttackTime[i] = true;
+                            updateData.UnitData.AttackRoundBaseTime[i] = lastSent;
+                            deferred = true;
+                        }
+                        else
+                        {
+                            state.LastSentBaseAttackTime[i] = raw;
+                            state.HasPendingBaseAttackTime[i] = false;
+                        }
+                    }
+
+                    if (!deferred)
+                        updateData.UnitData.AttackRoundBaseTime[i] = raw;
                 }
             }
             int UNIT_FIELD_RANGEDATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_RANGEDATTACKTIME);

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2955,10 +2955,21 @@ public partial class WorldClient
                         {
                             // The cached Applications is post-ReadAuraSlot adjustment:
                             //   wire + (1 if StackableAuras), then clamped to >=1.
-                            // Reverse the StackableAuras +1 to recover the expected wire byte.
+                            // Reverse both adjustments to recover the actual wire byte the server
+                            // would have written for THIS slot. Without the clamp reversal, every
+                            // non-stackable aura at wire-byte=0 (e.g. Kidney Shot, Cheap Shot, any
+                            // single-application debuff) gets a phantom re-emit whenever a *different*
+                            // slot in the same UNIT_FIELD_AURAAPPLICATIONS quad changes — because
+                            // the quad's mask fires for all 4 slots and the byte-diff check sees
+                            // cached=1 vs wire=0. Symptom: Hemorrhage cast on a target with Kidney
+                            // Shot in an adjacent slot triggered a Flicker refresh of the Kidney
+                            // Shot timer on every Hemorrhage proc.
                             byte expectedWire = cachedAuraForApps.Applications;
-                            if (GameData.StackableAuras.Contains(cachedAuraForApps.SpellID) && expectedWire > 0)
+                            bool isStackable = GameData.StackableAuras.Contains(cachedAuraForApps.SpellID);
+                            if (isStackable && expectedWire > 0)
                                 expectedWire = (byte)(expectedWire - 1);
+                            else if (!isStackable && expectedWire == 1)
+                                expectedWire = 0;
                             if (newWireApps != expectedWire)
                                 appsOnlyChanged = true;
                         }

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -497,6 +497,15 @@ public sealed class ThreatTracker
         }
         if (victim == default) return;
 
+        // JimsProxy: vanilla threat is creature-only. If the victim isn't a creature
+        // (e.g., an ally Mind-Controlled by an enemy mob, an enemy player in PvP, a
+        // friendly hunter pet caught in AoE), don't register them as a fake "mob"
+        // — doing so emits an SMSG_THREAT_UPDATE per damage event for a unit that
+        // can't actually hold threat, which cascades to every group member's proxy
+        // and addon (Plater, Details, TinyThreat) and shows up as a damage-tick-
+        // synchronized lag spike. Reported repeatedly against MC scenarios in BGs.
+        if (victim.GetHighType() != HighGuidType.Creature) return;
+
         double abilityMultiplier = ThreatModules.GetDamageMultiplier(spellId);
         double passiveModifier = GetPassiveModifier(attacker);
         double talentMultiplier = GetSpellTalentMultiplier(attacker, spellId);


### PR DESCRIPTION
## Symptom

Rogue applies a 5 CP Kidney Shot, then weaves Hemorrhage. On every Hemorrhage proc (each melee hit consumes one of Hemorrhage's 10 charges) the Kidney Shot debuff timer visibly refreshes on the target — the Flicker animation fires and the swing-bar/duration UI restarts. Sinister Strike does not cause this. Same shape applies to Cheap Shot and any other non-stackable aura sitting in a slot adjacent to a stackable aura whose charge count is decrementing.

## Root cause

`UNIT_FIELD_AURAAPPLICATIONS` packs four aura slots into one uint32 (one byte per slot). When ANY slot in a quad changes its application count, the wire mask fires for ALL four slots. The proxy's per-slot byte-diff guard at `UpdateHandler.cs:2962` exists specifically to filter this — it reverse-engineers the expected wire byte from the cached `AuraDataInfo.Applications` and re-emits only when the per-slot byte actually differs.

But the reversal only undid the `+1` adjustment applied for stackable auras (`UpdateHandler.cs:1625`). It didn't undo the second adjustment a few lines later (`UpdateHandler.cs:1636-1637`) — the clamp-to-1 from the Stealth idle-animation fix, which fires for non-stackable auras whose wire byte is 0. That clamp means:

- Wire byte for non-stackable aura at single application: 0
- `ReadAuraSlot` stores: `Applications = 1` (clamped)
- Diff check derives `expectedWire = 1` (no stackable subtraction applies)
- New wire byte for the unchanged slot: still 0
- 0 ≠ 1 → `appsOnlyChanged = true` → re-emit → SendAuraRefreshUpdate Flicker → timer refresh.

Hemorrhage (16511, 17347, 17348, 17349) is in `StackableAuras1.csv` so its charge decrement legitimately drives the quad mask. Kidney Shot (408, 9005-9007) and Cheap Shot (1833, 8643) are not in `StackableAuras1.csv` and only ever sit at wire-byte=0. Any time they share a quad with Hemorrhage (or any other actively-decrementing stackable aura) they hit this phantom-refresh path on every charge consumption.

## Why Sinister Strike doesn't repro the symptom

Sinister Strike is not in `AuraSpells1.csv` so its SMSG_SPELL_GO never enters `SendAuraRefreshUpdate`, and it doesn't apply a stackable aura whose charges would otherwise drive the quad mask. Hemorrhage hits both conditions, which is why it's the unique trigger.

## Fix

When reversing the cached `Applications` back to the expected wire byte, also reverse the non-stackable clamp:

```csharp
byte expectedWire = cachedAuraForApps.Applications;
bool isStackable = GameData.StackableAuras.Contains(cachedAuraForApps.SpellID);
if (isStackable && expectedWire > 0)
    expectedWire = (byte)(expectedWire - 1);
else if (!isStackable && expectedWire == 1)
    expectedWire = 0;
```

For non-stackable auras with `cached.Applications == 1`, the underlying wire byte is always 0 in vmangos/cmangos (procCharges - 1 = 0 for procCharges = 1). The reversal pairs with the existing stackable reversal so the diff check now matches the wire reality across both paths.

## Repro evidence

From bundle `jimsproxy-20260526-105424.jsonl`, immediately after Hemorrhage (17348) was applied at slot 33:

```
T=1779810911063 aura.slot.set: slot=32 spell_id=8643 mask_apps=true mask_aura=false slot_field_value=0 (Kidney Shot, NOT changed but phantom re-emitted)
T=1779810911064 aura.slot.set: slot=33 spell_id=17348 mask_apps=true (Hemorrhage, actually applied)
```

Slots 32 and 33 share the same UNIT_FIELD_AURAAPPLICATIONS uint32 (32/4 == 33/4 == 8). The slot 32 emit is the phantom this PR removes.

## Test plan

- [x] Build clean (0 warnings, 0 errors).
- [ ] In-game: rogue applies Kidney Shot to a target, weaves Hemorrhage during the stun, watches the Kidney Shot debuff timer on the target. Expected: smooth countdown, no Flicker animation on Hemorrhage hits. Cross-check by also testing during Sinister Strike weave to confirm baseline behavior unchanged.
- [ ] No regression for stackable aura stack tracking (Lightning Shield charges, Sunder Armor stacks, Devouring Plague ticks) — the stackable branch is untouched.