### PR TITLE
Revert off-GCD watchdog backstop (broke gathering chains)

### DIFF
--- a/HermesProxy.Tests/World/ClearNonStartedNormalCastsTests.cs
+++ b/HermesProxy.Tests/World/ClearNonStartedNormalCastsTests.cs
@@ -102,44 +102,4 @@ public class ClearNonStartedNormalCastsTests
         Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 7386);
         Assert.Contains(session.PendingNormalCasts, c => c.SpellId == 2687);
     }
-
-    [Fact]
-    public void OffGcdCast_SurvivesSweep_ButWatchdogReapsItWhenDeadlineExpires()
-    {
-        // #344 follow-up backstop: HandleCastSpell arms WatchdogDeadlineMs on off-GCD casts
-        // at enqueue. Since they're sweep-exempt and never become HasStarted, if their
-        // SPELL_GO is ever lost the sweep keeps them — so the watchdog must reap them, else
-        // they linger in PendingNormalCasts forever.
-        var session = NewSession();
-        var bloodrage = MakeCast(2687, hasStarted: false, isOffGcd: true);
-        bloodrage.WatchdogDeadlineMs = Environment.TickCount64 - 1; // armed at enqueue, now expired
-        session.PendingNormalCasts.Enqueue(bloodrage);
-
-        // Sweep keeps the off-GCD cast (the #344 exemption)...
-        var cleared = session.ClearNonStartedNormalCasts();
-        Assert.Empty(cleared);
-        Assert.Single(session.PendingNormalCasts);
-
-        // ...but the watchdog reaps it once the deadline passes, so it can't leak.
-        session.DrainExpiredWatchdogCasts(Environment.TickCount64, out var normalEvicted, out _);
-        Assert.Single(normalEvicted);
-        Assert.Equal(2687u, normalEvicted[0].SpellId);
-        Assert.Empty(session.PendingNormalCasts);
-    }
-
-    [Fact]
-    public void OffGcdCast_WithFreshWatchdogDeadline_NotReapedEarly()
-    {
-        // The armed window must be generous enough not to false-evict a legit off-GCD cast
-        // before its SPELL_GO arrives — premature eviction would re-create the stuck-lit bug.
-        var session = NewSession();
-        var bloodrage = MakeCast(2687, hasStarted: false, isOffGcd: true);
-        bloodrage.WatchdogDeadlineMs = Environment.TickCount64 + ClientCastRequest.WatchdogWindowMs;
-        session.PendingNormalCasts.Enqueue(bloodrage);
-
-        session.DrainExpiredWatchdogCasts(Environment.TickCount64, out var normalEvicted, out _);
-
-        Assert.Empty(normalEvicted);
-        Assert.Single(session.PendingNormalCasts);
-    }
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2284,11 +2284,6 @@ public class ClientCastRequest
     // permanently blocks HasStartedNormalCast(). 0 = no watchdog active.
     public long WatchdogDeadlineMs;
 
-    // Watchdog window (ms) after which an unresolved cast is force-evicted. Single
-    // source of truth for the failure-peek path (HandleSpellFailure) and the off-GCD
-    // enqueue arming (#344 follow-up).
-    public const long WatchdogWindowMs = 2500;
-
     // JimsProxy (PR #161 follow-up — destroy-hook fast path): captured from
     // CastSpell.Cast.Target.Unit at enqueue time. When HandleDestroyObject
     // sees this GUID, the proxy can immediately evict any pending casts that

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -18,7 +18,7 @@ public partial class WorldClient
     // any observed CAST_FAILED arrival on vmangos/Twinstar (~1ms after FAILURE)
     // and shorter than feels-laggy to the user when the pathological Kronos
     // case kicks in (target-dies-mid-cast, no trailing CAST_FAILED).
-    private const long WatchdogWindowMs = ClientCastRequest.WatchdogWindowMs;
+    private const long WatchdogWindowMs = 2500;
 
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_SEND_KNOWN_SPELLS)]

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -292,11 +292,6 @@ public partial class WorldSocket
             // Tag for the non-started-cast sweep: off-GCD casts must survive an unrelated
             // normal cast's SPELL_START (see ClearNonStartedNormalCasts / IsOffGcd).
             castRequest.IsOffGcd = isOffGcd;
-            // #344 follow-up: sweep-exempt off-GCD casts never become HasStarted, so they get
-            // no watchdog deadline from the failure/movement paths. Arm one at enqueue so a
-            // lost SPELL_GO can't leave the cast lingering in PendingNormalCasts forever.
-            if (isOffGcd)
-                castRequest.WatchdogDeadlineMs = Environment.TickCount64 + ClientCastRequest.WatchdogWindowMs;
 
             // JimsProxy (issue #43): off-GCD spells (Sprint, Evasion, Trinket, racials, etc)
             // bypass both the HasStartedNormalCast cast-bar gate and the GCD hold path. A real


### PR DESCRIPTION
Regression from the #344 follow-up backstop, reported in beta.5 testing: can't chain/queue **mining**.

**Root cause (from a live log):** the gather cast is **off-GCD with a ~5s cast time**, but the backstop armed a flat **2500ms** `WatchdogDeadlineMs` on off-GCD casts (assuming off-GCD = instant). So at 2.5s the watchdog evicted the still-casting mine and emitted a spurious `CastFailed`, breaking the cast/queue:
```
cast.forwarded     spell_id: 2668, source: off_gcd
spell.cast start   spell_id: 2668, cast_time: 5000
cast.watchdog_evicted  spell_id: 2668, had_started: true, ms_overdue: 2656   (every mine)
```

**Fix:** revert the backstop — remove the off-GCD arming, the shared `WatchdogWindowMs` const + its two tests. #344's sweep exemption (the real stuck-lit fix) is untouched; the lost-SPELL_GO edge the backstop guarded reverts to original #344 behavior (a theoretical concern that never warranted breaking gathering).