### PR TITLE
LowLatency forward-all: skip on-START sweep under LL (C2)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1372,23 +1372,34 @@ public partial class WorldClient
                 pendingCast.HasSentPrepare = true;
             }
 
-            // Clear non-started casts and send failures for them
-            // (keeps the started cast so SPELL_GO can dequeue it)
-            var failedCasts = GetSession().GameState.ClearNonStartedNormalCasts();
-            // DIAGNOSTIC (stuck-spell investigation): hoist toggle read; remove with diagnostics
-            bool debugEventsNormal = Framework.Settings.DebugOutput;
-            foreach (var failed in failedCasts)
+            // JimsProxy (C2 / forward-all): the on-START sweep fails OTHER non-started normal casts
+            // when one starts — correct under hold-and-fire (one cast at a time), but WRONG under
+            // LowLatencyMode forward-all, where concurrent non-started casts are legitimate mashed
+            // presses the server accepts/rejects individually. Sweeping them client-side while the
+            // server is still processing them is the ROOT of the dup-rejection-mis-dismiss class
+            // (the cast "interrupted but fired" desync). Under LowLatency skip it entirely; each cast
+            // resolves via its own SPELL_GO / CAST_FAILED (caller-aware dequeue) or the watchdog.
+            // Normal mode unchanged. (HasStarted / IsOffGcd casts are already exempt in the sweep.)
+            if (!Settings.LowLatencyMode)
             {
-                GetSession().InstanceSocket.SendCastRequestFailed(failed, false);
-                // DIAGNOSTIC (stuck-spell investigation): remove when closed
-                if (debugEventsNormal)
-                    Log.Event("cast.non_started_swept", new
-                    {
-                        queue = "normal",
-                        spell_id = failed.SpellId,
-                        triggering_spell_id = (uint)spell.Cast.SpellID,
-                        client_cast_id = failed.ClientGUID.ToString(),
-                    });
+                // Clear non-started casts and send failures for them
+                // (keeps the started cast so SPELL_GO can dequeue it)
+                var failedCasts = GetSession().GameState.ClearNonStartedNormalCasts();
+                // DIAGNOSTIC (stuck-spell investigation): hoist toggle read; remove with diagnostics
+                bool debugEventsNormal = Framework.Settings.DebugOutput;
+                foreach (var failed in failedCasts)
+                {
+                    GetSession().InstanceSocket.SendCastRequestFailed(failed, false);
+                    // DIAGNOSTIC (stuck-spell investigation): remove when closed
+                    if (debugEventsNormal)
+                        Log.Event("cast.non_started_swept", new
+                        {
+                            queue = "normal",
+                            spell_id = failed.SpellId,
+                            triggering_spell_id = (uint)spell.Cast.SpellID,
+                            client_cast_id = failed.ClientGUID.ToString(),
+                        });
+                }
             }
         }
         bool petCastWasPlayerPressed = false;


### PR DESCRIPTION
## What
Skip the on-START `ClearNonStartedNormalCasts` sweep under **LowLatencyMode**. The sweep fails OTHER non-started normal casts when one starts — right for hold-and-fire, wrong for forward-all, where concurrent non-started casts are legitimate mashed presses the server resolves individually. Sweeping them client-side while the server is still processing them is the **root** of the dup-rejection mis-dismiss class (the cast "interrupted but fired").

## Why it's the root
With the sweep off, a duplicate's rejection finds its own queue entry (caller-aware dequeue consumes it) instead of falling onto the live cast. So the transient-no-dismiss-started fix (#376) becomes a rarely-needed **backstop** — this removes the source. Field signal: `cast.non_started_swept` → 0 under LowLatency.

## Risks
- **Queue growth under mash:** non-started casts accumulate instead of being swept — bounded by the watchdog (2.5s eviction) + #372's dup-collapse.
- **Orphan-clear latency:** a cast the server never answers clears via the watchdog (≤2.5s) instead of the next SPELL_START's sweep. Slower but correct.
- Normal mode byte-unchanged (gated).

## Verification
- Build clean; 544 tests pass.
- Field: frantic-mash Frostbolt/AE under LowLatency → `cast.non_started_swept` should be 0, no stuck buttons / dismissed-but-fired.

## Stacking
Stacked on #376, `--base fix/transient-failure-no-dismiss-started` so this PR shows only the C2 diff; it auto-retargets to beta when #376 merges. First of the T2 conflict-scan items (C1/C3/C4 to follow). T3 deprioritized (handling > avoidance).