### PR TITLE
Opt-in identity-pinned cast correspondence + idle-orphan closure (T1)

### DIFF
--- a/HermesProxy.Tests/World/IdentityPinnedCastIdsTests.cs
+++ b/HermesProxy.Tests/World/IdentityPinnedCastIdsTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using HermesProxy;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (T1 identity-pinned cast correspondence): the 1.12 server strips the client's
+// CastID, so the proxy must re-derive which press a server event belongs to. T1 makes that
+// deterministic — every local-player terminating event (SPELL_GO / CAST_FAILED / SPELL_FAILURE)
+// and the watchdog's synthetic closure is stamped with the CastID recorded at SPELL_START,
+// drawn from a per-spell FIFO in START order, instead of depending on which queue entry the
+// dequeue heuristic picked. These tests pin the FIFO's ordering/lifecycle and the watchdog
+// data-path closure. The packet-handler wiring is gated behind Settings.IdentityPinnedCastIdsActive
+// (LowLatencyMode && IdentityPinnedCastIds); the last test guards that OFF can't activate it.
+public class IdentityPinnedCastIdsTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static WowGuid128 CastId(ulong n) => new WowGuid128(n, 0);
+
+    private static ClientCastRequest StartedCast(uint spellId, WowGuid128 serverGuid, long watchdogDeadlineMs = 0)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            HasStarted = true,
+            ServerGUID = serverGuid,
+            WatchdogDeadlineMs = watchdogDeadlineMs,
+        };
+    }
+
+    // --- Core invariant: START order is preserved, so interleaved same-spell START/GO pair. ---
+
+    [Fact]
+    public void EnqueueThenPop_TwoSameSpellStarts_PopReturnsStartOrder()
+    {
+        // Two casts of the same spell are forwarded in START order (A then B). The first GO must
+        // pop A's CastID (pairing GO 1 ↔ START 1) and the second GO pop B's — independent of any
+        // dequeue heuristic. This is the START↔GO correspondence the whole feature exists to make
+        // deterministic.
+        var session = NewSession();
+        var startA = CastId(101);
+        var startB = CastId(102);
+        session.EnqueueForwardedStartCastId(13877, startA);
+        session.EnqueueForwardedStartCastId(13877, startB);
+
+        Assert.True(session.TryPopForwardedStartCastId(13877, out var firstGo));
+        Assert.Equal(startA, firstGo);
+        Assert.True(session.TryPopForwardedStartCastId(13877, out var secondGo));
+        Assert.Equal(startB, secondGo);
+        Assert.False(session.TryPopForwardedStartCastId(13877, out _));
+    }
+
+    [Fact]
+    public void TryPopForwardedStartCastId_NoEntry_ReturnsFalse()
+    {
+        // Skip-START instants (server emits GO with no preceding START) leave no FIFO entry — the
+        // caller must fall back to the dequeued entry's ServerGUID, i.e. today's behavior.
+        var session = NewSession();
+
+        Assert.False(session.TryPopForwardedStartCastId(11305, out var castId));
+        Assert.Equal(default, castId);
+    }
+
+    [Fact]
+    public void TryPeekForwardedStartCastId_ReturnsFrontWithoutConsuming()
+    {
+        // SMSG_SPELL_FAILURE only PEEKS the pending cast (the trailing CAST_FAILED / GO / watchdog
+        // pops it), so peeking the FIFO must not remove the entry — a later pop still pairs.
+        var session = NewSession();
+        var start = CastId(55);
+        session.EnqueueForwardedStartCastId(133, start);
+
+        Assert.True(session.TryPeekForwardedStartCastId(133, out var peeked));
+        Assert.Equal(start, peeked);
+        // Still present for the real terminating event.
+        Assert.True(session.TryPopForwardedStartCastId(133, out var popped));
+        Assert.Equal(start, popped);
+    }
+
+    // --- Watchdog needs remove-by-value: an evicted cast may not be the FIFO head. ---
+
+    [Fact]
+    public void RemoveForwardedStartCastId_MiddleEntry_RemovesByValueNotHead()
+    {
+        // The watchdog evicts a specific started cast that timed out — which may be neither the
+        // oldest nor the newest. Removing it by value (not popping the head) keeps the remaining
+        // casts' CastIDs intact so their own GOs still pair.
+        var session = NewSession();
+        var a = CastId(1);
+        var b = CastId(2);
+        var c = CastId(3);
+        session.EnqueueForwardedStartCastId(133, a);
+        session.EnqueueForwardedStartCastId(133, b);
+        session.EnqueueForwardedStartCastId(133, c);
+
+        Assert.True(session.RemoveForwardedStartCastId(133, b));
+
+        Assert.True(session.TryPopForwardedStartCastId(133, out var first));
+        Assert.Equal(a, first);
+        Assert.True(session.TryPopForwardedStartCastId(133, out var second));
+        Assert.Equal(c, second);              // b was removed from the middle, order otherwise intact
+        Assert.False(session.TryPopForwardedStartCastId(133, out _));
+    }
+
+    [Fact]
+    public void RemoveForwardedStartCastId_AbsentValue_ReturnsFalse()
+    {
+        var session = NewSession();
+        session.EnqueueForwardedStartCastId(133, CastId(1));
+
+        Assert.False(session.RemoveForwardedStartCastId(133, CastId(999)));
+        Assert.False(session.RemoveForwardedStartCastId(999, CastId(1)));
+        // The real entry is untouched.
+        Assert.True(session.TryPopForwardedStartCastId(133, out var still));
+        Assert.Equal(CastId(1), still);
+    }
+
+    // --- Leak backstop: bounded depth so a missed pop can't grow without bound. ---
+
+    [Fact]
+    public void EnqueueForwardedStartCastId_ExceedsCap_DropsOldest()
+    {
+        // If some obscure removal path ever fails to pop, the per-spell FIFO is bounded (cap 8):
+        // the oldest are dropped, never growing unbounded. The dropped ones are the oldest casts,
+        // which are the most likely to already be resolved.
+        var session = NewSession();
+        for (ulong i = 1; i <= 10; i++)
+            session.EnqueueForwardedStartCastId(133, CastId(i));
+
+        var survivors = new List<WowGuid128>();
+        while (session.TryPopForwardedStartCastId(133, out var id))
+            survivors.Add(id);
+
+        Assert.Equal(8, survivors.Count);          // capped
+        Assert.Equal(CastId(3), survivors[0]);     // oldest two (1,2) dropped
+        Assert.Equal(CastId(10), survivors[^1]);   // newest retained
+    }
+
+    [Fact]
+    public void ForwardedStartCastIds_DifferentSpells_AreIndependent()
+    {
+        var session = NewSession();
+        session.EnqueueForwardedStartCastId(133, CastId(1));
+        session.EnqueueForwardedStartCastId(13877, CastId(2));
+
+        Assert.True(session.TryPopForwardedStartCastId(133, out var x));
+        Assert.Equal(CastId(1), x);
+        Assert.True(session.TryPopForwardedStartCastId(13877, out var y));
+        Assert.Equal(CastId(2), y);
+    }
+
+    [Fact]
+    public void ClearForwardedStartCastIds_RemovesAll()
+    {
+        // Reconnect / world transfer drops all in-flight cast bookkeeping, including this FIFO,
+        // so stale pre-reconnect CastIDs can't pair against a new server's casts.
+        var session = NewSession();
+        session.EnqueueForwardedStartCastId(133, CastId(1));
+        session.EnqueueForwardedStartCastId(13877, CastId(2));
+
+        session.ClearForwardedStartCastIds();
+
+        Assert.False(session.TryPopForwardedStartCastId(133, out _));
+        Assert.False(session.TryPopForwardedStartCastId(13877, out _));
+    }
+
+    // --- Guaranteed closure: an orphaned cast (no server response) gets a correctly-stamped
+    //     synthetic closure within the deadline, and the FIFO is kept consistent. ---
+
+    [Fact]
+    public void DrainExpiredWatchdogCasts_OrphanStartedCast_EvictsWithForwardedCastId_AndFifoRemovable()
+    {
+        // A started cast whose SPELL_GO / CAST_FAILED never arrived. Past its deadline, the
+        // watchdog drains it; the synthetic CastFailed it sends carries cast.ServerGUID — which is
+        // exactly the CastID forwarded at START (and stored in the FIFO), so the closure pairs with
+        // the client's open cast. Removing that entry by value then prevents a later same-spell GO
+        // from popping this dead cast's CastID.
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        var serverGuid = CastId(777);
+        var orphan = StartedCast(13877, serverGuid, watchdogDeadlineMs: now - 1000); // already overdue
+        session.PendingNormalCasts.Enqueue(orphan);
+        session.EnqueueForwardedStartCastId(13877, serverGuid); // what START forwarded == ServerGUID
+
+        session.DrainExpiredWatchdogCasts(now, out var normalEvicted, out var petEvicted);
+
+        Assert.Single(normalEvicted);
+        Assert.Same(orphan, normalEvicted[0]);
+        Assert.Equal(serverGuid, normalEvicted[0].ServerGUID);          // synthetic closure CastID is correct
+        Assert.Empty(petEvicted);
+        Assert.Empty(session.PendingNormalCasts);
+
+        // The watchdog wiring removes the evicted cast's forwarded CastID by value.
+        Assert.True(session.RemoveForwardedStartCastId(13877, serverGuid));
+        Assert.False(session.TryPopForwardedStartCastId(13877, out _));  // no stale head left behind
+    }
+
+    [Fact]
+    public void DrainExpiredWatchdogCasts_NotYetExpired_DoesNotEvict()
+    {
+        // The bounded deadline must not fire early: a cast still within its 2.5s window is left
+        // alone (a real GO / CAST_FAILED may still be in flight at high latency — no premature,
+        // false-positive closure).
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        var inFlight = StartedCast(13877, CastId(5), watchdogDeadlineMs: now + 100000); // future deadline
+        session.PendingNormalCasts.Enqueue(inFlight);
+
+        session.DrainExpiredWatchdogCasts(now, out var normalEvicted, out _);
+
+        Assert.Empty(normalEvicted);
+        Assert.Single(session.PendingNormalCasts);
+    }
+
+    // --- Regression guard: OFF can't activate the bundle. ---
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]   // LowLatencyMode alone — inactive
+    [InlineData(false, true, false)]   // sub-toggle alone — inactive
+    [InlineData(true, true, true)]     // both — active
+    public void IdentityPinnedCastIdsActive_RequiresBothToggles(bool lowLatency, bool subToggle, bool expectedActive)
+    {
+        // The entire T1 mechanism (FIFO stamping + the keepalive watchdog pump + watchdog FIFO
+        // removal) is gated on this property. With it false, none of the new code paths run, so
+        // the Hold-and-Fire path stays byte-identical — the default-OFF regression guarantee.
+        bool savedLowLatency = global::Framework.Settings.LowLatencyMode;
+        bool savedSubToggle = global::Framework.Settings.IdentityPinnedCastIds;
+        try
+        {
+            global::Framework.Settings.LowLatencyMode = lowLatency;
+            global::Framework.Settings.IdentityPinnedCastIds = subToggle;
+            Assert.Equal(expectedActive, global::Framework.Settings.IdentityPinnedCastIdsActive);
+        }
+        finally
+        {
+            global::Framework.Settings.LowLatencyMode = savedLowLatency;
+            global::Framework.Settings.IdentityPinnedCastIds = savedSubToggle;
+        }
+    }
+}

