### PR TITLE
Retract observed shooters' latched ranged-aim once they stop firing

### DIFF
--- a/HermesProxy.Tests/World/ObservedAutoRepeatTests.cs
+++ b/HermesProxy.Tests/World/ObservedAutoRepeatTests.cs
@@ -8,9 +8,10 @@ using Xunit;
 
 namespace HermesProxy.Tests.World;
 
-// JimsProxy (observed-bow retract): quiescence-sweep that lowers an observed shooter's latched
-// ranged-aim (Auto Shot 75 / wand Shoot 5019) by firing SMSG_CANCEL_AUTO_REPEAT once they stop.
-// The sweep clock is injected so the 3s quiet window is exercised deterministically with no waits.
+// JimsProxy (observed-bow retract): the retract that lowers an observed shooter's latched ranged-aim
+// (Auto Shot 75 / wand Shoot 5019) is driven by DETERMINISTIC stop edges — target death, shooter
+// death/move, retarget — instead of a time-based quiescence sweep. These cover the GameState tracking
+// the WorldClient packet handlers key off; no clock, so every case is synchronous.
 public class ObservedAutoRepeatTests
 {
     static ObservedAutoRepeatTests()
@@ -19,124 +20,191 @@ public class ObservedAutoRepeatTests
             global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
     }
 
-    private const long QuietMs = 4000;
     private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
     private static WowGuid128 Shooter(ulong counter) =>
         WowGuid128.Create(HighGuidType703.Creature, 0, 12345, counter);
+    private static WowGuid128 Mob(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 54321, counter);
 
     [Fact]
-    public void Sweep_FreshSession_ReturnsNothing()
+    public void TryEnd_FreshSession_ReturnsFalse()
     {
         var session = NewSession();
-        Assert.Empty(session.SweepObservedAutoRepeat(0));
+        Assert.False(session.TryEndObservedAutoRepeat(Shooter(1)));
     }
 
     [Fact]
-    public void Sweep_WithinQuietWindow_DoesNotExpire()
-    {
-        var session = NewSession();
-        var hunter = Shooter(1);
-        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
-
-        // Only 2.5s have passed — still actively shooting, keep the aim up.
-        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 10_000 + 2_500));
-    }
-
-    [Fact]
-    public void Sweep_PastQuietWindow_ExpiresAndReturnsShooter()
+    public void NoteThenStop_RetractsExactlyOnce()
     {
         var session = NewSession();
         var hunter = Shooter(1);
-        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
+        session.NoteObservedAutoRepeatActivity(hunter, Mob(1));
 
-        var expired = session.SweepObservedAutoRepeat(nowMs: 10_000 + QuietMs);
-
-        Assert.Single(expired);
-        Assert.Equal(hunter, expired[0]);
+        // First stop edge retracts; a second must not re-fire (one cancel per latch).
+        Assert.True(session.TryEndObservedAutoRepeat(hunter));
+        Assert.False(session.TryEndObservedAutoRepeat(hunter));
     }
 
     [Fact]
-    public void Sweep_AfterExpiry_IsIdempotent()
+    public void VictimDeath_RetractsEveryShooterAimedAtIt()
+    {
+        var session = NewSession();
+        var s1 = Shooter(1);
+        var s2 = Shooter(2);
+        var s3 = Shooter(3);
+        var mob = Mob(1);
+        session.NoteObservedAutoRepeatActivity(s1, mob);
+        session.NoteObservedAutoRepeatActivity(s2, mob);
+        session.NoteObservedAutoRepeatActivity(s3, Mob(2)); // aimed at a different mob
+
+        var retracted = session.EndObservedAutoRepeatForVictim(mob);
+
+        Assert.Equal(2, retracted.Count);
+        Assert.Contains(s1, retracted);
+        Assert.Contains(s2, retracted);
+        Assert.DoesNotContain(s3, retracted);
+        // s3 is still latched against the surviving mob.
+        Assert.True(session.TryEndObservedAutoRepeat(s3));
+    }
+
+    [Fact]
+    public void VictimDeath_UnrelatedVictim_RetractsNothingAndKeepsLatch()
     {
         var session = NewSession();
         var hunter = Shooter(1);
-        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
+        session.NoteObservedAutoRepeatActivity(hunter, Mob(1));
 
-        Assert.Single(session.SweepObservedAutoRepeat(nowMs: 100_000));
-        // Already removed — a second sweep must not re-fire a cancel for the same shooter.
-        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 200_000));
+        Assert.Empty(session.EndObservedAutoRepeatForVictim(Mob(2)));
+        // Untouched — still latched.
+        Assert.True(session.TryEndObservedAutoRepeat(hunter));
     }
 
     [Fact]
-    public void Sweep_PerShooter_OnlyExpiresTheQuietOne()
+    public void TargetChange_ToDifferentUnit_Retracts()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivity(hunter, Mob(1));
+
+        Assert.True(session.TryEndObservedAutoRepeatOnTargetChange(hunter, Mob(2)));
+        // Removed by the retract — a following stop edge is a no-op.
+        Assert.False(session.TryEndObservedAutoRepeat(hunter));
+    }
+
+    [Fact]
+    public void TargetChange_ToClearedTarget_Retracts()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivity(hunter, Mob(1));
+
+        Assert.True(session.TryEndObservedAutoRepeatOnTargetChange(hunter, WowGuid128.Empty));
+    }
+
+    [Fact]
+    public void TargetChange_SameTarget_DoesNotRetract()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        var mob = Mob(1);
+        session.NoteObservedAutoRepeatActivity(hunter, mob);
+
+        // A redundant UNIT_FIELD_TARGET update for the same mob must NOT lower a still-firing bow.
+        Assert.False(session.TryEndObservedAutoRepeatOnTargetChange(hunter, mob));
+        // Still latched.
+        Assert.True(session.TryEndObservedAutoRepeat(hunter));
+    }
+
+    [Fact]
+    public void TargetChange_UntrackedShooter_DoesNotRetract()
+    {
+        var session = NewSession();
+        // No latch for this shooter — a target change must not synthesize a phantom cancel.
+        Assert.False(session.TryEndObservedAutoRepeatOnTargetChange(Shooter(1), Mob(1)));
+    }
+
+    [Fact]
+    public void Note_RefreshesTarget_DeathMatchesTheLatestMob()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivity(hunter, Mob(1));
+        // Mid-series retarget: the next shot lands on a new mob, refreshing the cached target.
+        session.NoteObservedAutoRepeatActivity(hunter, Mob(2));
+
+        // The OLD target dying no longer matches.
+        Assert.Empty(session.EndObservedAutoRepeatForVictim(Mob(1)));
+        // The CURRENT target dying retracts.
+        Assert.Contains(hunter, session.EndObservedAutoRepeatForVictim(Mob(2)));
+    }
+
+    [Fact]
+    public void PerShooter_StoppingOneKeepsTheOther()
     {
         var session = NewSession();
         var stopped = Shooter(1);
-        var stillShooting = Shooter(2);
-        session.NoteObservedAutoRepeatActivityForTest(stopped, nowMs: 10_000);
-        session.NoteObservedAutoRepeatActivityForTest(stillShooting, nowMs: 12_500);
+        var firing = Shooter(2);
+        var mob = Mob(1);
+        session.NoteObservedAutoRepeatActivity(stopped, mob);
+        session.NoteObservedAutoRepeatActivity(firing, mob);
 
-        // At t=14_100: 'stopped' has been quiet 4.1s (expire); 'stillShooting' only 1.6s (keep).
-        var expired = session.SweepObservedAutoRepeat(nowMs: 14_100);
-
-        Assert.Single(expired);
-        Assert.Equal(stopped, expired[0]);
-        // The active shooter is still tracked, so a later quiet sweep still catches it.
-        Assert.Contains(stillShooting, session.SweepObservedAutoRepeat(nowMs: 20_000));
+        Assert.True(session.TryEndObservedAutoRepeat(stopped));
+        // The other shooter is untouched.
+        Assert.True(session.TryEndObservedAutoRepeat(firing));
     }
 
     [Fact]
