### PR TITLE
Fix Bagnon keyring sort loop (bag-family guard) + JimsPlus custom sort order

### DIFF
--- a/Addons/JimsPlus/BagnonSort.lua
+++ b/Addons/JimsPlus/BagnonSort.lua
@@ -1,0 +1,177 @@
+-- JimsPlus BagnonSort
+-- Two hooks into Bagnon's (Wildpants) client-side bag sorter. Bagnon's own files
+-- are never modified, so this survives Bagnon updates, and both hooks no-op when
+-- Bagnon isn't installed.
+--
+-- 1. LOOP BREAKER (always on): Bagnon's sorter has no retry cap or backoff — a
+--    move that never takes effect is recomputed and re-sent every 50ms forever
+--    (Wildpants/api/sorting.lua: Iterate -> Move -> Delay(0.05, 'Run')). Any move
+--    the proxy or server keeps rejecting becomes endless "That item cannot go in
+--    that container" spam until /reload. After 3 identical attempted moves in one
+--    sort run, the item is blacklisted for the rest of the run (marked sorted and
+--    made unstackable in the in-memory model) so the sort converges and finishes.
+--
+-- 2. CUSTOM SORT ORDER (Options toggle, default on): replaces the sort comparator
+--    with a category ranking — permanent fixtures (hearthstone), then profession/
+--    gathering tools, quest items, soulbound (BoP) gear, other gear, consumables,
+--    everything else, junk last. Within a category Bagnon's original ordering
+--    applies. Lower rank lands closer to backpack slot 1. The Sorting module is
+--    shared, so the order also applies to Bagnon's bank (and guild bank) sort.
+--
+-- Note: Bagnon prefers the server-side SortBags() when the client provides it
+-- (Wildpants/classes/inventory.lua, serverSort default true). 1.14.2 has no
+-- SortBags, so the client-side sorter — and these hooks — always run for the
+-- inventory; if a future client build adds SortBags, both hooks silently stop
+-- applying to the inventory sort and this file needs revisiting.
+
+local _, namespace = ...
+
+local FIXTURES = {
+    [6948] = true, -- Hearthstone
+}
+
+local TOOLS = {
+    [2901]  = true, -- Mining Pick
+    [5956]  = true, -- Blacksmith Hammer
+    [7005]  = true, -- Skinning Knife
+    [4471]  = true, -- Flint and Tinder
+    [6219]  = true, -- Arclight Spanner
+    [10498] = true, -- Gyromatic Micro-Adjustor
+    [6218]  = true, -- Runed Copper Rod
+    [6339]  = true, -- Runed Silver Rod
+    [11130] = true, -- Runed Golden Rod
+    [11145] = true, -- Runed Truesilver Rod
+    [16207] = true, -- Runed Arcanite Rod
+    [9149]  = true, -- Philosopher's Stone
+    [15846] = true, -- Salt Shaker
+    [6256]  = true, -- Fishing Pole
+    [6365]  = true, -- Strong Fishing Pole
+    [6366]  = true, -- Darkwood Fishing Pole
+    [6367]  = true, -- Big Iron Fishing Pole
+    [12225] = true, -- Blump Family Fishing Pole
+    [19022] = true, -- Nat Pagle's Extreme Angler FC-5000
+    [19970] = true, -- Arcanite Fishing Pole
+}
+
+local QUESTITEM = (Enum and Enum.ItemClass and Enum.ItemClass.Questitem) or 12
+local CONSUMABLE = (Enum and Enum.ItemClass and Enum.ItemClass.Consumable) or 0
+
+-- Category rank for one of Bagnon's in-memory item tables (fields id, class,
+-- quality, equip, bind — any of which may still be nil while item data loads).
+-- "Soulbound gear" is approximated by BoP bind type: BoP items in bags are
+-- necessarily soulbound; carried BoE gear ranks with other gear instead.
+local function Rank(item)
+    local id = item.id
+    if FIXTURES[id] then return 0 end
+    if TOOLS[id] then return 1 end
+    if item.quality == 0 then return 7 end                   -- junk last
+    if item.class == QUESTITEM then return 2 end
+    local equip = item.equip
+    if equip and equip ~= "" and equip ~= "INVTYPE_BAG" then -- equippable gear
+        return item.bind == 1 and 3 or 4                     -- soulbound (BoP) first
+    end
+    if item.class == CONSUMABLE then return 5 end
+    return 6
+end
+
+-- Item tables are rebuilt from scratch on every sort pass, so a rank stashed on
+-- the table can't go stale; this keeps rank computation O(n) per pass instead of
+-- O(n log n) comparator calls.
+local function GetRank(item)
+    local r = item.jpSortRank
+    if r == nil then
+        r = Rank(item)
+        item.jpSortRank = r
+    end
+    return r
+end
+
+local function Hook()
+    local Sorting = Bagnon and Bagnon.Sorting
+    if not Sorting or Sorting.jpHooked then return end
+    if type(Sorting.Start) ~= "function" or type(Sorting.Move) ~= "function"
+        or type(Sorting.GetSpaces) ~= "function" or type(Sorting.Rule) ~= "function" then
+        return
+    end
+    Sorting.jpHooked = true
+
+    ------------------------------------------------------------- loop breaker
+    local attempts, blacklist = {}, {}
+
+    local origStart = Sorting.Start
+    Sorting.Start = function(self, ...)
+        wipe(attempts)
+        wipe(blacklist)
+        return origStart(self, ...)
+    end
+
+    local origMove = Sorting.Move
+    Sorting.Move = function(self, from, to)
+        local id = from and from.item and from.item.id
+        if not id then
+            return origMove(self, from, to)
+        end
+        -- Deliberately no check of the DESTINATION against the blacklist: Iterate
+        -- schedules its re-run Delay unconditionally after every attempted move, so
+        -- silently skipping a move here would spin the sorter forever. A mover whose
+        -- swap with a blacklisted occupant keeps failing blacklists itself via its
+        -- own attempt count instead, which is bounded and terminates.
+        if blacklist[id] then return end
+        local sig = tostring(from.bag) .. ":" .. tostring(from.slot) .. ":"
+            .. tostring(to.bag) .. ":" .. tostring(to.slot) .. ":" .. id
+        if (attempts[sig] or 0) >= 3 then
+            -- The exact same move was sent 3 times without taking effect: it is
+            -- being rejected. Give up on this item for the rest of the run.
+            blacklist[id] = true
+            return
+        end
+        local moved = origMove(self, from, to)
+        if moved then
+            attempts[sig] = (attempts[sig] or 0) + 1
+        end
+        return moved
+    end
+
+    local origGetSpaces = Sorting.GetSpaces
+    Sorting.GetSpaces = function(self, ...)
+        local spaces = origGetSpaces(self, ...)
+        if next(blacklist) and type(spaces) == "table" then
+            for _, space in ipairs(spaces) do
+                local item = space.item
+                if item and item.id and blacklist[item.id] then
+                    item.sorted = true -- skipped by every placement pass
+                    item.stack = nil   -- and by the stack-merge pass
+                end
+            end
+        end
+        return spaces
+    end
+
+    ------------------------------------------------------------- custom order
+    local origRule = Sorting.Rule
+    Sorting.Rule = function(a, b)
+        local db = namespace.db
+        if db and db.bagSortOrder == false then
+            return origRule(a, b)
+        end
+        local ra, rb = GetRank(a), GetRank(b)
+        if ra ~= rb then
+            return ra < rb
+        end
+        return origRule(a, b)
+    end
+end
+
+-- PLAYER_LOGIN covers the normal case (fires after all non-LoD addons load);
+-- the ADDON_LOADED fallback covers Bagnon being loaded late (load-on-demand
+-- packaging or an addon manager enabling it mid-session).
+local f = CreateFrame("Frame")
+f:RegisterEvent("PLAYER_LOGIN")
+f:RegisterEvent("ADDON_LOADED")
+f:SetScript("OnEvent", function(self, event, name)
+    if event == "ADDON_LOADED" and name ~= "Bagnon" then return end
+    Hook()
+    if Bagnon and Bagnon.Sorting and Bagnon.Sorting.jpHooked then
+        self:UnregisterAllEvents()
+    end
+end)

