### PR TITLE
Refresh paladin Judgement debuff timer on the caster's melee hit

### DIFF
--- a/HermesProxy.Tests/World/JudgementDebuffSetTests.cs
+++ b/HermesProxy.Tests/World/JudgementDebuffSetTests.cs
@@ -1,0 +1,46 @@
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class JudgementDebuffSetTests
+{
+    // The set must contain every paladin Judgement DEBUFF aura (the ones applied to the
+    // target) so the local paladin's melee hit can synthesize the duration refresh.
+    [Theory]
+    [InlineData(20185u)] // Judgement of Light R1
+    [InlineData(20344u)] // Judgement of Light R2
+    [InlineData(20345u)] // Judgement of Light R3
+    [InlineData(20346u)] // Judgement of Light R4
+    [InlineData(20186u)] // Judgement of Wisdom R1
+    [InlineData(20354u)] // Judgement of Wisdom R2
+    [InlineData(20355u)] // Judgement of Wisdom R3
+    [InlineData(21183u)] // Judgement of the Crusader R1
+    [InlineData(20188u)] // Judgement of the Crusader R2
+    [InlineData(20300u)] // Judgement of the Crusader R3
+    [InlineData(20301u)] // Judgement of the Crusader R4
+    [InlineData(20302u)] // Judgement of the Crusader R5
+    [InlineData(20303u)] // Judgement of the Crusader R6
+    [InlineData(20184u)] // Judgement of Justice
+    public void IsJudgementDebuff_DebuffAura_ReturnsTrue(uint spellId)
+    {
+        Assert.True(GameData.IsJudgementDebuff(spellId));
+    }
+
+    // These must NOT be in the set: the JoL/JoW proc effects (heal/mana cast on the
+    // attacker, not a debuff on the target), the intermediate triggers, the Judgement
+    // cast itself, and unrelated spells. Including a proc id would refresh a non-debuff.
+    [Theory]
+    [InlineData(20267u)] // Judgement of Light R1 — heal proc effect
+    [InlineData(20341u)] // Judgement of Light R2 — heal proc effect
+    [InlineData(20268u)] // Judgement of Wisdom R1 — mana proc effect
+    [InlineData(20352u)] // Judgement of Wisdom R2 — mana proc effect
+    [InlineData(5373u)]  // Judgement of Light Intermediate
+    [InlineData(1826u)]  // Judgement of Wisdom Intermediate
+    [InlineData(20271u)] // Judgement (the cast)
+    [InlineData(133u)]   // Fireball — unrelated
+    public void IsJudgementDebuff_NonDebuff_ReturnsFalse(uint spellId)
+    {
+        Assert.False(GameData.IsJudgementDebuff(spellId));
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -146,6 +146,11 @@ public partial class WorldClient
         {
             int slot = (hitInfo & (uint)HitInfo.OffHand) != 0 ? 1 : 0;
             FlushDeferredBaseAttackTime(slot);
+
+            // JimsProxy (judgement-refresh-on-melee): our own swing refreshes our Judgement
+            // debuff on the victim server-side; synthesize the duration reset so the 1.14
+            // client's debuff timer follows (the 1.12 server doesn't echo enemy-debuff durations).
+            RefreshOwnJudgementOnVictim(attack.VictimGUID);
         }
 
         // Threat translation: feed melee swing damage into the threat tracker.
@@ -175,6 +180,50 @@ public partial class WorldClient
 
         state.LastSentBaseAttackTime[slot] = pending;
         state.HasPendingBaseAttackTime[slot] = false;
+    }
+
+    // JimsProxy (judgement-refresh-on-melee): mirror cmangos Unit.cpp DealMeleeDamage — a
+    // paladin's melee hit resets their OWN Judgement debuff (JoL/JoW/JoC/JoJ) on the victim
+    // to full duration server-side. The 1.12 server doesn't echo enemy-debuff durations, so
+    // the modern client's debuff timer would just count down. Re-emit a full-duration aura
+    // update for any of our Judgements on the victim. Gated to a paladin local player; an
+    // untracked caster is treated as ours since only the local paladin reaches here.
+    void RefreshOwnJudgementOnVictim(WowGuid128 victim)
+    {
+        var state = GetSession().GameState;
+        WowGuid128 localPlayer = state.CurrentPlayerGuid;
+        if (localPlayer == default || victim == default)
+            return;
+        if (state.CurrentPlayerClass != (byte)Class.Paladin)
+            return;
+
+        var updateFields = state.GetCachedObjectFieldsLegacy(victim);
+        if (updateFields == null)
+            return;
+        int auraField = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_AURA);
+        if (auraField < 0)
+            return;
+
+        int slots = LegacyVersion.GetAuraSlotsCount();
+        for (byte i = 0; i < slots; i++)
+        {
+            if (!updateFields.TryGetValue(auraField + i, out var field))
+                continue;
+            uint spellId = field.UInt32Value;
+            if (spellId == 0 || !GameData.IsJudgementDebuff(spellId))
+                continue;
+            WowGuid128 caster = state.GetAuraCaster(victim, i, spellId);
+            if (caster != localPlayer && caster != default)
+                continue;
+
+            SendAuraRefreshUpdate(victim, spellId, localPlayer, i, updateFields, forceFullRemaining: true);
+            Framework.Logging.Log.Event("judgement.refresh.synth", new
+            {
+                victim_low = victim.GetCounter(),
+                slot = (int)i,
+                spell_id = spellId,
+            });
+        }
     }
     [PacketHandler(Opcode.SMSG_ATTACKSWING_NOTINRANGE)]
     void HandleAttackSwingNotInRange(WorldPacket packet)

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -217,12 +217,14 @@ public partial class WorldClient
                 continue;
 
             SendAuraRefreshUpdate(victim, spellId, localPlayer, i, updateFields, forceFullRemaining: true);