-    public void Note_RefreshesTimestamp_KeepsAimAliveAcrossSlowCadence()
+    public void ClearAll_DropsAllTracking()
     {
         var session = NewSession();
-        var hunter = Shooter(1);
-        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
-        // A second shot lands at t=13_500 (3.5s later) — still one series, refresh the clock.
-        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 13_500);
-
-        // t=14_000 is a full quiet-window after the FIRST shot (would expire without the refresh)
-        // but only 0.5s after the second — the refresh keeps the aim up.
-        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 14_000));
-        // A full quiet-window after the SECOND shot — now the series is genuinely over.
-        Assert.Single(session.SweepObservedAutoRepeat(nowMs: 13_500 + QuietMs));
-    }
-
-    [Fact]
-    public void ClearAll_DropsTrackingAndUnbindsCallback()
-    {
-        var session = NewSession();
-        session.OnObservedAutoRepeatExpire = _ => { };
-        session.NoteObservedAutoRepeatActivityForTest(Shooter(1), nowMs: 10_000);
+        session.NoteObservedAutoRepeatActivity(Shooter(1), Mob(1));
+        session.NoteObservedAutoRepeatActivity(Shooter(2), Mob(1));
 
         session.ClearAllObservedAutoRepeat();
 
-        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 100_000));
-        Assert.Null(session.OnObservedAutoRepeatExpire);
+        Assert.False(session.TryEndObservedAutoRepeat(Shooter(1)));
+        Assert.False(session.TryEndObservedAutoRepeat(Shooter(2)));
     }
 
     [Fact]
     public void ResetInFlightCastState_ClearsObservedAutoRepeat()
     {
         var session = NewSession();
-        session.NoteObservedAutoRepeatActivityForTest(Shooter(1), nowMs: 10_000);
+        session.NoteObservedAutoRepeatActivity(Shooter(1), Mob(1));
 
         session.ResetInFlightCastState();
 
-        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 100_000));
+        Assert.False(session.TryEndObservedAutoRepeat(Shooter(1)));
     }
 
+    // Quiescence catch-all: a shooter that stops with its target still alive and stands still (out of
+    // ammo, /stopattack, LoS, target dummy) is covered by NO edge, so the sweep must retract it once it
+    // goes quiet past the threshold — and never before.
     [Fact]
-    public void Note_RealClockPath_RecordsAndExpires()
+    public void Sweep_QuietShooter_RetractsAfterThreshold()
     {
         var session = NewSession();
         var hunter = Shooter(1);
-        // Exercise the production entry point (stamps Environment.TickCount64, arms the timer).
-        session.NoteObservedAutoRepeatActivity(hunter);
+        session.NoteObservedAutoRepeatActivityForTest(hunter, Mob(1), nowMs: 0);
 
-        // A sweep far in the future relative to "now" must expire the just-recorded shot.
-        var expired = session.SweepObservedAutoRepeat(Environment.TickCount64 + 100_000);
+        // Still within the cadence window — a steady shooter must not flicker.
+        Assert.Empty(session.SweepObservedAutoRepeat(3999));
+        // Past the quiet threshold — the series ended, lower the bow.
+        Assert.Contains(hunter, session.SweepObservedAutoRepeat(4000));
+        // Removed by the sweep — a second sweep is a no-op.
+        Assert.Empty(session.SweepObservedAutoRepeat(10000));
+    }
 
-        Assert.Contains(hunter, expired);
-        session.ClearAllObservedAutoRepeat(); // dispose the real timer this test armed
+    [Fact]
+    public void Sweep_LatestShotRefreshesQuietWindow()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivityForTest(hunter, Mob(1), nowMs: 0);
+        // A fresh shot at t=3000 pushes the quiet deadline out to 7000.
+        session.NoteObservedAutoRepeatActivityForTest(hunter, Mob(1), nowMs: 3000);
+
+        Assert.Empty(session.SweepObservedAutoRepeat(6999));
+        Assert.Contains(hunter, session.SweepObservedAutoRepeat(7000));
     }
 }

