### PR TITLE
RefireSpellGo: re-fire SPELL_GO to clear stuck instant casts

### DIFF
--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -13,17 +13,6 @@ namespace Framework;
 
 public enum ServerFork { Kronos, Generic }
 
-// How the proxy handles an instant cast's completion (the SMSG_SPELL_GO it receives from the server)
-// to prevent the stuck-cast bug: frozen pose / looping sound / lit button / no cooldown until logout,
-// when the 1.14 client coalesces that GO with the same-frame START and never closes the cast.
-// Integer values are the launcher config contract — DO NOT renumber.
-public enum CastSuccessMode
-{
-    Off = 0,        // legacy — forward the GO once, no intervention; the stuck can occur
-    RefireGo = 1,   // re-fire a stripped duplicate SPELL_GO ~8ms later (clean frame) to re-deliver the commit (validated fix)
-    DelayGo = 2,    // experimental — space the real SPELL_GO into its own frame after START (not yet wired; treated as Off)
-}
-
 public static class Settings
 {
     public static byte[] ClientSeed = null!;
@@ -90,7 +79,7 @@ public static class Settings
     // logout. When set, on a local instant's SPELL_GO (cast success) re-fire the kit stop
     // (SMSG_CANCEL_SPELL_VISUAL) a few ms later in a clean frame. No-op on clean casts (the kit
     // already stopped). Independent of LowLatencyMode — works in both. Default OFF — opt-in.
-    public static CastSuccessMode CastSuccessHandler;
+    public static bool RefireSpellGo;
     // JimsProxy (#313): width (ms) of the spell-queue hold window. A press arriving in the
     // last SpellQueueWindowMs of an active GCD or cast bar is held and fired at expiry; earlier
     // presses are forwarded and the server arbitrates (NOT_READY / SpellInProgress). Mirrors the
@@ -147,7 +136,7 @@ public static class Settings
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
-        CastSuccessHandler = config.GetEnum("CastSuccessHandler", CastSuccessMode.RefireGo);
+        RefireSpellGo = config.GetBoolean("RefireSpellGo", true);
         SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 1300), 0, 1300);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);
         var serverTypeStr = config.GetString("ServerType", "Kronos");

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -73,6 +73,13 @@ public static class Settings
     public static bool IdentityPinnedCastIds;
     // Effective gate for the T1 mechanism: the sub-toggle is live only under LowLatencyMode.
     public static bool IdentityPinnedCastIdsActive => LowLatencyMode && IdentityPinnedCastIds;
+    // JimsProxy (Spell Success Kit Reset): an instant cast forwards SPELL_START+SPELL_GO in the same
+    // client frame; the 1.14 client can drop the cast kit's stop (SpellVisualEvent end-event 13),
+    // leaving the cast-hold kit — which carries the cast pose AND its looping sound — stuck on until
+    // logout. When set, on a local instant's SPELL_GO (cast success) re-fire the kit stop
+    // (SMSG_CANCEL_SPELL_VISUAL) a few ms later in a clean frame. No-op on clean casts (the kit
+    // already stopped). Independent of LowLatencyMode — works in both. Default OFF — opt-in.
+    public static bool SpellSuccessKitReset;
     // JimsProxy (#313): width (ms) of the spell-queue hold window. A press arriving in the
     // last SpellQueueWindowMs of an active GCD or cast bar is held and fired at expiry; earlier
     // presses are forwarded and the server arbitrates (NOT_READY / SpellInProgress). Mirrors the
@@ -129,6 +136,7 @@ public static class Settings
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
+        SpellSuccessKitReset = config.GetBoolean("SpellSuccessKitReset", false);
         SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 1300), 0, 1300);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);
         var serverTypeStr = config.GetString("ServerType", "Kronos");

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -13,6 +13,17 @@ namespace Framework;
 
 public enum ServerFork { Kronos, Generic }
 
