### PR TITLE
Drop stray trailing movement for just-destroyed / out-of-range units

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -330,6 +330,41 @@ public sealed class GameSessionData
     // Forwarding the first one is sufficient — the client cancels the cast bar / visual and
     // subsequent same-cast failures add no new state.
     public Dictionary<(WowGuid128 Caster, uint SpellId), long> RecentlyForwardedSpellFailedOther = new();
+
+    // JimsProxy (out-of-range-ghost): guids just destroyed / out-of-ranged and not yet re-created. Vanilla broadcasts a moving unit's trailing MSG_MOVE_* at map-level distance AFTER the per-object-visibility destroy; relaying that stray movement re-ghosts the unit "running in place" on the modern client until re-approach. Movement for these guids is dropped until a CreateObject clears the mark.
+    private readonly ConcurrentDictionary<WowGuid128, long> _recentlyDestroyedObjects = new();
+    private const long RecentlyDestroyedTtlMs = 10000;
+
+    public void MarkObjectRecentlyDestroyed(WowGuid128 guid)
+    {
+        if (guid.IsEmpty())
+            return;
+        _recentlyDestroyedObjects[guid] = Environment.TickCount64;
+        // Opportunistic sweep so a long session of spawns/despawns can't grow this unbounded.
+        if (_recentlyDestroyedObjects.Count > 4096)
+        {
+            long cutoff = Environment.TickCount64 - RecentlyDestroyedTtlMs;
+            foreach (var kvp in _recentlyDestroyedObjects)
+                if (kvp.Value < cutoff)
+                    _recentlyDestroyedObjects.TryRemove(kvp.Key, out _);
+        }
+    }
+
+    public void ClearRecentlyDestroyedObject(WowGuid128 guid) => _recentlyDestroyedObjects.TryRemove(guid, out _);
+
+    public bool WasObjectRecentlyDestroyed(WowGuid128 guid, out long agoMs)
+    {
+        agoMs = 0;
+        if (_recentlyDestroyedObjects.TryGetValue(guid, out long when))
+        {
+            agoMs = Environment.TickCount64 - when;
+            if (agoMs < RecentlyDestroyedTtlMs)
+                return true;
+            _recentlyDestroyedObjects.TryRemove(guid, out _);
+        }
+        return false;
+    }
+
     public string LeftChannelName = "";
     public bool IsPassingOnLoot;
     public int GroupUpdateCounter;

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -118,6 +118,19 @@ public partial class WorldClient
     {
         MoveUpdate moveUpdate = new MoveUpdate();
         moveUpdate.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
+        // JimsProxy (out-of-range-ghost): drop a stray movement packet for a unit we just destroyed/out-of-ranged so it can't re-ghost the unit running-in-place on the modern client.
+        if (moveUpdate.MoverGUID != GetSession().GameState.CurrentPlayerGuid &&
+            GetSession().GameState.WasObjectRecentlyDestroyed(moveUpdate.MoverGUID, out long ghostAgoMs))
+        {
+            if (Framework.Settings.DebugOutput)
+                Framework.Logging.Log.Event("movement.dropped_stray_after_destroy", new
+                {
+                    guid = moveUpdate.MoverGUID.GetCounter(),
+                    ms_since_destroy = ghostAgoMs,
+                    opcode = packet.GetUniversalOpcode(false).ToString(),
+                });
+            return;
+        }
         moveUpdate.MoveInfo = new();
         moveUpdate.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
         ApplyHoverOverrideIfNeeded(moveUpdate.MoverGUID, moveUpdate.MoveInfo);
@@ -737,6 +750,19 @@ public partial class WorldClient
     void HandleMonsterMove(WorldPacket packet)
     {
         WowGuid128 guid = packet.ReadPackedGuid().To128(GetSession().GameState);
+        // JimsProxy (out-of-range-ghost): drop a stray monster-move for a unit we just destroyed/out-of-ranged so it can't re-ghost moving-in-place on the modern client.
+        if (guid != GetSession().GameState.CurrentPlayerGuid &&
+            GetSession().GameState.WasObjectRecentlyDestroyed(guid, out long ghostAgoMs))
+        {
+            if (Framework.Settings.DebugOutput)
+                Framework.Logging.Log.Event("movement.dropped_stray_after_destroy", new
+                {
+                    guid = guid.GetCounter(),
+                    ms_since_destroy = ghostAgoMs,
+                    opcode = "monster_move",
+                });
+            return;
+        }
         ServerSideMovement moveSpline = new();
 
         if (packet.GetUniversalOpcode(false) == Opcode.SMSG_MONSTER_MOVE_TRANSPORT)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -205,6 +205,9 @@ public partial class WorldClient
         // the source of the problem instead of the watchdog catch-all.
         GetSession().EvictPendingCastsForDestroyedTarget(guid);
 
+        // JimsProxy (out-of-range-ghost): suppress any stray trailing movement the legacy server broadcasts for this guid after the destroy, until a CreateObject re-creates it.
+        GetSession().GameState.MarkObjectRecentlyDestroyed(guid);
+
         UpdateObject updateObject = new UpdateObject(GetSession().GameState);
         updateObject.DestroyedGuids.Add(guid);
         SendPacketToClient(updateObject);
@@ -313,6 +316,8 @@ public partial class WorldClient
                     // FarObjects bookkeeping so a later Values update for
                     // this guid doesn't double-promote.
                     GetSession().GameState.NeedsFullAuraRefresh.Remove(guid);
+                    // JimsProxy (out-of-range-ghost): unit re-created → stop suppressing its movement.
+                    GetSession().GameState.ClearRecentlyDestroyedObject(guid);
                     ReadCreateObjectBlock(packet, guid, updateData, auraUpdate, i);
 
                     if (updateData.Guid == GetSession().GameState.CurrentPlayerGuid)
@@ -349,6 +354,8 @@ public partial class WorldClient
                     ObjectUpdate updateData = new ObjectUpdate(guid, UpdateTypeModern.CreateObject2, GetSession());
                     AuraUpdate auraUpdate = new AuraUpdate(guid, true);
                     GetSession().GameState.NeedsFullAuraRefresh.Remove(guid);
+                    // JimsProxy (out-of-range-ghost): unit re-created → stop suppressing its movement.
+                    GetSession().GameState.ClearRecentlyDestroyedObject(guid);
                     ReadCreateObjectBlock(packet, guid, updateData, auraUpdate, i);
 
                     if (guid.IsItem() && updateData.ObjectData.EntryID != null &&
@@ -547,6 +554,9 @@ public partial class WorldClient
                 SendPacketToClient(updateObject2);
 
             }
+            // JimsProxy (out-of-range-ghost): suppress stray trailing movement for this guid until it is re-created on re-approach.
+            GetSession().GameState.MarkObjectRecentlyDestroyed(guid);
+
             updateObject.OutOfRangeGuids.Add(guid);
         }
     }


### PR DESCRIPTION
Vanilla broadcasts a moving unit's trailing `MSG_MOVE_*` (and `MONSTER_MOVE`) at map-level distance *after* it has already sent the per-object-visibility destroy for that unit. The proxy relayed that stray movement, so the modern client re-created and re-ghosted the just-destroyed unit "running in place" at its last position until the player re-approached and a real `CreateObject` arrived.

This tracks guids that were just destroyed or went out-of-range (`SMSG_DESTROY_OBJECT` and the FarObjects/out-of-range path) in a short-TTL set, and drops any trailing movement for them in `HandleMovementMessages` / `HandleMonsterMove` until a `CreateObject` re-creates the unit and clears the mark. The set is TTL-bounded (10s) with an opportunistic sweep so a long spawn/despawn session can't grow it unbounded. The local player is exempt.

The `movement.dropped_stray_after_destroy` diagnostic is gated behind `DebugOutput`.

> Note: lightly overlaps #370 in the `UpdateHandler` out-of-range block — trivial textual conflict if both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)