--- a/HermesProxy.Tests/World/ObservedAutoRepeatTests.cs
+++ b/HermesProxy.Tests/World/ObservedAutoRepeatTests.cs
@@ -1,0 +1,142 @@
+using System;
+using HermesProxy;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (observed-bow retract): quiescence-sweep that lowers an observed shooter's latched
+// ranged-aim (Auto Shot 75 / wand Shoot 5019) by firing SMSG_CANCEL_AUTO_REPEAT once they stop.
+// The sweep clock is injected so the 3s quiet window is exercised deterministically with no waits.
+public class ObservedAutoRepeatTests
+{
+    static ObservedAutoRepeatTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    private const long QuietMs = 4000;
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+    private static WowGuid128 Shooter(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 12345, counter);
+
+    [Fact]
+    public void Sweep_FreshSession_ReturnsNothing()
+    {
+        var session = NewSession();
+        Assert.Empty(session.SweepObservedAutoRepeat(0));
+    }
+
+    [Fact]
+    public void Sweep_WithinQuietWindow_DoesNotExpire()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
+
+        // Only 2.5s have passed — still actively shooting, keep the aim up.
+        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 10_000 + 2_500));
+    }
+
+    [Fact]
+    public void Sweep_PastQuietWindow_ExpiresAndReturnsShooter()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
+
+        var expired = session.SweepObservedAutoRepeat(nowMs: 10_000 + QuietMs);
+
+        Assert.Single(expired);
+        Assert.Equal(hunter, expired[0]);
+    }
+
+    [Fact]
+    public void Sweep_AfterExpiry_IsIdempotent()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
+
+        Assert.Single(session.SweepObservedAutoRepeat(nowMs: 100_000));
+        // Already removed — a second sweep must not re-fire a cancel for the same shooter.
+        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 200_000));
+    }
+
+    [Fact]
+    public void Sweep_PerShooter_OnlyExpiresTheQuietOne()
+    {
+        var session = NewSession();
+        var stopped = Shooter(1);
+        var stillShooting = Shooter(2);
+        session.NoteObservedAutoRepeatActivityForTest(stopped, nowMs: 10_000);
+        session.NoteObservedAutoRepeatActivityForTest(stillShooting, nowMs: 12_500);
+
+        // At t=14_100: 'stopped' has been quiet 4.1s (expire); 'stillShooting' only 1.6s (keep).
+        var expired = session.SweepObservedAutoRepeat(nowMs: 14_100);
+
+        Assert.Single(expired);
+        Assert.Equal(stopped, expired[0]);
+        // The active shooter is still tracked, so a later quiet sweep still catches it.
+        Assert.Contains(stillShooting, session.SweepObservedAutoRepeat(nowMs: 20_000));
+    }
+
+    [Fact]
+    public void Note_RefreshesTimestamp_KeepsAimAliveAcrossSlowCadence()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 10_000);
+        // A second shot lands at t=13_500 (3.5s later) — still one series, refresh the clock.
+        session.NoteObservedAutoRepeatActivityForTest(hunter, nowMs: 13_500);
+
+        // t=14_000 is a full quiet-window after the FIRST shot (would expire without the refresh)
+        // but only 0.5s after the second — the refresh keeps the aim up.
+        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 14_000));
+        // A full quiet-window after the SECOND shot — now the series is genuinely over.
+        Assert.Single(session.SweepObservedAutoRepeat(nowMs: 13_500 + QuietMs));
+    }
+
+    [Fact]
+    public void ClearAll_DropsTrackingAndUnbindsCallback()
+    {
+        var session = NewSession();
+        session.OnObservedAutoRepeatExpire = _ => { };
+        session.NoteObservedAutoRepeatActivityForTest(Shooter(1), nowMs: 10_000);
+
+        session.ClearAllObservedAutoRepeat();
+
+        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 100_000));
+        Assert.Null(session.OnObservedAutoRepeatExpire);
+    }
+
+    [Fact]
+    public void ResetInFlightCastState_ClearsObservedAutoRepeat()
+    {
+        var session = NewSession();
+        session.NoteObservedAutoRepeatActivityForTest(Shooter(1), nowMs: 10_000);
+
+        session.ResetInFlightCastState();
+
+        Assert.Empty(session.SweepObservedAutoRepeat(nowMs: 100_000));
+    }
+
+    [Fact]
+    public void Note_RealClockPath_RecordsAndExpires()
+    {
+        var session = NewSession();
+        var hunter = Shooter(1);
+        // Exercise the production entry point (stamps Environment.TickCount64, arms the timer).
+        session.NoteObservedAutoRepeatActivity(hunter);
+
+        // A sweep far in the future relative to "now" must expire the just-recorded shot.
+        var expired = session.SweepObservedAutoRepeat(Environment.TickCount64 + 100_000);
+
+        Assert.Contains(hunter, expired);
+        session.ClearAllObservedAutoRepeat(); // dispose the real timer this test armed
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -400,6 +400,14 @@ public sealed class GameSessionData
     private uint _lastFiredSpellId;                     // spell ID forwarded by the timer; used to drop same-spell late presses
     public Action<ClientCastRequest>? OnGcdHeldCastFire; // set by WorldSocket at attach time; invoked on a ThreadPool thread at GCD expiry
 
+    // JimsProxy (observed-bow retract): an observed (non-local) unit auto-repeating — Auto Shot 75 / wand Shoot 5019 — latches the 1.14 client's intrinsic ranged-aim the moment we forward its SPELL_START, and vanilla never broadcasts a stop for other units, so once the shooter quits nothing lowers the weapon (your own char is fine — SMSG_SPELL_FAILURE retracts the local aim). Track last-shot time per shooter; a 500ms sweep fires SMSG_CANCEL_AUTO_REPEAT carrying THAT unit's GUID once it goes quiet past ObservedAutoRepeatQuietMs (the modern packet is per-GUID; the legacy SMSG_CANCEL_AUTO_REPEAT handler only ever cancels the local player). Refreshed on every shot so it never fires mid-series; a premature fire self-heals — the next shot's START re-raises the aim.
+    private readonly object _observedAutoRepeatLock = new();
+    private readonly Dictionary<WowGuid128, long> _observedAutoRepeatLastShotMs = new();
+    private Timer? _observedAutoRepeatSweepTimer;
+    public Action<WowGuid128>? OnObservedAutoRepeatExpire; // set by WorldClient; invoked on a ThreadPool thread per quiesced shooter
+    private const long ObservedAutoRepeatQuietMs = 4000;   // no shot for this long => series ended, lower the weapon (above slowest ~3.0s bow cadence + jitter so a steady shooter never flickers)
+    private const long ObservedAutoRepeatSweepTickMs = 500;
+
     // JimsProxy: cast-time spell queue. While a cast-time spell is in progress
     // (HasStartedNormalCast), presses are held here instead of dropped. Fired
     // on SPELL_GO when the cast completes. Most-recent-press-wins, one slot.
@@ -1814,6 +1822,7 @@ public sealed class GameSessionData
         // path that normally nulls it.
         CurrentClientNextMeleeCast = null;
         CurrentClientAutoRepeatCast = null;
+        ClearAllObservedAutoRepeat();
         return (normalCount, petCount, otherCount);
     }
 
@@ -2037,6 +2046,66 @@ public sealed class GameSessionData
         }
         if (toFire != null)
             OnGcdHeldCastFire?.Invoke(toFire);
