### PR TITLE
Fix proxy corrupting DEFLATE-compressed addon comm

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -239,13 +239,13 @@ public class ByteBuffer : IDisposable
         return tmpString.ToString();
     }
 
-    public string ReadString(uint length)
+    public string ReadString(uint length, Encoding? encoding = null)
     {
         if (length == 0)
             return "";
 
         ResetBitPos();
-        return Encoding.UTF8.GetString(ReadBytes(length));
+        return (encoding ?? Encoding.UTF8).GetString(ReadBytes(length));
     }
 
     public bool ReadBool()
@@ -473,7 +473,7 @@ public class ByteBuffer : IDisposable
     /// Writes a string to the packet with a null terminated (0)
     /// </summary>
     /// <param name="str"></param>
-    public void WriteCString(string str)
+    public void WriteCString(string str, Encoding? encoding = null)
     {
         if (string.IsNullOrEmpty(str))
         {
@@ -481,16 +481,16 @@ public class ByteBuffer : IDisposable
             return;
         }
 
-        WriteString(str);
+        WriteString(str, encoding);
         WriteUInt8(0);
     }
 
-    public void WriteString(string str)
+    public void WriteString(string str, Encoding? encoding = null)
     {
         if (str.IsEmpty())
             return;
 
-        byte[] sBytes = Encoding.UTF8.GetBytes(str);
+        byte[] sBytes = (encoding ?? Encoding.UTF8).GetBytes(str);
         WriteBytes(sBytes);
     }
 

--- a/Framework/IO/SpanPacketWriter.cs
+++ b/Framework/IO/SpanPacketWriter.cs
@@ -200,13 +200,13 @@ public ref struct SpanPacketWriter
         WriteUInt8(0);
     }
 
-    public void WriteString(string value)
+    public void WriteString(string value, Encoding? encoding = null)
     {
         if (string.IsNullOrEmpty(value))
             return;
 
         FlushBits();
-        int bytesWritten = Encoding.UTF8.GetBytes(value, _buffer.Slice(_position));
+        int bytesWritten = (encoding ?? Encoding.UTF8).GetBytes(value, _buffer.Slice(_position));
         _position += bytesWritten;
     }
 

