### PR TITLE
Debug: log cast.received for every CMSG_CAST_SPELL at receipt

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -156,6 +156,20 @@ public partial class WorldSocket
         // a fast-clicker at login could otherwise be blocked from legitimate casts.
         var knownSpellsForCastGuard = GetSession().GameState.CurrentPlayerKnownSpells;
         uint guardSpellId = (uint)cast.Cast.SpellID;
+
+        // DIAGNOSTIC (stuck-checked-button investigation): log every CMSG_CAST_SPELL the
+        // moment it's received, before any gate. Presses are otherwise only logged once
+        // they're forwarded / held / dropped, so a press the client sends that gets
+        // suppressed or swallowed earlier leaves no spell_id trace — which blocked the
+        // Retaliation stuck-lit investigation (no 20230 anywhere in the session despite a
+        // reported press). Gated behind DebugOutput. Remove when that investigation closes.
+        if (Framework.Settings.DebugOutput)
+            Log.Event("cast.received", new
+            {
+                spell_id = guardSpellId,
+                client_cast_id = cast.Cast.CastID.ToString(),
+            });
+
         if (knownSpellsForCastGuard.Count > 0 && !knownSpellsForCastGuard.Contains(guardSpellId))
         {
             Log.Event("spell.cast.blocked_unknown_spell", new


### PR DESCRIPTION
## Why
Casts are only logged once they're **forwarded / held / dropped**. A press the client sends that gets suppressed or swallowed *before* any of those branches leaves **no spell_id trace at all**. That's the wall in the Retaliation stuck-checked-button investigation: the player reported pressing Retaliation (on CD) and the button stuck "pressed-in," but `20230` appears nowhere in the session log — so we can't tell whether the press even reached the proxy or which gate consumed it.

## What
Emit `cast.received` (spell_id + client_cast_id) at the very top of `HandleCastSpell`, before any gate, gated behind `DebugOutput`. The next recurrence will show definitively: did the press arrive, and if so which branch resolved (or failed to resolve) the button.

## Notes
- Debug-only (no behavior change); off in live unless `DebugOutput=true`.
- Tagged `DIAGNOSTIC … remove when closed` to match the existing stuck-spell diagnostics.
- Separate from #344 (off-GCD sweep fix) and #345 (item-use off-GCD gap).