### PR TITLE
Fix keyring stuck items, sort loop, and non-key leak

### DIFF
--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -15,6 +15,7 @@ ZoneSync.lua
 MoonkinSound.lua
 AuctionsPaginationFix.lua
 MailNameFix.lua
+KeyringClamp.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua
 castbars/Data.lua

--- a/Addons/JimsPlus/KeyringClamp.lua
+++ b/Addons/JimsPlus/KeyringClamp.lua
@@ -1,0 +1,50 @@
+-- JimsPlus KeyringClamp
+-- Two client-side fixes for the keyring (container -2) on the 1.14 client + Kronos:
+--   1. SIZE: the client reports the keyring as 32 slots, but Kronos only accepts 12; slots 13-32
+--      bounce. Clamp GetContainerNumSlots(-2) down to 12 so the UI/addons only see the real slots.
+--   2. FAMILY: the client reports the keyring's bag family as 0 (general) instead of 9 (keys-only),
+--      so Bagnon's sort (Wildpants/api/sorting.lua) treats it as normal storage and loops forever
+--      trying to move non-keys into it (server rejects WrongBagType; Bagnon retries). Force
+--      GetContainerNumFreeSlots(-2) to report family 9 -- Bagnon's FitsIn then only admits keys
+--      (GetItemFamily==256) into the keyring, so non-keys are never targeted at it.
+-- The proxy separately unlocks any item dropped on a phantom slot. Clamps DOWN only.
+
+local KEYRING_SIZE = 12
+local KEYRING_FAMILY = 9
+local KEYRING = (type(KEYRING_CONTAINER) == "number") and KEYRING_CONTAINER or -2
+
+local function clamp(orig, bag, ...)
+    local n = orig(bag, ...)
+    if bag == KEYRING and type(n) == "number" and n > KEYRING_SIZE then
+        return KEYRING_SIZE
+    end
+    return n
+end
+
+local function clampFree(orig, bag, ...)
+    if bag == KEYRING then
+        local free = orig(bag, ...)
+        return free, KEYRING_FAMILY
+    end
+    return orig(bag, ...)
+end
+
+if C_Container and type(C_Container.GetContainerNumSlots) == "function" then
+    local orig = C_Container.GetContainerNumSlots
+    C_Container.GetContainerNumSlots = function(bag, ...) return clamp(orig, bag, ...) end
+end
+
+if type(GetContainerNumSlots) == "function" then
+    local orig = GetContainerNumSlots
+    GetContainerNumSlots = function(bag, ...) return clamp(orig, bag, ...) end
+end
+
+if C_Container and type(C_Container.GetContainerNumFreeSlots) == "function" then
+    local orig = C_Container.GetContainerNumFreeSlots
+    C_Container.GetContainerNumFreeSlots = function(bag, ...) return clampFree(orig, bag, ...) end
+end
+
+if type(GetContainerNumFreeSlots) == "function" then
+    local orig = GetContainerNumFreeSlots
+    GetContainerNumFreeSlots = function(bag, ...) return clampFree(orig, bag, ...) end
+end

--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -26,6 +26,92 @@ local function CreateDescription(parent, text, yOffset)
     return fs
 end
 