--- a/Addons/JimsPlus/Core.lua
+++ b/Addons/JimsPlus/Core.lua
@@ -19,5 +19,6 @@ f:SetScript("OnEvent", function(_, _, addon)
     JimsPlusDB = JimsPlusDB or {}
     if JimsPlusDB.petFix == nil then JimsPlusDB.petFix = true end
     if JimsPlusDB.taxiFix == nil then JimsPlusDB.taxiFix = true end
+    if JimsPlusDB.bagSortOrder == nil then JimsPlusDB.bagSortOrder = true end
     namespace.db = JimsPlusDB
 end)

--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -4,7 +4,7 @@
 ## SavedVariables: JimsPlusDB, JimsPlusCastbarsDB
 ## SavedVariablesPerCharacter: JimsPlusCastbarsCharDB
 ## Author: JimsProxy Team (CastBars based on ClassicCastbars by Wardz)
-## Version: 1.1.1
+## Version: 1.2.0
 
 Core.lua
 Options.lua
@@ -17,6 +17,7 @@ AuctionsPaginationFix.lua
 MailNameFix.lua
 NameDashFix.lua
 KeyringClamp.lua
+BagnonSort.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua
 castbars/Data.lua

--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -67,7 +67,12 @@ local function KR_IsNonKey(id)
     if not id then return false end
     local classID = select(6, GetItemInfoInstant(id))
     if classID == nil then return false end -- unknown item: leave it alone