--- a/HermesProxy.Tests/World/IdentityPinnedCastIdsTests.cs
+++ b/HermesProxy.Tests/World/IdentityPinnedCastIdsTests.cs
@@ -54,6 +54,47 @@ public class IdentityPinnedCastIdsTests
         Assert.False(session.TryPopForwardedStartCastId(13877, out _));
     }
 
+    // --- Divergence proof: the ONLY by-construction evidence T1 does something the pre-T1 path
+    //     cannot. T1's per-spell FIFO replaces #362's single-slot PlayerForwardedCastIds recovery
+    //     (spellId -> one CastID). Under a CONCURRENT same-spell double-START whose GOs both reach
+    //     the orphan-GO recovery, the single slot is OVERWRITTEN — it collapses both casts onto the
+    //     latest CastID and loses the first, so START 1's cast never gets a matching GO and loops.
+    //     The FIFO keeps both in START order and pairs each GO correctly.
+    //     SCOPE (honest): this proves T1 is strictly more correct *when that interleaving occurs*.
+    //     It does NOT prove the Blade Flurry loop reaches it — the documented BF mechanism (a single
+    //     keypress's off-GCD double-send: START -> CAST_FAILED(dup) -> GO) is resolved by #372's
+    //     off-GCD collapse + prefer-started dequeue WITHOUT reaching this recovery path. Whether a
+    //     genuine concurrent double-START occurs in the wild is a field/log question, not a unit one.
+    [Fact]
+    public void Divergence_ConcurrentSameSpellStarts_PreT1SingleSlotCollapses_FifoPairsCorrectly()
+    {
+        var startA = CastId(0xA);
+        var startB = CastId(0xB);
+
+        // PRE-T1 (#362 single-slot recovery): the second START overwrites the first — A is lost.
+        var preT1 = NewSession();
+        preT1.PlayerForwardedCastIds[13877] = startA;
+        preT1.PlayerForwardedCastIds[13877] = startB;   // overwrite
+
+        // GO 1's orphan recovery reads B (WRONG — it should pair with START A), and GO 2 finds
+        // nothing. START A's CastID is never recovered -> the client's cast A never closes -> loop.
+        Assert.True(preT1.PlayerForwardedCastIds.TryRemove(13877, out var preGo1));
+        Assert.Equal(startB, preGo1);                   // GO 1 mis-stamped with B
+        Assert.NotEqual(startA, preGo1);                // START A collapsed away
+        Assert.False(preT1.PlayerForwardedCastIds.TryRemove(13877, out _)); // nothing left for GO 2
+
+        // T1 (per-spell FIFO): both retained in START order — GO 1 pops A, GO 2 pops B. No collapse.
+        var t1 = NewSession();
+        t1.EnqueueForwardedStartCastId(13877, startA);
+        t1.EnqueueForwardedStartCastId(13877, startB);
+
+        Assert.True(t1.TryPopForwardedStartCastId(13877, out var t1Go1));
+        Assert.Equal(startA, t1Go1);                    // GO 1 ↔ START A
+        Assert.True(t1.TryPopForwardedStartCastId(13877, out var t1Go2));
+        Assert.Equal(startB, t1Go2);                    // GO 2 ↔ START B
+        Assert.False(t1.TryPopForwardedStartCastId(13877, out _));
+    }
+
     [Fact]
     public void TryPopForwardedStartCastId_NoEntry_ReturnsFalse()
     {

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -62,6 +62,17 @@ public static class Settings
     // the client doesn't show red error text during rapid spam. Independent of
     // LowLatencyMode — useful as a companion setting but not required.
     public static bool SuppressSpellCastErrors;
+    // JimsProxy (T1 identity-pinned cast correspondence): make the START↔terminating
+    // CastID pairing deterministic. Every local-player terminating event
+    // (SPELL_GO / CAST_FAILED / SPELL_FAILURE) and the watchdog's synthetic closure
+    // is stamped with the CastID recorded at SPELL_START, drawn from a per-spell FIFO,
+    // instead of relying on which queue entry the dequeue heuristic picked. Sub-toggle
+    // of LowLatencyMode: only the immediate-forward path creates the concurrent
+    // same-spell entries this disambiguates, so it has no effect (and the Hold-and-Fire
+    // path stays byte-identical) unless BOTH are on. Default OFF — opt-in experiment.
+    public static bool IdentityPinnedCastIds;
+    // Effective gate for the T1 mechanism: the sub-toggle is live only under LowLatencyMode.
+    public static bool IdentityPinnedCastIdsActive => LowLatencyMode && IdentityPinnedCastIds;
     // JimsProxy (PR #228 follow-up): synthesize SMSG_THREAT_UPDATE / HIGHEST /
     // CLEAR so the modern client's native threat APIs (UnitDetailedThreatSituation,
     // UNIT_THREAT_LIST_UPDATE) populate. Default on. Disable for players who
@@ -111,6 +122,7 @@ public static class Settings
         EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
+        IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);
         var serverTypeStr = config.GetString("ServerType", "Kronos");
         ServerType = serverTypeStr.Equals("Generic", StringComparison.OrdinalIgnoreCase)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -488,6 +488,20 @@ public sealed class GameSessionData
     // cast is dequeued at GO, so normal casts are wire-identical. Cleared on world
     // transfer alongside the pet/other-caster cast-id maps.
     public ConcurrentDictionary<uint, WowGuid128> PlayerForwardedCastIds = new();