+    }
+
+    // JimsProxy (observed-bow retract): record a shot from an observed auto-repeat shooter and lazily arm the 500ms quiescence sweep. SweepObservedAutoRepeat self-disarms the timer once the table empties.
+    public void NoteObservedAutoRepeatActivity(WowGuid128 shooter)
+    {
+        lock (_observedAutoRepeatLock)
+        {
+            _observedAutoRepeatLastShotMs[shooter] = Environment.TickCount64;
+            _observedAutoRepeatSweepTimer ??= new Timer(OnObservedAutoRepeatSweepTick, null, ObservedAutoRepeatSweepTickMs, ObservedAutoRepeatSweepTickMs);
+        }
+    }
+
+    // Test seam: record a shot at an injected timestamp without arming the real background timer (which runs on Environment.TickCount64 and would race injected-clock sweeps).
+    internal void NoteObservedAutoRepeatActivityForTest(WowGuid128 shooter, long nowMs)
+    {
+        lock (_observedAutoRepeatLock)
+            _observedAutoRepeatLastShotMs[shooter] = nowMs;
+    }
+
+    private void OnObservedAutoRepeatSweepTick(object? state)
+    {
+        // Invoke the cancel callback outside the lock (mirrors OnGcdTimerElapsed) so the off-thread SendPacketToClient never runs under _observedAutoRepeatLock.
+        foreach (var shooter in SweepObservedAutoRepeat(Environment.TickCount64))
+        {
+            // A sweep landing during session teardown must never surface an unhandled exception on the ThreadPool (would crash the process); the aim is moot once disconnected.
+            try { OnObservedAutoRepeatExpire?.Invoke(shooter); }
+            catch { }
+        }
+    }
+
+    // JimsProxy (observed-bow retract): remove and return shooters quiet past ObservedAutoRepeatQuietMs; disposes the sweep timer once the table empties so it self-disarms. Internal + injectable clock for deterministic tests.
+    internal List<WowGuid128> SweepObservedAutoRepeat(long nowMs)
+    {
+        var expired = new List<WowGuid128>();
+        lock (_observedAutoRepeatLock)
+        {
+            foreach (var kvp in _observedAutoRepeatLastShotMs)
+                if (nowMs - kvp.Value >= ObservedAutoRepeatQuietMs)
+                    expired.Add(kvp.Key);
+            foreach (var shooter in expired)
+                _observedAutoRepeatLastShotMs.Remove(shooter);
+            if (_observedAutoRepeatLastShotMs.Count == 0)
+            {
+                _observedAutoRepeatSweepTimer?.Dispose();
+                _observedAutoRepeatSweepTimer = null;
+            }
+        }
+        return expired;
+    }
+
+    // JimsProxy (observed-bow retract): drop all observed auto-repeat tracking, disarm the sweep, and unbind the cancel callback so a post-reconnect shot re-binds it to the live WorldClient. Called from ResetInFlightCastState alongside the other auto-repeat trackers.
+    public void ClearAllObservedAutoRepeat()
+    {
+        lock (_observedAutoRepeatLock)
+        {
+            _observedAutoRepeatLastShotMs.Clear();
+            _observedAutoRepeatSweepTimer?.Dispose();
+            _observedAutoRepeatSweepTimer = null;
+            OnObservedAutoRepeatExpire = null;
+        }
     }
 
     /// <summary>

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -400,13 +400,21 @@ public sealed class GameSessionData
     private uint _lastFiredSpellId;                     // spell ID forwarded by the timer; used to drop same-spell late presses
     public Action<ClientCastRequest>? OnGcdHeldCastFire; // set by WorldSocket at attach time; invoked on a ThreadPool thread at GCD expiry
 
-    // JimsProxy (observed-bow retract): an observed (non-local) unit auto-repeating — Auto Shot 75 / wand Shoot 5019 — latches the 1.14 client's intrinsic ranged-aim the moment we forward its SPELL_START, and vanilla never broadcasts a stop for other units, so once the shooter quits nothing lowers the weapon (your own char is fine — SMSG_SPELL_FAILURE retracts the local aim). Track last-shot time per shooter; a 500ms sweep fires SMSG_CANCEL_AUTO_REPEAT carrying THAT unit's GUID once it goes quiet past ObservedAutoRepeatQuietMs (the modern packet is per-GUID; the legacy SMSG_CANCEL_AUTO_REPEAT handler only ever cancels the local player). Refreshed on every shot so it never fires mid-series; a premature fire self-heals — the next shot's START re-raises the aim.
+    // JimsProxy (observed-bow retract): an observed (non-local) unit auto-repeating — Auto Shot 75 / wand Shoot 5019 — latches the 1.14 client's intrinsic ranged-aim the moment we forward its SPELL_START, and vanilla never broadcasts a stop for other units, so once the shooter quits nothing lowers the weapon (your own char is fine — SMSG_SPELL_FAILURE retracts the local aim). Hybrid retract: DETERMINISTIC stop edges — the target dies (PARTY_KILL_LOG / health->0), or the shooter itself dies, moves, or retargets — lower the bow instantly, AND a quiescence timer is the catch-all for the case no edge covers: the shooter stops with its target still alive and stands still (out of ammo, /stopattack, LoS, target dummy). Each latched shooter tracks its current target (for the death/retarget edges) and its last-shot time (for the sweep). The sweep fires SMSG_CANCEL_AUTO_REPEAT carrying THAT unit's GUID once it goes quiet past ObservedAutoRepeatQuietMs (the modern packet is per-GUID; the legacy handler only ever cancels the local player); the threshold sits above the slowest bow cadence + jitter so a steady shooter never flickers, and a premature retract self-heals — the next shot's START re-raises the aim.
     private readonly object _observedAutoRepeatLock = new();
-    private readonly Dictionary<WowGuid128, long> _observedAutoRepeatLastShotMs = new();
+    private readonly Dictionary<WowGuid128, ObservedShooterState> _observedShooterTargets = new();
     private Timer? _observedAutoRepeatSweepTimer;
-    public Action<WowGuid128>? OnObservedAutoRepeatExpire; // set by WorldClient; invoked on a ThreadPool thread per quiesced shooter
+    public Action<WowGuid128>? OnObservedAutoRepeatExpire; // set by WorldClient; invoked on a ThreadPool thread per quiesced shooter (also gates the timer — null in tests, so no real timer is armed)
     private const long ObservedAutoRepeatQuietMs = 4000;   // no shot for this long => series ended, lower the weapon (above slowest ~3.0s bow cadence + jitter so a steady shooter never flickers)
     private const long ObservedAutoRepeatSweepTickMs = 500;
+
+    // JimsProxy (observed-bow retract): per-shooter latch state — the unit it's shooting (death/retarget edges match on it) and its last-shot time (the quiescence sweep retracts once this goes stale).
+    private readonly struct ObservedShooterState
+    {
+        public readonly WowGuid128 Target;
+        public readonly long LastShotMs;
+        public ObservedShooterState(WowGuid128 target, long lastShotMs) { Target = target; LastShotMs = lastShotMs; }
+    }
 
     // JimsProxy: cast-time spell queue. While a cast-time spell is in progress
     // (HasStartedNormalCast), presses are held here instead of dropped. Fired
@@ -2048,21 +2056,58 @@ public sealed class GameSessionData
             OnGcdHeldCastFire?.Invoke(toFire);
     }
 