--- a/HermesProxy.Tests/World/AddonCommCompressionTests.cs
+++ b/HermesProxy.Tests/World/AddonCommCompressionTests.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using System.Text;
+using Framework.IO;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Guards the addon-comm corruption fix: DEFLATE-compressed addon-channel bodies
+// (e.g. Details talent sync) must survive the proxy byte-for-byte. These tests are
+// written RED-first — they fail on current code and pass once the fix lands.
+public class AddonCommCompressionTests
+{
+    static AddonCommCompressionTests()
+    {
+        // ChatPkt resolves an opcode through ModernVersion, whose static ctor needs a
+        // real client build (mirrors the other packet-construction tests).
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    // ---- T-A (vector 2): CheckAddonPrefix must preserve the addon body verbatim ----
+    // The legacy wire is "prefix\tbody"; only the FIRST tab is the delimiter. A
+    // DEFLATE body can contain raw 0x09 (tab) bytes — the WoW addon-channel codec
+    // only escapes 0x00 — so any rejoin that splits on every tab corrupts the body.
+    [Fact]
+    public void CheckAddonPrefix_AddonBodyWithEmbeddedTabs_PreservesBodyVerbatim()
+    {
+        var registered = new HashSet<string> { "Details" };
+        uint language = (uint)Language.Addon;
+        string body = "ab\tcd«ef\tgh";          // embedded 0x09 tabs + a high char
+        string text = "Details\t" + body;
+        string addonPrefix = "";
+
+        bool ok = ChatPkt.CheckAddonPrefix(registered, ref language, ref text, ref addonPrefix);
+
+        Assert.True(ok);
+        Assert.Equal("Details", addonPrefix);
+        Assert.Equal(body, text);                    // RED today: Join(" ") turns the body's tabs into spaces
+    }
+
+    // ---- T-B (vectors 1+3): ChatPkt must frame an addon binary body byte-exact ----
+    // 255 bytes → fits the SpanPacketWriter fast path; 600 bytes → forces the
+    // ByteBuffer Write() fallback (exceeds the 512-byte MaxChatTextBytes cap). One
+    // public path (WritePacketData/GetData) routes to both internal writers by size.
+    [Theory]
+    [InlineData(255)]
+    [InlineData(600)]
+    public void ChatPkt_AddonBinaryBody_SurvivesFramingByteExact(int bodyLen)
+    {
+        byte[] body = new byte[bodyLen];
+        for (int i = 0; i < bodyLen; i++)
+            body[i] = (byte)((i % 255) + 1);         // 0x01..0xFF, never 0x00
+
+        // The inbound read path should hand ChatPkt a 1:1 byte->char (Latin1) string.
+        string chatText = Encoding.Latin1.GetString(body);
+
+        var pkt = new ChatPkt(
+            null!, ChatMessageTypeModern.Say, chatText,
+            language: (uint)Language.AddonBfA,       // value CheckAddonPrefix assigns to addon msgs
+            senderName: "S", receiverName: "T",
+            addonPrefix: "Details");
+
+        pkt.WritePacketData();
+        byte[] data = pkt.GetData()!;
+
+        (uint chatTextBytes, byte[] payload) = ExtractChatTextField(data);
+
+        Assert.Equal((uint)bodyLen, chatTextBytes);  // RED today: UTF-8 byte count (high bytes doubled)
+        Assert.Equal(body, payload);                 // RED today: UTF-8-mangled payload bytes
+    }
+
+    // ---- (realistic) ChatPkt: an actual zlib/DEFLATE blob body survives byte-exact ----
+    [Fact]
+    public void ChatPkt_AddonDeflateBlobBody_SurvivesFramingByteExact()
+    {
+        // Mirror a real Details broadcast: zlib-compressed data (high-entropy bytes >= 0x80).
+        byte[] plain = new byte[200];
+        for (int i = 0; i < plain.Length; i++)
+            plain[i] = (byte)((i * 37 + 11) % 256);  // deterministic, poorly compressible
+        byte[] body = ZLib.Compress(plain);
+
+        string chatText = Encoding.Latin1.GetString(body);
+        var pkt = new ChatPkt(
+            null!, ChatMessageTypeModern.Say, chatText,
+            language: (uint)Language.AddonBfA, senderName: "S", receiverName: "T",
+            addonPrefix: "Details");
+
+        pkt.WritePacketData();
+        (uint chatTextBytes, byte[] payload) = ExtractChatTextField(pkt.GetData()!);
+
+        Assert.Equal((uint)body.Length, chatTextBytes);
+        Assert.Equal(body, payload);
+    }
+
+    // ---- T-B' (vector 1, OUTBOUND read): the modern->legacy addon body must survive ----
+    // "YOUR addon data as others receive it": ChatAddonMessageParams.Read currently
+    // UTF-8-decodes the raw CMSG body, mangling bytes >= 0x80. RED today; green after E-read.
+    [Theory]
+    [InlineData(200)]
+    public void ChatAddonMessageParams_Read_AddonBody_SurvivesByteExact(int bodyLen)
+    {
+        byte[] body = new byte[bodyLen];
+        for (int i = 0; i < bodyLen; i++)
+            body[i] = (byte)((i % 255) + 1);         // 0x01..0xFF (8-bit textLen caps at 255)
+        string prefix = "Details";
+
+        var wp = new WorldPacket(1u);                // opcode value irrelevant to Read()
+        wp.WriteBits(prefix.Length, 5);
+        wp.WriteBits(body.Length, 8);
+        wp.WriteBit(false);                          // IsLogged
+        wp.FlushBits();
+        wp.WriteInt32((int)ChatMessageTypeModern.Say);
+        wp.WriteString(prefix);
+        wp.WriteBytes(body);                         // raw addon body on the wire
+
+        var readPkt = new WorldPacket(1u, wp.GetData());
+        var prms = new ChatAddonMessageParams();
+        prms.Read(readPkt);
+
+        Assert.Equal(prefix, prms.Prefix);
+        Assert.Equal(body, Encoding.Latin1.GetBytes(prms.Text));  // RED today: UTF-8 read mangles high bytes
+    }
+
+    // ---- (regression guard) CheckAddonPrefix: a normal single-tab message is unchanged ----
+    // Fix C (split on first tab) must produce identical output for the single-tab messages
+    // every real addon sends (PallyPower, HealComm, DBM, BigWigs...). Green now AND after.
+    [Theory]
+    [InlineData("PLPWR\tASSIGN Bob 4 3", "PLPWR", "ASSIGN Bob 4 3")]
+    [InlineData("LHC40\tD:2:33076:1500:abc", "LHC40", "D:2:33076:1500:abc")]
+    public void CheckAddonPrefix_SingleTabMessage_SplitsIdentically(string wire, string expectedPrefix, string expectedBody)
+    {
+        var registered = new HashSet<string> { expectedPrefix };
+        uint language = (uint)Language.Addon;
+        string text = wire;
+        string addonPrefix = "";
+
+        bool ok = ChatPkt.CheckAddonPrefix(registered, ref language, ref text, ref addonPrefix);
+
+        Assert.True(ok);
+        Assert.Equal(expectedPrefix, addonPrefix);
+        Assert.Equal(expectedBody, text);
+        Assert.Equal((uint)Language.AddonBfA, language);
+    }
+
+    // ---- (regression guard) CheckAddonPrefix: unregistered prefix / no tab still rejected ----
+    [Theory]
+    [InlineData("Unregistered\tbody")]
+    [InlineData("NoTabAtAll")]
+    public void CheckAddonPrefix_UnregisteredOrUntabbed_ReturnsFalse(string wire)
+    {
+        var registered = new HashSet<string> { "Details" };
+        uint language = (uint)Language.Addon;
+        string text = wire;
+        string addonPrefix = "";
+
+        bool ok = ChatPkt.CheckAddonPrefix(registered, ref language, ref text, ref addonPrefix);
+
+        Assert.False(ok);
+    }
+
+    // ---- (regression guard) ChatPkt: NON-addon chat stays UTF-8 (the fix must not touch it) ----
+    [Fact]
+    public void ChatPkt_NonAddonChat_StaysUtf8()
+    {
+        string msg = "Café déjà vu — naïve";        // multi-byte UTF-8 characters
+        var pkt = new ChatPkt(
+            null!, ChatMessageTypeModern.Say, msg,
+            language: (uint)Language.Common, senderName: "S", receiverName: "T");
+
+        pkt.WritePacketData();
+        (uint chatTextBytes, byte[] payload) = ExtractChatTextField(pkt.GetData()!);
+
+        Assert.Equal((uint)Encoding.UTF8.GetByteCount(msg), chatTextBytes);
+        Assert.Equal(Encoding.UTF8.GetBytes(msg), payload);
+    }
+
+    // ---- T-C (vector 1, IO primitive): Latin1 overloads are byte-exact; UTF-8 default intact ----
+    [Fact]
+    public void ByteBuffer_Latin1RoundTrip_IsByteIdentical()
+    {
+        byte[] body = new byte[255];
+        for (int i = 0; i < body.Length; i++)
+            body[i] = (byte)(i + 1);             // 0x01..0xFF
+
+        using var wb = new ByteBuffer();
+        wb.WriteString(Encoding.Latin1.GetString(body), Encoding.Latin1);
+        byte[] wire = wb.GetData();
+        Assert.Equal(body, wire);                // Latin1 = 1 byte/char, no expansion
+
+        using var rb = new ByteBuffer(wire);
+        string read = rb.ReadString((uint)wire.Length, Encoding.Latin1);
+        Assert.Equal(body, Encoding.Latin1.GetBytes(read));
+    }
+
+    [Fact]
+    public void ByteBuffer_Utf8Default_PreservesAccentedText()
+    {
+        const string text = "Café déjà — naïve";
+        using var wb = new ByteBuffer();
+        wb.WriteString(text);                     // default still UTF-8
+        byte[] wire = wb.GetData();
+        Assert.Equal(Encoding.UTF8.GetBytes(text), wire);
+
+        using var rb = new ByteBuffer(wire);
+        Assert.Equal(text, rb.ReadString((uint)wire.Length));
+    }
+
+    // Mirrors ChatPkt.WriteToSpan()/Write() field order to reach the ChatText body.
+    private static (uint chatTextBytes, byte[] payload) ExtractChatTextField(byte[] data)
+    {
+        var r = new SpanPacketReader(data);
+        r.ReadUInt8();                       // SlashCmd
+        r.ReadUInt32();                      // _Language
+        r.ReadPackedGuid128(out _, out _);   // SenderGUID
+        r.ReadPackedGuid128(out _, out _);   // SenderGuildGUID
+        r.ReadPackedGuid128(out _, out _);   // SenderAccountGUID
+        r.ReadPackedGuid128(out _, out _);   // TargetGUID
+        r.ReadUInt32();                      // TargetVirtualAddress
+        r.ReadUInt32();                      // SenderVirtualAddress
+        r.ReadPackedGuid128(out _, out _);   // PartyGUID
+        r.ReadUInt32();                      // AchievementID
+        r.ReadFloat();                       // DisplayTime
+        uint senderNameBytes = r.ReadBits<uint>(11);
+        uint targetNameBytes = r.ReadBits<uint>(11);
+        uint prefixBytes = r.ReadBits<uint>(5);
+        uint channelBytes = r.ReadBits<uint>(7);
+        uint chatTextBytes = r.ReadBits<uint>(12);
+        r.ReadBits<uint>(14);                // _ChatFlags
+        r.ReadBit();                         // HideChatLog
+        r.ReadBit();                         // FakeSenderName
+        r.ReadBit();                         // Unused_801.HasValue
+        r.ReadBit();                         // ChannelGUID != default
+        r.ReadBytes((int)senderNameBytes);
+        r.ReadBytes((int)targetNameBytes);
+        r.ReadBytes((int)prefixBytes);
+        r.ReadBytes((int)channelBytes);
+        byte[] payload = r.ReadBytes((int)chatTextBytes).ToArray();
+        return (chatTextBytes, payload);
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -6,6 +6,7 @@ using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Globalization;
+using System.Text;
 using Framework.Logging;
 using static HermesProxy.World.Server.Packets.ChannelListResponse;
 
@@ -209,7 +210,8 @@ public partial class WorldClient
         }
 
         uint textLength = packet.ReadUInt32();
-        string text = packet.ReadString(textLength);
+        // Addon bodies are binary (DEFLATE etc.); read 1:1 (Latin1) so bytes >= 0x80 survive.
+        string text = packet.ReadString(textLength, language == (uint)Language.Addon ? Encoding.Latin1 : null);
         var chatTag = (ChatTag)packet.ReadUInt8();
         var chatFlags = chatTag.CastEnum<ChatFlags>();
 
@@ -410,7 +412,8 @@ public partial class WorldClient
         }
 
         uint textLength = packet.ReadUInt32();
-        string text = packet.ReadString(textLength);
+        // Addon bodies are binary (DEFLATE etc.); read 1:1 (Latin1) so bytes >= 0x80 survive.
+        string text = packet.ReadString(textLength, language == (uint)Language.Addon ? Encoding.Latin1 : null);
         var chatFlags = (ChatFlags)packet.ReadUInt8();
 
         if (LegacyVersion.InVersion(ClientVersionBuild.V2_0_1_6180, ClientVersionBuild.V3_0_2_9056) &&
@@ -492,7 +495,11 @@ public partial class WorldClient
 
     public void SendMessageChatVanilla(ChatMessageTypeVanilla type, uint lang, string msg, string channel, string to)
     {
-        if (HandleHermesInternalChatCommand(msg))
+        // Addon-language bodies are binary (DEFLATE): skip the text transforms below and write
+        // the body 1:1 (Latin1) so bytes >= 0x80 survive. Normal chat keeps UTF-8 + transforms.
+        bool isAddon = lang == (uint)Language.Addon;
+        Encoding? msgEnc = isAddon ? Encoding.Latin1 : null;
+        if (!isAddon && HandleHermesInternalChatCommand(msg))
         {
             return; // was handled by us
         }
@@ -508,7 +515,7 @@ public partial class WorldClient
         //   [0] enchantID, [1-4] gem1-4, [5] suffixID, [6] uniqueID, [7] linkLevel, ...
         // Vanilla 1.12 itemString fields after itemID:
         //   [0] enchantID, [1] randomProperty (signed; matches modern suffixID), [2] creator
-        msg = System.Text.RegularExpressions.Regex.Replace(msg, @"\|Hitem:(\d+)([^|]*)\|h(\[[^\]]*\])?", match =>
+        if (!isAddon) msg = System.Text.RegularExpressions.Regex.Replace(msg, @"\|Hitem:(\d+)([^|]*)\|h(\[[^\]]*\])?", match =>
         {
             string itemId = match.Groups[1].Value;
             string raw = match.Groups[2].Value;
@@ -560,11 +567,11 @@ public partial class WorldClient
         {
             case ChatMessageTypeVanilla.Channel:
                 packet.WriteCString(channel);
-                packet.WriteCString(msg);
+                packet.WriteCString(msg, msgEnc);
                 break;
             case ChatMessageTypeVanilla.Whisper:
                 packet.WriteCString(NormalizeLegacyWhisperTarget(to));
-                packet.WriteCString(msg);
+                packet.WriteCString(msg, msgEnc);
                 break;
             case ChatMessageTypeVanilla.Say:
             case ChatMessageTypeVanilla.Emote:
@@ -579,7 +586,7 @@ public partial class WorldClient
             case ChatMessageTypeVanilla.BattlegroundLeader:
             case ChatMessageTypeVanilla.Afk:
             case ChatMessageTypeVanilla.Dnd:
-                packet.WriteCString(msg);
+                packet.WriteCString(msg, msgEnc);
                 break;
         }
 
@@ -623,7 +630,9 @@ public partial class WorldClient
 
     public void SendMessageChatWotLK(ChatMessageTypeWotLK type, uint lang, string msg, string channel, string to)
     {
-        if (HandleHermesInternalChatCommand(msg))
+        bool isAddon = lang == (uint)Language.Addon;
+        Encoding? msgEnc = isAddon ? Encoding.Latin1 : null;
+        if (!isAddon && HandleHermesInternalChatCommand(msg))
         {
             return; // was handled by us
         }
@@ -636,11 +645,11 @@ public partial class WorldClient
         {
             case ChatMessageTypeWotLK.Channel:
                 packet.WriteCString(channel);
-                packet.WriteCString(msg);
+                packet.WriteCString(msg, msgEnc);
                 break;
             case ChatMessageTypeWotLK.Whisper:
                 packet.WriteCString(NormalizeLegacyWhisperTarget(to));
-                packet.WriteCString(msg);
+                packet.WriteCString(msg, msgEnc);
                 break;
             case ChatMessageTypeWotLK.Say:
             case ChatMessageTypeWotLK.Emote:
@@ -656,7 +665,7 @@ public partial class WorldClient
             case ChatMessageTypeWotLK.BattlegroundLeader:
             case ChatMessageTypeWotLK.Afk:
             case ChatMessageTypeWotLK.Dnd:
-                packet.WriteCString(msg);
+                packet.WriteCString(msg, msgEnc);
                 break;
         }
 

--- a/HermesProxy/World/Server/Packets/ChatPackets.cs
+++ b/HermesProxy/World/Server/Packets/ChatPackets.cs
@@ -360,7 +360,8 @@ public class ChatAddonMessageParams
         IsLogged = data.HasBit();
         Type = (ChatMessageTypeModern)data.ReadInt32();
         Prefix = data.ReadString(prefixLen);
-        Text = data.ReadString(textLen);
+        // Addon bodies are binary (DEFLATE etc.); read 1:1 byte<->char so high bytes survive.
+        Text = data.ReadString(textLen, Encoding.Latin1);
     }
 
     public string Prefix = string.Empty;
@@ -408,11 +409,14 @@ public class ChatPkt : ServerPacket, ISpanWritable
         {
             language = (uint)Language.AddonBfA;
             char tab = '\t';
-            if (text.Contains(tab))
+            int tabIdx = text.IndexOf(tab);
+            if (tabIdx >= 0)
             {
-                string[] parts = text.Split(tab);
-                addonPrefix = parts[0];
-                text = string.Join(" ", parts.Skip(1).ToList());
+                // Split on the FIRST tab only: "prefix\tbody". The body is passed through
+                // verbatim — a DEFLATE addon payload can contain raw 0x09 bytes, and the
+                // old Split('\t')+Join(" ") turned every one into a space, corrupting it.
+                addonPrefix = text.Substring(0, tabIdx);
+                text = text.Substring(tabIdx + 1);
 
                 if (!registeredPrefixes.Contains(addonPrefix))
                     return false;
@@ -422,6 +426,12 @@ public class ChatPkt : ServerPacket, ISpanWritable
         }
         return true;
     }
+    // Addon-language chat bodies are binary (DEFLATE); encode 1:1 (Latin1) so bytes >= 0x80
+    // survive. Normal chat stays UTF-8. Applies to the ChatText body field only.
+    private Encoding BodyEncoding =>
+        _Language == (uint)Language.AddonBfA || _Language == (uint)Language.Addon
+            ? Encoding.Latin1 : Encoding.UTF8;
+
     public override void Write()
     {
         _worldPacket.WriteUInt8((byte)SlashCmd);
@@ -439,7 +449,7 @@ public class ChatPkt : ServerPacket, ISpanWritable
         _worldPacket.WriteBits(TargetName.GetByteCount(), 11);
         _worldPacket.WriteBits(Prefix.GetByteCount(), 5);
         _worldPacket.WriteBits(Channel.GetByteCount(), 7);
-        _worldPacket.WriteBits(ChatText.GetByteCount(), 12);
+        _worldPacket.WriteBits(BodyEncoding.GetByteCount(ChatText ?? ""), 12);
         _worldPacket.WriteBits((byte)_ChatFlags, 14);
         _worldPacket.WriteBit(HideChatLog);
         _worldPacket.WriteBit(FakeSenderName);
@@ -451,7 +461,7 @@ public class ChatPkt : ServerPacket, ISpanWritable
         _worldPacket.WriteString(TargetName);
         _worldPacket.WriteString(Prefix);
         _worldPacket.WriteString(Channel);
-        _worldPacket.WriteString(ChatText);
+        _worldPacket.WriteString(ChatText ?? "", BodyEncoding);
 
         if (Unused_801.HasValue)
             _worldPacket.WriteUInt32(Unused_801.Value);
@@ -476,7 +486,7 @@ public class ChatPkt : ServerPacket, ISpanWritable
         int targetNameBytes = Encoding.UTF8.GetByteCount(TargetName ?? "");
         int prefixBytes = Encoding.UTF8.GetByteCount(Prefix ?? "");
         int channelBytes = Encoding.UTF8.GetByteCount(Channel ?? "");
-        int chatTextBytes = Encoding.UTF8.GetByteCount(ChatText ?? "");
+        int chatTextBytes = BodyEncoding.GetByteCount(ChatText ?? "");
 
         // Check against our reduced MaxSize limits - fallback to Write() for oversized messages
         // Protocol limits are larger (2047/4095) but we optimize for typical usage
@@ -512,7 +522,7 @@ public class ChatPkt : ServerPacket, ISpanWritable
         writer.WriteString(TargetName ?? "");
         writer.WriteString(Prefix ?? "");
         writer.WriteString(Channel ?? "");
-        writer.WriteString(ChatText ?? "");
+        writer.WriteString(ChatText ?? "", BodyEncoding);
 
         if (Unused_801.HasValue)
             writer.WriteUInt32(Unused_801.Value);


### PR DESCRIPTION
## Summary
- Addon-channel chat bodies (Details talent sync, some WeakAuras/Plater imports) are DEFLATE binary. The proxy round-tripped them through transforms that are lossy for non-text bytes, so the modern client's `DecompressDeflate` returned nil — Details spammed "couldn't uncompress the data" and other players' talents never appeared on inspect.
- Three corruption vectors, all fixed:
  1. UTF-8 re-encode of body bytes >= 0x80 (irreversible U+FFFD)
  2. `CheckAddonPrefix` `Split('\t')` + `Join(" ")` replaced embedded `0x09` body bytes with spaces
  3. `ChatPkt` body length-prefix computed with a UTF-8 byte count while the payload would be Latin1
- Reads/writes addon-language bodies as `Encoding.Latin1` (1:1 byte<->char), splits the addon prefix on the first tab only (body verbatim), and frames the ChatPkt body length-prefix with the same encoding as the payload. Gated to `Language.Addon`/`AddonBfA`; normal chat stays UTF-8 (the IO change is an additive optional param, default unchanged).

## Test plan
- [x] New `AddonCommCompressionTests` (12 tests): reproduces all 3 vectors inbound + outbound, both `ChatPkt` write paths, plus a real zlib blob — red->green
- [x] Regression guards: single-tab PallyPower/HealComm split unchanged, unregistered/no-tab rejected, normal accented chat stays UTF-8
- [x] IO Latin1 byte-identity + UTF-8 round-trip
- [x] Full suite 526 passed / 0 failed; full-solution build clean, no new warnings
- [ ] PTR: group with another player — confirm "couldn't uncompress" spam stops and inspect talents populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)