### PR TITLE
Fix JimsPlus castbar checkboxes showing unchecked while castbars are running

### DIFF
--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -114,11 +114,14 @@ local function RefreshCheckboxes()
     end
 end
 panel:SetScript("OnShow", RefreshCheckboxes)
+panel.refresh = RefreshCheckboxes
 
 local initFrame = CreateFrame("Frame")
 initFrame:RegisterEvent("PLAYER_LOGIN")
 initFrame:SetScript("OnEvent", function()
-    RefreshCheckboxes()
+    -- Defer to next frame so CastBars.lua's PLAYER_LOGIN handler runs first
+    -- and populates JimsPlusCastbars.db before we read it.
+    C_Timer.After(0, RefreshCheckboxes)
     initFrame:UnregisterAllEvents()
 end)
 


### PR DESCRIPTION
## Symptom

The JimsPlus settings panel shows the Target / Nameplate / Focus castbar checkboxes as **unchecked**, even though the castbars themselves are actually running on screen.

## Root cause

Frame registration order at PLAYER_LOGIN.

`Options.lua` is loaded before `castbars/CastBars.lua` (per `JimsPlus.toc`), so its PLAYER_LOGIN-listening frame registers first. WoW fires PLAYER_LOGIN to handlers in registration order:

1. `Options.lua`'s `initFrame` runs `RefreshCheckboxes()` — but `JimsPlusCastbars.db` is still `nil` at this moment (the frame exists, but `.db` is only assigned inside `CastBars.lua`'s own PLAYER_LOGIN handler, which hasn't run yet). The `if cdb then ... end` block is skipped, so the castbar checkboxes never get their state set.
2. `CastBars.lua` runs second — `self.db` gets populated from `CopyDefaults(namespace.defaultConfig, JimsPlusCastbarsDB)`, `ToggleUnitEvents()` registers events, and the castbars start working with the defaults (`target.enabled = true`, `nameplate.enabled = true`, `focus.enabled = true`).

Net effect: castbars work, but the checkboxes look off.

The existing `OnShow` script is a secondary safety net, but in Classic Era the Interface Options panel doesn't always re-fire `OnShow` if it was already shown once at registration time. The Blizzard-canonical refresh hook is `panel.refresh`, which wasn't set.

## Fix

Two small changes in `Options.lua`:

1. Defer the initial PLAYER_LOGIN refresh via `C_Timer.After(0, RefreshCheckboxes)` so it runs after every other PLAYER_LOGIN handler — `JimsPlusCastbars.db` is populated by then.
2. Add `panel.refresh = RefreshCheckboxes` so the standard Interface Options API path also re-syncs the checkboxes every time the panel is opened.

The `OnShow` script is left in place as additional belt-and-suspenders coverage.

## Test plan

- [ ] Fresh login with default settings — Target / Nameplate / Focus checkboxes display as checked; Player / Party as unchecked
- [ ] `/jp` opens the panel with correct state on first invocation
- [ ] Toggle a checkbox off, `/reload`, panel re-opens with that checkbox off
- [ ] Toggle a checkbox back on and confirm castbars actually start/stop appropriately