### PR TITLE
Restore run-speed buff lost when CC ends mid-spline

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -503,6 +503,13 @@ public partial class WorldClient
         speed.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         speed.Speed = packet.ReadFloat();
         SendPacketToClient(speed);
+
+        // JimsProxy (speed-stuck-cc-spline): when CC ends mid-spline the server restores run speed via the spline opcode, not FORCE; mirror the FORCE cache so the regain-control reassert restores the buffed speed. See memory.
+        if (packet.GetUniversalOpcode(false) == Opcode.SMSG_MOVE_SPLINE_SET_RUN_SPEED &&
+            speed.MoverGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            GetSession().GameState.LastKnownPlayerRunSpeed = speed.Speed;
+        }
     }
 
     // for own player


### PR DESCRIPTION
Recreates @Mongrul's #342 on an origin branch so CI can run (the fork PR's workflows weren't triggered). Cherry-picked from his commit; authorship preserved.

When crowd control ends mid-spline, the 1.12 server restores run speed via `SMSG_MOVE_SPLINE_SET_RUN_SPEED` (not FORCE). `LastKnownPlayerRunSpeed` was only updated on FORCE changes, so it went stale after a spline restore and the regain-control reassert re-applied the base speed — dropping the player's buffed run speed. Mirrors the existing FORCE cache for the spline opcode.

Supersedes #342.