-    return classID ~= 13 -- 13 = Key
+    if classID == 13 then return false end -- 13 = Key
+    -- Keyring bag family (bit 256): Kronos marks some non-Key-class items keyring-able
+    -- (e.g. Alarm-O-Bot) and the proxy's item hotfixes pass that through — those belong
+    -- in the keyring, leave them there.
+    local family = GetItemFamily(id)
+    return not (family and bit.band(family, 256) ~= 0)
 end
 
 local function KR_FirstFreeBagSlot()
@@ -193,6 +198,11 @@ local btnBagAudit = CreateButton(panel, y, "Bag Audit", 150,
     "Moves non-key items out of your keyring and into your bags.\nUse it if a character has items stuck in the keyring from a past\nbug. Keys are left in place.")
 btnBagAudit:SetScript("OnClick", KR_StartCleanup)
 y = y - 30
+
+local cbBagSort = CreateCheckbox(panel, y,
+    "Custom bag sort order  |cFF888888(Bagnon)|r",
+    "Changes Bagnon's sort button to a curated layout:\npermanent fixtures (hearthstone) first, then profession and\ngathering tools, quest items, soulbound gear, other gear,\nconsumables, everything else, and junk last.\n\nAlso applies to Bagnon's bank sort. Takes effect on the\nnext sort — no reload needed.")
+y = y - 28
 -- More tool buttons can be added below (decrement y per button).
 
 ---------------------------------------------------------------------------
@@ -202,6 +212,7 @@ local function RefreshCheckboxes()
     local db = namespace.db or JimsPlusDB or {}
     cbTooltipFix:SetChecked(db.tooltipFix == true)
     cbMoonkinSound:SetChecked(db.moonkinSound ~= false)
+    cbBagSort:SetChecked(db.bagSortOrder ~= false)
 
     local cdb = JimsPlusCastbars and JimsPlusCastbars.db
     if cdb then