-    // JimsProxy (observed-bow retract): record a shot from an observed auto-repeat shooter and lazily arm the 500ms quiescence sweep. SweepObservedAutoRepeat self-disarms the timer once the table empties.
-    public void NoteObservedAutoRepeatActivity(WowGuid128 shooter)
+    // JimsProxy (observed-bow retract): mark an observed shooter latched (we forwarded its auto-repeat aim), cache the unit it's shooting (refreshed each shot so a mid-series retarget updates the death-match key) and stamp the shot time, then lazily arm the quiescence sweep. The timer is armed only when OnObservedAutoRepeatExpire is bound (production WorldClient) — null in tests, so the suite never spins a real timer; the deterministic edges run regardless.
+    public void NoteObservedAutoRepeatActivity(WowGuid128 shooter, WowGuid128 target)
     {
         lock (_observedAutoRepeatLock)
         {
-            _observedAutoRepeatLastShotMs[shooter] = Environment.TickCount64;
-            _observedAutoRepeatSweepTimer ??= new Timer(OnObservedAutoRepeatSweepTick, null, ObservedAutoRepeatSweepTickMs, ObservedAutoRepeatSweepTickMs);
+            _observedShooterTargets[shooter] = new ObservedShooterState(target, Environment.TickCount64);
+            if (OnObservedAutoRepeatExpire != null)
+                _observedAutoRepeatSweepTimer ??= new Timer(OnObservedAutoRepeatSweepTick, null, ObservedAutoRepeatSweepTickMs, ObservedAutoRepeatSweepTickMs);
         }
     }
 
