### PR TITLE
Append EmotesTextID to the EmotesTextData /spit hotfix

### DIFF
--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -5077,10 +5077,14 @@ public static partial class GameData
         // Blizzard changed /spit in the modern client (post-2019) to always
         // display "spits on the ground" even when targeting a player. Restore
         // the original vanilla targeted text so proxy players see it properly.
-        // Inline payload is Text_lang (CString) + RelationshipFlags (u8). EmotesTextID
-        // is a non-inline relation field and is NOT written to the hotfix record.
+        // 1.14.2 EmotesTextData record (DBD layout 93E6D146): Text_lang (CString),
+        // RelationshipFlags (u8), then EmotesTextID (u32 — the relation FK to
+        // EmotesText.ID, 89 for /spit). The relation field IS appended to the hotfix
+        // payload; omitting it leaves the record 4 bytes short of the client's meta, so
+        // the client silently drops the hotfix and the override never applies.
         // RelationshipFlags selects the perspective: 0 = third party, 1 = you are the
         // target, 2 = you are the source.
+        const uint SpitEmotesTextId = 89;
         ReadOnlySpan<(uint id, string text, byte relationshipFlags)> spitFixes =
         [
             (458, "%s spits on %s.", 0),
@@ -5101,6 +5105,7 @@ public static partial class GameData
             record.UniqueId = record.HotfixId;
             record.HotfixContent.WriteCString(text);
             record.HotfixContent.WriteUInt8(relationshipFlags);
+            record.HotfixContent.WriteUInt32(SpitEmotesTextId);
             Hotfixes.Add(record.HotfixId, record);
         }
     }


### PR DESCRIPTION
The actual fix for /spit (beta.5's #319 + beta.6's #353 were partial — confirmed in testing that /spit showed "spits on the ground" on **both** player and NPC targets).

**Root cause:** the EmotesTextData hotfix record was the wrong size. The 1.14.2 client (WoWDBDefs layout `93E6D146`, build 1.14.2.42597) expects `Text_lang` (CString) + `RelationshipFlags` (u8) + **`EmotesTextID` (u32, relation FK)**. We wrote only the first two, so the record was 4 bytes short of the client's meta and the client **silently dropped the hotfix** — the targeted rows (458/459/460) never got the vanilla wording, so every /spit fell back to "spits on the ground."

**Fix:** append `EmotesTextID` (89 for /spit) as u32. Verified field order + sizes against the DBD for the exact build. (My beta.5 review cited layout `2682E49B`/1.13.x where the field is u16 — wrong build.)

With this, #353's NPC-target fallback should also start mattering (it sets the targeted GUID so the client picks the now-restored row 460).