### PR TITLE
Fix login crash on truncated AccountData cache files

### DIFF
--- a/HermesProxy/World/Server/AccountDataManager.cs
+++ b/HermesProxy/World/Server/AccountDataManager.cs
@@ -297,35 +297,42 @@ public class AccountDataManager
 
     public AccountData? LoadData(WowGuid128 guid, uint type)
     {
-        AccountData? data = null;
         string fileName = GetFullFileName(guid, type);
+        if (!File.Exists(fileName))
+            return null;
 
-        if (File.Exists(fileName))
+        try
         {
-            using (FileStream file = File.OpenRead(GetFullFileName(guid, type)))
+            using BinaryReader reader = new BinaryReader(File.OpenRead(fileName));
+            AccountData data = new();
+            ulong guidLow = reader.ReadUInt64();
+            ulong guidHigh = reader.ReadUInt64();
+            data.Guid = new WowGuid128(guidLow, guidHigh);
+
+            if (!IsGlobalDataType(type) && guid != data.Guid)
             {
-                using (BinaryReader reader = new BinaryReader(File.OpenRead(GetFullFileName(guid, type))))
-                {
-                    data = new();
-                    ulong guidLow = reader.ReadUInt64();
-                    ulong guidHigh = reader.ReadUInt64();
-                    data.Guid = new WowGuid128(guidLow, guidHigh);
-
-                    if (!IsGlobalDataType(type))
-                        System.Diagnostics.Trace.Assert(guid == data.Guid);
-
-                    data.Timestamp = reader.ReadInt64();
-                    data.Type = reader.ReadUInt32();
-                    System.Diagnostics.Trace.Assert(type == data.Type);
-                    data.UncompressedSize = reader.ReadUInt32();
-
-                    int compressedSize = reader.ReadInt32();
-                    data.CompressedData = reader.ReadBytes(compressedSize);
-                }
+                Log.Print(LogType.Warn, $"AccountData cache '{fileName}' has wrong GUID ({data.Guid} vs expected {guid}); discarding.");
+                return null;
             }
+
+            data.Timestamp = reader.ReadInt64();
+            data.Type = reader.ReadUInt32();
+            if (type != data.Type)
+            {
+                Log.Print(LogType.Warn, $"AccountData cache '{fileName}' has wrong type ({data.Type} vs expected {type}); discarding.");
+                return null;
+            }
+            data.UncompressedSize = reader.ReadUInt32();
+
+            int compressedSize = reader.ReadInt32();
+            data.CompressedData = reader.ReadBytes(compressedSize);
+            return data;
         }
-        
-        return data;
+        catch (Exception ex)
+        {
+            Log.Print(LogType.Warn, $"AccountData cache '{fileName}' is corrupt or unreadable ({ex.GetType().Name}: {ex.Message}); discarding. A fresh file will be written on next save.");
+            return null;
+        }
     }
 
     public void SaveData(WowGuid128 guid, long timestamp, uint type, uint uncompressedSize, byte[] compressedData)
@@ -341,7 +348,10 @@ public class AccountDataManager
         Data[type].UncompressedSize = uncompressedSize;
         Data[type].CompressedData = compressedData;
 
-        using (BinaryWriter writer = new BinaryWriter(File.Open(GetFullFileName(guid, type), FileMode.Create)))
+        string finalPath = GetFullFileName(guid, type);
+        string tempPath = finalPath + ".tmp";
+
+        using (BinaryWriter writer = new BinaryWriter(File.Open(tempPath, FileMode.Create)))
         {
             writer.Write(guid.GetLowValue());
             writer.Write(guid.GetHighValue());
@@ -351,6 +361,7 @@ public class AccountDataManager
             writer.Write(compressedData.Length);
             writer.Write(compressedData);
         }
+        File.Move(tempPath, finalPath, overwrite: true);
     }
 
     public byte[] LoadCUFProfiles()


### PR DESCRIPTION
## Summary

A per-character `AccountData` cache file with fewer than 16 bytes makes `AccountDataManager.LoadData` throw `EndOfStreamException` on the first `ReadUInt64`, crashing the proxy during `SendAccountDataTimes` on every login attempt for the affected character. One real player hit this with `data-7-26254-576465150349934592.bin` (type 7 = `PerCharacterLayoutCache`), zero bytes on disk; same stack every login, repeated across three Kronos servers. Deleting the empty file unstuck them and a fresh valid file got written on the next save.

Root cause: `SaveData` used `FileMode.Create` with incremental writes and no atomicity, so a kill between the truncate and the final write left an empty or partial file. `LoadData` had no defense against that.

## Stack trace (from affected player, `2026-05-26 5.1.5-beta.3`)

```
Packet Read Error: Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.InternalRead(Span`1 buffer)
   at System.IO.BinaryReader.ReadUInt64()
   at HermesProxy.World.Server.AccountDataManager.LoadData(WowGuid128 guid, UInt32 type)
   at HermesProxy.World.Server.AccountDataManager.LoadAllData(WowGuid128 guid)
   at HermesProxy.World.Server.WorldSocket.SendAccountDataTimes()
   at HermesProxy.World.Client.WorldClient.HandleAccountDataTimes(WorldPacket packet)
   at HermesProxy.World.Client.WorldClient.ReceiveLoop()
```

## Changes (one file: `HermesProxy/World/Server/AccountDataManager.cs`)

**`LoadData`**
- Wrap the read in `try/catch (Exception)`. Log a warning with the file path + exception type/message, return `null`. The two call sites (`WorldSocket.SendAccountDataTimes:1320` and `ClientConfigHandler.cs:24-31`) already null-guard the `Data[]` entries, so null flows safely and a fresh file is written on the next save.
- Replace the two `Trace.Assert` calls (GUID match / type match) with the same explicit log + return null bailout — a decoded-but-stale file no longer crashes.
- Drop the unused outer `FileStream` that was opening the same file a second time alongside the `BinaryReader`'s own `File.OpenRead`. Cleanup, not a bug.

**`SaveData`**
- Write to `{path}.tmp` then `File.Move(..., overwrite: true)`. `MoveFileEx` is atomic for same-volume moves on Windows, so the truncate-mid-write window that produces the empty file is closed for new corruption.

## Test plan — STILL OWED BEFORE MERGE

This PR shipped on code review + downstream null-handling audit; the live-truncated-file repro has not been run yet against the built binary. Before merging:

- [ ] Stop the proxy.
- [ ] Copy a known-good `Hermes/AccountData/<acct>/<realm>/data-N-X-Y.bin` to a `.bak`, then truncate the original to 0 bytes (PowerShell: `Clear-Content file.bin`).
- [ ] Launch the character whose GUID matches `X-Y` in the filename.
- [ ] Confirm: clean login (no proxy crash). Proxy log shows the new warning `AccountData cache '...' is corrupt or unreadable (EndOfStreamException: ...); discarding.`. File is rewritten to a valid non-empty size on the next cache save (logout, /reload, or any cache update from the client).
- [ ] Bonus: kill the proxy via Task Manager mid-session to provoke a partial write; confirm next login either gets the prior valid file (move hadn't happened) or the new valid file (it had) — never a zero-byte file.

## Immediate player workaround (already in use, confirmed working)

Stop the proxy, delete any zero-byte `data-*-*-*.bin` from `Hermes/AccountData/<account>/<realm>/`. Proxy writes a fresh file on the next save. The affected player used this and login was restored.