+// How the proxy handles an instant cast's completion (the SMSG_SPELL_GO it receives from the server)
+// to prevent the stuck-cast bug: frozen pose / looping sound / lit button / no cooldown until logout,
+// when the 1.14 client coalesces that GO with the same-frame START and never closes the cast.
+// Integer values are the launcher config contract — DO NOT renumber.
+public enum CastSuccessMode
+{
+    Off = 0,        // legacy — forward the GO once, no intervention; the stuck can occur
+    RefireGo = 1,   // re-fire a stripped duplicate SPELL_GO ~8ms later (clean frame) to re-deliver the commit (validated fix)
+    DelayGo = 2,    // experimental — space the real SPELL_GO into its own frame after START (not yet wired; treated as Off)
+}
+
 public static class Settings
 {
     public static byte[] ClientSeed = null!;
@@ -79,7 +90,7 @@ public static class Settings
     // logout. When set, on a local instant's SPELL_GO (cast success) re-fire the kit stop
     // (SMSG_CANCEL_SPELL_VISUAL) a few ms later in a clean frame. No-op on clean casts (the kit
     // already stopped). Independent of LowLatencyMode — works in both. Default OFF — opt-in.
-    public static bool SpellSuccessKitReset;
+    public static CastSuccessMode CastSuccessHandler;
     // JimsProxy (#313): width (ms) of the spell-queue hold window. A press arriving in the
     // last SpellQueueWindowMs of an active GCD or cast bar is held and fired at expiry; earlier
     // presses are forwarded and the server arbitrates (NOT_READY / SpellInProgress). Mirrors the
@@ -136,7 +147,7 @@ public static class Settings
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
-        SpellSuccessKitReset = config.GetBoolean("SpellSuccessKitReset", false);
+        CastSuccessHandler = config.GetEnum("CastSuccessHandler", CastSuccessMode.RefireGo);
         SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 1300), 0, 1300);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);
         var serverTypeStr = config.GetString("ServerType", "Kronos");

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -73,12 +73,12 @@ public static class Settings
     public static bool IdentityPinnedCastIds;
     // Effective gate for the T1 mechanism: the sub-toggle is live only under LowLatencyMode.
     public static bool IdentityPinnedCastIdsActive => LowLatencyMode && IdentityPinnedCastIds;
-    // JimsProxy (Spell Success Kit Reset): an instant cast forwards SPELL_START+SPELL_GO in the same
-    // client frame; the 1.14 client can drop the cast kit's stop (SpellVisualEvent end-event 13),
-    // leaving the cast-hold kit — which carries the cast pose AND its looping sound — stuck on until
-    // logout. When set, on a local instant's SPELL_GO (cast success) re-fire the kit stop
-    // (SMSG_CANCEL_SPELL_VISUAL) a few ms later in a clean frame. No-op on clean casts (the kit
-    // already stopped). Independent of LowLatencyMode — works in both. Default OFF — opt-in.
+    // JimsProxy (RefireSpellGo): an instant cast forwards SPELL_START+SPELL_GO in the same client
+    // frame; the 1.14 client can drop the coalesced SPELL_GO, so the cast never closes — a stuck
+    // cast pose + looping cast sound + lit action button that persists until logout (survives
+    // /reload). When set, on a local instant's first SPELL_GO re-fire a stripped duplicate SPELL_GO
+    // (~8ms later, in a clean frame, visual suppressed, no targets/log) so the client processes it
+    // and closes the cast. No-op on clean casts. Independent of LowLatencyMode. Default OFF — opt-in.
     public static bool RefireSpellGo;
     // JimsProxy (#313): width (ms) of the spell-queue hold window. A press arriving in the
     // last SpellQueueWindowMs of an active GCD or cast bar is held and fired at expiry; earlier
@@ -136,7 +136,7 @@ public static class Settings
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
-        RefireSpellGo = config.GetBoolean("RefireSpellGo", true);
+        RefireSpellGo = config.GetBoolean("RefireSpellGo", false);
         SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 1300), 0, 1300);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);
         var serverTypeStr = config.GetString("ServerType", "Kronos");

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1757,15 +1757,18 @@ public partial class WorldClient
                 });
             }
 
