### PR TITLE
JimsPlus v1.1.0: name dash, target cast-bar durations, handshake reconnect, versioning

### DIFF
--- a/Addons/JimsPlus/Core.lua
+++ b/Addons/JimsPlus/Core.lua
@@ -1,8 +1,8 @@
 local ADDON_NAME, namespace = ...
 
-namespace.BUILD = 20
+namespace.VERSION = (GetAddOnMetadata and GetAddOnMetadata(ADDON_NAME, "Version")) or "?"
 
-print("|cFF00FF00[JimsPlus]|r Core loaded (build " .. namespace.BUILD .. ")")
+print("|cFF00FF00[JimsPlus]|r v" .. namespace.VERSION .. " loaded")
 
 C_ChatInfo.RegisterAddonMessagePrefix("JP")
 

--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -4,7 +4,7 @@
 ## SavedVariables: JimsPlusDB, JimsPlusCastbarsDB
 ## SavedVariablesPerCharacter: JimsPlusCastbarsCharDB
 ## Author: JimsProxy Team (CastBars based on ClassicCastbars by Wardz)
-## Version: 1.0.1
+## Version: 1.1.0
 
 Core.lua
 Options.lua

--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -15,6 +15,7 @@ ZoneSync.lua
 MoonkinSound.lua
 AuctionsPaginationFix.lua
 MailNameFix.lua
+NameDashFix.lua
 KeyringClamp.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua

