### PR TITLE
Erkagon misc fixes

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -383,6 +383,7 @@ public sealed class GameSessionData
     private bool _gcdTimerHasFired;                     // true after OnGcdTimerElapsed runs; prevents orphaned holds
     private uint _lastFiredSpellId;                     // spell ID forwarded by the timer; used to drop same-spell late presses
     public Action<ClientCastRequest>? OnGcdHeldCastFire; // set by WorldSocket at attach time; invoked on a ThreadPool thread at GCD expiry
+    public Action<ClientCastRequest>? OnAutoRepeatRetry; // set by WorldSocket; refires Shoot/Auto Shot after retryable legacy failures
 
     // JimsProxy: cast-time spell queue. While a cast-time spell is in progress
     // (HasStartedNormalCast), presses are held here instead of dropped. Fired
@@ -1700,6 +1701,7 @@ public sealed class GameSessionData
         // path that normally nulls it.
         CurrentClientNextMeleeCast = null;
         CurrentClientAutoRepeatCast = null;
+        OnAutoRepeatRetry = null;
         return (normalCount, petCount, otherCount);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -563,7 +563,7 @@ public partial class WorldClient
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeVanilla.Whisper:
-                packet.WriteCString(to);
+                packet.WriteCString(NormalizeLegacyWhisperTarget(to));
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeVanilla.Say:
@@ -639,7 +639,7 @@ public partial class WorldClient
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeWotLK.Whisper:
-                packet.WriteCString(to);
+                packet.WriteCString(NormalizeLegacyWhisperTarget(to));
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeWotLK.Say:
@@ -661,6 +661,16 @@ public partial class WorldClient
         }
 
         SendPacket(packet);
+    }
+
+    private static string NormalizeLegacyWhisperTarget(string target)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+            return target;
+
+        target = target.Trim();
+        int realmSeparator = target.IndexOf('-');
+        return realmSeparator >= 0 ? target.Substring(0, realmSeparator) : target;
     }
 
     [PacketHandler(Opcode.SMSG_EMOTE)]

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -19,6 +19,9 @@ public partial class WorldClient
     // and shorter than feels-laggy to the user when the pathological Kronos
     // case kicks in (target-dies-mid-cast, no trailing CAST_FAILED).
     private const long WatchdogWindowMs = 2500;
+    private const int AutoRepeatRetryFallbackDelayMs = 1500;
+    private const int AutoRepeatRetryMinDelayMs = 500;
+    private const int AutoRepeatRetryMaxDelayMs = 3500;
 
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_SEND_KNOWN_SPELLS)]
@@ -374,8 +377,14 @@ public partial class WorldClient
             failed.FailedArg2 = arg2;
             SendPacketToClient(failed);
 
-            if (isAutoRepeat)
+            if (isAutoRepeat && IsRetryableAutoRepeatFailure(reason))
+            {
+                ScheduleAutoRepeatRetry(specialCast);
+            }
+            else if (isAutoRepeat)
+            {
                 GetSession().GameState.CurrentClientAutoRepeatCast = null;
+            }
             else
                 GetSession().GameState.CurrentClientNextMeleeCast = null;
         }
@@ -622,6 +631,52 @@ public partial class WorldClient
             failed.FailedArg2 = packet.ReadInt32();
 
         SendPacketToClient(failed);