@@ -240,6 +251,14 @@ cbMoonkinSound:SetScript("OnClick", function(self)
         namespace.db.moonkinSound = enabled
     end
     print("|cFF00FF00[JimsPlus]|r Moonkin Form sound " .. (enabled and "enabled" or "disabled") .. ". Type /reload to apply.")
+end)
+
+cbBagSort:SetScript("OnClick", function(self)
+    local enabled = self:GetChecked() and true or false
+    if namespace.db then
+        namespace.db.bagSortOrder = enabled
+    end
+    print("|cFF00FF00[JimsPlus]|r Custom bag sort order " .. (enabled and "enabled" or "disabled") .. ".")
 end)
 
 for _, info in ipairs(castbarUnits) do

--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Framework.Constants;
+using Framework.Logging;
 using System;
 using HermesProxy.Enums;
 using HermesProxy.World;
@@ -45,9 +46,10 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SPLIT_ITEM)]
     void HandleSplitItem(SplitItem item)
     {
-        RememberMoveItems(item.FromPackSlot, item.FromSlot, item.ToPackSlot, item.ToSlot);
-        if (BlockNonKeySplitIntoKeyring(item.ToPackSlot, item.ToSlot))
+        var (moveItem0, moveItem1) = ResolveMoveItems(item.FromPackSlot, item.FromSlot, item.ToPackSlot, item.ToSlot);
+        if (BlockNonKeySplitIntoKeyring(item.ToPackSlot, item.ToSlot, moveItem0, moveItem1))
             return;
+        RememberMoveItems(moveItem0, moveItem1);
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SPLIT_ITEM);
         byte containerSlot1 = item.FromPackSlot != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.FromPackSlot) : item.FromPackSlot;
         byte slot1 = item.FromPackSlot == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.FromSlot) : item.FromSlot;
@@ -67,9 +69,10 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SWAP_INV_ITEM)]
     void HandleSwapInvItem(SwapInvItem item)
     {
-        RememberMoveItems(Enums.Classic.InventorySlots.Bag0, item.Slot1, Enums.Classic.InventorySlots.Bag0, item.Slot2);
-        if (BlockNonKeyIntoKeyring(Enums.Classic.InventorySlots.Bag0, item.Slot1, Enums.Classic.InventorySlots.Bag0, item.Slot2))
+        var (moveItem0, moveItem1) = ResolveMoveItems(Enums.Classic.InventorySlots.Bag0, item.Slot1, Enums.Classic.InventorySlots.Bag0, item.Slot2);
+        if (BlockNonKeyIntoKeyring(Enums.Classic.InventorySlots.Bag0, item.Slot1, Enums.Classic.InventorySlots.Bag0, item.Slot2, moveItem0, moveItem1))
             return;
+        RememberMoveItems(moveItem0, moveItem1);
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SWAP_INV_ITEM);
         byte slot1 = ModernVersion.AdjustInventorySlot(item.Slot1);
         byte slot2 = ModernVersion.AdjustInventorySlot(item.Slot2);
@@ -81,9 +84,10 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SWAP_ITEM)]
     void HandleSwapItem(SwapItem item)
     {
-        RememberMoveItems(item.ContainerSlotA, item.SlotA, item.ContainerSlotB, item.SlotB);
-        if (BlockNonKeyIntoKeyring(item.ContainerSlotA, item.SlotA, item.ContainerSlotB, item.SlotB))
+        var (moveItem0, moveItem1) = ResolveMoveItems(item.ContainerSlotA, item.SlotA, item.ContainerSlotB, item.SlotB);
+        if (BlockNonKeyIntoKeyring(item.ContainerSlotA, item.SlotA, item.ContainerSlotB, item.SlotB, moveItem0, moveItem1))
             return;
+        RememberMoveItems(moveItem0, moveItem1);
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SWAP_ITEM);
         byte containerSlotB = item.ContainerSlotB != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.ContainerSlotB) : item.ContainerSlotB;
         byte slotB = item.ContainerSlotB == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(item.SlotB) : item.SlotB;