+local function CreateButton(parent, yOffset, label, width, tooltip)
+    local btn = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
+    btn:SetPoint("TOPLEFT", parent, "TOPLEFT", 16, yOffset)
+    btn:SetSize(width or 160, 24)
+    btn:SetText(label)
+    if tooltip then
+        btn:HookScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+            GameTooltip:SetText(tooltip, 1, 1, 1, 1, true)
+            GameTooltip:Show()
+        end)
+        btn:HookScript("OnLeave", function() GameTooltip:Hide() end)
+    end
+    return btn
+end
+
+---------------------------------------------------------------------------
+-- Keyring cleanup: move non-key items out of the keyring into free bag slots.
+-- Older characters can have non-keys stuck in the keyring from a past client bug;
+-- the proxy now blocks new ones, this button clears existing ones. Keys (item
+-- class 13) are left in place. One move per timer tick so each settles server-side.
+---------------------------------------------------------------------------
+local KEYRING = (type(KEYRING_CONTAINER) == "number") and KEYRING_CONTAINER or -2
+
+local function KR_NumSlots(bag)
+    if C_Container and C_Container.GetContainerNumSlots then return C_Container.GetContainerNumSlots(bag) or 0 end
+    return (GetContainerNumSlots and GetContainerNumSlots(bag)) or 0
+end
+local function KR_ItemID(bag, slot)
+    if C_Container and C_Container.GetContainerItemID then return C_Container.GetContainerItemID(bag, slot) end
+    return GetContainerItemID and GetContainerItemID(bag, slot)
+end
+local function KR_Pickup(bag, slot)
+    if C_Container and C_Container.PickupContainerItem then return C_Container.PickupContainerItem(bag, slot) end
+    if PickupContainerItem then return PickupContainerItem(bag, slot) end
+end
+
+local function KR_IsNonKey(id)
+    if not id then return false end
+    local classID = select(6, GetItemInfoInstant(id))
+    if classID == nil then return false end -- unknown item: leave it alone
+    return classID ~= 13 -- 13 = Key
+end
+
+local function KR_FirstFreeBagSlot()
+    for bag = 0, 4 do
+        for slot = 1, KR_NumSlots(bag) do
+            if not KR_ItemID(bag, slot) then return bag, slot end
+        end
+    end
+end
+
+local KR_cleaning, KR_steps = false, 0
+local function KR_Step()
+    KR_steps = KR_steps + 1
+    if KR_steps > 40 then KR_cleaning = false; return end
+    for slot = 1, KR_NumSlots(KEYRING) do
+        if KR_IsNonKey(KR_ItemID(KEYRING, slot)) then
+            local bag, bslot = KR_FirstFreeBagSlot()
+            if not bag then
+                print("|cFF00FF00[JimsPlus]|r Keyring cleanup: bags are full - free a slot and click again.")
+                KR_cleaning = false
+                return
+            end
+            ClearCursor()
+            KR_Pickup(KEYRING, slot)
+            KR_Pickup(bag, bslot)
+            ClearCursor()
+            C_Timer.After(0.2, KR_Step)
+            return
+        end
+    end
+    if KR_cleaning then print("|cFF00FF00[JimsPlus]|r Keyring cleanup complete.") end
+    KR_cleaning = false
+end
+
+local function KR_StartCleanup()
+    if InCombatLockdown() then
+        print("|cFF00FF00[JimsPlus]|r Can't clean the keyring in combat.")
+        return
+    end
+    if KR_cleaning then return end
+    KR_cleaning, KR_steps = true, 0
+    KR_Step()
+end
+
 ---------------------------------------------------------------------------
 -- Panel
 ---------------------------------------------------------------------------
@@ -96,6 +182,18 @@ for _, info in ipairs(castbarUnits) do
     castbarCBs[info.key] = CreateCheckbox(panel, y, info.label, info.tooltip)
     y = y - 28
 end
+
+---------------------------------------------------------------------------
+-- Tools
+---------------------------------------------------------------------------
+y = y - 12
+CreateHeader(panel, "Tools", y)
+y = y - 26
+local btnBagAudit = CreateButton(panel, y, "Bag Audit", 150,
+    "Moves non-key items out of your keyring and into your bags.\nUse it if a character has items stuck in the keyring from a past\nbug. Keys are left in place.")
+btnBagAudit:SetScript("OnClick", KR_StartCleanup)
+y = y - 30
+-- More tool buttons can be added below (decrement y per button).
 
 ---------------------------------------------------------------------------
 -- Sync checkboxes from saved state

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -802,6 +802,16 @@ public sealed class GameSessionData
 
         return bagFields.GetGuidValue(containerSlotField + slot * 2);
     }
