### PR TITLE
Fix cast-time "interrupted but fired" on dup-rejection (LowLatencyMode)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2604,6 +2604,23 @@ public class GlobalSessionData
             failed.Reason = (byte)SpellCastResultClassic.DontReport;
             failed.CastID = cast.ServerGUID;
             InstanceSocket.SendPacket(failed);
+
+            // JimsProxy (transient-no-dismiss-started): under LowLatencyMode, HandleSpellFailure
+            // deferred a started cast's caster-side visual-cancel to its trailing CAST_FAILED. If
+            // that CAST_FAILED was dropped (e.g. Kronos target-dies-mid-cast) the cast lands here
+            // instead — so cancel the casting-pose / channel visual too, not just dismiss the bar,
+            // or the pose can linger until the next cast. Idempotent on the client.
+            if (Framework.Settings.LowLatencyMode && cast.HasStarted)
+            {
+                uint resolvedVisual = GameData.GetSpellVisualIdFromXSpellVisual(cast.SpellXSpellVisualId);
+                if (resolvedVisual != 0)
+                {
+                    CancelSpellVisual cancelVisual = new();
+                    cancelVisual.Source = GameState.CurrentPlayerGuid;
+                    cancelVisual.SpellVisualID = (int)resolvedVisual;
+                    InstanceSocket.SendPacket(cancelVisual);
+                }
+            }
         }
 
         foreach (var cast in petEvicted)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -346,6 +346,21 @@ public partial class WorldClient
         bool isTransientReason = reason == (uint)SpellCastResultVanilla.NotReady ||
                                  reason == (uint)SpellCastResultVanilla.SpellInProgress;
 
+        // JimsProxy (transient-no-dismiss-started): under LowLatencyMode a transient failure
+        // (NOT_READY / SpellInProgress) is the server rejecting a DUPLICATE press, never an
+        // interrupt of the cast already in progress. If no unstarted duplicate is still queued to
+        // consume (the on-START sweep already cleared + acked it), this rejection is stale — drop it
+        // BEFORE the suppression branch and the dequeue below, both of which would otherwise fall
+        // back to the STARTED cast and dismiss its bar (the "interrupted but fired" desync). Normal
+        // mode is unaffected (no dups reach the server); real failures (OOR/LoS/OOM) are non-transient.
+        if (isTransientReason && Settings.LowLatencyMode &&
+            !GetSession().GameState.HasNonStartedPendingCastForSpell(spellId))
+        {
+            if (Framework.Settings.DebugOutput)
+                Log.Event("cast.transient_stale_dropped", new { spell_id = spellId });
+            return;
+        }
+
         // JimsProxy: optional suppression of transient cast errors (NotReady = GCD active,
         // SpellInProgress = cast bar active). Useful with Low Latency Mode where mid-GCD
         // presses reach the server and bounce back. The 1.14 client's "Suppress Error Speech"
@@ -463,6 +478,24 @@ public partial class WorldClient
             failed.FailedArg1 = arg1;
             failed.FailedArg2 = arg2;
             SendPacketToClient(failed);
+
+            // JimsProxy (transient-no-dismiss-started): under LowLatencyMode the SPELL_FAILURE
+            // deferred the caster-side visual-cancel to here so the REAL reason drives it. A real
+            // failure of a STARTED cast still needs its casting-pose / channel visual cancelled (the
+            // 1.14 client doesn't reliably do it from CAST_FAILED alone) — mirror HandleSpellFailure's
+            // cast-failure-stuck-visual cleanup. Transient dup-rejections and movement-cancelled casts
+            // never reach here started, so this is real failures only.
+            if (Settings.LowLatencyMode && pendingCast.HasStarted && !movementSuppressed)
+            {
+                uint resolvedVisual = GameData.GetSpellVisualIdFromXSpellVisual(pendingCast.SpellXSpellVisualId);
+                if (resolvedVisual != 0)
+                {
+                    CancelSpellVisual cancelVisual = new CancelSpellVisual();
+                    cancelVisual.Source = GetSession().GameState.CurrentPlayerGuid;
+                    cancelVisual.SpellVisualID = (int)resolvedVisual;
+                    SendPacketToClient(cancelVisual);
+                }
+            }
 
             var gameState = GetSession().GameState;
             var heldCastTimeDrop = gameState.ClearHeldCastTimeCast();
@@ -980,6 +1013,11 @@ public partial class WorldClient
         // reason and renders the correct popup.
         bool overrideReasonForLocalBroadcast = false;
         bool skipBroadcastFailure = false;