@@ -222,21 +226,29 @@ public partial class WorldSocket
         SendPacketToServer(packet);
     }
 
-    // JimsProxy: remember the items at both endpoints of an item move (looked up from the
-    // cached player inventory at the legacy slots we're about to forward), so the failure
-    // handler can repair an empty-GUID InventoryChangeFailure and unlock the source item.
-    // Kronos sends empty item GUIDs for invalid-slot rejections (e.g. the modern client's
-    // phantom keyring slots 13-32 that the server lacks), which otherwise leaves the picked-
-    // up item locked until relog.
-    void RememberMoveItems(byte containerA, byte slotA, byte containerB, byte slotB)
+    // JimsProxy: resolve the items currently sitting at both endpoints of an item move (looked
+    // up from the cached player inventory at the legacy slots we're about to forward).
+    (WowGuid128, WowGuid128) ResolveMoveItems(byte containerA, byte slotA, byte containerB, byte slotB)
     {
         var state = GetSession().GameState;
         byte lcA = containerA != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(containerA) : containerA;
         byte lsA = containerA == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(slotA) : slotA;
         byte lcB = containerB != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(containerB) : containerB;
         byte lsB = containerB == Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(slotB) : slotB;
-        state.LastMoveItem0 = state.GetInventorySlotItem(lcA, lsA).To128(state);
-        state.LastMoveItem1 = state.GetInventorySlotItem(lcB, lsB).To128(state);
+        return (state.GetInventorySlotItem(lcA, lsA).To128(state), state.GetInventorySlotItem(lcB, lsB).To128(state));
+    }
+
+    // JimsProxy: remember a forwarded move's endpoint items so the failure handler can repair an
+    // empty-GUID InventoryChangeFailure and unlock the source item. Kronos sends empty item GUIDs
+    // for invalid-slot rejections (e.g. the modern client's phantom keyring slots 13-32 that the
+    // server lacks), which otherwise leaves the picked-up item locked until relog. Only called for
+    // moves that are actually forwarded — a blocked move can't produce a server failure, and letting
+    // it clobber this state would mis-attribute the backfill of an in-flight earlier move.
+    void RememberMoveItems(WowGuid128 item0, WowGuid128 item1)
+    {
+        var state = GetSession().GameState;
+        state.LastMoveItem0 = item0;
+        state.LastMoveItem1 = item1;
         state.LastMoveItemsTickMs = Environment.TickCount;
     }
 
@@ -252,51 +264,86 @@ public partial class WorldSocket
            && slot >= Enums.Classic.InventorySlots.KeyringStart
            && slot < Enums.Classic.InventorySlots.KeyringEnd;
 
-    bool IsKnownNonKey(WowGuid128 item)
+    uint ResolveItemId(WowGuid128 item)
+        => item.IsEmpty() ? 0 : GetSession().GameState.GetItemId(item);
+
+    // Keyring-eligible means legacy class Key (13) OR the keyring bag-family bit — the same rule
+    // the vanilla server's CanStoreItem enforces, and the same data our own ItemSparse hotfixes
+    // advertise to the client (ItemTemplate.ReadFromLegacyPacket translates the vanilla keyring
+    // bag-family bit 0x8 to the modern 0x100). Kronos marks some non-Key-class items keyring-able
+    // (e.g. 18645 Alarm-O-Bot: class 7 + keyring family); judging by class alone made the proxy
+    // bounce the very move its own hotfix told Bagnon to make, and Bagnon retries a rejected sort
+    // move every 50ms forever.
+    static bool IsKnownNonKey(uint itemId)
     {
-        if (item.IsEmpty())
-            return false;
-        uint itemId = GetSession().GameState.GetItemId(item);
         if (itemId == 0)
             return false;
         var template = GameData.GetItemTemplate(itemId);
-        return template != null && template.Class != 13; // 13 = ItemClass.Key
+        return template != null && template.Class != 13 && (template.BagFamily & 0x100) == 0;
     }
 
     // Bounce a blocked keyring move with a clean WrongBagType. Unlocks BOTH move endpoints so a
     // swap never leaves the dragged item OR the swapped item locked (stuck).