+
+    // JimsProxy: the items in the last inventory move, remembered so we can repair an
+    // InventoryChangeFailure the server sends with empty item GUIDs (it does this for
+    // invalid-slot rejections — e.g. the modern client's phantom keyring slots 13-32 that
+    // Kronos lacks). Without the GUIDs the client can't unlock the source item, so it
+    // stays stuck until relog. Set in the item-move handlers, consumed in the failure handler.
+    public WowGuid128 LastMoveItem0;
+    public WowGuid128 LastMoveItem1;
+    public int LastMoveItemsTickMs;
+
     public uint GetItemStackCount(WowGuid128 itemGuid)
     {
         uint count = GetLegacyFieldValueUInt32(itemGuid, ItemField.ITEM_FIELD_STACK_COUNT);

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -258,6 +258,20 @@ public partial class WorldClient
         failure.Item[1] = packet.ReadGuid().To128(GetSession().GameState);
         failure.ContainerBSlot = packet.ReadUInt8();
 
+        // JimsProxy: Kronos sends invalid-slot rejections (e.g. the modern client's phantom
+        // keyring slots 13-32 that the server lacks) with empty item GUIDs, so the client
+        // can't unlock the item the player picked up and it stays stuck until relog. Backfill
+        // the GUIDs from the move we just forwarded so the client releases the item.
+        if (failure.Item[0].IsEmpty() && failure.Item[1].IsEmpty())
+        {
+            var state = GetSession().GameState;
+            if (Environment.TickCount - state.LastMoveItemsTickMs < 2000)
+            {
+                failure.Item[0] = state.LastMoveItem0;
+                failure.Item[1] = state.LastMoveItem1;
+            }
+        }
+
         SendPacketToClient(failure);
 
         // Check if item use cast failed (queue-based)

--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Framework.Constants;
+using System;
 using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
@@ -44,6 +45,9 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SPLIT_ITEM)]
     void HandleSplitItem(SplitItem item)
     {
+        RememberMoveItems(item.FromPackSlot, item.FromSlot, item.ToPackSlot, item.ToSlot);
+        if (BlockNonKeySplitIntoKeyring(item.ToPackSlot, item.ToSlot))
+            return;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SPLIT_ITEM);
         byte containerSlot1 = item.FromPackSlot != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.FromPackSlot) : item.FromPackSlot;
         byte slot1 = item.FromPackSlot == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.FromSlot) : item.FromSlot;
@@ -63,6 +67,9 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SWAP_INV_ITEM)]
     void HandleSwapInvItem(SwapInvItem item)
     {
+        RememberMoveItems(Enums.Classic.InventorySlots.Bag0, item.Slot1, Enums.Classic.InventorySlots.Bag0, item.Slot2);
+        if (BlockNonKeyIntoKeyring(Enums.Classic.InventorySlots.Bag0, item.Slot1, Enums.Classic.InventorySlots.Bag0, item.Slot2))
+            return;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SWAP_INV_ITEM);
         byte slot1 = ModernVersion.AdjustInventorySlot(item.Slot1);
         byte slot2 = ModernVersion.AdjustInventorySlot(item.Slot2);
@@ -74,6 +81,9 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SWAP_ITEM)]
     void HandleSwapItem(SwapItem item)
     {
+        RememberMoveItems(item.ContainerSlotA, item.SlotA, item.ContainerSlotB, item.SlotB);
+        if (BlockNonKeyIntoKeyring(item.ContainerSlotA, item.SlotA, item.ContainerSlotB, item.SlotB))
+            return;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SWAP_ITEM);
         byte containerSlotB = item.ContainerSlotB != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ContainerSlotB) : item.ContainerSlotB;
         byte slotB = item.ContainerSlotB == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.SlotB) : item.SlotB;
@@ -210,5 +220,83 @@ public partial class WorldSocket
         packet.WriteUInt8(itemBag);
         packet.WriteUInt8(itemSlot);
         SendPacketToServer(packet);
