### PR TITLE
Fix off-GCD spell icons stuck lit after a concurrent GCD cast

### DIFF
--- a/HermesProxy.Tests/World/ClearNonStartedNormalCastsTests.cs
+++ b/HermesProxy.Tests/World/ClearNonStartedNormalCastsTests.cs
@@ -1,0 +1,105 @@
+using System;
+using HermesProxy;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (stuck-Bloodrage fix): ClearNonStartedNormalCasts must not sweep off-GCD
+// casts. When a normal cast's SMSG_SPELL_START arrives it sweeps the other non-started
+// pending casts to release their button-lit state — but off-GCD casts (Bloodrage,
+// Sprint, racials, trinkets) coexist with the GCD cast and the server casts them
+// independently. Sweeping them sent a premature CAST_FAILED while the real SPELL_GO
+// still arrived unmatched, leaving the action-bar icon stuck-lit until relog. These
+// tests pin the exemption: started AND off-GCD casts are kept; only non-started
+// normal casts are cleared.
+public class ClearNonStartedNormalCastsTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static ClientCastRequest MakeCast(uint spellId, bool hasStarted = false, bool isOffGcd = false)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            HasStarted = hasStarted,
+            IsOffGcd = isOffGcd,
+        };
+    }
+
+    [Fact]
+    public void ClearNonStartedNormalCasts_EmptyQueue_ReturnsEmpty()
+    {
+        var session = NewSession();
+
+        var cleared = session.ClearNonStartedNormalCasts();
+
+        Assert.Empty(cleared);
+        Assert.Empty(session.PendingNormalCasts);
+    }
+
+    [Fact]
+    public void ClearNonStartedNormalCasts_NonStartedNormalCast_IsCleared()
+    {
+        // Stale queued press (Fireball) with no off-GCD exemption — the case the sweep
+        // exists for: release its button-lit state when another cast starts.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(133, hasStarted: false, isOffGcd: false));
+
+        var cleared = session.ClearNonStartedNormalCasts();
+
+        Assert.Single(cleared);
+        Assert.Equal(133u, cleared[0].SpellId);
+        Assert.Empty(session.PendingNormalCasts);
+    }
+
+    [Fact]
+    public void ClearNonStartedNormalCasts_StartedCast_IsKept()
+    {
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(133, hasStarted: true));
+
+        var cleared = session.ClearNonStartedNormalCasts();
+
+        Assert.Empty(cleared);
+        Assert.Single(session.PendingNormalCasts);
+    }
+
+    [Fact]
+    public void ClearNonStartedNormalCasts_NonStartedOffGcdCast_IsKept()
+    {
+        // The fix: a pending off-GCD Bloodrage (2687) must survive the sweep so its
+        // own SPELL_GO / CAST_FAILED resolves it instead of a premature failure.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(2687, hasStarted: false, isOffGcd: true));
+
+        var cleared = session.ClearNonStartedNormalCasts();
+
+        Assert.Empty(cleared);
+        Assert.Single(session.PendingNormalCasts);
+        Assert.Equal(2687u, session.PendingNormalCasts.ToArray()[0].SpellId);
+    }
+
+    [Fact]
+    public void ClearNonStartedNormalCasts_BloodragePendingWhenSunderStarts_BloodrageKept()
+    {
+        // The exact stuck-lit scenario: Sunder Armor (7386, normal) has just started —
+        // which triggers the sweep — while an off-GCD Bloodrage (2687) is still pending
+        // and a stale queued Fireball (133) press is also sitting in the queue. Only the
+        // stale Fireball should be cleared; the started Sunder and the off-GCD Bloodrage
+        // are both kept.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(7386, hasStarted: true, isOffGcd: false));   // Sunder, started → kept
+        session.PendingNormalCasts.Enqueue(MakeCast(2687, hasStarted: false, isOffGcd: true));   // Bloodrage off-GCD → kept (the fix)
+        session.PendingNormalCasts.Enqueue(MakeCast(133, hasStarted: false, isOffGcd: false));   // stale Fireball press → cleared
+
+        var cleared = session.ClearNonStartedNormalCasts();
+
+        Assert.Single(cleared);
+        Assert.Equal(133u, cleared[0].SpellId);
+
+        Assert.Equal(2, session.PendingNormalCasts.Count);
+        Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 7386);
+        Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 2687);
+    }
+}

