### PR TITLE
Fix orphaned player cast loop via GO-side CastID recovery

### DIFF
--- a/HermesProxy.Tests/World/PlayerForwardedCastIdsTests.cs
+++ b/HermesProxy.Tests/World/PlayerForwardedCastIdsTests.cs
@@ -1,0 +1,54 @@
+using HermesProxy;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (cast-go-castid-recovery): PlayerForwardedCastIds records the client-facing
+// CastID forwarded for the local player's SMSG_SPELL_START so HandleSpellGo can re-stamp
+// the GO with the SAME id when no PendingNormalCast / melee / auto-repeat entry matches.
+// This is the deterministic fix for the orphaned-cast family (stuck casting animation +
+// looping cast sound): the 1.14 client pairs START<->GO by CastID, and a mismatch leaves
+// the cast un-terminated. It hits server-initiated player casts with no CMSG (GO loot
+// subspells e.g. Whipper Root 15343, weapon/trinket procs) and casts whose pending entry
+// was consumed by an interleaved duplicate CAST_FAILED before the GO (Blade Flurry,
+// re-clicked gathers).
+//
+// The full handler wiring (store at forward-time, recall as the last-resort GO fallback)
+// needs a live WorldSocket and isn't reachable from this harness. These tests pin the two
+// GameState invariants the fix relies on: the store/recall round-trip is exact and
+// single-shot, and a world transfer clears the map so a stale CastID can't leak across a
+// zone/realm change onto an unrelated later cast.
+public class PlayerForwardedCastIdsTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    [Fact]
+    public void StoredCastId_RoundTripsExactly_AndIsConsumedOnRecall()
+    {
+        var session = NewSession();
+        var forwardedCastId = new WowGuid128(0x123456789ABCDEF0, 0x0FEDCBA987654321);
+
+        session.PlayerForwardedCastIds[13877] = forwardedCastId; // Blade Flurry
+
+        // HandleSpellGo recalls via TryRemove: the GO gets the exact CastID the START forwarded.
+        Assert.True(session.PlayerForwardedCastIds.TryRemove(13877, out var recovered));
+        Assert.Equal(forwardedCastId, recovered);
+
+        // Single-shot: a second GO (or a later proc GO of the same spell) must NOT reuse it.
+        Assert.False(session.PlayerForwardedCastIds.TryRemove(13877, out _));
+    }
+
+    [Fact]
+    public void ResetInFlightCastState_ClearsForwardedCastIds()
+    {
+        var session = NewSession();
+        session.PlayerForwardedCastIds[15343] = new WowGuid128(1, 2); // Create Whipper Root Tubers
+        session.PlayerForwardedCastIds[13877] = new WowGuid128(3, 4); // Blade Flurry
+
+        // World transfer (BG entry, instance change, realm swap) must not carry CastIDs over.
+        session.ResetInFlightCastState();
+
+        Assert.Empty(session.PlayerForwardedCastIds);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -475,6 +475,18 @@ public sealed class GameSessionData
     // overridden with ServerGUID downstream → the auto-cast map entry is a harmless
     // orphan in that case.
     public ConcurrentDictionary<(WowGuid128 caster, uint spellId), WowGuid128> PetAutoCastActiveCastIds = new();
+    // JimsProxy (cast-go-castid-recovery): client-facing CastID forwarded for the LOCAL
+    // PLAYER's SMSG_SPELL_START, keyed by spellId. HandleSpellGo recalls it when no
+    // PendingNormalCast / melee / auto-repeat entry matches at SPELL_GO, so START and GO
+    // ship the SAME CastID. The 1.14 client pairs START↔GO by CastID; a mismatch leaves
+    // the cast un-terminated → stuck casting animation + looping cast sound. Covers
+    // server-initiated player casts with no CMSG (GO loot subspells e.g. Whipper Root
+    // "Create Whipper Root Tubers" 15343, weapon/trinket procs) and casts whose pending
+    // entry was consumed by an interleaved duplicate CAST_FAILED before the GO (Blade
+    // Flurry, re-clicked gathers). Fallback ONLY — never consulted when a real pending
+    // cast is dequeued at GO, so normal casts are wire-identical. Cleared on world
+    // transfer alongside the pet/other-caster cast-id maps.
+    public ConcurrentDictionary<uint, WowGuid128> PlayerForwardedCastIds = new();
     // Tracks last-seen UNIT_CHANNEL_SPELL per unit so we can synthesize
     // SMSG_SPELL_CHANNEL_START/UPDATE for observers (vanilla only sends
     // MSG_CHANNEL_START to the caster, not to nearby players).
@@ -1746,6 +1758,7 @@ public sealed class GameSessionData
         int otherCount = OtherCasterActiveCastIds.Count;
         OtherCasterActiveCastIds.Clear();
         PetAutoCastActiveCastIds.Clear();
+        PlayerForwardedCastIds.Clear();
         // Single-slot trackers for melee + auto-repeat (Auto Shot, Shoot Wand)
         // — same lifecycle as PendingNormalCasts; if a tracker was set when
         // the DC fired, it never gets cleared by the SPELL_GO/CAST_FAILED

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1399,6 +1399,13 @@ public partial class WorldClient
         }
         else
         {
+            // JimsProxy (cast-go-castid-recovery): record the CastID we forward for the
+            // local player's SPELL_START so HandleSpellGo can recover it if the pending
+            // entry is gone by GO time (server-initiated casts with no CMSG, or a
+            // duplicate's CAST_FAILED having consumed the entry). See PlayerForwardedCastIds.
+            // Fallback only — normal casts override with ServerGUID at GO and never read it.
+            if (casterIsLocalPlayer)
+                GetSession().GameState.PlayerForwardedCastIds[(uint)spell.Cast.SpellID] = spell.Cast.CastID;
             SendPacketToClient(spell);
         }
 
