### PR TITLE
Diag: log parsed HasControl value on SMSG_CONTROL_UPDATE

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -192,6 +192,24 @@ public partial class WorldClient
         //    "log in mounted, walk at unmounted speed until I remount."
         bool isLocalPlayer = control.Guid == GetSession().GameState.CurrentPlayerGuid;
         bool justRegainedControl = control.HasControl && !GetSession().GameState.LastObservedHasControl;
+
+        // JimsProxy (diag): SMSG_CONTROL_UPDATE body is one PackGUID + one byte
+        // HasControl bool, neither captured by the existing packet.in event (size +
+        // opcode only). Without HasControl in the log, post-incident triage of
+        // movement-wedge bugs has to guess whether the proxy saw a freeze (false)
+        // or a restore (true) — including for the BG-exit lockout family where the
+        // entire question is "did the server send the restore packet or not." Emit
+        // the parsed values + the transition signal so future logs answer that
+        // directly. Zero behavior impact; one structured event per inbound packet.
+        Framework.Logging.Log.Event("movement.control_update.observed", new
+        {
+            guid_low = control.Guid.GetCounter(),
+            has_control = control.HasControl,
+            is_local_player = isLocalPlayer,
+            last_observed_before = GetSession().GameState.LastObservedHasControl,
+            just_regained_control = justRegainedControl,
+        });
+
         if (isLocalPlayer)
             GetSession().GameState.LastObservedHasControl = control.HasControl;
 


### PR DESCRIPTION
## Summary

Adds a structured `movement.control_update.observed` log event in `HandleControlUpdate` carrying the parsed `HasControl` bool, the GUID, the `isLocalPlayer` check, the previous `LastObservedHasControl` value, and the `justRegainedControl` transition signal.

Zero behavior change — purely diagnostic.

## Why

`SMSG_CONTROL_UPDATE`'s body is one PackGUID + one byte HasControl. Neither `packet.in` nor `packet.translated` captures that byte (they only record opcode + size). For the BG-exit lockout family (issue #328 and related), the entire root-cause question is: *does the post-LEAVE CONTROL_UPDATE the proxy receives carry `HasControl=true` (a restore the client should respond to) or `HasControl=false` (a redundant freeze that leaves the client locked)?* The existing logging can't tell us.

A 602k-line log analyzed against the Kronos dev's `HandleWorldPort` packet sequence shows that the broken and working BG exits have **identical** opcode/size sequences — they differ only in the HasControl payload byte that the logs don't capture. PR #327 was opened based on a claim of "no `true` for 2000 lines"; whether that holds up is exactly what this event would let us verify in future logs.

## What ships in the log

For every inbound `SMSG_CONTROL_UPDATE`, alongside the existing `packet.in`:

```json
{
  "eventType": "movement.control_update.observed",
  "payload": {
    "guid_low": 23217,
    "has_control": false,
    "is_local_player": true,
    "last_observed_before": true,
    "just_regained_control": false
  }
}
```

Volume: ~60 events in a representative long session (one per inbound CONTROL_UPDATE, e.g., CC start/end, BG-end freeze, post-port restore, vehicle/charm changes).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [ ] Manual: take any zone change / CC application → verify the new event appears in the JSONL bundle with sensible values

## Not in scope

- No behavior change. Doesn't fix any wedge, doesn't change any synth.
- Doesn't decide PR #327's outcome — but unblocks that decision by giving us the data needed to verify whether its premise is correct.