### PR TITLE
Fix: synthesize ControlUpdate restore when server omits it after BG exit

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -103,6 +103,10 @@ public sealed class GameSessionData
     // by hardcoding 7.0f. Default true: a player who has never been CC'd is
     // always in control, so the natural login state is "has control already."
     public bool LastObservedHasControl = true;
+    // JimsProxy (bg-exit-control-stuck): TickCount64 of the most recent
+    // HandleNewWorld inside the IsWaitingForNewWorld path. Gates the
+    // defensive ControlUpdate synth to a narrow post-transfer window.
+    public long WorldTransferTimestampMs;
     // JimsProxy (speed-stuck-after-fear-while-mounted): cached for reassert; see memory.
     public float LastKnownPlayerRunSpeed = 7.0f;
     // JimsProxy (speed-stuck-after-bg-end-while-mounted): deferred reassert flag; see memory.

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -319,6 +319,7 @@ public partial class WorldClient
         {
             GetSession().GameState.IsWaitingForNewWorld = false;
             GetSession().GameState.IsWaitingForWorldPortAck = true;
+            GetSession().GameState.WorldTransferTimestampMs = Environment.TickCount64;
 
             // JimsProxy (zone-transfer cast-state cleanup): the source map's server
             // state is torn down on transition (BG entry, instance change, zep arrival,
@@ -601,6 +602,39 @@ public partial class WorldClient
         flag.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         flag.MoveCounter = packet.ReadUInt32();
         SendPacketToClient(flag);
+
+        // JimsProxy (bg-exit-control-stuck): when SMSG_MOVE_UNROOT arrives for
+        // the local player within 5s of a world transfer and the server never
+        // sent CONTROL_UPDATE(HasControl=true), synthesize one. Without this,
+        // a missing server restore leaves the player permanently locked out
+        // (black action bars, can't move). PTR-verified: flight paths and
+        // death do not use CONTROL_UPDATE, so this only triggers on BG-exit
+        // or instance-exit control restores. A redundant HasControl=true is
+        // a no-op if the server already restored control normally.
+        if (packet.GetUniversalOpcode(false) == Opcode.SMSG_MOVE_UNROOT
+            && flag.MoverGUID == GetSession().GameState.CurrentPlayerGuid
+            && !GetSession().GameState.LastObservedHasControl
+            && (Environment.TickCount64 - GetSession().GameState.WorldTransferTimestampMs) < 5000)
+        {
+            ControlUpdate controlFix = new ControlUpdate();
+            controlFix.Guid = flag.MoverGUID;
+            controlFix.HasControl = true;
+            SendPacketToClient(controlFix);
+            GetSession().GameState.LastObservedHasControl = true;
+
+            MoveSetSpeed runFix = new MoveSetSpeed(Opcode.SMSG_MOVE_SET_RUN_SPEED);
+            runFix.MoverGUID = flag.MoverGUID;
+            runFix.MoveCounter = 0;
+            runFix.Speed = GetSession().GameState.LastKnownPlayerRunSpeed;
+            SendPacketToClient(runFix);
+
+            Log.Event("movement.control_restore.synthesized", new
+            {
+                player_low = flag.MoverGUID.GetCounter(),
+                ms_since_world_transfer = Environment.TickCount64 - GetSession().GameState.WorldTransferTimestampMs,
+                map_id = GetSession().GameState.CurrentMapId,
+            });
+        }
     }
 
     [PacketHandler(Opcode.SMSG_COMPRESSED_MOVES)]


### PR DESCRIPTION
## Summary

When a BG ends, the server sends `SMSG_CONTROL_UPDATE(HasControl=false)` to freeze the player for the scoreboard. After the world transfer back, the server should send `SMSG_CONTROL_UPDATE(HasControl=true)` to restore control. In rare cases the restore never arrives — permanent lockout (black action bars, can't move, must relog).

When `SMSG_MOVE_UNROOT` arrives for the local player within 5s of a world transfer and `LastObservedHasControl` is still false, synthesize `ControlUpdate(HasControl=true)` + run speed reassert.

## Evidence

602k-line JSONL log (C*******L, Kronos V, 2026-05-26): 4/5 BG exits had paired CONTROL_UPDATE false/true. 5th exit had false with no true for the remaining ~2000 lines until logout. Zero CMSG_MOVE_* from the player after the bug — total lockout confirmed.

## Safety

- **Flight paths** do not use CONTROL_UPDATE — they use the taxi handler's own control synthesis. PTR-verified.
- **Death/spirit release** does not use CONTROL_UPDATE. PTR-verified.
- **Login spawn burst** always sends its own CONTROL_UPDATE(true) before any UNROOT, so `LastObservedHasControl` is already true by the time this check runs.
- **5s time window** prevents triggering during normal gameplay root/unroot cycles (frost nova, hamstring root, etc.).
- **Redundant HasControl=true** is a no-op if the server already restored control normally.
- Emits `movement.control_restore.synthesized` structured event for monitoring.

## Open questions

- Root cause is likely server-side (Kronos). The trigger appears to be accumulated state from earlier transitions (mage portal + flight path chain before the BG), not the destination position. This fix is a defensive safety net, not a root cause fix.
- Should we also log the `HasControl` value in `HandleControlUpdate` for future diagnostics? Currently we track it in GameState but don't emit it to JSONL.

## Test plan

- Enter and exit multiple BGs. Verify no `movement.control_restore.synthesized` events in normal operation (server sends its own restore).
- If the bug reproduces (rare), verify the synthesized event fires and the player regains control without needing to relog.
- Check that flight path takeoff/landing is unaffected.
- Check that death/rez near water is unaffected.