--- a/HermesProxy.Tests/World/ClearNonStartedNormalCastsTests.cs
+++ b/HermesProxy.Tests/World/ClearNonStartedNormalCastsTests.cs
@@ -102,4 +102,44 @@ public class ClearNonStartedNormalCastsTests
         Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 7386);
         Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 2687);
     }
+
+    [Fact]
+    public void OffGcdCast_SurvivesSweep_ButWatchdogReapsItWhenDeadlineExpires()
+    {
+        // #344 follow-up backstop: HandleCastSpell arms WatchdogDeadlineMs on off-GCD casts
+        // at enqueue. Since they're sweep-exempt and never become HasStarted, if their
+        // SPELL_GO is ever lost the sweep keeps them — so the watchdog must reap them, else
+        // they linger in PendingNormalCasts forever.
+        var session = NewSession();
+        var bloodrage = MakeCast(2687, hasStarted: false, isOffGcd: true);
+        bloodrage.WatchdogDeadlineMs = Environment.TickCount64 - 1; // armed at enqueue, now expired
+        session.PendingNormalCasts.Enqueue(bloodrage);
+
+        // Sweep keeps the off-GCD cast (the #344 exemption)...
+        var cleared = session.ClearNonStartedNormalCasts();
+        Assert.Empty(cleared);
+        Assert.Single(session.PendingNormalCasts);
+
+        // ...but the watchdog reaps it once the deadline passes, so it can't leak.
+        session.DrainExpiredWatchdogCasts(Environment.TickCount64, out var normalEvicted, out _);
+        Assert.Single(normalEvicted);
+        Assert.Equal(2687u, normalEvicted[0].SpellId);
+        Assert.Empty(session.PendingNormalCasts);
+    }
+
+    [Fact]
+    public void OffGcdCast_WithFreshWatchdogDeadline_NotReapedEarly()
+    {
+        // The armed window must be generous enough not to false-evict a legit off-GCD cast
+        // before its SPELL_GO arrives — premature eviction would re-create the stuck-lit bug.
+        var session = NewSession();
+        var bloodrage = MakeCast(2687, hasStarted: false, isOffGcd: true);
+        bloodrage.WatchdogDeadlineMs = Environment.TickCount64 + ClientCastRequest.WatchdogWindowMs;
+        session.PendingNormalCasts.Enqueue(bloodrage);
+
+        session.DrainExpiredWatchdogCasts(Environment.TickCount64, out var normalEvicted, out _);
+
+        Assert.Empty(normalEvicted);
+        Assert.Single(session.PendingNormalCasts);
+    }
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1622,6 +1622,10 @@ public sealed class GameSessionData
     /// <summary>
     /// Clear only pending normal casts that haven't started yet.
     /// Keeps started casts so SPELL_GO can dequeue them later.
+    /// Also keeps off-GCD casts (Bloodrage, Sprint, racials, trinkets): they coexist
+    /// with a normal GCD cast and the server processes them independently, so a normal
+    /// cast's SMSG_SPELL_START must not fail them — they resolve via their own
+    /// SPELL_GO / CAST_FAILED. See ClientCastRequest.IsOffGcd for the stuck-lit rationale.
     /// Returns the cleared casts so they can be failed.
     /// </summary>
     public List<ClientCastRequest> ClearNonStartedNormalCasts()