-    // Test seam: record a shot at an injected timestamp without arming the real background timer (which runs on Environment.TickCount64 and would race injected-clock sweeps).
-    internal void NoteObservedAutoRepeatActivityForTest(WowGuid128 shooter, long nowMs)
+    // Test seam: latch a shooter at an injected timestamp without arming the real background timer (which runs on Environment.TickCount64 and would race injected-clock sweeps).
+    internal void NoteObservedAutoRepeatActivityForTest(WowGuid128 shooter, WowGuid128 target, long nowMs)
     {
         lock (_observedAutoRepeatLock)
-            _observedAutoRepeatLastShotMs[shooter] = nowMs;
+            _observedShooterTargets[shooter] = new ObservedShooterState(target, nowMs);
+    }
+
+    // JimsProxy (observed-bow retract): a deterministic stop edge for one shooter (it moved or died, or we're tearing down) — drop the latch and report whether it WAS latched so the caller sends exactly one SMSG_CANCEL_AUTO_REPEAT.
+    public bool TryEndObservedAutoRepeat(WowGuid128 shooter)
+    {
+        lock (_observedAutoRepeatLock)
+            return _observedShooterTargets.Remove(shooter);
+    }
+
+    // JimsProxy (observed-bow retract): the shooter's UNIT_FIELD_TARGET changed — if it's latched and now aimed elsewhere (or cleared), the prior series ended, so drop the latch and report it for retract. A still-firing retarget self-heals on the next shot's START.
+    public bool TryEndObservedAutoRepeatOnTargetChange(WowGuid128 shooter, WowGuid128 newTarget)
+    {
+        lock (_observedAutoRepeatLock)
+        {
+            if (_observedShooterTargets.TryGetValue(shooter, out var cached) && cached.Target != newTarget)
+            {
+                _observedShooterTargets.Remove(shooter);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    // JimsProxy (observed-bow retract): a unit died (PARTY_KILL_LOG victim or health->0) — collect and drop every observed shooter aimed at it so the caller retracts each. Terminal-proof: a corpse can't be shot, so the retract can never be contradicted.
+    public List<WowGuid128> EndObservedAutoRepeatForVictim(WowGuid128 victim)
+    {
+        var hit = new List<WowGuid128>();
+        lock (_observedAutoRepeatLock)
+        {
+            foreach (var kvp in _observedShooterTargets)
+                if (kvp.Value.Target == victim)
+                    hit.Add(kvp.Key);
+            foreach (var shooter in hit)
+                _observedShooterTargets.Remove(shooter);
+        }
+        return hit;
     }
 
     private void OnObservedAutoRepeatSweepTick(object? state)
@@ -2076,18 +2121,18 @@ public sealed class GameSessionData
         }
     }
 
-    // JimsProxy (observed-bow retract): remove and return shooters quiet past ObservedAutoRepeatQuietMs; disposes the sweep timer once the table empties so it self-disarms. Internal + injectable clock for deterministic tests.
+    // JimsProxy (observed-bow retract): the quiescence catch-all — remove and return shooters quiet past ObservedAutoRepeatQuietMs (no edge covered their stop: out of ammo, /stopattack, LoS, target dummy), and dispose the sweep timer once the table empties so it self-disarms. Internal + injectable clock for deterministic tests.
     internal List<WowGuid128> SweepObservedAutoRepeat(long nowMs)
     {
         var expired = new List<WowGuid128>();
         lock (_observedAutoRepeatLock)
         {
-            foreach (var kvp in _observedAutoRepeatLastShotMs)
-                if (nowMs - kvp.Value >= ObservedAutoRepeatQuietMs)
+            foreach (var kvp in _observedShooterTargets)
+                if (nowMs - kvp.Value.LastShotMs >= ObservedAutoRepeatQuietMs)
                     expired.Add(kvp.Key);
             foreach (var shooter in expired)
-                _observedAutoRepeatLastShotMs.Remove(shooter);
-            if (_observedAutoRepeatLastShotMs.Count == 0)
+                _observedShooterTargets.Remove(shooter);
+            if (_observedShooterTargets.Count == 0)
             {
                 _observedAutoRepeatSweepTimer?.Dispose();
                 _observedAutoRepeatSweepTimer = null;
@@ -2096,12 +2141,12 @@ public sealed class GameSessionData
         return expired;
     }
 
-    // JimsProxy (observed-bow retract): drop all observed auto-repeat tracking, disarm the sweep, and unbind the cancel callback so a post-reconnect shot re-binds it to the live WorldClient. Called from ResetInFlightCastState alongside the other auto-repeat trackers.
+    // JimsProxy (observed-bow retract): drop all observed auto-repeat tracking on reconnect, disarm the sweep, and unbind the cancel callback so a post-reconnect shot re-binds it to the live WorldClient. Called from ResetInFlightCastState alongside the other auto-repeat trackers.
     public void ClearAllObservedAutoRepeat()
     {
         lock (_observedAutoRepeatLock)
         {
-            _observedAutoRepeatLastShotMs.Clear();
+            _observedShooterTargets.Clear();
             _observedAutoRepeatSweepTimer?.Dispose();
             _observedAutoRepeatSweepTimer = null;
             OnObservedAutoRepeatExpire = null;

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -244,5 +244,8 @@ public partial class WorldClient
         // client's threat APIs go quiet on this unit instead of waiting for
         // the corpse-despawn SMSG_DESTROY_OBJECT.
         GetSession().ThreatTracker.ClearMob(log.Victim);
+
+        // JimsProxy (observed-bow retract): the victim's death is a terminal stop edge — lower the bow of any observed shooter aimed at it (a corpse can't be shot, so this can't be contradicted).
+        RetractObservedShootersOnUnitDeath(log.Victim);
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -118,6 +118,12 @@ public partial class WorldClient
     {
         MoveUpdate moveUpdate = new MoveUpdate();
         moveUpdate.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
+        // JimsProxy (observed-bow retract): a unit physically moving stops its auto-repeat server-side — lower a latched observed shooter's bow on a translational-start move (excludes the local player; turn/facing/heartbeat/stop are not stop edges). A still-firing shooter that briefly steps self-heals on its next shot's START.
+        if (moveUpdate.MoverGUID != GetSession().GameState.CurrentPlayerGuid &&
+            IsAutoRepeatStoppingMove(packet.GetUniversalOpcode(false)))
+        {
+            RetractObservedShooterOnStop(moveUpdate.MoverGUID);
+        }
         moveUpdate.MoveInfo = new();
         moveUpdate.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
         ApplyHoverOverrideIfNeeded(moveUpdate.MoverGUID, moveUpdate.MoveInfo);
@@ -128,6 +134,18 @@ public partial class WorldClient
         moveUpdate.MoveInfo.ValidateMovementInfo();
         SendPacketToClient(moveUpdate);
     }
+
+    // JimsProxy (observed-bow retract): translational-start moves mean the mover left its firing stance (auto-shot requires standing still); turn/facing/heartbeat/stop are excluded so a shooter that only turns to track its target isn't falsely retracted.
+    private static bool IsAutoRepeatStoppingMove(Opcode op) => op switch
+    {
+        Opcode.MSG_MOVE_START_FORWARD or
+        Opcode.MSG_MOVE_START_BACKWARD or
+        Opcode.MSG_MOVE_START_STRAFE_LEFT or
+        Opcode.MSG_MOVE_START_STRAFE_RIGHT or
+        Opcode.MSG_MOVE_JUMP or
+        Opcode.MSG_MOVE_START_SWIM => true,
+        _ => false,
+    };
 
     [PacketHandler(Opcode.MSG_MOVE_KNOCK_BACK)]
     void HandleMoveKnockBack(WorldPacket packet)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1234,15 +1234,37 @@ public partial class WorldClient
     // JimsProxy (observed-bow): forwarding an observed ranged auto-repeat SPELL_START (Auto Shot/Shoot) latches the 1.14 client's intrinsic auto-repeat aim (spell 75 = SPELL_ATTR2_AUTO_REPEAT, no client SpellVisual) and nothing retracts it for observers (SPELL_GO / SPELL_FAILURE / SPELL_FAILED_OTHER / CANCEL_AUTO_REPEAT / a SheatheState push were all verified non-working in-client — SheatheState only stows the weapon, leaving the arms locked in the aim). So we hold each observed auto-repeat START here and replay it paired with its SPELL_GO (HandleSpellGo) only when the shot fires — the draw shows for shots that fire, and a shot that aborts (no GO) is never forwarded, so it can't stick. Held per caster; touched only on the WorldClient ReceiveLoop (HandleSpellStart/Go), so no lock needed.
     private readonly Dictionary<WowGuid128, SpellStart> _pendingObservedAutoRepeatStart = new();
 
-    // JimsProxy (observed-bow retract): lower an observed shooter's latched ranged-aim by synthesizing SMSG_CANCEL_AUTO_REPEAT with THAT unit's GUID (the legacy handler only ever cancels the local player, and vanilla never broadcasts a stop for other units). Invoked off the WorldClient ReceiveLoop on the quiescence sweep's ThreadPool thread; SendPacketToClient is already used off-thread (taxi/GCD), so this is safe.
+    // JimsProxy (observed-bow retract): lower an observed shooter's latched ranged-aim by synthesizing SMSG_CANCEL_AUTO_REPEAT with THAT unit's GUID (the legacy handler only ever cancels the local player, and vanilla never broadcasts a stop for other units). Driven both from deterministic stop edges on the WorldClient ReceiveLoop (target death / shooter death / move / retarget) and from the quiescence sweep's ThreadPool thread; SendPacketToClient is already used off-thread (taxi/GCD), so this is safe.
     private void SendObservedAutoRepeatCancel(WowGuid128 shooter)
     {
-        // Runs on the sweep's ThreadPool thread; if the session is mid-teardown, skip rather than block in SendPacketToClient's wait-for-instance loop — the aim is moot once disconnected.
+        // If the session is mid-teardown skip rather than block in SendPacketToClient's wait-for-instance loop — the aim is moot once disconnected.
         if (GetSession().InstanceSocket == null || !GetSession().GameState.IsConnectedToInstance)
             return;
         SendPacketToClient(new CancelAutoRepeat { Guid = shooter });
         if (Framework.Settings.DebugOutput)
             Log.Event("ranged.auto_repeat.remote_cancel", new { caster_low = shooter.GetCounter() });
+    }
+
+    // JimsProxy (observed-bow retract): a shooter stopped firing in place (moved) or died — lower its bow if it was latched. One dict remove => exactly one cancel.
+    private void RetractObservedShooterOnStop(WowGuid128 shooter)
+    {
+        if (GetSession().GameState.TryEndObservedAutoRepeat(shooter))
+            SendObservedAutoRepeatCancel(shooter);
+    }
+
+    // JimsProxy (observed-bow retract): the shooter switched or cleared its target — the prior auto-repeat series ended; retract if it was latched and the target actually changed.
+    private void RetractObservedShooterOnTargetChange(WowGuid128 shooter, WowGuid128 newTarget)
+    {
+        if (GetSession().GameState.TryEndObservedAutoRepeatOnTargetChange(shooter, newTarget))
+            SendObservedAutoRepeatCancel(shooter);
+    }
+
+    // JimsProxy (observed-bow retract): a unit died — retract every observed shooter aimed at it (terminal-proof), plus the dead unit itself if it was a shooter.
+    private void RetractObservedShootersOnUnitDeath(WowGuid128 victim)
+    {
+        foreach (var shooter in GetSession().GameState.EndObservedAutoRepeatForVictim(victim))
+            SendObservedAutoRepeatCancel(shooter);
+        RetractObservedShooterOnStop(victim);
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_START)]
@@ -1804,7 +1826,7 @@ public partial class WorldClient
             spell.Cast.CasterUnit = stunTarget;
         }
 
-        // JimsProxy (observed-bow): replay this observed caster's held auto-repeat START now, paired to this GO (CastID-matched) so the client renders a complete draw+fire, and note the shot so the quiescence sweep can lower the weapon once the series ends. A held START whose GO never arrives is never forwarded, so it can't latch the aim.
+        // JimsProxy (observed-bow): replay this observed caster's held auto-repeat START now, paired to this GO (CastID-matched) so the client renders a complete draw+fire, and latch the shooter against its target so a deterministic stop edge can lower the weapon. A held START whose GO never arrives is never forwarded, so it can't latch the aim.
         if (spell.Cast.CasterUnit != GetSession().GameState.CurrentPlayerGuid
             && spell.Cast.CasterUnit != GetSession().GameState.CurrentPetGuid
             && GameData.AutoRepeatSpells.Contains((uint)spell.Cast.SpellID))
@@ -1816,9 +1838,14 @@ public partial class WorldClient
                 if (Framework.Settings.DebugOutput)
                     Log.Event("ranged.auto_repeat.start_replayed", new { caster_low = spell.Cast.CasterUnit.GetCounter(), spell_id = spell.Cast.SpellID });
             }
-            // Track every observed shot (replayed START or bare tick GO); the sweep fires SMSG_CANCEL_AUTO_REPEAT for this shooter once it goes quiet, so the aim doesn't stay latched after they stop. Callback bound lazily to this live WorldClient (mirrors OnGcdHeldCastFire).
+            // Latch the shooter against the unit it's shooting (explicit target, else the hit/miss target) so target-death retracts it; refreshed each shot so a mid-series retarget updates the death-match key. Every observed shot re-latches (replayed START or bare tick GO).
+            WowGuid128 shotTarget = !spell.Cast.Target.Unit.IsEmpty() ? spell.Cast.Target.Unit
+                : spell.Cast.HitTargets.Count > 0 ? spell.Cast.HitTargets[0]
+                : spell.Cast.MissTargets.Count > 0 ? spell.Cast.MissTargets[0]
+                : WowGuid128.Empty;
+            // Bind the sweep's cancel callback lazily to this live WorldClient (mirrors OnGcdHeldCastFire); also gates the quiescence timer on in NoteObservedAutoRepeatActivity.
             GetSession().GameState.OnObservedAutoRepeatExpire ??= SendObservedAutoRepeatCancel;
-            GetSession().GameState.NoteObservedAutoRepeatActivity(spell.Cast.CasterUnit);
+            GetSession().GameState.NoteObservedAutoRepeatActivity(spell.Cast.CasterUnit, shotTarget);
         }
 
         SendPacketToClient(spell);

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1234,6 +1234,17 @@ public partial class WorldClient
     // JimsProxy (observed-bow): forwarding an observed ranged auto-repeat SPELL_START (Auto Shot/Shoot) latches the 1.14 client's intrinsic auto-repeat aim (spell 75 = SPELL_ATTR2_AUTO_REPEAT, no client SpellVisual) and nothing retracts it for observers (SPELL_GO / SPELL_FAILURE / SPELL_FAILED_OTHER / CANCEL_AUTO_REPEAT / a SheatheState push were all verified non-working in-client — SheatheState only stows the weapon, leaving the arms locked in the aim). So we hold each observed auto-repeat START here and replay it paired with its SPELL_GO (HandleSpellGo) only when the shot fires — the draw shows for shots that fire, and a shot that aborts (no GO) is never forwarded, so it can't stick. Held per caster; touched only on the WorldClient ReceiveLoop (HandleSpellStart/Go), so no lock needed.
     private readonly Dictionary<WowGuid128, SpellStart> _pendingObservedAutoRepeatStart = new();
 
+    // JimsProxy (observed-bow retract): lower an observed shooter's latched ranged-aim by synthesizing SMSG_CANCEL_AUTO_REPEAT with THAT unit's GUID (the legacy handler only ever cancels the local player, and vanilla never broadcasts a stop for other units). Invoked off the WorldClient ReceiveLoop on the quiescence sweep's ThreadPool thread; SendPacketToClient is already used off-thread (taxi/GCD), so this is safe.
+    private void SendObservedAutoRepeatCancel(WowGuid128 shooter)
+    {
+        // Runs on the sweep's ThreadPool thread; if the session is mid-teardown, skip rather than block in SendPacketToClient's wait-for-instance loop — the aim is moot once disconnected.
+        if (GetSession().InstanceSocket == null || !GetSession().GameState.IsConnectedToInstance)
+            return;
+        SendPacketToClient(new CancelAutoRepeat { Guid = shooter });
+        if (Framework.Settings.DebugOutput)
+            Log.Event("ranged.auto_repeat.remote_cancel", new { caster_low = shooter.GetCounter() });
+    }
+
     [PacketHandler(Opcode.SMSG_SPELL_START)]
     void HandleSpellStart(WorldPacket packet)
     {
@@ -1445,7 +1456,8 @@ public partial class WorldClient
         if (!casterIsLocalPlayer && !casterIsLocalPet && isRangedAutoAttack)
         {
             _pendingObservedAutoRepeatStart[spell.Cast.CasterUnit] = spell;
-            Log.Event("ranged.auto_repeat.start_held", new { caster_low = spell.Cast.CasterUnit.GetCounter(), spell_id = spell.Cast.SpellID });
+            if (Framework.Settings.DebugOutput)
+                Log.Event("ranged.auto_repeat.start_held", new { caster_low = spell.Cast.CasterUnit.GetCounter(), spell_id = spell.Cast.SpellID });
         }
         else
         {
@@ -1792,15 +1804,21 @@ public partial class WorldClient
             spell.Cast.CasterUnit = stunTarget;
         }
 
-        // JimsProxy (observed-bow): replay this observed caster's held auto-repeat START now, paired to this GO (CastID-matched) so the client renders a complete draw+fire. A held START whose GO never arrives is never forwarded, so it can't latch the aim.
+        // JimsProxy (observed-bow): replay this observed caster's held auto-repeat START now, paired to this GO (CastID-matched) so the client renders a complete draw+fire, and note the shot so the quiescence sweep can lower the weapon once the series ends. A held START whose GO never arrives is never forwarded, so it can't latch the aim.
         if (spell.Cast.CasterUnit != GetSession().GameState.CurrentPlayerGuid
             && spell.Cast.CasterUnit != GetSession().GameState.CurrentPetGuid
-            && GameData.AutoRepeatSpells.Contains((uint)spell.Cast.SpellID)
-            && _pendingObservedAutoRepeatStart.Remove(spell.Cast.CasterUnit, out var heldStart))
+            && GameData.AutoRepeatSpells.Contains((uint)spell.Cast.SpellID))
         {
-            heldStart.Cast.CastID = spell.Cast.CastID;
-            SendPacketToClient(heldStart);
-            Log.Event("ranged.auto_repeat.start_replayed", new { caster_low = spell.Cast.CasterUnit.GetCounter(), spell_id = spell.Cast.SpellID });
+            if (_pendingObservedAutoRepeatStart.Remove(spell.Cast.CasterUnit, out var heldStart))
+            {
+                heldStart.Cast.CastID = spell.Cast.CastID;
+                SendPacketToClient(heldStart);
+                if (Framework.Settings.DebugOutput)
+                    Log.Event("ranged.auto_repeat.start_replayed", new { caster_low = spell.Cast.CasterUnit.GetCounter(), spell_id = spell.Cast.SpellID });
+            }
+            // Track every observed shot (replayed START or bare tick GO); the sweep fires SMSG_CANCEL_AUTO_REPEAT for this shooter once it goes quiet, so the aim doesn't stay latched after they stop. Callback bound lazily to this live WorldClient (mirrors OnGcdHeldCastFire).
+            GetSession().GameState.OnObservedAutoRepeatExpire ??= SendObservedAutoRepeatCancel;
+            GetSession().GameState.NoteObservedAutoRepeatActivity(spell.Cast.CasterUnit);
         }
 
         SendPacketToClient(spell);

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2128,7 +2128,10 @@ public partial class WorldClient
             int UNIT_FIELD_TARGET = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_TARGET);
             if (UNIT_FIELD_TARGET >= 0 && updateMaskArray[UNIT_FIELD_TARGET])
             {
-                updateData.UnitData.Target = GetGuidValue(updates, UnitField.UNIT_FIELD_TARGET).To128(GetSession().GameState);
+                WowGuid128 newTarget = GetGuidValue(updates, UnitField.UNIT_FIELD_TARGET).To128(GetSession().GameState);
+                updateData.UnitData.Target = newTarget;
+                // JimsProxy (observed-bow retract): a latched shooter that retargets or drops its target has ended the prior series — lower its bow (a still-firing retarget self-heals on the next shot's START).
+                RetractObservedShooterOnTargetChange(guid, newTarget);
             }
             int UNIT_FIELD_CHANNEL_OBJECT = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_CHANNEL_OBJECT);
             if (UNIT_FIELD_CHANNEL_OBJECT >= 0 && updateMaskArray[UNIT_FIELD_CHANNEL_OBJECT])