-            // JimsProxy (Spell Success Kit Reset — B2 probe): an instant cast forwards SPELL_START and
-            // SPELL_GO in the same client frame; the 1.14 client can drop the cast's teardown, leaving
-            // the casting pose + sound stuck until logout. Re-fire the cast-finish a few ms later in a
-            // clean frame via a DUPLICATE SPELL_GO with the visual suppressed and no targets/log — so
-            // nothing replays (no double explosion/ring), only the UNIT_SPELLCAST_SUCCEEDED that clears
-            // the pose. The real GO forwards first (below, synchronously); this fires after the bounded
-            // delay. Cancels nothing, so it can't blank a spell effect. Local-player instants only;
-            // opt-in via SpellSuccessKitReset, off by default. Probe for the duplicate-GO mechanism.
-            if (Settings.SpellSuccessKitReset && pendingCast.StartedCastTimeMs == 0)
+            // Cast Success Handler — RefireGo mode. This runs on the FIRST SMSG_SPELL_GO the proxy
+            // receives from the server (Kronos always sends it — that's what triggers us). The 1.14
+            // client can coalesce that GO with the same-frame START and fail to process it (renders the
+            // GO as absent), so the cast never closes → frozen pose + looping sound + lit button + no
+            // cooldown, until logout. We re-fire the cast-finish ~8ms later as a DUPLICATE SPELL_GO in a
+            // CLEAN frame (visual suppressed, no targets/log): the client processes the clean-frame copy
+            // and closes the cast (clears the pose, restores the cooldown). No effect/CLEU replay,
+            // cancels nothing. The real GO forwards first (below); this fires after the bounded delay.
+            // Local-player instants only. (Off = legacy no-op; DelayGo = experimental sibling, not yet
+            // wired so it currently behaves as Off.) Caveat: requires the server to send the first GO —
+            // a truly server-missing GO wouldn't trigger this (believed to be the client-coalesce case).
+            if (Settings.CastSuccessHandler == CastSuccessMode.RefireGo && pendingCast.StartedCastTimeMs == 0)
             {
                 var rfCasterGuid = spell.Cast.CasterGUID;
                 var rfCasterUnit = spell.Cast.CasterUnit;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1758,15 +1758,16 @@ public partial class WorldClient
             }
 
             // RefireSpellGo: runs on the FIRST SMSG_SPELL_GO the proxy receives from the server (Kronos
-            // always sends it — that's the trigger). The 1.14 client can coalesce that GO with the
-            // same-frame START and fail to process it (renders the GO as absent), so the cast never
-            // closes → frozen pose + looping sound + lit button + no cooldown, until logout. We re-fire
-            // the cast-finish ~8ms later as a DUPLICATE SPELL_GO in a CLEAN frame (visual suppressed, no
-            // targets/log): the client processes the clean-frame copy and closes the cast (clears the
-            // pose, restores the cooldown). No effect/CLEU replay, cancels nothing, no-op on clean casts.
-            // The original GO forwards first (below). Local-player instants only. Caveat: needs the
-            // server to send the first GO — a truly server-missing GO wouldn't trigger this (believed to
-            // be the client-coalesce case).
+            // always sends it — that's the trigger). When the client doesn't process that GO for an
+            // instant, the cast never closes client-side → the reported stuck cast: frozen cast pose +
+            // looping cast sound + lit action button, persisting until logout (survives /reload). Seen on
+            // Blade Flurry, Sunder, Battle Shout, holy casts. (Natural trigger appears to be the client
+            // coalescing the GO with the same-frame START, but that's inferred — we reproduce it with the
+            // injector, not yet captured in the wild.) We re-fire the cast-finish ~8ms later as a
+            // DUPLICATE SPELL_GO in a CLEAN frame (visual suppressed, no targets/log): the client
+            // processes the clean-frame copy and closes the cast. No effect/CLEU replay, cancels nothing,
+            // no-op on clean casts. Original GO forwards first (below). Local-player instants only.
+            // Caveat: needs the server to send the first GO — a server-missing GO wouldn't trigger this.
             if (Settings.RefireSpellGo && pendingCast.StartedCastTimeMs == 0)
             {
                 var rfCasterGuid = spell.Cast.CasterGUID;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -21,9 +21,9 @@ public partial class WorldClient
     // case kicks in (target-dies-mid-cast, no trailing CAST_FAILED).
     private const long WatchdogWindowMs = 2500;
 
-    // JimsProxy (experimental cast-kit-stop): defer (ms) before the synthesized cast-kit stop, so it
-    // lands in a clean client frame past the coalesced START+GO burst. A couple of frames at 60fps.
-    private const int CastKitStopDeferMs = 8;
+    // JimsProxy (Spell Success Kit Reset): defer (ms) before re-firing the cast-finish, so it lands
+    // in a clean client frame past the coalesced START+GO burst. A couple of frames at 60fps.
+    private const int SpellSuccessRefireDeferMs = 8;
 
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_SEND_KNOWN_SPELLS)]
@@ -1757,42 +1757,51 @@ public partial class WorldClient
                 });
             }
 