+        // JimsProxy (transient-no-dismiss-started): under LowLatencyMode, defer a STARTED local
+        // cast's bar-dismiss AND visual-cancel to the caller-aware trailing CAST_FAILED (which
+        // knows the real reason — spare a dup-rejection, dismiss a real failure). Set in the
+        // local-player branch; gates the cast-failure visual cleanup below.
+        bool deferLocalDismissToCastFailed = false;
         // 1.14 needs SMSG_SPELL_FAILURE to retract the bow-draw / wand-aim visual
         // for ranged auto-attacks; CastFailed + CANCEL_AUTO_REPEAT alone leaves the
         // bow stuck drawn. Other instants can drop the broadcast entirely -- there's
@@ -1039,6 +1077,16 @@ public partial class WorldClient
             // which clears button-lit state and shows the correct popup.
             else if (!pendingNormal.HasStarted && !isRangedAutoAttack)
                 skipBroadcastFailure = true;
+            // JimsProxy (transient-no-dismiss-started): under LowLatencyMode this SPELL_FAILURE may be
+            // a duplicate-rejection rather than an interrupt of the in-progress cast (the server
+            // hardcodes the reason, so we can't tell here). Defer BOTH the bar-dismiss and the
+            // visual-cancel to the caller-aware trailing CAST_FAILED, which knows the real reason.
+            // Ranged auto-attacks still forward (the bow-draw / wand-aim retract needs it).
+            else if (Settings.LowLatencyMode && !isRangedAutoAttack)
+            {
+                skipBroadcastFailure = true;
+                deferLocalDismissToCastFailed = true;
+            }
             else
                 overrideReasonForLocalBroadcast = true;
         }
@@ -1209,7 +1257,7 @@ public partial class WorldClient
         // #72's instant-suppression was removed once SpellFailure switched to peek),
         // so for auto-repeat ticks the visual is live on the client regardless of
         // whether the pending queue tracked it.
-        if (casterIsLocalPlayer && (wasStarted || isRangedAutoAttack) && !sentCancelVisual)
+        if (casterIsLocalPlayer && (wasStarted || isRangedAutoAttack) && !sentCancelVisual && !deferLocalDismissToCastFailed)
         {
             resolvedSpellVisualId = GameData.GetSpellVisualIdFromXSpellVisual(spellVisual);
             if (resolvedSpellVisualId != 0)


### PR DESCRIPTION
## Symptom
A cast-time spell (Frostbolt) under **LowLatencyMode** shows as interrupted — cast bar dismissed with **no reason** — but the spell still **fires** (GO + damage + aura). Reported in-game, isolated from `jimsproxy-20260615-194959.jsonl`. Pre-existing on the forward-all path; independent of T1.

## Mechanism (correlated, not guessed)
Mashing a cast-time spell under LowLatency forwards mid-cast duplicate presses. The server rejects them (`NOT_READY` / `SpellInProgress`) and sends `SMSG_SPELL_FAILURE` (reason hardcoded to 1 by Twinstar's `SendInterrupted`, so a dup-rejection and a real interrupt are indistinguishable there). The on-START sweep already removed the duplicate's queue entry, so the rejection had nothing to attribute to except the in-progress **started** cast — whose bar got dismissed while the cast completed server-side. In one 55-press session this fired 11×; **movement is exonerated** (movement-cancelled casts are correctly skipped).

## Fix — invariant: a transient/duplicate-rejection never dismisses a STARTED cast
- **`HandleCastFailed`** (before the suppression branch + the dequeue): a transient failure with no unstarted dup still queued is a *stale* rejection (the dup was already swept + acked) → drop it, so neither the suppression branch nor the dequeue falls back to the started cast.
- **`HandleSpellFailure`**: for a started local cast under LowLatency, defer **both** the bar-dismiss and the caster-side visual-cancel to the caller-aware trailing `CAST_FAILED` (which knows the real reason — spare a dup-rejection, dismiss a real failure). Ranged auto-attacks still forward (bow-draw retract).
- **`HandleCastFailed` + `RunWatchdogEviction`**: a real failure of a started cast now also cancels the casting-pose / channel visual (moved off the deferred SPELL_FAILURE) — including the dropped-CAST_FAILED case where the watchdog closes the cast.

## Result
- Dup-rejection → spared (no dismiss, no visual cancel, cast completes clean).
- Real interrupt → bar **and** visual cancelled (via CAST_FAILED, or the watchdog if it's dropped).
- All gated to `LowLatencyMode`; **normal mode byte-unchanged**.

## Verification
- Build clean; **544 tests pass** (no regression).
- No new unit test: the change is in the socket-sending handlers and the repo has no handler-socket harness (same boundary #375 flagged); the GameState primitives it composes (`HasNonStartedPendingCastForSpell`, the caller-aware dequeue) are already covered. Field-verified.
- Adds one DebugOutput-gated diagnostic (`cast.transient_stale_dropped`).

## Coordination
Cut from #372 (uses its caller-aware dequeue), `--base beta`. Overlaps #375's region in `HandleCastFailed` (adjacent, non-conflicting); for suppression-on, this guard + #375's ack are complementary. Draft until field-verified.