### PR TITLE
JimsPlus: strip realm suffix from mail recipient names

### DIFF
--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -14,6 +14,7 @@ TooltipFix.lua
 ZoneSync.lua
 MoonkinSound.lua
 AuctionsPaginationFix.lua
+MailNameFix.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua
 castbars/Data.lua

--- a/Addons/JimsPlus/MailNameFix.lua
+++ b/Addons/JimsPlus/MailNameFix.lua
@@ -1,0 +1,61 @@
+-- JimsPlus MailNameFix
+-- Strip the redundant realm suffix from mail recipients on the 1.14 Classic Era client.
+--
+-- The modern client appends a realm suffix to mail-recipient autocomplete entries for
+-- any character that isn't on your own account (friends + recently-interacted players).
+-- The proxy's player GUIDs carry a 13-bit realm-id (1) that does not match the home
+-- realm's virtual-realm address, so the client has no name for that realm and renders a
+-- bare trailing dash, e.g. "Babalucci-". Your own alts are exempt (same account, no
+-- suffix). Worse, the suffix is forwarded verbatim to the legacy 1.12 server on send,
+-- which has no such player and rejects the mail.
+--
+-- Vanilla 1.12 character names never contain "-" (letters only) and this server is a
+-- single realm, so the realm portion is always safe to strip. We clean it in two places:
+--   1. The SendMail API, so delivery always uses the bare character name regardless of
+--      how the recipient got into the To: box (typed, autocompleted, or pasted).
+--   2. The shared autocomplete dropdown (display + the value inserted on select), so the
+--      list shows clean names.
+
+local function StripRealm(name)
+    if type(name) ~= "string" then return name end
+    local dash = name:find("-", 1, true)
+    if dash then
+        return name:sub(1, dash - 1)
+    end
+    return name
+end
+
+-- 1) Guarantee delivery: wrap SendMail so the recipient is always the bare name.
+if type(SendMail) == "function" then
+    local origSendMail = SendMail
+    SendMail = function(recipient, subject, body)
+        return origSendMail(StripRealm(recipient), subject, body)
+    end
+end
+
+-- 2) Clean the shared autocomplete dropdown. Runs for every autocomplete editbox
+--    (mail, whisper, who, invite); stripping "-" from a vanilla name is always safe,
+--    so no per-box gating is needed. Fix both the visible button text and the stored
+--    nameInfo the client inserts when an entry is chosen.
+if type(AutoComplete_Update) == "function" then
+    hooksecurefunc("AutoComplete_Update", function()
+        local i = 1
+        while true do
+            local button = _G["AutoCompleteButton" .. i]
+            if not button then break end
+            if button:IsShown() then
+                if button.nameInfo and type(button.nameInfo.name) == "string" then
+                    button.nameInfo.name = StripRealm(button.nameInfo.name)
+                end
+                local txt = button:GetText()
+                if txt then
+                    local clean = StripRealm(txt)
+                    if clean ~= txt then
+                        button:SetText(clean)
+                    end
+                end
+            end
+            i = i + 1
+        end
+    end)
+end


### PR DESCRIPTION
## Summary
- Client-side JimsPlus fix for the mail-recipient trailing dash (e.g. "Babalucci-") shown for any character not on your own account (friends + recently-interacted players); own alts are exempt.
- Root cause: player GUIDs carry a 13-bit realm-id of 1, which the 1.14 client reads as realm address `0x00000001` ≠ the home VRA `0x01010001`, so it appends an empty realm name in the mail autocomplete. Confirmed it never queries realm names (instrumented: 0 `CMSG_QUERY_REALM_NAME` during repro).
- `MailNameFix` wraps `SendMail` so the recipient is always the bare name — this also fixes a real delivery bug, since the dash was forwarded raw to the 1.12 server and rejected — and hooks `AutoComplete_Update` to clean the dropdown display. Vanilla names never contain "-" and this is a single realm, so stripping is always safe.

## Test plan
- [x] Mail autocomplete dropdown shows clean names (verified on Kronos, 1.14.2)
- [x] Selecting a name + Enter sends to the bare name (delivery works)
- [ ] Cold-start the client if `/reload` doesn't pick up the new module