-            // JimsProxy (Spell Success Kit Reset): an instant cast forwards SPELL_START and SPELL_GO
-            // in the same client frame; the 1.14 client can lose the cast kit's stop-event, leaving
-            // the cast-hold kit (pose + its looping sound, e.g. BF SpellVisual 211 kit 353 "InnerFire")
-            // running until logout. On the cast's SPELL_GO (success), re-fire the stop via
-            // SMSG_CANCEL_SPELL_VISUAL a few ms later in a clean frame, past the coalesced START+GO.
-            // No-op on clean casts (the kit already stopped at the real stop-event). Local-player
-            // instants only; opt-in via SpellSuccessKitReset (works in both latency modes).
+            // JimsProxy (Spell Success Kit Reset — B2 probe): an instant cast forwards SPELL_START and
+            // SPELL_GO in the same client frame; the 1.14 client can drop the cast's teardown, leaving
+            // the casting pose + sound stuck until logout. Re-fire the cast-finish a few ms later in a
+            // clean frame via a DUPLICATE SPELL_GO with the visual suppressed and no targets/log — so
+            // nothing replays (no double explosion/ring), only the UNIT_SPELLCAST_SUCCEEDED that clears
+            // the pose. The real GO forwards first (below, synchronously); this fires after the bounded
+            // delay. Cancels nothing, so it can't blank a spell effect. Local-player instants only;
+            // opt-in via SpellSuccessKitReset, off by default. Probe for the duplicate-GO mechanism.
             if (Settings.SpellSuccessKitReset && pendingCast.StartedCastTimeMs == 0)
             {
-                uint kitVisual = GameData.GetSpellVisualIdFromXSpellVisual(spell.Cast.SpellXSpellVisualID);
-                if (kitVisual != 0)
+                var rfCasterGuid = spell.Cast.CasterGUID;
+                var rfCasterUnit = spell.Cast.CasterUnit;
+                var rfCastId = spell.Cast.CastID;
+                var rfOriginalCastId = spell.Cast.OriginalCastID;
+                int rfSpellId = spell.Cast.SpellID;
+                uint rfCastFlags = spell.Cast.CastFlags;
+                uint rfCastFlagsEx = spell.Cast.CastFlagsEx;
+                _ = Task.Run(async () =>
                 {
-                    WowGuid128 kitCaster = spell.Cast.CasterUnit;
-                    int kitSpellId = spell.Cast.SpellID;
-                    uint kitXVisual = spell.Cast.SpellXSpellVisualID;
-                    _ = Task.Run(async () =>
+                    await Task.Delay(SpellSuccessRefireDeferMs);
+                    try
                     {
-                        await Task.Delay(CastKitStopDeferMs);
-                        try
-                        {
-                            SendPacketToClient(new CancelSpellVisual { Source = kitCaster, SpellVisualID = (int)kitVisual });
-                            if (Framework.Settings.DebugOutput)
-                                Log.Event("cast.kit_stop_synth", new
-                                {
-                                    spell_id = kitSpellId,
-                                    spell_x_spell_visual_id = kitXVisual,
-                                    resolved_visual = kitVisual,
-                                    defer_ms = CastKitStopDeferMs,
-                                });
-                        }
-                        catch
-                        {
-                            // session/socket may have torn down during the defer — best-effort cosmetic cleanup
-                        }
-                    });
-                }
+                        var refire = new SpellGo();
+                        refire.Cast.CasterGUID = rfCasterGuid;
+                        refire.Cast.CasterUnit = rfCasterUnit;
+                        refire.Cast.CastID = rfCastId;
+                        refire.Cast.OriginalCastID = rfOriginalCastId;
+                        refire.Cast.SpellID = rfSpellId;
+                        refire.Cast.SpellXSpellVisualID = 0; // suppress visual so nothing replays
+                        refire.Cast.CastFlags = rfCastFlags;
+                        refire.Cast.CastFlagsEx = rfCastFlagsEx;
+                        // targets + LogData left empty: a pure cast-finish, no effect/CLEU replay
+                        SendPacketToClient(refire);
+                        if (Framework.Settings.DebugOutput)
+                            Log.Event("cast.success_refire", new
+                            {
+                                spell_id = rfSpellId,
+                                defer_ms = SpellSuccessRefireDeferMs,
+                            });
+                    }
+                    catch
+                    {
+                        // session/socket may have torn down during the defer — best-effort
+                    }
+                });
             }
 
             var gameStateAfter = GetSession().GameState;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1757,18 +1757,17 @@ public partial class WorldClient
                 });
             }
 