+    // JimsProxy (T1 identity-pinned cast correspondence): per-spell FIFO of the CastIDs
+    // forwarded to the modern client at the LOCAL PLAYER's SMSG_SPELL_START. Supersedes the
+    // single-slot PlayerForwardedCastIds (above) when Settings.IdentityPinnedCastIdsActive.
+    // A single slot is overwritten when two same-spell casts are in flight at once (the
+    // immediate-forward / Low-Latency path), so a later GO recovers the wrong CastID; the
+    // FIFO preserves START order so each terminating event consumes the matching forwarded
+    // CastID and START↔GO/FAILED pair deterministically, independent of which queue entry
+    // the dequeue heuristic picks. Bounded per spell (oldest dropped past the cap) and
+    // cleared on reconnect so a missed pop can neither leak nor stale-head a future cast.
+    // Lock-guarded plain Dictionary/List (not Concurrent*) so enqueue+bound and the
+    // remove-by-value the watchdog needs are atomic; contention is negligible (cast events).
+    private readonly Dictionary<uint, List<WowGuid128>> _playerForwardedStartCastIds = new();
+    private readonly object _playerForwardedStartCastIdsLock = new();
+    private const int MaxForwardedStartCastIdsPerSpell = 8;
     // Tracks last-seen UNIT_CHANNEL_SPELL per unit so we can synthesize
     // SMSG_SPELL_CHANNEL_START/UPDATE for observers (vanilla only sends
     // MSG_CHANNEL_START to the caster, not to nearby players).