@@ -1656,6 +1663,27 @@ public partial class WorldClient
                 prepare.ServerCastID = spell.Cast.CastID;
                 SendPacketToClient(prepare);
             }
+        }
+        // JimsProxy (cast-go-castid-recovery): FALLBACK — reached only when none of the
+        // branches above matched, i.e. the local player's SPELL_GO has no PendingNormalCast,
+        // melee, or auto-repeat entry. HandleSpellStartOrGo therefore left a freshly-minted
+        // sequence-unique CastID that won't match the CastID we forwarded at SPELL_START.
+        // The 1.14 client pairs START↔GO by CastID, so the mismatch leaves the player's cast
+        // un-terminated → stuck casting animation + looping cast sound. Re-stamp the GO with
+        // the START's forwarded CastID so the pair matches and the client closes the cast.
+        // Hits server-initiated player casts with no CMSG (GO loot subspells e.g. Whipper
+        // Root 15343, weapon/trinket procs) and casts whose pending entry was consumed by a
+        // duplicate's CAST_FAILED before the GO (Blade Flurry, re-clicked gathers).
+        else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
+                 GetSession().GameState.PlayerForwardedCastIds.TryRemove((uint)spell.Cast.SpellID, out var forwardedStartCastId))
+        {
+            spell.Cast.CastID = forwardedStartCastId;
+            Log.Event("cast.go.castid_recovered", new
+            {
+                spell_id = spell.Cast.SpellID,
+                caster_low = spell.Cast.CasterUnit.GetCounter(),
+                recovered_cast_id = forwardedStartCastId.ToString(),
+            });
         }
 
         if (!spell.Cast.CasterUnit.IsEmpty() && GameData.AuraSpells.Contains((uint)spell.Cast.SpellID))


### PR DESCRIPTION
## Summary
The 1.14 client pairs `SMSG_SPELL_START`/`SPELL_GO` by CastID. `HandleSpellGo` only stamps the matching `ServerGUID` when it dequeues the started `PendingNormalCast`; when that entry is missing, the GO ships a fresh sequence-unique CastID the client can't pair with the START it already received → the cast never terminates → **stuck casting animation + looping cast sound** (cleared by zoning, *not* `/reload`).

Two ways the entry goes missing, both seen in tester JSONL logs:
- **server-initiated player casts with no `CMSG_CAST_SPELL`** — GameObject loot subspells (e.g. Whipper Root "Create Whipper Root Tubers" 15343), weapon/trinket procs. No pending entry ever exists.
- **a duplicate press's interleaved `CAST_FAILED`** consuming the in-flight entry before the GO — Blade Flurry double-send (1.14 client sends 2× CMSG for off-GCD instants), re-clicked gathers.

**Fix:** record the CastID forwarded for the local player's `SPELL_START` in `PlayerForwardedCastIds`; recall it in `HandleSpellGo` as the **last fallback** (after the pending / melee / auto-repeat branches) so START and GO ship the same CastID. Deterministic pairing only — no timeouts/heuristics, no packet suppression. Emits `cast.go.castid_recovered`.

## Why it's low-risk
- The recall is the final `else if` in the existing override chain — **unreachable** when a normal cast dequeues its pending entry. Working casts are wire-identical (one extra dictionary write at START).
- Map cleared on world transfer (`ResetInFlightCastState`) alongside the pet/other-caster CastID maps.
- **514/514** existing tests pass + **2** new (`PlayerForwardedCastIdsTests`: store/recall round-trip + world-transfer clear). Handler else-if needs a live WorldSocket so it isn't unit-reachable; the tests pin the GameState invariants and the diagnostic is the integration check.

## In-game test plan (do later, on a real build)

**Primary — confirm the loop is gone AND `cast.go.castid_recovered` fires for the cast:**
- [ ] **Whipper Root Tuber** gather (Felwood/Un'Goro): single gather → loot received, no stuck cast / looping sound. Then **spam-click at cast-end** (the #334 chain scenario) → loot still delivered, still no loop.
- [ ] **Blade Flurry** (Rogue) spammed through a full **UBRS/Stratholme** run (the tester's repro) → no stuck hand animation / looping sound, no forced relog. Test in **both Queue and Low-Latency** modes.
- [ ] **Re-clicked mining/herb node** mid-cast → no looping sound.
- [ ] **Other Un'Goro plants** (Bloodpetal Sprouts, Night Dragon's Breath) → same as Whipper Root.
- [ ] **Weapon nature proc** ("green orb on hands") if reproducible → proc visual doesn't stick.

**Check — may or may not be covered by this fix; report findings:**
- [ ] **Insignia of the Alliance** trinket glow (#337) → still stuck? (item-proc variant)
- [ ] Off-GCD item-use **stuck-lit button** (#345).

**Regression — must stay unchanged:**
- [ ] Caster rotation (Frostbolt/Shadow Bolt spam, chain-casting): cast bars appear and clear normally, GCD sweep intact, no new stuck casts.
- [ ] Instant on-GCD (Sinister Strike) and off-GCD (Sprint, trinkets) casts feel unchanged.
- [ ] Pet casts, Hunter Auto Shot / wand, channels (Cannibalize, Arcane Missiles) unaffected.
- [ ] ⚠️ `cast.go.castid_recovered` should fire **only** on the orphan cases above. If it appears on ordinary player casts, the fallback is over-firing — flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)