-            // Cast Success Handler — RefireGo mode. This runs on the FIRST SMSG_SPELL_GO the proxy
-            // receives from the server (Kronos always sends it — that's what triggers us). The 1.14
-            // client can coalesce that GO with the same-frame START and fail to process it (renders the
-            // GO as absent), so the cast never closes → frozen pose + looping sound + lit button + no
-            // cooldown, until logout. We re-fire the cast-finish ~8ms later as a DUPLICATE SPELL_GO in a
-            // CLEAN frame (visual suppressed, no targets/log): the client processes the clean-frame copy
-            // and closes the cast (clears the pose, restores the cooldown). No effect/CLEU replay,
-            // cancels nothing. The real GO forwards first (below); this fires after the bounded delay.
-            // Local-player instants only. (Off = legacy no-op; DelayGo = experimental sibling, not yet
-            // wired so it currently behaves as Off.) Caveat: requires the server to send the first GO —
-            // a truly server-missing GO wouldn't trigger this (believed to be the client-coalesce case).
-            if (Settings.CastSuccessHandler == CastSuccessMode.RefireGo && pendingCast.StartedCastTimeMs == 0)
+            // RefireSpellGo: runs on the FIRST SMSG_SPELL_GO the proxy receives from the server (Kronos
+            // always sends it — that's the trigger). The 1.14 client can coalesce that GO with the
+            // same-frame START and fail to process it (renders the GO as absent), so the cast never
+            // closes → frozen pose + looping sound + lit button + no cooldown, until logout. We re-fire
+            // the cast-finish ~8ms later as a DUPLICATE SPELL_GO in a CLEAN frame (visual suppressed, no
+            // targets/log): the client processes the clean-frame copy and closes the cast (clears the
+            // pose, restores the cooldown). No effect/CLEU replay, cancels nothing, no-op on clean casts.
+            // The original GO forwards first (below). Local-player instants only. Caveat: needs the
+            // server to send the first GO — a truly server-missing GO wouldn't trigger this (believed to
+            // be the client-coalesce case).
+            if (Settings.RefireSpellGo && pendingCast.StartedCastTimeMs == 0)
             {
                 var rfCasterGuid = spell.Cast.CasterGUID;
                 var rfCasterUnit = spell.Cast.CasterUnit;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace HermesProxy.World.Client;
 
@@ -19,6 +20,10 @@ public partial class WorldClient
     // and shorter than feels-laggy to the user when the pathological Kronos
     // case kicks in (target-dies-mid-cast, no trailing CAST_FAILED).
     private const long WatchdogWindowMs = 2500;
+
+    // JimsProxy (experimental cast-kit-stop): defer (ms) before the synthesized cast-kit stop, so it
+    // lands in a clean client frame past the coalesced START+GO burst. A couple of frames at 60fps.
+    private const int CastKitStopDeferMs = 8;
 
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_SEND_KNOWN_SPELLS)]
@@ -1750,6 +1755,44 @@ public partial class WorldClient
                     forced_cooldown_ms = gcdMs,
                     flags = 0x01,
                 });