@@ -1329,6 +1343,99 @@ public sealed class GameSessionData
         return false;
     }
 
+    // JimsProxy (T1 identity-pinned cast correspondence) — per-spell forwarded-START CastID
+    // FIFO helpers. Active only when Settings.IdentityPinnedCastIdsActive; OFF path never
+    // calls these. See _playerForwardedStartCastIds.
+
+    /// <summary>
+    /// Record the CastID forwarded to the client at the local player's SMSG_SPELL_START.
+    /// Oldest-first; bounded so a missed pop can't grow without bound.
+    /// </summary>
+    public void EnqueueForwardedStartCastId(uint spellId, WowGuid128 castId)
+    {
+        lock (_playerForwardedStartCastIdsLock)
+        {
+            if (!_playerForwardedStartCastIds.TryGetValue(spellId, out var list))
+            {
+                list = new List<WowGuid128>(2);
+                _playerForwardedStartCastIds[spellId] = list;
+            }
+            list.Add(castId);
+            while (list.Count > MaxForwardedStartCastIdsPerSpell)
+                list.RemoveAt(0);
+        }
+    }
+
+    /// <summary>
+    /// Pop the oldest forwarded-START CastID for a spell — a terminating event (SPELL_GO or a
+    /// real CAST_FAILED) consuming the cast it opened.
+    /// </summary>
+    public bool TryPopForwardedStartCastId(uint spellId, out WowGuid128 castId)
+    {
+        lock (_playerForwardedStartCastIdsLock)
+        {
+            if (_playerForwardedStartCastIds.TryGetValue(spellId, out var list) && list.Count > 0)
+            {
+                castId = list[0];
+                list.RemoveAt(0);
+                if (list.Count == 0)
+                    _playerForwardedStartCastIds.Remove(spellId);
+                return true;
+            }
+        }
+        castId = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Peek the oldest forwarded-START CastID without consuming it. SMSG_SPELL_FAILURE only
+    /// peeks the pending cast (the trailing SMSG_CAST_FAILED / GO / watchdog is what pops),
+    /// so it stamps from the FIFO front without removing it.
+    /// </summary>
+    public bool TryPeekForwardedStartCastId(uint spellId, out WowGuid128 castId)
+    {
+        lock (_playerForwardedStartCastIdsLock)
+        {
+            if (_playerForwardedStartCastIds.TryGetValue(spellId, out var list) && list.Count > 0)
+            {
+                castId = list[0];
+                return true;
+            }
+        }
+        castId = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Remove a specific forwarded-START CastID by value. The watchdog evicts a known cast
+    /// that may not be the oldest, so removing by value (not popping the front) keeps the FIFO
+    /// consistent — a later same-spell cast's GO can't then pop this evicted cast's stale CastID.
+    /// </summary>
+    public bool RemoveForwardedStartCastId(uint spellId, WowGuid128 castId)
+    {
+        lock (_playerForwardedStartCastIdsLock)
+        {
+            if (_playerForwardedStartCastIds.TryGetValue(spellId, out var list) && list.Remove(castId))
+            {
+                if (list.Count == 0)
+                    _playerForwardedStartCastIds.Remove(spellId);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Drop all forwarded-START CastIDs (reconnect / world-transfer state reset).
+    /// </summary>
+    public void ClearForwardedStartCastIds()
+    {
+        lock (_playerForwardedStartCastIdsLock)
+        {
+            _playerForwardedStartCastIds.Clear();
+        }
+    }
+
     /// <summary>
     /// Clear all pending normal casts (used on timeout or disconnect).
     /// </summary>
@@ -1832,6 +1939,7 @@ public sealed class GameSessionData
         OtherCasterActiveCastIds.Clear();
         PetAutoCastActiveCastIds.Clear();
         PlayerForwardedCastIds.Clear();
+        ClearForwardedStartCastIds();
         // Single-slot trackers for melee + auto-repeat (Auto Shot, Shoot Wand)
         // — same lifecycle as PendingNormalCasts; if a tracker was set when
         // the DC fired, it never gets cleared by the SPELL_GO/CAST_FAILED
@@ -2591,6 +2699,12 @@ public class GlobalSessionData
                 had_started = cast.HasStarted,
                 ms_overdue = nowMs - cast.WatchdogDeadlineMs,
             });
+            // T1 (identity-pinned): the started cast is being force-closed without a server
+            // terminating event — release its forwarded-START CastID so a later same-spell cast
+            // can't pop this evicted cast's stale CastID. Remove by value (it may not be the FIFO
+            // head). The synthetic CastFailed below already carries cast.ServerGUID == that CastID.
+            if (Framework.Settings.IdentityPinnedCastIdsActive && cast.HasStarted)
+                GameState.RemoveForwardedStartCastId(cast.SpellId, cast.ServerGUID);
             if (!cast.HasStarted)
             {
                 SpellPrepare prepare = new();

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -475,6 +475,13 @@ public partial class WorldClient
             failed.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
             failed.Reason = effectiveReason;
             failed.CastID = pendingCast.ServerGUID;
+            // T1 (identity-pinned): a real failure terminates the STARTED cast — stamp it with the
+            // recorded START CastID (popped FIFO) and consume the FIFO entry so a later same-spell
+            // GO can't pop this now-resolved cast's CastID. Transient dup rejections resolve the
+            // UNSTARTED dup (HasStarted=false, no FIFO entry) and leave the started cast's entry.
+            if (Settings.IdentityPinnedCastIdsActive && pendingCast.HasStarted &&
+                GetSession().GameState.TryPopForwardedStartCastId(pendingCast.SpellId, out var pinnedFailCastId))
+                failed.CastID = pinnedFailCastId;
             failed.FailedArg1 = arg1;
             failed.FailedArg2 = arg2;
             SendPacketToClient(failed);
@@ -1045,6 +1052,12 @@ public partial class WorldClient
             GetSession().GameState.PendingNormalCasts.FirstOrDefault(c => c.SpellId == spellId || (c.LegacySpellId != 0 && c.LegacySpellId == spellId)) is { } pendingNormal)
         {
             castId = pendingNormal.ServerGUID;
+            // T1 (identity-pinned): SPELL_FAILURE only PEEKS the pending cast (the trailing
+            // CAST_FAILED / GO / watchdog pops it), so stamp the forwarded failure's CastID from
+            // the FIFO front WITHOUT consuming it — the later pop stays paired.
+            if (Settings.IdentityPinnedCastIdsActive && pendingNormal.HasStarted &&
+                GetSession().GameState.TryPeekForwardedStartCastId(pendingNormal.SpellId, out var pinnedFailureCastId))
+                castId = pinnedFailureCastId;
             spellVisual = pendingNormal.SpellXSpellVisualId;
             if (pendingNormal.LegacySpellId != 0)
                 spellId = pendingNormal.SpellId;
@@ -1523,7 +1536,14 @@ public partial class WorldClient
             // duplicate's CAST_FAILED having consumed the entry). See PlayerForwardedCastIds.
             // Fallback only — normal casts override with ServerGUID at GO and never read it.
             if (casterIsLocalPlayer)
-                GetSession().GameState.PlayerForwardedCastIds[(uint)spell.Cast.SpellID] = spell.Cast.CastID;
+            {
+                if (Settings.IdentityPinnedCastIdsActive)
+                    // T1: per-spell FIFO supersedes the single-slot recovery so concurrent
+                    // same-spell starts each retain their forwarded CastID in START order.
+                    GetSession().GameState.EnqueueForwardedStartCastId((uint)spell.Cast.SpellID, spell.Cast.CastID);
+                else
+                    GetSession().GameState.PlayerForwardedCastIds[(uint)spell.Cast.SpellID] = spell.Cast.CastID;
+            }
             SendPacketToClient(spell);
         }
 
@@ -1638,6 +1658,15 @@ public partial class WorldClient
             GetSession().GameState.TryDequeuePendingNormalCast((uint)spell.Cast.SpellID, out var pendingCast))
         {
             spell.Cast.CastID = pendingCast!.ServerGUID;
+            // T1 (identity-pinned): for a STARTED cast, stamp GO with the CastID recorded at
+            // SPELL_START (popped from the per-spell FIFO) instead of the dequeued entry's
+            // ServerGUID, so START↔GO pair even if the dequeue resolved a different concurrent
+            // same-spell entry. Skip-START instants (HasStarted=false, no FIFO entry) keep the
+            // dequeued ServerGUID. Belt-and-suspenders over #372's preferStarted dequeue: matches
+            // it in the common case, diverges only under concurrent same-spell starts.
+            if (Settings.IdentityPinnedCastIdsActive && pendingCast.HasStarted &&
+                GetSession().GameState.TryPopForwardedStartCastId(pendingCast.SpellId, out var pinnedGoCastId))
+                spell.Cast.CastID = pinnedGoCastId;
             spell.Cast.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
             // SoM-renumbered item: rewrite the legacy spell id back to the modern one the client expects.
             if (pendingCast.LegacySpellId != 0)
@@ -1792,6 +1821,24 @@ public partial class WorldClient
         // Hits server-initiated player casts with no CMSG (GO loot subspells e.g. Whipper
         // Root 15343, weapon/trinket procs) and casts whose pending entry was consumed by a
         // duplicate's CAST_FAILED before the GO (Blade Flurry, re-clicked gathers).
+        // JimsProxy (T1 identity-pinned cast correspondence): FIFO-backed promotion of the
+        // #362 recovery below to the primary path. When the GO has no pending entry (consumed by
+        // a duplicate's CAST_FAILED, or a server-initiated cast with no CMSG), recover the
+        // forwarded START CastID from the per-spell FIFO so START↔GO still pair. Supersedes the
+        // single-slot recovery (next branch) when active; the single-slot isn't populated then.
+        else if (Settings.IdentityPinnedCastIdsActive &&
+                 GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
+                 GetSession().GameState.TryPopForwardedStartCastId((uint)spell.Cast.SpellID, out var pinnedRecoverCastId))
+        {
+            spell.Cast.CastID = pinnedRecoverCastId;
+            Log.Event("cast.go.castid_recovered", new
+            {
+                spell_id = spell.Cast.SpellID,
+                caster_low = spell.Cast.CasterUnit.GetCounter(),
+                recovered_cast_id = pinnedRecoverCastId.ToString(),
+                pinned = true,
+            });
+        }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
                  GetSession().GameState.PlayerForwardedCastIds.TryRemove((uint)spell.Cast.SpellID, out var forwardedStartCastId))
         {

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -946,6 +946,16 @@ public partial class WorldClient
         if (!IsConnected() || _isSuccessful == false)
             return;
 
+        // JimsProxy (T1 guaranteed-closure companion): pump the cast watchdog on the keepalive
+        // tick so an orphaned cast (server sent no GO / CAST_FAILED / SPELL_FAILURE) still gets
+        // its synthetic closure when the player goes idle. The existing watchdog otherwise only
+        // runs on the next inbound spell packet, so a truly idle orphan leaks until the next cast.
+        // The 2.5s per-cast deadline and the eviction logic are unchanged — this only adds a pump
+        // cadence (≤ one keepalive interval late). Gated with the T1 bundle so OFF is byte-identical;
+        // RunWatchdogEviction is already invoked cross-thread and no-ops when nothing is overdue.
+        if (Framework.Settings.IdentityPinnedCastIdsActive)
+            GetSession()?.RunWatchdogEviction();
+
         // JimsProxy silent-stall watchdog: before sending the next keepalive
         // ping, check whether the legacy server has gone silent on us. The
         // existing reconnect path (HandleDisconnect / receive-loop catch)


### PR DESCRIPTION
## Summary
Opt-in, **default-OFF**. T1 of the cast-correspondence rewrite, built on #372. The 1.12 server strips the client CastID, so the proxy re-derives START↔terminating pairing by heuristics in several places; T1 makes it deterministic.

- **Identity-pinning (T1):** a per-spell **FIFO** of forwarded-START CastIDs replaces the single-slot store; `SMSG_SPELL_GO` / `SMSG_CAST_FAILED` / `SMSG_SPELL_FAILURE` and the watchdog's synthetic closure are stamped from it. Promotes #362's recovery from a last-ditch fallback to **the rule**; keeps #372's caller-aware dequeue as belt-and-suspenders.
- **Guaranteed closure:** the PR #161 watchdog now also fires on the 30s keepalive tick, so a cast the server never answered still gets its synthetic `CastFailed` when the player goes idle (2.5s deadline + eviction logic unchanged; only the pump cadence is added). Evicting a started cast releases its FIFO entry so the closure carries the right CastID.
- Gated behind `IdentityPinnedCastIds`, effective only under `LowLatencyMode`, default OFF -> the Hold-and-Fire path is **byte-identical** when off.

**Stacked on #372** (`claude/sad-cohen-0099c5`): this diff shows #372 + T1 until #372 merges, then narrows to T1. Draft until #372's beta telemetry confirms the desync funnel.

**Not included:** T2 (parallel forward) / T3 (local doomed-press reject) -- gated on #372's beta telemetry first.

## Honest calibration
Benefits are **UNCONFIRMED**. Post-#372, T1 is behaviorally ~ #372's `preferStarted` dequeue in the common case; its value is making the pairing *deterministic* (independent of the dequeue heuristic) and laying the T2 foundation -- not a confirmed new fix. Latency is not a justification here.

## Test plan
- [x] `dotnet build` clean; `dotnet test` **558 pass** (544 + 14 new)
- [x] New unit tests (`IdentityPinnedCastIdsTests`): FIFO START-order pairing, peek-vs-pop, remove-by-value, bounded depth, watchdog orphan closure + within-deadline, and the all-OFF gate regression guard
- [ ] Beta: enable `IdentityPinnedCastIds` under `LowLatencyMode`; confirm stuck-cast reports drop; watch `cast.go.castid_recovered pinned=true`, `cast.watchdog_evicted`, `cast.go.prefer_started`