### PR TITLE
Normalize legacy whisper targets

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -563,7 +563,7 @@ public partial class WorldClient
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeVanilla.Whisper:
-                packet.WriteCString(to);
+                packet.WriteCString(NormalizeLegacyWhisperTarget(to));
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeVanilla.Say:
@@ -639,7 +639,7 @@ public partial class WorldClient
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeWotLK.Whisper:
-                packet.WriteCString(to);
+                packet.WriteCString(NormalizeLegacyWhisperTarget(to));
                 packet.WriteCString(msg);
                 break;
             case ChatMessageTypeWotLK.Say:
@@ -661,6 +661,16 @@ public partial class WorldClient
         }
 
         SendPacket(packet);
+    }
+
+    private static string NormalizeLegacyWhisperTarget(string target)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+            return target;
+
+        target = target.Trim();
+        int realmSeparator = target.IndexOf('-');
+        return realmSeparator >= 0 ? target.Substring(0, realmSeparator) : target;
     }
 
     [PacketHandler(Opcode.SMSG_EMOTE)]


### PR DESCRIPTION
Splits the low-risk whisper-normalization prong out of #338 (by @erkagoon) so it can land in beta.5 independently.

Strips a realm/`-` suffix from the whisper target before the legacy `CMSG_MESSAGECHAT`, so `Player-` / `Player-Realm` → `Player`. Fixes whisper **delivery** for the issue #202 names (the legacy server was looking for a char literally named `Player-`). Safe because 1.12 names contain no hyphens.

Note: this fixes delivery, not the trailing `-` shown in the whisper box (client-side name display — the deeper #202 root cause).

Prong A of #338 (ranged auto-repeat LoS retry) is held separately — spell-system change with a repeated-`CAST_FAILED` error-spam concern to settle first.

Cherry-picked from f348665 (#338), authored by @erkagoon.