### PR TITLE
Fix own-name "Unknown" after relogin (migrate queued name queries)

### DIFF
--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -556,6 +556,26 @@ public partial class WorldClient
         }
     }
 
+    // JimsProxy (relogin name "Unknown"): the delayed-send queues live on the WorldClient
+    // instance, so a CMSG_NAME_QUERY queued at char-select (delayUntil SMSG_LOGIN_VERIFY_WORLD)
+    // is discarded when HandlePlayerLogin recreates the WorldClient on relogin — and the
+    // player's own name then resolves to "Unknown" in target / target-of-target frames. Carry
+    // the SERVER-bound queue (only name queries are ever delayed there) over to the new
+    // instance so it flushes on the new login-verify. The client-bound queue is intentionally
+    // NOT migrated: it holds world-state-specific ordering packets that must not cross a relogin.
+    public void AdoptDelayedServerPacketsFrom(WorldClient previous)
+    {
+        if (previous == null || previous == this)
+            return;
+        foreach (var (opcode, packets) in previous._delayedPacketsToServer)
+        {
+            if (!_delayedPacketsToServer.TryGetValue(opcode, out var list))
+                _delayedPacketsToServer[opcode] = list = new List<WorldPacket>();
+            list.AddRange(packets);
+        }
+        previous._delayedPacketsToServer.Clear();
+    }
+
     /// <summary>
     /// Opcodes the legacy server may legitimately send before SMSG_AUTH_RESPONSE
     /// which we don't (yet) translate. They arrive during the auth handshake

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -260,6 +260,12 @@ public partial class WorldSocket
                 AbortLogin(LoginFailureReason.NoWorld);
                 return;
             }
+            // JimsProxy (relogin name "Unknown"): the new WorldClient starts with empty delayed
+            // queues; carry over the old client's queued name queries (queued at char-select
+            // delayUntil SMSG_LOGIN_VERIFY_WORLD) so they flush on the new login-verify instead of
+            // being dropped — otherwise the player's own name shows "Unknown" in target frames.
+            if (staleWorldClient != null)
+                GetSession().WorldClient!.AdoptDelayedServerPacketsFrom(staleWorldClient);
             GetSession().WorldClientNeedsRecreateOnNextLogin = false;
         }
         GetSession().IsInCharacterSelect = false;


### PR DESCRIPTION
## Summary
After a character switch / relogin, the local player's own name renders as **"Unknown"** when shown as a unit-frame *target* (a mob's target-of-target, or self-target), even though the player's own unit frame and nearby creature names resolve fine.

## Root cause
The delayed-send queue `WorldClient._delayedPacketsToServer` is a **per-instance** field. `HandleNameQueryRequest` (`CharacterHandler.cs`) queues the legacy `CMSG_NAME_QUERY` with `delayUntil SMSG_LOGIN_VERIFY_WORLD` when not yet in world (at char-select). On relogin, `HandlePlayerLogin` recreates the WorldClient (`new WorldClient()` + `ConnectToWorldServer`) with **empty** delayed queues and discards the old client without migrating them — so the queued name query is dropped and never sent. With no `SMSG_QUERY_PLAYER_NAME_RESPONSE`, the client falls back to "Unknown". Any query queued in the char-select→login window is lost on the recreate.

Upstream (Xian55) shares the delayed queue + name-query delay but does **not** recreate the WorldClient, so it never hits this — specific to our relogin recreate (`0d873bc`).

## Fix
Migrate the **server-bound** delayed queue from the old WorldClient to the new one at the recreate, so queued queries flush on the new login-verify. Only name queries are ever delayed server-bound, so the migration is safe. The **client-bound** queue is intentionally **not** migrated — it holds world-state-specific ordering packets that must not cross a relogin.

## Evidence
JSONL + `.pkt` captures: across a multi-relogin session, the char-select `CMSG_QUERY_PLAYER_NAME` before each recreate gets no response and there is zero name traffic afterward — the player's own name never resolves. Reproduces on **every** relogin; clean first logins are unaffected.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 581/581 pass
- [x] In-game **verified 2026-06-25** (build `30d7bc7`): after relog / character-switch, self-target and a mob's target-of-target resolve the player's own name — no "Unknown". A control build *without* this fix still showed "Unknown" on the same flow.
- [x] Pet "Unknown" confirmed a **separate** issue (immediate pet-name query path, petNumber→GUID mapping; not covered here) — tracked under #384.

## Note — unrelated finding (not introduced here)
A pre-existing **"World Server Down"** on *fast* character switches was observed during this PR's testing and filed separately as **#388**. It is **not** caused by this PR: the recreate aborts when `ConnectToWorldServer` returns false (server transiently refuses the new world TCP socket → `AbortLogin(NoWorld)`) *before* this PR's `AdoptDelayedServerPacketsFrom` call, which runs only on the success path. The recreate path itself predates this PR (`0d873bc`).