-    void SendKeyringBounce()
+    void SendKeyringBounce(WowGuid128 item0, WowGuid128 item1)
     {
-        var state = GetSession().GameState;
         InventoryChangeFailure failure = new();
         failure.BagResult = InventoryResult.WrongBagType;
-        failure.Item[0] = state.LastMoveItem0;
-        failure.Item[1] = state.LastMoveItem1;
+        failure.Item[0] = item0;
+        failure.Item[1] = item1;
         SendPacket(failure);
     }
 
-    // Swap/move: the item from A lands in B (LastMoveItem0) and the item from B lands in A
-    // (LastMoveItem1). Block if either lands a known non-key in a client keyring slot.
-    bool BlockNonKeyIntoKeyring(byte containerA, byte slotA, byte containerB, byte slotB)
+    // Swap/move: the item from A lands in B (item0) and the item from B lands in A (item1).
+    // Block if either lands a known non-key in a client keyring slot.
+    bool BlockNonKeyIntoKeyring(byte containerA, byte slotA, byte containerB, byte slotB, WowGuid128 item0, WowGuid128 item1)
     {
-        var state = GetSession().GameState;
-        if ((IsKeyringSlot(containerB, slotB) && IsKnownNonKey(state.LastMoveItem0))
-            || (IsKeyringSlot(containerA, slotA) && IsKnownNonKey(state.LastMoveItem1)))
+        bool keyringA = IsKeyringSlot(containerA, slotA);
+        bool keyringB = IsKeyringSlot(containerB, slotB);
+        if (!keyringA && !keyringB)
+            return false;
+        uint itemId0 = ResolveItemId(item0);
+        uint itemId1 = ResolveItemId(item1);
+        if (!(keyringB && IsKnownNonKey(itemId0)) && !(keyringA && IsKnownNonKey(itemId1)))
+            return false;
+        // Same item at both endpoints: the server merges the stacks (nothing lands back in the
+        // source slot), so the keyring contents can't get worse — and blocking it would make an
+        // orphaned stack impossible to merge out of the keyring onto an existing bag stack.
+        if (itemId0 != 0 && itemId0 == itemId1)
+            return false;
+        Log.Event("item.keyring_bounce", new
         {
-            SendKeyringBounce();
-            return true;
-        }
-        return false;
+            container_a = containerA,
+            slot_a = slotA,
+            container_b = containerB,
+            slot_b = slotB,
+            item_id_a = itemId0,
+            item_id_b = itemId1,
+        });
+        SendKeyringBounce(item0, item1);
+        return true;
     }
 
     // Split: only the destination receives the split portion (no swap-back), so check the dest only.
-    bool BlockNonKeySplitIntoKeyring(byte toContainer, byte toSlot)
+    bool BlockNonKeySplitIntoKeyring(byte toContainer, byte toSlot, WowGuid128 item0, WowGuid128 item1)
     {
-        if (IsKeyringSlot(toContainer, toSlot) && IsKnownNonKey(GetSession().GameState.LastMoveItem0))
+        if (!IsKeyringSlot(toContainer, toSlot))
+            return false;
+        uint itemId0 = ResolveItemId(item0);
+        if (!IsKnownNonKey(itemId0))
+            return false;
+        // Splitting onto the item's own stack in the keyring is a merge — nothing new enters.
+        uint itemId1 = ResolveItemId(item1);
+        if (itemId0 == itemId1)
+            return false;
+        Log.Event("item.keyring_bounce", new
         {
-            SendKeyringBounce();
-            return true;
-        }
-        return false;
+            split = true,
+            container_b = toContainer,
+            slot_b = toSlot,
+            item_id_a = itemId0,
+            item_id_b = itemId1,
+        });
+        SendKeyringBounce(item0, item1);
+        return true;
     }
 }