+            }
+
+            // JimsProxy (Spell Success Kit Reset): an instant cast forwards SPELL_START and SPELL_GO
+            // in the same client frame; the 1.14 client can lose the cast kit's stop-event, leaving
+            // the cast-hold kit (pose + its looping sound, e.g. BF SpellVisual 211 kit 353 "InnerFire")
+            // running until logout. On the cast's SPELL_GO (success), re-fire the stop via
+            // SMSG_CANCEL_SPELL_VISUAL a few ms later in a clean frame, past the coalesced START+GO.
+            // No-op on clean casts (the kit already stopped at the real stop-event). Local-player
+            // instants only; opt-in via SpellSuccessKitReset (works in both latency modes).
+            if (Settings.SpellSuccessKitReset && pendingCast.StartedCastTimeMs == 0)
+            {
+                uint kitVisual = GameData.GetSpellVisualIdFromXSpellVisual(spell.Cast.SpellXSpellVisualID);
+                if (kitVisual != 0)
+                {
+                    WowGuid128 kitCaster = spell.Cast.CasterUnit;
+                    int kitSpellId = spell.Cast.SpellID;
+                    uint kitXVisual = spell.Cast.SpellXSpellVisualID;
+                    _ = Task.Run(async () =>
+                    {
+                        await Task.Delay(CastKitStopDeferMs);
+                        try
+                        {
+                            SendPacketToClient(new CancelSpellVisual { Source = kitCaster, SpellVisualID = (int)kitVisual });
+                            if (Framework.Settings.DebugOutput)
+                                Log.Event("cast.kit_stop_synth", new
+                                {
+                                    spell_id = kitSpellId,
+                                    spell_x_spell_visual_id = kitXVisual,
+                                    resolved_visual = kitVisual,
+                                    defer_ms = CastKitStopDeferMs,
+                                });
+                        }
+                        catch
+                        {
+                            // session/socket may have torn down during the defer — best-effort cosmetic cleanup
+                        }
+                    });
+                }
             }
 
             var gameStateAfter = GetSession().GameState;


### PR DESCRIPTION
## Summary
Opt-in fix (`RefireSpellGo` config, **boolean**) for the stuck-instant-cast bug — a frozen cast pose / looping cast sound / lit action button that persists until logout (survives `/reload`). Reported on Blade Flurry, Sunder, Battle Shout, holy casts, etc.

## Root cause
The modern client treats the server's `SMSG_SPELL_GO` as the cast's completion. **When the client doesn't process that GO for an instant, the cast never closes client-side** — the reported stuck cast: frozen cast pose + looping cast sound + lit action button, persisting until logout. We reproduce it by dropping the GO on the wire (injector `/jpd drop`: `SPELL_START` present, terminating `SPELL_GO` absent). The natural trigger *appears* to be the client coalescing the GO with the same-frame `SPELL_START` and not processing it — but we haven't captured a natural occurrence, so the exact client-side cause is **inferred, not confirmed**.

## Fix
Triggers on the **first `SMSG_SPELL_GO` the proxy receives from the server** — always present at the proxy hop; the client's coalesce/drop is one hop downstream. Re-fire the cast-finish ~8ms later as a **stripped duplicate `SPELL_GO`** in a clean frame (visual suppressed, no targets/log): the client processes the clean-frame copy and closes the cast (clears the pose, sound, and button). No effect/CLEU replay, cancels nothing, no-op on clean casts. Local-player instants only.

> The re-fire is a **backup, not a delay** — the original GO is forwarded immediately, so normal casts complete with **zero added latency** (the re-fire only matters for the stuck ~1%). And because it's a separate, later packet, it *shouldn't* be tightly tied to framerate (the gap only needs to beat TCP coalescing, not the frame time) — to be confirmed across low/high `maxfps`.

> Caveat: needs the server to send the first GO (it is the trigger). A server-missing GO wouldn't fire a re-fire.

> Earlier approach (`a9a324a`) used `SMSG_CANCEL_SPELL_VISUAL`; scrapped — the visual layer is `(unit, visualID)` with no CastID and blanked legit effect visuals. Switched to the duplicate-GO commit.

## Validation
Reproduced deterministically with a local test-only injector (`JimsPlusDiag`, gitignored): `/jpd stuck` (GO-before-START reorder) and `/jpd drop` (drops the terminating GO — faithful repro of the reported Blade Flurry loop). GO-drop reproduced the full reported symptom — looping cast animation + sound + stuck lit button — wire-confirmed (`SPELL_START` present, terminating `SPELL_GO` absent). With `RefireSpellGo` on, the stripped re-fired GO (87B vs 114B original) clears it — both repro modes, every fire, wire-confirmed; works even when the first GO never reaches the client.

## Open / follow-ups
- Fires on **every** instant — characterize side effects on the 99% of normal casts (occasional visual clip; check for double `UNIT_SPELLCAST_SUCCEEDED`) before defaulting on for users.
- Confirm the ~8ms re-fire holds across framerate (low/high `maxfps`).
- Launcher: bool toggle writing `RefireSpellGo` (replaces `SpellSuccessKitReset`); dual-write both keys during the cutover.