-            Framework.Logging.Log.Event("judgement.refresh.synth", new
-            {
-                victim_low = victim.GetCounter(),
-                slot = (int)i,
-                spell_id = spellId,
-            });
+            // JimsProxy: gate this per-swing diagnostic behind DebugOutput (fires on every melee hit while a Judgement is up).
+            if (Framework.Settings.DebugOutput)
+                Framework.Logging.Log.Event("judgement.refresh.synth", new
+                {
+                    victim_low = victim.GetCounter(),
+                    slot = (int)i,
+                    spell_id = spellId,
+                });
         }
     }
     [PacketHandler(Opcode.SMSG_ATTACKSWING_NOTINRANGE)]

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3040,7 +3040,7 @@ public partial class WorldClient
     /// Sends an AuraUpdate packet to refresh the duration of an existing aura on a target.
     /// Called when an aura spell is recast on a target that already has the aura.
     /// </summary>
-    private void SendAuraRefreshUpdate(WowGuid128 target, uint spellId, WowGuid128 caster, byte slot, Dictionary<int, UpdateField> updateFields)
+    private void SendAuraRefreshUpdate(WowGuid128 target, uint spellId, WowGuid128 caster, byte slot, Dictionary<int, UpdateField> updateFields, bool forceFullRemaining = false)
     {
         AuraDataInfo? auraData = ReadAuraSlot(slot, target, updateFields);
         if (auraData == null || auraData.SpellID != spellId)
@@ -3090,7 +3090,7 @@ public partial class WorldClient
             {
                 auraData.Flags |= AuraFlagsModern.Duration;
                 auraData.Duration = durationFull;
-                auraData.Remaining = durationLeft > 0 ? durationLeft : durationFull;
+                auraData.Remaining = forceFullRemaining ? durationFull : (durationLeft > 0 ? durationLeft : durationFull);
 
                 GetSession().GameState.StoreAuraDurationLeft(target, slot, durationFull, Environment.TickCount);
                 GetSession().GameState.StoreAuraDurationFull(target, slot, durationFull);

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -635,6 +635,21 @@ public static partial class GameData
         return (int)(seconds * 1000f);
     }
 
+    // JimsProxy (judgement-refresh-on-melee): paladin Judgement DEBUFF auras applied to the
+    // target — NOT the heal/mana proc effects (20267/20341.., 20268/20352..) or the 1826/5373
+    // intermediates. cmangos Unit.cpp refreshes the caster's own ALWAYS_HIT paladin-family aura
+    // on the victim every melee hit; the 1.12 server doesn't echo enemy-debuff durations so we
+    // synthesize that refresh on the local paladin's swing. Vanilla 1.12 ranks only.
+    public static readonly FrozenSet<uint> JudgementDebuffSpells = new uint[]
+    {
+        20185, 20344, 20345, 20346,                 // Judgement of Light R1-R4
+        20186, 20354, 20355,                        // Judgement of Wisdom R1-R3
+        20188, 20300, 20301, 20302, 20303, 21183,   // Judgement of the Crusader R1-R6
+        20184,                                       // Judgement of Justice
+    }.ToFrozenSet();
+
+    public static bool IsJudgementDebuff(uint spellId) => JudgementDebuffSpells.Contains(spellId);
+
     /// <summary>
     /// JimsProxy: true if the spell is a CP-scaling enemy-debuff finisher we compute
     /// duration for locally. Used by the CMSG_CAST_SPELL handler to decide whether to


### PR DESCRIPTION
## Problem
A paladin's Judgement debuff (Judgement of Light / Wisdom / the Crusader /
Justice) shows a duration timer on the target, but on the 1.14 client that
timer counted down from the initial judge and never reset — even though the
paladin's melee hits refresh it server-side. The proc/effect still worked;
only the displayed timer was wrong.

## Cause
Vanilla mechanic (cmangos `Unit.cpp` `DealMeleeDamage`): when a paladin
lands a melee hit, the server resets their OWN Judgement debuff (ALWAYS_HIT,
paladin-family, caster == attacker) on the victim to full duration via
`RefreshHolder()`.

The 1.12 server doesn't echo enemy-debuff durations (only self-cast auras get
`SMSG_UPDATE_AURA_DURATION`), and the refresh doesn't change the
`UNIT_FIELD_AURA` slot — so the proxy's aura-discovery loop never re-fires and
the modern client's timer just keeps draining.

## Fix
Synthesize the refresh, mirroring the server: on the local player's
`SMSG_ATTACKER_STATE_UPDATE`, if they're a paladin, scan the victim's aura
slots for the player's own Judgement debuff and re-emit a full-duration
`AuraUpdate` (via `SendAuraRefreshUpdate` with a new `forceFullRemaining` flag,
default false so existing recast callers are unchanged).

- Judgement debuff IDs verified against the 1.14.2 client `SpellName` table and
  cmangos; the heal/mana **proc** effects (20267/20268/…) and intermediate
  triggers (1826/5373) are excluded so only the debuff refreshes.
- JoL/JoW reuse the existing Improved-Judgement-aware duration table; JoC/JoJ
  durations come from `AuraDurations1.csv` (10 s).
- Melee-only (the cmangos refresh is in the melee-damage path); gated to a
  paladin local player.
- Diagnostic event `judgement.refresh.synth`.

## Testing
Clean build; `dotnet test` green — 536 total, including 22 new tests guarding
the Judgement ID set (debuff ranks included; proc/intermediate/cast IDs
excluded). Mechanic and IDs cross-checked against cmangos `Unit.cpp` and the
1.14.2 client `SpellName` table.
