### PR TITLE
Release predicted pet-button GCD on failed pet cast (warlock imp Firebolt LoS)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -624,6 +624,20 @@ public partial class WorldClient
         SendPacketToClient(failed);
     }
 
+    // JimsProxy (warlock-pet-gcd-on-failure): synth SMSG_PET_CAST_FAILED(DontReport) so the modern client releases its predicted pet-button GCD sweep for a failed pet cast. Silent (the fizzle already played); the client matches by SpellID since CMSG_PET_ACTION presses carry no client CastID.
+    void SendPetGcdRelease(uint spellId, WowGuid128 castId)
+    {
+        PetCastFailed petFailed = new PetCastFailed();
+        petFailed.SpellID = spellId;
+        petFailed.Reason = (uint)SpellCastResultClassic.DontReport;
+        petFailed.CastID = castId;
+        SendPacketToClient(petFailed);
+    }
+
+    // JimsProxy (warlock-pet-gcd-on-failure): true if a CMSG_PET_CAST_SPELL for this spell is still queued — those get their own trailing SMSG_PET_CAST_FAILED, so the synthesized GCD release is gated to unqueued CMSG_PET_ACTION presses to avoid a double-fail.
+    bool HasQueuedPetCast(uint spellId) =>
+        GetSession().GameState.PendingPetCasts.Any(c => c.SpellId == spellId || (c.LegacySpellId != 0 && c.LegacySpellId == spellId));
+
     [PacketHandler(Opcode.SMSG_SPELL_FAILED_OTHER)]
     void HandleSpellFailedOther(WorldPacket packet)
     {
@@ -660,12 +674,17 @@ public partial class WorldClient
         if (GetSession().GameState.RecentlyForwardedSpellFailedOther.TryGetValue(dedupKey, out var lastMs) &&
             nowMs - lastMs < DedupWindowMs)
         {
+            // JimsProxy (warlock-pet-gcd-on-failure): the visual/SpellFailure storm is deduped, but a double-clicked pet-bar press is a distinct failed cast whose predicted GCD sweep must still be released. Gated to unqueued presses (CMSG_PET_ACTION, deterministic seed CastID).
+            bool dedupReleasePetGcd = GetSession().GameState.CurrentPetGuid == casterUnit && !HasQueuedPetCast(spellId);
+            if (dedupReleasePetGcd)
+                SendPetGcdRelease(spellId, WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, spellId, spellId + casterUnit.GetCounter()));
             Log.Event("spell.failed_other.dedup_skipped", new
             {
                 spellId,
                 reason,
                 casterCounter = casterUnit.GetCounter(),
                 ms_since_last = nowMs - lastMs,
+                sentPetCastFailed = dedupReleasePetGcd,
             });
             return;
         }
@@ -797,6 +816,14 @@ public partial class WorldClient
             }
         }
 
+        // JimsProxy (warlock-pet-gcd-on-failure): Kronos reports failed pet-bar casts via FAILED_OTHER only — release the client's predicted pet-button GCD sweep. Gated to unqueued presses (CMSG_PET_ACTION); a queued CMSG_PET_CAST_SPELL gets its own trailing PetCastFailed. The dedup branch above covers double-clicks.
+        bool sentPetCastFailed = false;
+        if (casterIsPet && !HasQueuedPetCast(spellId))
+        {
+            SendPetGcdRelease(spellId, castId);
+            sentPetCastFailed = true;
+        }
+
         Log.Event("spell.failed_other.routed", new
         {
             spellId,
@@ -808,6 +835,7 @@ public partial class WorldClient
             casterIsPet,
             sentInterruptLog,
             sentCancelVisual,
+            sentPetCastFailed,
             resolvedSpellVisualId,
             // Diagnostic: actual content of synthesized cleanup packets
             interruptLogCasterLow,
@@ -1113,6 +1141,14 @@ public partial class WorldClient
             }
         }
 
+        // JimsProxy (warlock-pet-gcd-on-failure): pet failures via SMSG_SPELL_FAILURE (not FAILED_OTHER) also need the predicted pet-button GCD sweep released. Gated to unqueued presses for the same reason as HandleSpellFailedOther.
+        bool sentPetCastFailed = false;
+        if (casterIsPet && !HasQueuedPetCast(spellId))
+        {
+            SendPetGcdRelease(spellId, castId);
+            sentPetCastFailed = true;
+        }
+
         // JimsProxy (cast-failure-stuck-visual 2026-05-10): For local-player cast
         // failures where SPELL_START was forwarded, the modern 1.14 client does not
         // reliably cancel the caster-side visual kit (casting pose, looping channel
@@ -1169,6 +1205,7 @@ public partial class WorldClient
             foundActiveCastId,
             sentInterruptLog,
             sentCancelVisual,
+            sentPetCastFailed,
             spellVisual,
             resolvedSpellVisualId,
             // Diagnostic: actual content of synthesized cleanup packets


### PR DESCRIPTION
## Problem
Pressing a pet ability the pet can't use — e.g. a warlock's imp Firebolt while the imp is out of line of sight — plays the failure sound but runs a **full 1.5s GCD sweep** on the pet action button, even though nothing was cast. Spamming the button just re-triggers the bogus sweep.

## Root cause
A pet-bar press arrives as `CMSG_PET_ACTION`, which creates no `PendingPetCast`. The modern 1.14 client locally predicts a GCD on the pet button at press time. On Kronos the failure is reported via `SMSG_SPELL_FAILED_OTHER` (plus a trailing `SMSG_CAST_FAILED` that `HandleCastFailed` drops, since there's no matching normal cast) — **never `SMSG_PET_CAST_FAILED`**, which is the only packet that releases the client's predicted pet-button GCD. So the sweep ran to completion.

`HandlePetCastFailed` already synthesizes a release for this exact "no pending pet cast" case, but only when the failure arrives as `SMSG_PET_CAST_FAILED` — which Kronos doesn't send for pet-bar actions.

## Fix
Synthesize `SMSG_PET_CAST_FAILED(DontReport)` for own-pet failures via a shared `SendPetGcdRelease` helper:
- Called from `HandleSpellFailedOther` (the path Kronos uses) and defensively from `HandleSpellFailure`.
- `DontReport` is silent, so the existing `SpellFailure` still plays the error sound — no double sound.
- Also fired inside the `SMSG_SPELL_FAILED_OTHER` 500 ms dedup branch so rapid double-clicks each get released (the release is cheap/idempotent; only the `CancelSpellVisual`/`SpellFailure` storm needs throttling).
- All three call sites are gated to **unqueued** presses (`!HasQueuedPetCast`) so a queued `CMSG_PET_CAST_SPELL` — which receives its own trailing real-reason `SMSG_PET_CAST_FAILED` — isn't double-failed.

Only fires for the player's own pet (`CurrentPetGuid == casterUnit`); player and mob/enemy cast paths are untouched.

## Testing
- Validated in-game on Twinstar (Kronos) with a warlock imp: Firebolt out of LoS no longer GCD-sweeps; double-click spam is clean after the dedup-branch fix.
- Log analysis (33 presses = 33 failures, all `CMSG_PET_ACTION`): release fires once per failure, no flood; no overlap with successful casts; no double-send (Kronos never sends `SMSG_SPELL_FAILURE`/`SMSG_PET_CAST_FAILED` for pets).
- Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
