### PR TITLE
Fix Whipper Root loot loss on chain-cast (#334)

### DIFF
--- a/HermesProxy.Tests/World/GameObjectChainCastTests.cs
+++ b/HermesProxy.Tests/World/GameObjectChainCastTests.cs
@@ -1,0 +1,123 @@
+using System;
+using HermesProxy;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (issue #334): coverage for HasStartedCastOnGameObject — the predicate
+// that gates the same-GO chain-cast drop in CMSG_CAST_SPELL handling. The bug it
+// fixes: spam-clicking a Whipper Root at the end of its 5s harvest cast caused the
+// proxy to hold the chain press and release it 1ms after SPELL_GO, preempting the
+// legacy server's loot-creating subspell (15343 "Create Whipper Root Tubers") and
+// silently losing the item.
+public class GameObjectChainCastTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static WowGuid128 MakeGameObjectGuid(uint entry, ulong counter) =>
+        WowGuid128.Create(HighGuidType703.GameObject, 0, entry, counter);
+
+    private static WowGuid128 MakeCreatureGuid(uint entry, ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, entry, counter);
+
+    private static ClientCastRequest MakeCast(uint spellId, WowGuid128 target, bool hasStarted)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            TargetGuid = target,
+            HasStarted = hasStarted,
+        };
+    }
+
+    [Fact]
+    public void EmptyQueue_ReturnsFalse()
+    {
+        var session = NewSession();
+        var target = MakeGameObjectGuid(164725, 1); // Whipper Root entry id, arbitrary
+        Assert.False(session.HasStartedCastOnGameObject(target));
+    }
+
+    [Fact]
+    public void EmptyTargetGuidArgument_ReturnsFalse()
+    {
+        // AoE / self-cast presses have an empty TargetGuid. The guard short-circuits
+        // before walking the queue so we never match an empty-vs-empty TargetGuid.
+        var session = NewSession();
+        var goTarget = MakeGameObjectGuid(164725, 1);
+        session.PendingNormalCasts.Enqueue(MakeCast(22810, goTarget, hasStarted: true));
+
+        Assert.False(session.HasStartedCastOnGameObject(WowGuid128.Empty));
+    }
+
+    [Fact]
+    public void NonGameObjectArgument_ReturnsFalse()
+    {
+        // A unit target shouldn't match a started GO cast even if (impossibly) the
+        // GUID values aligned. The high-type guard rejects non-GO arguments outright.
+        var session = NewSession();
+        var creatureTarget = MakeCreatureGuid(720, 1);
+        Assert.False(session.HasStartedCastOnGameObject(creatureTarget));
+    }
+
+    [Fact]
+    public void StartedCastOnDifferentGameObject_ReturnsFalse()
+    {
+        // Player completed a harvest on GO A, then a new press arrives targeting GO B.
+        // The bug only manifests on same-GO chain spam — different-GO chains must fall
+        // through to the existing hold path so mining/herb chain-gather still works.
+        var session = NewSession();
+        var goA = MakeGameObjectGuid(164725, 1);
+        var goB = MakeGameObjectGuid(164725, 2);
+
+        session.PendingNormalCasts.Enqueue(MakeCast(22810, goA, hasStarted: true));
+
+        Assert.False(session.HasStartedCastOnGameObject(goB));
+    }
+
+    [Fact]
+    public void StartedCastOnSameGameObject_ReturnsTrue()
+    {
+        // The exact issue #334 scenario: same GO, started cast, new press targeting
+        // the same GO. Caller drops the press silently to avoid the post-SPELL_GO race.
+        var session = NewSession();
+        var go = MakeGameObjectGuid(164725, 7);
+
+        session.PendingNormalCasts.Enqueue(MakeCast(22810, go, hasStarted: true));
+
+        Assert.True(session.HasStartedCastOnGameObject(go));
+    }
+
+    [Fact]
+    public void PendingCastNotYetStarted_ReturnsFalse()
+    {
+        // A cast that's been forwarded but hasn't received SPELL_START yet shouldn't
+        // trigger the drop — the script-subspell race only opens once the first cast
+        // has actually started server-side.
+        var session = NewSession();
+        var go = MakeGameObjectGuid(164725, 1);
+
+        session.PendingNormalCasts.Enqueue(MakeCast(22810, go, hasStarted: false));
+
+        Assert.False(session.HasStartedCastOnGameObject(go));
+    }
+
+    [Fact]
+    public void MultipleStartedCasts_MatchingOneInQueue_ReturnsTrue()
+    {
+        // Defensive: the queue can hold more than one entry. Match if any started cast
+        // shares the target.
+        var session = NewSession();
+        var goA = MakeGameObjectGuid(164725, 1);
+        var goB = MakeGameObjectGuid(164725, 2);
+
+        session.PendingNormalCasts.Enqueue(MakeCast(22810, goA, hasStarted: true));
+        session.PendingNormalCasts.Enqueue(MakeCast(22810, goB, hasStarted: true));
+
+        Assert.True(session.HasStartedCastOnGameObject(goA));
+        Assert.True(session.HasStartedCastOnGameObject(goB));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1293,6 +1293,29 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy (issue #334): returns true if a started normal cast targets the
+    /// given GameObject. Used to drop chain CMSG_CAST_SPELL on the same GO without
+    /// holding-and-releasing it 1ms after SPELL_GO. Releasing a held same-GO cast
+    /// preempts the legacy server's loot-creating script subspell (cast FROM the
+    /// player at SPELL_GO + ~440ms — e.g. spell 15343 "Create Whipper Root
+    /// Tubers"), and the loot is silently lost.
+    /// Returns false if the argument is empty or not a GameObject GUID.
+    /// </summary>
+    public bool HasStartedCastOnGameObject(WowGuid128 gameObjectGuid)
+    {
+        if (gameObjectGuid.IsEmpty())
+            return false;
+        if (gameObjectGuid.GetHighType() != HighGuidType.GameObject)
+            return false;
+        foreach (var item in PendingNormalCasts)
+        {
+            if (item.HasStarted && item.TargetGuid == gameObjectGuid)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// JimsProxy (PR #161 follow-up): walks PendingNormalCasts and PendingPetCasts,
     /// dequeues any entry whose WatchdogDeadlineMs has expired, and returns the
     /// evicted entries via the out parameters. Caller (GlobalSessionData

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -338,6 +338,30 @@ public partial class WorldSocket
                     return;
                 }
 
+                // JimsProxy (issue #334): GameObject-Opening chain-cast race. If the player
+                // spam-clicks the same GO at the end of a cast, the held cast is released 1ms
+                // after SPELL_GO and lands at the server before its OnUse script can fire the
+                // loot-creating subspell FROM the player (e.g. spell 15343 "Create Whipper Root
+                // Tubers", ~440ms after SPELL_GO). The chain cast occupies the player's slot,
+                // the subspell fails, and the item is silently lost while the GO is consumed.
+                // GOs are one-shot interactions — a second cast on the same GO never delivers
+                // a second item even on a clean run. Drop the chain press silently here so it
+                // never enters the hold-and-replay path. Different-GO chains and mining/herb
+                // chain casts (loot delivered directly via SMSG_LOOT_RESPONSE, no script
+                // subspell) are unaffected.
+                WowGuid128 newPressTarget = cast.Cast.Target.Unit;
+                if (GetSession().GameState.HasStartedCastOnGameObject(newPressTarget))
+                {
+                    Log.Event("cast.dropped.go_in_flight", new
+                    {
+                        spell_id = cast.Cast.SpellID,
+                        target_low = newPressTarget.GetCounter(),
+                        client_cast_id = castRequest.ClientGUID.ToString(),
+                    });
+                    SendCastFailedWithoutPrepare(castRequest);
+                    return;
+                }
+
                 // Guard: cast-time spell in progress — hold (most-recent-wins, hidden queue).
                 // JimsProxy (GCD-sweep-during-cast-time-spam 2026-05-07): keep the held press
                 // hidden from the modern client. Previously this path sent SendCastFailedWithoutPrepare


### PR DESCRIPTION
Fixes #334.

## Mechanism

Spam-clicking a Whipper Root at the end of its 5s harvest cast caused the proxy to hold the chain press and release it 1ms after `SMSG_SPELL_GO`. The chain cast landed at the legacy server ~199ms before the GO's `OnUse` script could fire its loot-creating subspell from the player — spell 15343 *Create Whipper Root Tubers*, instant cast, ~440ms after `SPELL_GO`. The chain cast occupied the player's cast slot, 15343 failed with `reason=1`, the GO was destroyed by the script anyway, and the tuber was silently lost.

Confirmed by log diff (issue body has full timeline):

**Success — single click** (`jimsproxy-20260527-204336.jsonl`):
```
T+0ms    SMSG_SPELL_GO      spell 22810 (player harvest)
T+440ms  SMSG_SPELL_START   spell 15343  caster=player  cast_time=0
T+440ms  SMSG_SPELL_GO      spell 15343  caster=GO/server  → tuber delivered
```

**Fail — chain spam** (`jimsproxy-20260527-205949.jsonl`):
```
T+0ms    SMSG_SPELL_GO              spell 22810 cast 1
T+1ms    EVT cast.forwarded         source=held_gcd_release   ← chain hits server here
T+199ms  SMSG_SPELL_START           spell 22810 cast 2        ← occupies player cast slot
T+462ms  SMSG_SPELL_FAILURE         spell 15343 reason=1      ← loot subspell preempted
```

## Scope

Same mechanism affects every GO whose `OnUse` script casts an instant subspell **from the player** to deliver loot or a buff:

- Felwood Cenarion plants: Whipper Root, Night Dragon's Breath (15344), Windblossom Berries (15342), Felvine Shard (22949)
- Un'Goro: Bloodpetal Zapper (22565), Orange Crystal Liquid (21884)
- Songflower Serenade (15366) — buff applied via the same player-cast pattern
- Likely the Un'Goro crystal pylon buffs (pattern matches, needs verification)

Mining and herbalism are **not** affected — those deliver via `SMSG_LOOT_RESPONSE` directly from the GO loot template, no script subspell to preempt. The reporter's observation that mining chain-gather still works is consistent.

## Fix

Drop chain `CMSG_CAST_SPELL` at the cast-time hold gate when the new press targets the same `GameObject` as an already-started cast. The chain press never enters the hold-and-replay path that produces the race.

```csharp
WowGuid128 newPressTarget = cast.Cast.Target.Unit;
if (GetSession().GameState.HasStartedCastOnGameObject(newPressTarget))
{
    Log.Event("cast.dropped.go_in_flight", new {
        spell_id = cast.Cast.SpellID,
        target_low = newPressTarget.GetCounter(),
        client_cast_id = castRequest.ClientGUID.ToString(),
    });
    SendCastFailedWithoutPrepare(castRequest);
    return;
}
```

Same-GO chain spam never legitimately delivers a second item — the GO is consumed by the first cast. Different-GO chains and non-GO casts during a GO cast fall through to the existing hold-and-replay path unchanged, so mining/herb chain-gather is preserved.

## What this PR does **not** do

- Doesn't catch the cross-GO race (player completes harvest on Whipper Root A, then within ~440ms casts on Whipper Root B). Far rarer than spam-clicking one GO; can be addressed in a follow-up if it shows up in player reports.
- Doesn't change `Low Latency Mode` (which forwards everything immediately without holding). LLM users would hit the bug differently (chain cast forwarded immediately rather than held+released), and that path needs its own analysis — out of scope here.
- No changes to `DrainPendingCastsForDestroyedTarget` (PR #293/#310) or the `held_gcd_release` path itself.

## Why other PRs in flight don't cover this

- **PR #285** (`Fix proxy DC on short SMSG_LOOT_RESPONSE`) — only bounds the loot-packet parse; doesn't drop packets. The fail session has zero `SMSG_LOOT_RESPONSE` because the server never sent one (subspell failed before loot creation), not because the proxy dropped one.
- **PR #293** (`Fix gather nodes stuck after the first tick`) — only evicts not-yet-started casts on GO destroy. Here the chain cast forwards at SPELL_GO+1ms, server starts it at +199ms, destroy fires at +465ms; the cast has been started by the time the destroy hook runs.
- **PR #313** (`narrow GCD and cast-time hold gates to last 400ms`) — both chain clicks (274ms and 124ms before SPELL_GO) fall inside the narrowed 400ms window. Wouldn't change this scenario.

## Test plan

- [x] `dotnet test` — 509/509 pass (502 existing + 7 new in `GameObjectChainCastTests`).
- [ ] PTR: harvest Whipper Root with single click — tuber delivered (regression guard).
- [ ] PTR: harvest Whipper Root with spam click at end of cast — tuber delivered (the bug case).
- [ ] PTR: mining chain — two consecutive copper nodes, chain-cast the second one near the end of the first — both nodes loot.
- [ ] PTR: Songflower Serenade — buff applied normally on single use; ideally also test with spam-click to confirm cross-coverage.