--- a/Addons/JimsPlus/NameDashFix.lua
+++ b/Addons/JimsPlus/NameDashFix.lua
@@ -1,0 +1,195 @@
+-- JimsPlus NameDashFix
+-- Suppress the bare trailing realm dash ("Name-") the 1.14 Classic client renders for
+-- any character that is NOT on your own account, across the UI surfaces that MailNameFix
+-- does not cover: chat/emotes, the Friends list, and the mail inbox sender.
+--
+-- Why this lives in the addon and not the proxy: the proxy cannot stop it. The client
+-- appends the realm separator itself, and it is NOT driven by any realm-id, realm-address,
+-- or account-GUID field the proxy controls (each was built and tested live 2026-06-05 with
+-- zero effect). Vanilla 1.12 character names are letters-only and this is a single realm,
+-- so the realm portion is always empty/local and stripping at the first "-" is always safe.
+
+local function StripRealm(name)
+    if type(name) ~= "string" then return name end
+    local dash = name:find("-", 1, true)
+    if dash then
+        return name:sub(1, dash - 1)
+    end
+    return name
+end
+
+-- 1) Broad coverage. Ambiguate() is the function most name-display code routes a
+--    realm-qualified name through; wrapping it drops the realm everywhere at once
+--    (unit frames, many chat paths, tooltips, etc.). Safe here -- single realm, so the
+--    "short" form is always what we want and the realm suffix is always empty.
+if type(Ambiguate) == "function" then
+    local origAmbiguate = Ambiguate
+    Ambiguate = function(name, context)
+        if name == nil then return name end
+        return StripRealm(origAmbiguate(name, context))
+    end
+end
+
+-- 2) Emotes come through the chat system and don't always pass through Ambiguate. Strip
+--    the sender's realm dash from both the author field and the formatted message text.
+local JP_EMOTE_DEBUG = false  -- diagnostics only; left in (off) in case another emote path surfaces
+local function emoteFilter(_, event, msg, author, ...)
+    local cleanAuthor = StripRealm(author)
+    local newMsg = msg
+    -- Strip the realm dash that follows the performer's name in the message body, whether or
+    -- not the author field itself carries it ("Goop- laughs." -> "Goop laughs.").
+    if type(msg) == "string" and type(cleanAuthor) == "string" and cleanAuthor ~= "" then
+        local namePat = cleanAuthor:gsub("(%W)", "%%%1")
+        newMsg = msg:gsub(namePat .. "%-", cleanAuthor)
+    end
+    if JP_EMOTE_DEBUG
+       and ((type(author) == "string" and author:find("-", 1, true))
+            or (type(msg) == "string" and msg:find("-", 1, true))) then
+        DEFAULT_CHAT_FRAME:AddMessage("|cFFFF8800[JP-EMOTE-DBG]|r " .. tostring(event)
+            .. " author='" .. tostring(author) .. "' msg='" .. tostring(msg) .. "'")
+    end
+    if (cleanAuthor ~= author) or (newMsg ~= msg) then
+        return false, newMsg, cleanAuthor, ...
+    end
+end
+
+if type(ChatFrame_AddMessageEventFilter) == "function" then
+    ChatFrame_AddMessageEventFilter("CHAT_MSG_TEXT_EMOTE", emoteFilter)
+    ChatFrame_AddMessageEventFilter("CHAT_MSG_EMOTE", emoteFilter)
+end
+
+-- 3) Friends list: after each refresh, strip the dash from the visible name fontstrings.
+--    Best-effort and fully guarded so a UI-layout difference can only no-op, never error.
+local function cleanFriendsList()
+    local scroll = FriendsFrameFriendsScrollFrame or FriendsListFrameScrollFrame
+    local buttons = scroll and scroll.buttons
+    if not buttons then return end
+    for _, button in ipairs(buttons) do
+        local fs = button.name
+        if fs and fs.GetText and fs.SetText then
+            local txt = fs:GetText()
+            local clean = StripRealm(txt)
+            if clean ~= nil and clean ~= txt then
+                fs:SetText(clean)
+            end
+        end
+    end
+end
+if type(FriendsFrame_UpdateFriends) == "function" then
+    hooksecurefunc("FriendsFrame_UpdateFriends", cleanFriendsList)
+end
+
+-- 4) Mail inbox: strip the dash from each sender fontstring after the inbox refreshes.
+--    Best-effort and guarded (frame names vary by client build).
+local function cleanInbox()
+    for i = 1, 7 do
+        local fs = _G["MailItem" .. i .. "Sender"]
+        if fs and fs.GetText and fs.SetText then
+            local txt = fs:GetText()
+            local clean = StripRealm(txt)
+            if clean ~= nil and clean ~= txt then
+                fs:SetText(clean)
+            end
+        end
+    end
+end
+if type(InboxFrame_Update) == "function" then
+    hooksecurefunc("InboxFrame_Update", cleanInbox)
+end
+
+-- 5) Mail recipient autofill INLINE GHOST. The dropdown is handled by MailNameFix, but the
+--    inline auto-completion the client ghosts into the To: editbox still carries the realm
+--    dash ("Nath-"). After the text changes (including the autocomplete's own SetText), strip
+--    from the first dash and re-highlight the auto-added remainder, so the suggestion UX is
+--    preserved -- just without the dash. Re-entrancy guarded so our own SetText can't loop.
+local stripping = false
+local function fixMailInline(editBox)
+    if stripping then return end
+    if not editBox or not editBox.GetText then return end
+    local text = editBox:GetText()
+    if not text then return end
+    local dash = text:find("-", 1, true)
+    if not dash then return end
+    local userLen = editBox:GetCursorPosition()  -- autocomplete leaves the cursor at the typed length
+    local clean = text:sub(1, dash - 1)
+    stripping = true
+    editBox:SetText(clean)
+    if userLen and userLen > 0 and userLen < #clean then
+        editBox:SetCursorPosition(userLen)
+        editBox:HighlightText(userLen, #clean)
+    else
+        editBox:SetCursorPosition(#clean)
+    end
+    stripping = false
+end
+
+local mailHooked = false
+local function hookMailNameEditBox()
+    if mailHooked then return end
+    local eb = SendMailNameEditBox
+    if eb and eb.HookScript then
+        eb:HookScript("OnTextChanged", fixMailInline)
+        mailHooked = true
+    end
+end
+-- The mail frame is base UI, but hook on first MAIL_SHOW to be safe about load order;
+-- also try immediately in case it already exists.
+local mailWatcher = CreateFrame("Frame")
+mailWatcher:RegisterEvent("MAIL_SHOW")
+mailWatcher:SetScript("OnEvent", hookMailNameEditBox)
+hookMailNameEditBox()
+
+-- 6) Auction House Browse "Seller" column shows the cross-realm indicator "(*)" on
+--    other-account/other-realm sellers -- same root cause as the dash, different glyph.
+--    Seller-cell frame names are version-specific, so rather than target them we scan the
+--    AuctionFrame's font strings after each list refresh and strip " (*)" wherever it appears.
+--    Only strings that actually contain "(*)" are touched, so it's safe; recursion is depth-capped.
+local function jpStripStar(text)
+    if type(text) == "string" and text:find("(*)", 1, true) then
+        return (text:gsub("%s*%(%*%)", ""))
+    end
+    return text
+end
+local function jpScanStars(frame, depth)
+    if not frame or depth > 6 then return end
+    if frame.GetRegions then
+        for _, r in ipairs({ frame:GetRegions() }) do
+            if r.GetText and r.SetText then
+                local t = r:GetText()
+                local c = jpStripStar(t)
+                if c ~= t then r:SetText(c) end
+            end
+        end
+    end
+    if frame.GetChildren then
+        for _, child in ipairs({ frame:GetChildren() }) do
+            jpScanStars(child, depth + 1)
+        end
+    end
+end
+local function jpCleanAHStars()
+    if AuctionFrame then jpScanStars(AuctionFrame, 0) end
+end
+local jpAhHooked = false
+local function jpHookBrowseUpdate()
+    -- Blizzard_AuctionUI is load-on-demand: AuctionFrameBrowse_Update doesn't exist until the AH
+    -- is first opened. Hooking it (once it exists) makes the strip re-run on EVERY browse redraw,
+    -- including scrolling -- which is why the "(*)" came back on scroll before.
+    if not jpAhHooked and type(AuctionFrameBrowse_Update) == "function" then
+        hooksecurefunc("AuctionFrameBrowse_Update", jpCleanAHStars)
+        jpAhHooked = true
+    end
+end
+local ahWatcher = CreateFrame("Frame")
+ahWatcher:RegisterEvent("AUCTION_ITEM_LIST_UPDATE")
+ahWatcher:RegisterEvent("AUCTION_HOUSE_SHOW")
+ahWatcher:RegisterEvent("ADDON_LOADED")
+ahWatcher:SetScript("OnEvent", function(_, evt, name)
+    if evt == "ADDON_LOADED" then
+        if name == "Blizzard_AuctionUI" then jpHookBrowseUpdate() end
+        return
+    end
+    jpHookBrowseUpdate()
+    if C_Timer and C_Timer.After then C_Timer.After(0, jpCleanAHStars) else jpCleanAHStars() end
+end)
+jpHookBrowseUpdate()  -- in case Blizzard_AuctionUI is already loaded

--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -124,7 +124,7 @@ title:SetText("|cFF00FF00JimsPlus|r Settings")
 
 local subtitle = panel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
 subtitle:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -4)
-subtitle:SetText("Build " .. namespace.BUILD)
+subtitle:SetText("v" .. (namespace.VERSION or "?"))
 
 ---------------------------------------------------------------------------
 -- Client Fixes (always on by default — these fix real bugs)

--- a/Addons/JimsPlus/castbars/CastBars.lua
+++ b/Addons/JimsPlus/castbars/CastBars.lua
@@ -351,6 +351,13 @@ end
 function addon:PLAYER_ENTERING_WORLD(isInitialLogin)
     if isInitialLogin then return end
 
+    -- Re-announce the JP sideband handshake. A reconnect (or any loading screen) gives the
+    -- proxy a fresh session with JimsPlusSideband=false, so without re-sending "1" the cast-time
+    -- and channel sidebands silently stop until /reload. Idempotent on same-session zone changes.
+    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
+        C_ChatInfo.SendAddonMessage("JP", "1", "WHISPER", UnitName("player"))
+    end
+
     -- Reset all data on loading screens
     wipe(activeGUIDs)
     wipe(activeTimers)
@@ -411,6 +418,17 @@ function addon:CHAT_MSG_SYSTEM(message)
                 local spellId = tonumber(front:sub(lastColon1 + 1))
                 if guidStr and spellId then
                     proxyCastTimes[guidStr] = castTime
+                    -- JP_CS lands just after SMSG_SPELL_START, so the bar's COMBAT_LOG start
+                    -- usually fires first and reads the PREVIOUS cast's time (one-cast lag, e.g.
+                    -- rank-1 shown for a rank-7 cast). If a player cast for this GUID just started,
+                    -- re-apply the correct duration in place (keep timeStart) and consume it.
+                    local activeCast = activeTimers[guidStr]
+                    if activeCast and activeCast.isPlayer and not activeCast.isChanneled
+                        and (GetTime() - (activeCast.timeStart or 0)) < 0.2 then
+                        activeCast.maxValue = (castTime / 1000) - 0.1
+                        activeCast.endTime = activeCast.timeStart + ((castTime / 1000) - 0.1)
+                        proxyCastTimes[guidStr] = nil
+                    end
                 end
             end
         end


### PR DESCRIPTION
Full JimsPlus update (started as the cross-realm name-dash PR, expanded at request).

- **Name dash:** suppress the trailing cross-realm dash on emotes, mail, friends, inbox, and mail autofill, plus the AH "(*)" seller glyph (`NameDashFix.lua`, via `Ambiguate` + targeted hooks).
- **Target cast-bar durations:** fix the one-cast lag where an observed player's cast bar showed the *previous* cast's duration (e.g. rank-1 time on a rank-7 cast). The proxy sends `JP_CS` just after `SMSG_SPELL_START`, so the bar's COMBAT_LOG start reads the prior cast's `proxyCastTimes`. On `JP_CS`, re-apply the correct duration to a just-started player cast in place and consume it. **Verified in-game.**
- **Handshake reconnect:** re-send the JP sideband handshake on `PLAYER_ENTERING_WORLD` so cast-time/channel sidebands survive a reconnect (fresh proxy session) without `/reload`.
- **Versioning:** → `1.1.0`; load message + Options subtitle read the `.toc` Version via `GetAddOnMetadata` (single source of truth); removed the hardcoded `BUILD`.