+    }
+
+    // JimsProxy: remember the items at both endpoints of an item move (looked up from the
+    // cached player inventory at the legacy slots we're about to forward), so the failure
+    // handler can repair an empty-GUID InventoryChangeFailure and unlock the source item.
+    // Kronos sends empty item GUIDs for invalid-slot rejections (e.g. the modern client's
+    // phantom keyring slots 13-32 that the server lacks), which otherwise leaves the picked-
+    // up item locked until relog.
+    void RememberMoveItems(byte containerA, byte slotA, byte containerB, byte slotB)
+    {
+        var state = GetSession().GameState;
+        byte lcA = containerA != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(containerA) : containerA;
+        byte lsA = containerA == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(slotA) : slotA;
+        byte lcB = containerB != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(containerB) : containerB;
+        byte lsB = containerB == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(slotB) : slotB;
+        state.LastMoveItem0 = state.GetInventorySlotItem(lcA, lsA).To128(state);
+        state.LastMoveItem1 = state.GetInventorySlotItem(lcB, lsB).To128(state);
+        state.LastMoveItemsTickMs = Environment.TickCount;
+    }
+
+    // JimsProxy: Kronos only enforces keys-only on its real (level-gated) keyring slots; the
+    // modern client's keyring slots past that size — and Bagnon, which treats the keyring as a
+    // 12/32-slot bag — map to regular vanilla slots that accept ANY item, so non-keys leak in and
+    // orphan there. Block any move dropping a known non-key into a client keyring slot (94-125) and
+    // bounce a clean WrongBagType with the item's GUID, so the client unlocks it (no stuck). Unknown
+    // items (template not loaded) pass through so we never false-block a real key — Kronos still
+    // enforces keys-only on the real slots in that rare case. Returns true if the move was blocked.
+    static bool IsKeyringSlot(byte container, byte slot)
+        => container == Enums.Classic.InventorySlots.Bag0
+           && slot >= Enums.Classic.InventorySlots.KeyringStart
+           && slot < Enums.Classic.InventorySlots.KeyringEnd;
+
+    bool IsKnownNonKey(WowGuid128 item)
+    {
+        if (item.IsEmpty())
+            return false;
+        uint itemId = GetSession().GameState.GetItemId(item);
+        if (itemId == 0)
+            return false;
+        var template = GameData.GetItemTemplate(itemId);
+        return template != null && template.Class != 13; // 13 = ItemClass.Key
+    }
+
+    // Bounce a blocked keyring move with a clean WrongBagType. Unlocks BOTH move endpoints so a
+    // swap never leaves the dragged item OR the swapped item locked (stuck).
+    void SendKeyringBounce()
+    {
+        var state = GetSession().GameState;
+        InventoryChangeFailure failure = new();
+        failure.BagResult = InventoryResult.WrongBagType;
+        failure.Item[0] = state.LastMoveItem0;
+        failure.Item[1] = state.LastMoveItem1;
+        SendPacket(failure);
+    }
+
+    // Swap/move: the item from A lands in B (LastMoveItem0) and the item from B lands in A
+    // (LastMoveItem1). Block if either lands a known non-key in a client keyring slot.
+    bool BlockNonKeyIntoKeyring(byte containerA, byte slotA, byte containerB, byte slotB)
+    {
+        var state = GetSession().GameState;
+        if ((IsKeyringSlot(containerB, slotB) && IsKnownNonKey(state.LastMoveItem0))
+            || (IsKeyringSlot(containerA, slotA) && IsKnownNonKey(state.LastMoveItem1)))
+        {
+            SendKeyringBounce();
+            return true;
+        }
+        return false;
+    }
+
+    // Split: only the destination receives the split portion (no swap-back), so check the dest only.
+    bool BlockNonKeySplitIntoKeyring(byte toContainer, byte toSlot)
+    {
+        if (IsKeyringSlot(toContainer, toSlot) && IsKnownNonKey(GetSession().GameState.LastMoveItem0))
+        {
+            SendKeyringBounce();
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
Four keyring issues on the 1.14 Classic Era client against a vanilla (Kronos) server:

- **Stuck items (proxy):** an item dropped on a keyring slot the client shows but the server lacks is rejected with empty item GUIDs, so the client can't unlock it — stuck until relog. The proxy remembers each move's items and backfills the empty-GUID failure so the client releases it.
- **Non-key leak (proxy):** Kronos enforces keys-only only on a character's level-gated keyring slots; the client shows more, so non-keys dropped on the extra slots are accepted and orphan there. The proxy blocks any move landing a known non-key (item class != Key) in a client keyring slot and bounces a clean WrongBagType, unlocking both endpoints.
- **Bagnon sort loop (JimsPlus):** the client reports the keyring's bag family as general (0); JimsPlus forces it to keys-only (9) and clamps the slot count to 12, so Bagnon stops looping its sort trying to move non-keys into the keyring.
- **Bag Audit (JimsPlus):** a Tools-page button that relocates non-keys already orphaned in the keyring (pre-fix characters) into the bags.

The true root is a Kronos-side keys-only gap (enforcement scoped to the level-gated slots); these client/proxy layers protect launcher users regardless of whether the server is hardened.

## Test plan
- [x] Drag onto a phantom keyring slot → item bounces and releases, no relog (Layer 1).
- [x] Swaps in/out of the keyring unstick cleanly; no flashing; no stuck on occupied-slot swaps (both endpoints unlocked).
- [x] Bagnon auto-sort completes, no loop.
- [x] Drag a non-key onto a keyring slot → bounces ("Item doesn't go in that container"); keys still go in.
- [x] Bag Audit relocates orphaned non-keys to bags ("cleanup complete").