### PR TITLE
Restore run-speed buff lost when crowd control ends mid-spline

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -503,6 +503,13 @@ public partial class WorldClient
         speed.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         speed.Speed = packet.ReadFloat();
         SendPacketToClient(speed);
+
+        // JimsProxy (speed-stuck-cc-spline): when CC ends mid-spline the server restores run speed via the spline opcode, not FORCE; mirror the FORCE cache so the regain-control reassert restores the buffed speed. See memory.
+        if (packet.GetUniversalOpcode(false) == Opcode.SMSG_MOVE_SPLINE_SET_RUN_SPEED &&
+            speed.MoverGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            GetSession().GameState.LastKnownPlayerRunSpeed = speed.Speed;
+        }
     }
 
     // for own player


### PR DESCRIPTION
**Problem** — With a movement-speed buff up (e.g. Skull of Impending Doom, +60% run), getting Blinded/Feared/Confused and having the CC end while still mid-spline drops you to a reduced speed for the rest of the buff. Intermittent — it depends on whether the CC ended before or after the server-side wander spline started.

**Root cause** — When CC ends the server restores run speed. `Unit::SetSpeedRate` sends `SMSG_FORCE_RUN_SPEED_CHANGE` only when `forced && IsClientControlled()`; otherwise (still server-controlled mid-spline) it sends `SMSG_MOVE_SPLINE_SET_RUN_SPEED`. Both carry the true `GetSpeed(MOVE_RUN)`. `HandleMoveForceSpeedChange` seeds `LastKnownPlayerRunSpeed` (used by the regain-control RP-walk reassert), but `HandleMoveSplineSetSpeed` forwarded the spline variant without updating the cache. So when the restore arrived via the spline opcode, the reassert fired `SMSG_MOVE_SET_RUN_SPEED` with a stale value — the transient slow the CC applied while still controlled — clobbering the buffed speed.

**Fix** — Seed `LastKnownPlayerRunSpeed` from the player's `SMSG_MOVE_SPLINE_SET_RUN_SPEED` too, mirroring the FORCE handler. The end-burst spline packet is processed right before the control update, so the reassert reads the fresh buffed value.

**Validation** — In-game on a 1.12 server (Blind + Skull of Impending Doom), 2/2 mid-spline blind sequences fixed. Traced: Skull buffs run 7→11.2; Blind applies a 0.4x slow (11.2→4.48) via FORCE while controlled; blind ends mid-spline → spline restore now caches 11.2 → reassert sends 11.2 (previously the stale 4.48). 509/509 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)