### PR TITLE
Flag off-GCD item-use casts to exempt from non-started sweep (#345)

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -798,6 +798,17 @@ public partial class WorldSocket
         if (legacySpellId != 0)
             castRequest.LegacySpellId = legacySpellId;
 
+        // JimsProxy (#345): mirror HandleCastSpell — flag off-GCD item-use casts (trinkets,
+        // potions, bombs, engineering gadgets) so the ClearNonStartedNormalCasts exemption
+        // from #344 covers them. Without this they default to IsOffGcd=false and get swept
+        // when a concurrent GCD cast's SMSG_SPELL_START arrives: the sweep emits a premature
+        // CAST_FAILED while the server casts the item anyway, leaving the action button
+        // stuck-lit. Key the lookup on the legacy 1.12 id when the on-use spell was
+        // SoM-renumbered (OffGcdSpells is a vanilla Spell.dbc extract), matching the
+        // gcdLookupId pattern in HandleSpellGo.
+        castRequest.IsOffGcd = LegacyVersion.ExpansionVersion == 1 &&
+            GameData.IsOffGcd(castRequest.LegacySpellId != 0 ? castRequest.LegacySpellId : (uint)use.Cast.SpellID);
+
         // Enqueue the cast - responses will be matched by SpellId (or LegacySpellId) in FIFO order
         // DIAGNOSTIC (stuck-spell investigation): remove when closed
         if (Framework.Settings.DebugOutput)


### PR DESCRIPTION
## Summary
Fixes #345. `HandleUseItem` enqueues item-use casts into `PendingNormalCasts` but never set `ClientCastRequest.IsOffGcd`, so the off-GCD sweep exemption from #344 didn't cover them. An off-GCD item-use cast (trinket / potion / bomb / gadget) still pending when a concurrent GCD cast's `SMSG_SPELL_START` arrives gets swept with a premature `CAST_FAILED` while the server casts it anyway → **stuck-lit action button** (the same class #344 fixed for Bloodrage etc.).

## Fix
Set `castRequest.IsOffGcd` in `HandleUseItem`, mirroring `HandleCastSpell` and keyed on the legacy 1.12 id for SoM-renumbered on-use spells (matches the `gcdLookupId` pattern in `HandleSpellGo`).

Exercised in the test builds; the existing `ClearNonStartedNormalCastsTests` cover the exemption logic this feeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)