+    }
+
+    private static bool IsRetryableAutoRepeatFailure(uint reason)
+    {
+        uint classicReason = LegacyVersion.ConvertSpellCastResult(reason);
+        return classicReason == (uint)SpellCastResultClassic.LineOfSight ||
+               classicReason == (uint)SpellCastResultClassic.OutOfRange;
+    }
+
+    private void ScheduleAutoRepeatRetry(ClientCastRequest cast)
+    {
+        int delayMs = GetAutoRepeatRetryDelayMs(cast);
+        // Legacy servers stop ranged auto-repeat after pre-shot LoS/range failures.
+        // Keep the user's Shoot/Auto Shot intent alive at the natural ranged swing cadence.
+        System.Threading.Tasks.Task.Delay(delayMs).ContinueWith(_ =>
+        {
+            try
+            {
+                var current = GetSession().GameState.CurrentClientAutoRepeatCast;
+                if (!ReferenceEquals(current, cast))
+                    return;
+
+                GetSession().GameState.OnAutoRepeatRetry?.Invoke(cast);
+            }
+            catch
+            {
+                // Best-effort retry: a stale callback should never tear down the world session.
+            }
+        });
+    }
+
+    private int GetAutoRepeatRetryDelayMs(ClientCastRequest cast)
+    {
+        uint rangedAttackTime = GetSession().GameState.GetLegacyFieldValueUInt32(
+            GetSession().GameState.CurrentPlayerGuid,
+            UnitField.UNIT_FIELD_RANGEDATTACKTIME);
+        int attackTimeMs = rangedAttackTime > 0
+            ? (int)rangedAttackTime
+            : AutoRepeatRetryFallbackDelayMs;
+        attackTimeMs = Math.Clamp(attackTimeMs, AutoRepeatRetryMinDelayMs, AutoRepeatRetryMaxDelayMs);
+
+        int elapsedSinceAttemptMs = (int)Math.Max(0, Environment.TickCount - cast.Timestamp);
+        return Math.Clamp(
+            attackTimeMs - elapsedSinceAttemptMs,
+            AutoRepeatRetryMinDelayMs,
+            AutoRepeatRetryMaxDelayMs);
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_FAILED_OTHER)]
@@ -1624,8 +1679,9 @@ public partial class WorldClient
             GetSession().GameState.CurrentClientAutoRepeatCast != null &&
             GetSession().GameState.CurrentClientAutoRepeatCast!.SpellId == spell.Cast.SpellID)
         {
-            spell.Cast.CastID = GetSession().GameState.CurrentClientAutoRepeatCast!.ServerGUID;
-            spell.Cast.SpellXSpellVisualID = GetSession().GameState.CurrentClientAutoRepeatCast!.SpellXSpellVisualId;
+            var current = GetSession().GameState.CurrentClientAutoRepeatCast!;
+            spell.Cast.CastID = current.ServerGUID;
+            spell.Cast.SpellXSpellVisualID = current.SpellXSpellVisualId;
             // Note: Don't clear auto-repeat cast here - it stays active until cancelled
         }
         else if (GetSession().GameState.CurrentPetGuid == spell.Cast.CasterUnit &&

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -243,6 +243,8 @@ public partial class WorldSocket
         // in GameSessionData can forward held casts via this socket.
         if (isVanillaServer && GetSession().GameState.OnGcdHeldCastFire == null)
             GetSession().GameState.OnGcdHeldCastFire = ForwardHeldGcdCast;
+        if (isVanillaServer)
+            GetSession().GameState.OnAutoRepeatRetry = ForwardAutoRepeatRetry;
 
         if (isNextMelee || isAutoRepeat)
         {
@@ -254,6 +256,8 @@ public partial class WorldSocket
             castRequest.SpellXSpellVisualId = cast.Cast.SpellXSpellVisualID;
             castRequest.ClientGUID = cast.Cast.CastID;
             castRequest.TargetGuid = cast.Cast.Target.Unit;
+            if (isAutoRepeat)
+                castRequest.HeldPacketForReplay = BuildCastSpellPacket(cast);
 
             // Get the appropriate tracking variable based on spell type
             ref ClientCastRequest? currentCast = ref (isAutoRepeat
@@ -677,6 +681,16 @@ public partial class WorldSocket
         });
         SendPacketToServer(cast.HeldPacketForReplay);
     }
+
+    internal void ForwardAutoRepeatRetry(ClientCastRequest cast)
+    {
+        if (cast.HeldPacketForReplay == null)
+            return;
+
+        cast.Timestamp = Environment.TickCount;
+        SendPacketToServer(cast.HeldPacketForReplay);
+    }
+
     [PacketHandler(Opcode.CMSG_PET_CAST_SPELL)]
     void HandlePetCastSpell(PetCastSpell cast)
     {
@@ -845,6 +859,7 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_CANCEL_AUTO_REPEAT_SPELL)]
     void HandleCancelAutoRepeatSpell(CancelAutoRepeatSpell spell)
     {
+        GetSession().GameState.CurrentClientAutoRepeatCast = null;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_AUTO_REPEAT_SPELL);
         SendPacketToServer(packet);
     }


### PR DESCRIPTION
## Summary

This PR contains two small client/proxy compatibility fixes for Classic 1.14 clients connected to legacy 1.12 servers.

## Ranged auto-repeat after LoS failures

When using ranged auto-repeat spells such as `Shoot`, if the initial cast failed because the target was behind line of sight, the proxy cleared the current auto-repeat state after receiving the legacy spell failure.

On a native 1.12 client this behavior recovers once the target becomes visible again, but with the 1.14 client through HermesProxy the client did not send another cast request. The character stayed visually ready to attack, but ranged auto-repeat never resumed.

The fix keeps retryable ranged auto-repeat casts active for LoS/range-style failures and schedules a replay of the original held cast packet based on the player's ranged attack speed. Explicit `CMSG_CANCEL_AUTO_REPEAT_SPELL` still clears the state normally.

## Whisper target normalization

Some clients can produce reply targets in modern cross-realm format, for example `Player-Realm`. In the reported broken case the realm suffix was empty, producing `Player-`.

HermesProxy previously forwarded that target string directly to the legacy server, causing the server to look for a character literally named `Player-`, so the whisper failed.

The fix normalizes whisper targets before writing the legacy `CMSG_MESSAGECHAT` packet. If the target contains a realm separator (`-`), only the local player name before the separator is sent to the legacy server.

This is safe for 1.12-style servers because player names do not contain hyphens and the legacy whisper packet expects a local character name.

## Testing

- Built successfully with `dotnet build HermesProxy/HermesProxy.csproj -c Release`.
- Ranged auto-repeat LoS retry was tested in game and confirmed working.
- Whisper normalization is a defensive proxy-side fix for a reported issue that could not be reproduced locally.