### PR TITLE
Fix action button stuck lit on suppressed transient cast failures (LowLatencyMode)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -352,7 +352,18 @@ public partial class WorldClient
         // setting covers audio but not the red error text; this covers both.
         if (Settings.SuppressSpellCastErrors && isTransientReason)
         {
-            GetSession().GameState.TryDequeuePendingNormalCast(spellId, out _, preferStarted: false);
+            // JimsProxy (suppress-ack-stuck-button): suppress the red error text, but STILL ack
+            // the client so the action-button pending/lit state clears. Under LowLatencyMode the
+            // mid-GCD press was forwarded immediately and bounced back NOT_READY/SpellInProgress;
+            // the SPELL_FAILURE broadcast is already skipped for the local caster, and this dequeue
+            // is the proxy's LAST record of the press — so returning silently strands the button
+            // lit forever (the later ClearNonStartedNormalCasts sweep can't help; the entry is
+            // gone). SendCastRequestFailed emits a SpellPrepare first (only if never started, so
+            // the client can match by CastID) then a CastFailed(DontReport) — clears the button
+            // with no popup / error sound. Mirrors the item-use-orphan eviction ack above.
+            // preferStarted:false (H7, from #372): consume the UNSTARTED dup, leave the started cast for its GO.
+            if (GetSession().GameState.TryDequeuePendingNormalCast(spellId, out var suppressedCast, preferStarted: false) && suppressedCast != null)
+                GetSession().InstanceSocket.SendCastRequestFailed(suppressedCast, false, SpellCastResultClassic.DontReport);
             Log.Event("cast.error_suppressed", new
             {
                 spell_id = spellId,


### PR DESCRIPTION
## Symptom
Action button stays "lit"/pending on spammed instant on-GCD spells under **LowLatencyMode + SuppressSpellCastErrors** (repro: an instant on-GCD mage spell spammed during the GCD; `jimsproxy-20260615-142105.jsonl` ~702-719, `client_cast_id Low=3`). Pre-existing; independent of #372/T1.

## Mechanism
A mid-GCD press is forwarded immediately (LowLatencyMode), the server bounces it `NOT_READY`/`SpellInProgress`, and the client receives **no terminating event** because:
- `HandleSpellFailure` intentionally skips the `SMSG_SPELL_FAILURE` broadcast for the local caster (GCD-lock guard — kept), and
- `HandleCastFailed`'s `SuppressSpellCastErrors` branch dequeued the pending cast but **returned without acking the client**.

That dequeue is the proxy's last record of the press (the entry is gone, so the later `ClearNonStartedNormalCasts` sweep can't clear it), so the button's pending/lit state never clears.

## Fix
In the suppression branch, capture the dequeued cast and emit `SendCastRequestFailed(..., DontReport)` — a `SpellPrepare` (only if it never started, so the client can match by CastID) then a silent `CastFailed` — clearing the button with no popup/error text. Mirrors the item-use-orphan eviction ack a few lines above. `cast.error_suppressed` telemetry unchanged.

## Verification
- Build clean; **535 tests pass** (no regression).
- Field A/B (per spec): `SuppressSpellCastErrors` on-with-fix vs off, spam an instant on-GCD spell through the GCD → button clears, no error popup.
- This is a handler socket-send; per the codebase's test boundary (GameState-only unit tests; cf. `GcdHoldTests` + the identical, untested ack pattern in the item-use-orphan path) it is field-verified rather than unit-tested. Building mock-networking infra for one ack would be the repo's first handler test — flagged for a future infra decision if wanted.

## Notes
- **Suppression-specific:** without `SuppressSpellCastErrors` the same `CAST_FAILED` falls to the main path which already acks (with the real reason). So plain beta without suppression does not reproduce this.
- **Merge overlap with #372:** #372 also edits this suppress branch (adds `preferStarted:false` + `isTransientReason`); trivial to combine when both land (capture the dequeued cast + ack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