@@ -1633,7 +1637,7 @@ public sealed class GameSessionData
         {
             while (PendingNormalCasts.TryDequeue(out var current))
             {
-                if (current.HasStarted)
+                if (current.HasStarted || current.IsOffGcd)
                     keep.Add(current);
                 else
                     cleared.Add(current);
@@ -2257,6 +2261,15 @@ public class ClientCastRequest
     // The GCD hold gate in HandleSpellGo uses this instead of HasStarted so Kronos-flavored
     // instants still trigger BeginGcd. See JimsProxy issue #43 follow-up.
     public uint StartedCastTimeMs;
+
+    // JimsProxy (stuck-Bloodrage fix): true for off-GCD spells (Sprint, Evasion,
+    // Bloodrage, racials, trinkets). Off-GCD casts coexist with a normal GCD cast,
+    // so when a normal cast's SMSG_SPELL_START arrives, ClearNonStartedNormalCasts
+    // must NOT sweep these out of the queue. The server casts them independently and
+    // their own SPELL_GO / CAST_FAILED resolves the button. Without this exemption the
+    // off-GCD cast gets a premature CAST_FAILED while its real SPELL_GO still arrives
+    // unmatched, leaving the action-bar highlight stuck-lit until relog.
+    public bool IsOffGcd;
 
     // JimsProxy (PR #161 follow-up): when HandleSpellFailure peeks this entry
     // (instead of dequeuing) so the trailing SMSG_CAST_FAILED can deliver the

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1622,7 +1622,7 @@ public sealed class GameSessionData
     /// <summary>
     /// Clear only pending normal casts that haven't started yet.
     /// Keeps started casts so SPELL_GO can dequeue them later.
-    /// Also keeps off-GCD casts (Bloodrage, Sprint, racials, trinkets): they coexist
+    /// Also keeps off-GCD casts (Bloodrage, Sprint, Rapid Fire, racials): they coexist
     /// with a normal GCD cast and the server processes them independently, so a normal
     /// cast's SMSG_SPELL_START must not fail them — they resolve via their own
     /// SPELL_GO / CAST_FAILED. See ClientCastRequest.IsOffGcd for the stuck-lit rationale.
@@ -2263,12 +2263,14 @@ public class ClientCastRequest
     public uint StartedCastTimeMs;
 
     // JimsProxy (stuck-Bloodrage fix): true for off-GCD spells (Sprint, Evasion,
-    // Bloodrage, racials, trinkets). Off-GCD casts coexist with a normal GCD cast,
+    // Bloodrage, Rapid Fire, racials). Off-GCD casts coexist with a normal GCD cast,
     // so when a normal cast's SMSG_SPELL_START arrives, ClearNonStartedNormalCasts
     // must NOT sweep these out of the queue. The server casts them independently and
     // their own SPELL_GO / CAST_FAILED resolves the button. Without this exemption the
     // off-GCD cast gets a premature CAST_FAILED while its real SPELL_GO still arrives
     // unmatched, leaving the action-bar highlight stuck-lit until relog.
+    // NOTE: only spell casts (HandleCastSpell) set this; item-use casts take a
+    // separate path and are NOT tagged off-GCD here — tracked in jimsproxy issue #345.
     public bool IsOffGcd;
 
     // JimsProxy (PR #161 follow-up): when HandleSpellFailure peeks this entry

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2284,6 +2284,11 @@ public class ClientCastRequest
     // permanently blocks HasStartedNormalCast(). 0 = no watchdog active.
     public long WatchdogDeadlineMs;
 
+    // Watchdog window (ms) after which an unresolved cast is force-evicted. Single
+    // source of truth for the failure-peek path (HandleSpellFailure) and the off-GCD
+    // enqueue arming (#344 follow-up).
+    public const long WatchdogWindowMs = 2500;
+
     // JimsProxy (PR #161 follow-up — destroy-hook fast path): captured from
     // CastSpell.Cast.Target.Unit at enqueue time. When HandleDestroyObject
     // sees this GUID, the proxy can immediately evict any pending casts that

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -18,7 +18,7 @@ public partial class WorldClient
     // any observed CAST_FAILED arrival on vmangos/Twinstar (~1ms after FAILURE)
     // and shorter than feels-laggy to the user when the pathological Kronos
     // case kicks in (target-dies-mid-cast, no trailing CAST_FAILED).
-    private const long WatchdogWindowMs = 2500;
+    private const long WatchdogWindowMs = ClientCastRequest.WatchdogWindowMs;
 
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_SEND_KNOWN_SPELLS)]

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -292,6 +292,11 @@ public partial class WorldSocket
             // Tag for the non-started-cast sweep: off-GCD casts must survive an unrelated
             // normal cast's SPELL_START (see ClearNonStartedNormalCasts / IsOffGcd).
             castRequest.IsOffGcd = isOffGcd;
