### PR TITLE
Fix Blade Flurry looping cast in LowLatencyMode (run dup-guard)

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -318,6 +318,29 @@ public partial class WorldSocket
                 // for players with very low RTT.
                 if (Settings.LowLatencyMode)
                 {
+                    // Guard: in-flight same-spell duplicate. Mirrors the normal-mode guard below.
+                    // Low-Latency mode bypasses the hold/guard paths, which let an on-GCD
+                    // double-send (e.g. Blade Flurry 13877, which the 1.14 client double-sends)
+                    // enqueue TWO entries for one spell: SMSG_SPELL_START marks one started,
+                    // SMSG_SPELL_GO / CAST_FAILED resolve the other, so START and GO carry
+                    // different CastIDs, the client never closes the cast, and we get a stuck
+                    // cast animation + looping sound. Drop the duplicate and ack it via
+                    // SendCastFailedWithoutPrepare (same purpose/reasoning as normal mode) so
+                    // the button doesn't stick lit.
+                    if (GetSession().GameState.HasNonStartedPendingCastForSpell((uint)cast.Cast.SpellID))
+                    {
+                        Log.Event("cast.dropped.duplicate", new
+                        {
+                            spell_id = cast.Cast.SpellID,
+                            reason = "in_flight_same_spell",
+                            client_cast_id = cast.Cast.CastID.ToString(),
+                            queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+                            source = "low_latency",
+                        });
+                        SendCastFailedWithoutPrepare(castRequest);
+                        return;
+                    }
+
                     // DIAGNOSTIC (stuck-spell investigation): remove when closed
                     if (Framework.Settings.DebugOutput)
                         Log.Event("cast.forwarded", new


### PR DESCRIPTION
## Summary
- `LowLatencyMode`'s early-return in `HandleCastSpell` skipped the in-flight same-spell dup-guard that normal mode runs. On an on-GCD double-send (the 1.14 client sends Blade Flurry `13877` twice), LL enqueued **two** pending entries for one spell — `SPELL_START` marked one started while `SPELL_GO`/`CAST_FAILED` resolved the other, so START and GO carried different CastIDs and the client never closed the cast -> **stuck cast animation + looping cast sound** (cleared by zoning, not `/reload`).
- Restores the guard at the top of the `LowLatencyMode` branch, **mirroring the normal-mode guard exactly**: drop the in-flight duplicate via `HasNonStartedPendingCastForSpell` and ack it with `SendCastFailedWithoutPrepare` (so the duplicate press cannot leave the button stuck lit), tagged `source=low_latency` on `cast.dropped.duplicate`.

## Why LL specifically
The dup-guard lives inside the `!isOffGcd` block **after** the LL early-return, so LL bypassed it entirely. Blade Flurry is on-GCD (`Spell1sGcd1.csv`, not off-GCD), so it takes this path; normal mode already drops its double-send, which is why the loop reproduces in LowLatency but not normal mode.

## Test plan
- [x] `dotnet build` clean (0 warnings / 0 errors)
- [x] `dotnet test` — 581/581 pass
- [ ] In-game: Blade Flurry spam in LowLatencyMode no longer loops; `cast.dropped.duplicate source=low_latency` fires on the double-send