### PR TITLE
Fix ranged swing timer/paperdoll ignoring attack-speed buffs

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2438,16 +2438,7 @@ public partial class WorldClient
                 uint rangedAttackTime = updates[UNIT_FIELD_RANGEDATTACKTIME].UInt32Value;
                 updateData.UnitData.RangedAttackRoundBaseTime = rangedAttackTime;
 
-                // JimsProxy: vanilla bakes ranged haste straight into RANGEDATTACKTIME, but the
-                // modern client treats RangedAttackRoundBaseTime as the *un-hasted* base and
-                // time-scales the bow draw/release animation by ModRangedHaste. With no haste
-                // multiplier the bow animation can't keep up with hasted Auto Shot (Rapid Fire /
-                // Quick Shots) and freezes in the drawn pose until it catches up. Track the
-                // slowest (resting) RANGEDATTACKTIME seen for this unit as the base and send
-                // ModRangedHaste = resting / current so the client scales the animation. Note:
-                // a mid-session swap to a *faster* ranged weapon leaves the cached resting
-                // stale-high until a slower value is seen again — the failure mode there is a
-                // mildly fast animation, far less jarring than the freeze, so it degrades well.
+                // JimsProxy: keep the hasted base so UnitRangedDamage (paperdoll/swing-timer addons) reads the real speed; Classic Era ignores ModRangedHaste for that API, so send ModRangedHaste = resting/current only to scale the bow-draw animation.
                 if (rangedAttackTime > 0)
                 {
                     WowGuid128 rangedUnitGuid = guid.To128(GetSession().GameState);
@@ -2455,7 +2446,6 @@ public partial class WorldClient
                         rangedUnitGuid, rangedAttackTime,
                         (_, prev) => Math.Max(prev, rangedAttackTime));
                     float modRangedHaste = (float)restingRangedAttackTime / rangedAttackTime;
-                    updateData.UnitData.RangedAttackRoundBaseTime = restingRangedAttackTime;
                     updateData.UnitData.ModRangedHaste = modRangedHaste;
                     if (modRangedHaste > 1.0f)
                         Log.Event("ranged.haste.synth", new


### PR DESCRIPTION
## Problem
Hunter ranged swing-timer addons (WeakAuras) and the character-sheet
Ranged attack speed stopped reflecting attack-speed buffs (Rapid Fire,
Berserking, Improved Aspect of the Hawk's Quick Shots) — they showed the
resting/un-hasted speed regardless of haste.

## Cause
Regression from "Fix bow shoot animation freezing during ranged haste"
(0b6dfdf), which decomposed ranged haste into:
- `RangedAttackRoundBaseTime = resting`
- `ModRangedHaste = resting / current`

1.14 Classic Era's `UnitRangedDamage` reads `RangedAttackRoundBaseTime`
directly and **ignores `ModRangedHaste`** — the same vanilla-faithful
behavior already confirmed for melee's `UnitAttackSpeed` (#320). So a
resting base made every field-reading consumer (paperdoll, swing-timer
WeakAuras) report the un-hasted speed.

## Fix
The base field and `ModRangedHaste` are independent levers: the API reads
the base, while the bow animation scales a weapon-native draw time by
`ModRangedHaste` (the original freeze proves the animation doesn't read
the speed field). So keep the **hasted** base (timer/paperdoll correct)
and still send `ModRangedHaste` (animation stays fixed). One line removed.

## Testing
Validated in-game on a hunter: ranged WeakAura timer and paperdoll Ranged
speed now track Rapid Fire / Quick Shots and return to resting on fade,
with the bow-draw animation still smooth — both timer and animation
correct. `dotnet build` clean; no tests cover this block.
