### PR TITLE
Restore movement after a taxi flight resumed across login (#330)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -224,6 +224,62 @@ public partial class WorldClient
         }
     }
 
+    // JimsProxy (taxi-resume-control-stuck #330): packets the 1.14 client needs to leave the taxi/passenger state — control restore + gravity + clear-fly + unroot. Mirrors the dismount Task; used by the resumed-taxi SPLINE_ENABLED-clear path in ReadMovementUpdateBlock which never reaches HandleMonsterMove. See memory.
+    public void SendTaxiDismountRestore(WowGuid128 guid)
+    {
+        ControlUpdate control = new ControlUpdate();
+        control.Guid = guid;
+        control.HasControl = true;
+        SendPacketToClient(control);
+
+        MoveSetFlag enableGravity = new MoveSetFlag(Opcode.SMSG_MOVE_ENABLE_GRAVITY);
+        enableGravity.MoverGUID = guid;
+        SendPacketToClient(enableGravity);
+
+        MoveSetFlag unsetFly = new MoveSetFlag(Opcode.SMSG_MOVE_UNSET_CAN_FLY);
+        unsetFly.MoverGUID = guid;
+        SendPacketToClient(unsetFly);
+
+        MoveSetFlag unroot = new MoveSetFlag(Opcode.SMSG_MOVE_UNROOT);
+        unroot.MoverGUID = guid;
+        SendPacketToClient(unroot);
+    }
+
+    // JimsProxy (taxi-resume-control-stuck #330): a resumed taxi's flight spline arrives only in the player's CREATE block (UpdateHandler), bypassing HandleMonsterMove's dismount scheduling; schedule the same dismount off the create-spline's remaining duration so control/gravity restore fires at landing. Mirrors the HandleMonsterMove dismount Task (CTS + atomic claim + cancel-on-disconnect via TaxiDismountCts). See memory.
+    public void ScheduleTaxiResumeDismount(WowGuid128 guid, uint remainingMs)
+    {
+        var gameState = GetSession().GameState;
+        System.Threading.Volatile.Write(ref gameState.IsInTaxiFlight, true);
+        gameState.CancelTaxiDismount("taxi_resume_reschedule");
+
+        const uint TAXI_FLIGHT_MAX_MS = 600_000;
+        int delayMs = (int)Math.Min(remainingMs, TAXI_FLIGHT_MAX_MS) + 250;
+        var cts = new System.Threading.CancellationTokenSource();
+        gameState.TaxiDismountCts = cts;
+        gameState.TaxiDismountFiresAtTickMs = Environment.TickCount64 + delayMs;
+
+        var capturedSession = GetSession();
+        var capturedClient = this;
+        var token = cts.Token;
+        WowGuid128 playerGuid = guid;
+        _ = System.Threading.Tasks.Task.Run(async () =>
+        {
+            try { await System.Threading.Tasks.Task.Delay(delayMs, token).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+
+            var prior = System.Threading.Interlocked.CompareExchange(ref capturedSession.GameState.TaxiDismountCts, null, cts);
+            if (!ReferenceEquals(prior, cts))
+                return;
+            if (!System.Threading.Volatile.Read(ref capturedSession.GameState.IsInTaxiFlight))
+                return;
+            if (capturedSession.InstanceSocket == null)
+                return;
+
+            capturedClient.SendTaxiDismountRestore(playerGuid);
+            System.Threading.Volatile.Write(ref capturedSession.GameState.IsInTaxiFlight, false);
+        });
+    }
+
     [PacketHandler(Opcode.MSG_MOVE_TELEPORT_ACK)]
     void HandleMoveTeleportAck(WorldPacket packet)
     {

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1275,6 +1275,16 @@ public partial class WorldClient
                 monsterMove.SplineTime = packet.ReadUInt32();
                 monsterMove.SplineTimeFull = packet.ReadUInt32();
                 monsterMove.SplineId = packet.ReadUInt32();
+
+                // JimsProxy (taxi-resume-control-stuck #330): a taxi resumed across login arrives only as this CREATE-block flight spline (no per-leg SMSG_ON_MONSTER_MOVE reaches the player, so HandleMonsterMove's dismount never schedules) and the vanilla server sends no flag-clear/teleport/control-update at flight end; schedule the dismount from the spline's own remaining duration, the only reliable landing signal. Create only (updateData != null), local player, vanilla. See memory.
+                if (updateData != null && hasTaxiFlightFlags && guid.IsPlayer() && flags.HasAnyFlag(UpdateFlag.Self) &&
+                    LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+                {
+                    uint remainingMs = monsterMove.SplineTimeFull > monsterMove.SplineTime
+                        ? monsterMove.SplineTimeFull - monsterMove.SplineTime
+                        : monsterMove.SplineTimeFull;
+                    ScheduleTaxiResumeDismount(guid, remainingMs);
+                }
                 
                 if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_0_9767))
                 {


### PR DESCRIPTION
**Problem** — If a player disconnects mid-taxi (or the server saves them mid-flight) and logs back in while still flying, the resumed flight completes but the 1.14 client stays a taxi-spline passenger: after landing you can't move — stuck/suspended in air, only Blink works (#330).

**Root cause** — A taxi resumed across login is delivered as the flight spline embedded in the player's CREATE block, not as per-leg `SMSG_ON_MONSTER_MOVE` packets. So `HandleMonsterMove` — which schedules the flight-end dismount (control restore + gravity + clear-fly + unroot) for a normal in-session taxi — is never invoked for a resumed flight. The vanilla server also sends no teleport or control-update at flight end (control is already `true` on the resume), so nothing tells the modern client to leave the passenger state.

**Fix** — The CREATE-block spline parse already recognizes the taxi spline (`Runmode|Flying`) and reads its remaining duration (`SplineTimeFull - SplineTime`). Use that to schedule the same dismount the normal path uses, mirroring the `HandleMonsterMove` dismount Task (CTS + atomic claim + cancel-on-disconnect). Gated to the player's own CREATE block on vanilla, so normal in-session flights (which flow through `HandleMonsterMove`) are untouched.

**Validation** — In-game on a 1.12 server: resumed a flight mid-air (81s flight, 27s elapsed -> 53.7s remaining); the dismount fired at the computed landing (+54.0s), the client ACKed gravity/unroot/unset-fly, reported spline-done, and regained movement. Separately confirmed a normal in-session taxi is unaffected (the resume path never fires; the existing dismount handles it). 509/509 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)