@@ -2162,6 +2165,9 @@ public partial class WorldClient
                         healthUpdated ? updates[UNIT_FIELD_HEALTH].Int32Value : existing.Hp,
                         maxHealthUpdated ? updates[UNIT_FIELD_MAXHEALTH].Int32Value : existing.MaxHp));
             }
+            // JimsProxy (observed-bow retract): health hitting 0 is a terminal stop edge — retract any observed shooter aimed at this unit, plus the unit itself if it was a shooter (fallback for deaths PARTY_KILL_LOG doesn't cover: DoTs, non-party kills, environment).
+            if (healthUpdated && updates[UNIT_FIELD_HEALTH].Int32Value <= 0)
+                RetractObservedShootersOnUnitDeath(guid);
             int UNIT_FIELD_LEVEL = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_LEVEL);
             if (UNIT_FIELD_LEVEL >= 0 && updateMaskArray[UNIT_FIELD_LEVEL])
             {


### PR DESCRIPTION
## Problem

Watching another unit auto-repeat (Auto Shot 75 / wand Shoot 5019) on a modern 1.14 client draws and holds the bow/wand and **never lowers it** after they stop. Forwarding the observed `SPELL_START` latches the 1.14 client's intrinsic auto-repeat aim (spell 75 is `SPELL_ATTR2_AUTO_REPEAT` with no client `SpellVisual`), and vanilla never broadcasts a "stopped" for *other* units, so nothing retracts it. Your own character is fine — `SMSG_SPELL_FAILURE` lowers the local aim.

The prior hold-and-replay (#352) only guarded an *aborted* shot (an unpaired START with no GO). A *completed* START+GO latches the aim just the same, so an observed shooter stayed stuck after the last shot of every series.

## Fix

A **hybrid retract** that synthesizes `SMSG_CANCEL_AUTO_REPEAT` carrying **that unit's GUID** (the modern `CancelAutoRepeat` packet is per-GUID; the legacy handler only ever cancels the local player, so a per-shooter cancel had never actually been tried). Each shot latches the shooter against the unit it's shooting, then two mechanisms lower the weapon:

**Deterministic stop edges — instant retract** from signals the wire already gives us:
- **Target dies** — `PARTY_KILL_LOG`, or the target's health hits 0 (covers DoT / non-party / environment deaths). Terminal-proof: a corpse can't be shot, so the retract can't be contradicted.
- **Shooter dies.**
- **Shooter moves** — translational-start opcodes only (`START_FORWARD/BACKWARD/STRAFE/JUMP/SWIM`); turn/facing/heartbeat/stop are excluded so a shooter that only pivots to track its target is never falsely retracted.
- **Shooter retargets or clears its target** (`UNIT_FIELD_TARGET` change).

**Quiescence sweep — catch-all** for the case no edge covers: a shooter that stops *with its target still alive and stands still* (out of ammo, `/stopattack`, LoS break, **target dummy**). A 500 ms sweep lowers the weapon once it goes quiet past 4 s.

Properties:
- **No mid-series flicker** — the 4 s threshold sits above the slowest bow cadence + jitter; every shot refreshes it.
- **Self-healing** — a premature retract is harmless: the next shot's START re-raises the aim.
- **No splash to you** — tracking excludes the local player and pet, so your own auto-shot is never retracted.
- Sweep callback runs off the lock; the timer self-disarms when the table empties and is cleared on reconnect (`ResetInFlightCastState`). Per-shooter target state lives in one struct (`ObservedShooterState`).
- The `start_held` / `start_replayed` / `remote_cancel` diagnostics are gated behind `DebugOutput`.

> Why both? An edge-driven retract alone can't cover a shooter that stops with its target alive and stationary — there's no packet edge for it, so the sweep is load-bearing. The edges just make the common cases (kill / move / retarget) lower instantly instead of waiting out the 4 s window.

## Testing

**In-game (Twinstar/Kronos 1.12 ↔ 1.14 client):**
- **Quiescence (target dummy):** an observer watching a hunter stop firing at a target dummy — target stays alive, shooter stationary — lowers the bow ~4 s after the last shot.
- **Edges:** killing the mob, or the shooter moving / retargeting, lowers the bow **instantly**.
- Original sweep validation still holds: 6 stop/start Auto Shot cycles each sheathed cleanly 4.0–4.5 s after the last shot, no flicker mid-series (including across a haste change from ~2.55 s to ~1.95 s cadence).
- **No splash:** confirmed on a hunter observer that firing your *own* Auto Shot while watching another shooter stop does not interrupt your shots when their cancel fires.

**Automated:** full suite green, including **14** `ObservedAutoRepeatTests` (9 sweep + 5 edge) covering target-death fan-out, retarget vs. same-target, per-shooter isolation, the quiet window and refresh-keeps-alive across slow cadence, idempotency, and teardown.