+            // #344 follow-up: sweep-exempt off-GCD casts never become HasStarted, so they get
+            // no watchdog deadline from the failure/movement paths. Arm one at enqueue so a
+            // lost SPELL_GO can't leave the cast lingering in PendingNormalCasts forever.
+            if (isOffGcd)
+                castRequest.WatchdogDeadlineMs = Environment.TickCount64 + ClientCastRequest.WatchdogWindowMs;
 
             // JimsProxy (issue #43): off-GCD spells (Sprint, Evasion, Trinket, racials, etc)
             // bypass both the HasStartedNormalCast cast-bar gate and the GCD hold path. A real

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -289,6 +289,9 @@ public partial class WorldSocket
             castRequest.ClientGUID = cast.Cast.CastID;
             castRequest.TargetGuid = cast.Cast.Target.Unit;
             castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, cast.Cast.SpellID, 10000 + cast.Cast.CastID.GetCounter());
+            // Tag for the non-started-cast sweep: off-GCD casts must survive an unrelated
+            // normal cast's SPELL_START (see ClearNonStartedNormalCasts / IsOffGcd).
+            castRequest.IsOffGcd = isOffGcd;
 
             // JimsProxy (issue #43): off-GCD spells (Sprint, Evasion, Trinket, racials, etc)
             // bypass both the HasStartedNormalCast cast-bar gate and the GCD hold path. A real


### PR DESCRIPTION
## Summary
- Off-GCD casts (Bloodrage, Sprint, Rapid Fire, racials) are enqueued in `PendingNormalCasts` but bypass the GCD gate. When an unrelated normal cast's `SMSG_SPELL_START` arrived, `ClearNonStartedNormalCasts` swept **every** non-started pending cast — including the off-GCD one — and sent it a premature `CAST_FAILED`.
- The server casts off-GCD spells independently, so the real `SPELL_START`/`SPELL_GO` still arrived but no longer matched a pending cast. The modern client's "current spell" flag stuck on: the action-bar icon stayed lit (spell still functional, cooldown correct) until relog. `/reloadui` did not clear it; only a full relog did.
- **Fix:** tag off-GCD casts at enqueue (`ClientCastRequest.IsOffGcd`) and exempt them from the sweep — kept like started casts, so they resolve via their own `SPELL_GO`/`CAST_FAILED`. Also fixes the off-GCD self double-press (previously failed the 2nd press with a synthetic `SpellInProgress` instead of the server's real result).

## Scope
Covers off-GCD **spell** casts (`HandleCastSpell`). **Item-use** casts (trinkets/potions/bombs) go through `HandleUseItem`, which enqueues without the off-GCD tag — not covered here, tracked separately in #345.

## Evidence
Live log fingerprint: a Sunder Armor (7386) `SPELL_START` swept a pending off-GCD Bloodrage (2687) — `cast.non_started_swept queue:normal spell_id:2687 triggering_spell_id:7386`. Symptom is client transient state (survives `/reloadui`, cleared by relog).

## Test plan
- [x] `dotnet test` — 514/514 pass, including new `ClearNonStartedNormalCastsTests` (off-GCD kept, started kept, non-started normal cleared, and the Bloodrage-pending-while-Sunder-starts scenario).
- [x] Live (build `9a63e4e`, log `jimsproxy-20260529-095616.jsonl`): race triggered 3× (Bloodrage forwarded with `queue_depth_before:1`); **0** `cast.non_started_swept` for any off-GCD spell; duplicate presses resolved via server `CAST_FAILED`.