### PR DESCRIPTION
## Problem

Bagnon auto-sort loops forever spamming "That item cannot go in that container" (recurrence of the bug class #357 fixed). Log forensics on `jimsproxy-20260611-091806.jsonl`:

- **Zero** `SMSG_INVENTORY_CHANGE_FAILURE` from Kronos in the whole session — the error toasts were the proxy's own `SendKeyringBounce`, which is invisible in the JSONL (`packet.translated` fires even for blocked packets; synthesized s2c packets are never logged).
- Final burst: 54 identical CMSG_SWAP_ITEM at an exact 50ms cadence with total server silence; the loop re-armed 7s after a `/reload` and only died on the second `/reload`. The character's keyring was **empty** afterward — the move never landed.

## Root cause

The proxy contradicts itself. Kronos marks some non-Key-class items keyring-able via the vanilla keyring **bag-family** bit (0x8) — the repo's own Kronos overlay ships `18645 Alarm-O-Bot` (class 7) with `BagFamily=256`, and `ItemTemplate.ReadFromLegacyPacket` translates the bit to modern 0x100 and advertises it to the client via ItemSparse hotfixes. So the client reports `GetItemFamily(id)==256`, Bagnon (correctly) sorts the item into the keyring — and the #357 guard, judging by `Class != 13` **only**, bounces every attempt. Bagnon has no retry cap: identical move every 50ms until `/reload`. The vanilla server itself accepts keyring placement by bag family, not class, so the forwarded move would have succeeded.

## Fix

**Proxy** (`World/Server/PacketHandlers/ItemHandler.cs`):
- `IsKnownNonKey`: keyring-eligible = `Class == 13` **or** `BagFamily & 0x100` — same rule the server enforces and the proxy advertises.
- Same-itemId endpoint moves (stack merges) are exempt — the old guard made an orphaned stack impossible to merge out of the keyring onto an existing bag stack.
- Every bounce now emits `item.keyring_bounce` (containers/slots/item ids) so this is diagnosable from the JSONL next time.
- Handlers now Resolve → Block → Remember: blocked moves no longer clobber `LastMoveItem0/1`, so the #357 empty-GUID backfill can't be poisoned by bounce spam during sorts.

**JimsPlus 1.2.0** (`Addons/JimsPlus/BagnonSort.lua`, new):
- **Loop breaker** (always on): hooks Bagnon's Wildpants `Sorting` module at runtime (no Bagnon files modified; type-checked no-op if Bagnon is absent or restructured). After 3 identical attempted moves in one sort run the item is benched for the run (`sorted=true`, `stack=nil` in the in-memory model), so *any* future rejection source — old proxy builds, server-side rejections, data mismatches the proxy can't see — degrades to three error toasts and a completed sort instead of an infinite loop. Convergence traced against Bagnon 9.1.5.
- **Curated sort order** (Options toggle, default on): hearthstone first, then profession/gathering tools, quest items, soulbound (BoP) gear, other gear, consumables, everything else, junk last; ties fall back to Bagnon's original comparator. Applies to bank sort too.
- Bag Audit now leaves keyring-bag-family non-keys (e.g. Alarm-O-Bot) in place, consistent with the proxy rule.

## Verification

- `dotnet build` clean; `dotnet test` 535/535 passing.
- Multi-agent adversarial review: hook targets, loop-breaker convergence, comparator strict-weak-ordering, and 1.14.2 API availability verified against the installed Bagnon 9.1.5 source; minor hardening findings applied (late-load `ADDON_LOADED` fallback, docs for bank-sort scope and the future-`SortBags` bypass).
- Root-cause chain verified in repo data: `CSV/Hotfix/ItemSparse1.kronos.csv` row 18645 is the only BagFamily-drift row (0 → 256) among all 585 overlay rows; `ItemTemplate.cs` stores the translated mask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
