### PR TITLE
Render targeted /spit text when the target is an NPC

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -730,6 +730,16 @@ public partial class WorldClient
         uint nameLength = packet.ReadUInt32();
         string targetName = packet.ReadString(nameLength);
         emote.TargetGUID = GetSession().GameState.GetPlayerGuidByName(targetName);
+        // JimsProxy (spit-npc-target): the legacy server sends the emote target as a name,
+        // and GetPlayerGuidByName only resolves players. For the local player's own targeted
+        // emote at an NPC (e.g. /spit), fall back to the current selection so the modern client
+        // renders the targeted text instead of the untargeted "on the ground" row.
+        if (emote.TargetGUID.IsEmpty()
+            && !string.IsNullOrEmpty(targetName)
+            && emote.SourceGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            emote.TargetGUID = GetSession().GameState.CurrentSelection;
+        }
         SendPacketToClient(emote);
     }
 


### PR DESCRIPTION
Follow-up to #319. Reported in beta.5 testing: `/spit` at an **NPC** still shows "You spit on the ground."

**Root cause:** `SMSG_TEXT_EMOTE` carries the target as a *name string*. `HandleTextEmote` resolves it with `GetPlayerGuidByName`, which only iterates `CachedPlayers` — so an NPC name returns empty, `TargetGUID` is empty, and the 1.14 client renders the **untargeted** EmotesTextData row ("on the ground"). On a player target it resolved fine, which is why #319 appeared to work.

**Fix:** for the local player's own emote, when the name doesn't resolve to a player, fall back to `CurrentSelection` (the #319 cache) so the client gets the NPC's GUID and renders the targeted row. Guarded to own-emote + non-empty target name, so untargeted /spit is unaffected.

Scope: covers your own /spit on NPCs (and players). Observing *another* player spit on an NPC would need a creature-name lookup — deferred.