### PR TITLE
Preempt auto-attack stop when our target dies (ghost-swing fix)

### DIFF
--- a/HermesProxy.Tests/World/AttackStopPreemptOnDeathTests.cs
+++ b/HermesProxy.Tests/World/AttackStopPreemptOnDeathTests.cs
@@ -1,0 +1,90 @@
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (ghost-swing fix): gating for the preemptive auto-attack SMSG_ATTACK_STOP the proxy
+// sends to the modern client when the unit we're meleeing dies (SMSG_PARTY_KILL_LOG), instead of
+// waiting ~1 RTT for the legacy server to echo our stop. These tests lock in the disjoint-state
+// contract with PR #321 ("auto-attack stuck for ~30s when server rejects CMSG_ATTACK_SWING"):
+// the preempt fires ONLY in a settled auto-attack, and must defer (leave state untouched)
+// whenever a swing-start handshake is in flight — that state is owned by the SMSG_ATTACK_STOP
+// handler's #321 logic.
+public class AttackStopPreemptOnDeathTests
+{
+    private static GameSessionData NewState() => WowGuidTestHelper.CreateMockGameSessionData();
+    private static WowGuid64 Creature(uint counter) => new WowGuid64(HighGuidTypeLegacy.Creature, 1234, counter);
+
+    [Fact]
+    public void TryClearSettledAttackTargetOnDeath_SettledAttackOnDeadVictim_ClearsAndReturnsTrue()
+    {
+        var state = NewState();
+        var victim = Creature(1);
+        state.CurrentAttackTarget = victim;
+        state.WaitingForAttackStart = false;
+        state.DeferredAttackStop = false;
+
+        bool preempt = state.TryClearSettledAttackTargetOnDeath(victim);
+
+        Assert.True(preempt);
+        Assert.Equal(WowGuid64.Empty, state.CurrentAttackTarget);
+    }
+
+    [Fact]
+    public void TryClearSettledAttackTargetOnDeath_DifferentVictim_DoesNotFireOrClear()
+    {
+        // A different unit died (a party member's kill, our DoT on another mob). Our melee
+        // target is unaffected — must not fire and must not touch CurrentAttackTarget.
+        var state = NewState();
+        var attacking = Creature(1);
+        state.CurrentAttackTarget = attacking;
+
+        bool preempt = state.TryClearSettledAttackTargetOnDeath(Creature(2));
+
+        Assert.False(preempt);
+        Assert.Equal(attacking, state.CurrentAttackTarget);
+    }
+
+    [Fact]
+    public void TryClearSettledAttackTargetOnDeath_WaitingForAttackStart_DefersToPr321()
+    {
+        // Swing-start handshake in flight: PR #321's SMSG_ATTACK_STOP path owns this state.
+        // We must not preempt and must not clear, or the two fixes would fight over the target.
+        var state = NewState();
+        var victim = Creature(1);
+        state.CurrentAttackTarget = victim;
+        state.WaitingForAttackStart = true;
+
+        bool preempt = state.TryClearSettledAttackTargetOnDeath(victim);
+
+        Assert.False(preempt);
+        Assert.Equal(victim, state.CurrentAttackTarget);
+    }
+
+    [Fact]
+    public void TryClearSettledAttackTargetOnDeath_DeferredAttackStop_DoesNotFire()
+    {
+        var state = NewState();
+        var victim = Creature(1);
+        state.CurrentAttackTarget = victim;
+        state.DeferredAttackStop = true;
+
+        bool preempt = state.TryClearSettledAttackTargetOnDeath(victim);
+
+        Assert.False(preempt);
+        Assert.Equal(victim, state.CurrentAttackTarget);
+    }
+
+    [Fact]
+    public void TryClearSettledAttackTargetOnDeath_NotAutoAttacking_ReturnsFalse()
+    {
+        // Pure caster: never sent CMSG_ATTACK_SWING, so there is no settled target to tear down.
+        var state = NewState();
+
+        bool preempt = state.TryClearSettledAttackTargetOnDeath(Creature(1));
+
+        Assert.False(preempt);
+        Assert.Equal(WowGuid64.Empty, state.CurrentAttackTarget);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1552,6 +1552,29 @@ public sealed class GameSessionData
     }
 
     /// <summary>
+    /// JimsProxy (ghost-swing fix): the local player's auto-attack target just died, proven
+    /// terminally by SMSG_PARTY_KILL_LOG. If we were in a SETTLED auto-attack on it — the stop
+    /// victim matches CurrentAttackTarget, no swing-start handshake is in flight
+    /// (WaitingForAttackStart) and no stop is deferred (DeferredAttackStop) — clear the target
+    /// and return true so the caller can push the modern client an immediate SMSG_ATTACK_STOP
+    /// instead of waiting ~1 RTT for the legacy server to echo our CMSG_ATTACK_STOP. A dead unit
+    /// can never be auto-attacked, so the server can never contradict the early stop. Returns
+    /// false for the handshake / target-switch states, which are owned by the SMSG_ATTACK_STOP
+    /// handler's PR #321 logic — the two fixes stay on disjoint state. Pure data operation —
+    /// no socket dependency, easy to unit-test.
+    /// </summary>
+    public bool TryClearSettledAttackTargetOnDeath(WowGuid64 deadVictim)
+    {
+        if (CurrentAttackTarget == default || deadVictim != CurrentAttackTarget)
+            return false;
+        if (WaitingForAttackStart || DeferredAttackStop)
+            return false;
+
+        CurrentAttackTarget = default;
+        return true;
+    }
+
+    /// <summary>
     /// JimsProxy (PR #161 follow-up): walks PendingNormalCasts and PendingPetCasts,
     /// dequeues any entry whose WatchdogDeadlineMs has expired, and returns the
     /// evicted entries via the out parameters. Caller (GlobalSessionData

--- a/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CombatHandler.cs
@@ -288,8 +288,38 @@ public partial class WorldClient
     {
         PartyKillLog log = new();
         log.Player = packet.ReadGuid().To128(GetSession().GameState);
-        log.Victim = packet.ReadGuid().To128(GetSession().GameState);
+        var rawVictim = packet.ReadGuid();
+        log.Victim = rawVictim.To128(GetSession().GameState);
         SendPacketToClient(log);
+
+        var state = GetSession().GameState;
+
+        // JimsProxy (ghost-swing fix): if our SETTLED auto-attack target is the unit that just
+        // died, tear our melee down NOW instead of waiting ~1 RTT (~200ms on a remote realm)
+        // for the legacy server to echo our CMSG_ATTACK_STOP. The modern client treats
+        // auto-attack as server-authoritative, so until that SMSG_ATTACK_STOP lands it keeps
+        // swinging the corpse — a damage-less "ghost swing" with no combat-log line.
+        //
+        // Terminal proof, so safe to preempt: PARTY_KILL_LOG means the victim is already dead
+        // server-side, and a dead unit can never be auto-attacked — the server cannot contradict
+        // "you stopped attacking it." TryClearSettledAttackTargetOnDeath gates on a settled
+        // attack state so a swing-start handshake / target-switch (owned by PR #321's
+        // SMSG_ATTACK_STOP handling) is never disturbed; the real stop ~200ms later is a no-op.
+        // Same shape as the movement-cancel preempt (Server/PacketHandlers/MovementHandler.cs).
+        if (state.TryClearSettledAttackTargetOnDeath(rawVictim))
+        {
+            SAttackStop stop = new();
+            stop.Attacker = state.CurrentPlayerGuid;
+            stop.Victim = log.Victim;
+            stop.NowDead = true; // proven by PARTY_KILL_LOG
+            SendPacketToClient(stop);
+
+            Framework.Logging.Log.Event("combat.attack_stop_preempted", new
+            {
+                victim_low = log.Victim.GetCounter(),
+                trigger = "party_kill_log",
+            });
+        }
 
         // Mob just died — drop its threat list immediately so the modern
         // client's threat APIs go quiet on this unit instead of waiting for


### PR DESCRIPTION
## Summary
- When a *settled* auto-attack target dies, the modern client keeps swinging the corpse for ~1 RTT (~200ms on a remote realm). It treats auto-attack as **server-authoritative**, so it only tears the swing down once the legacy server echoes our `CMSG_ATTACK_STOP` — a full round trip after the kill. The result is a damage-less "ghost swing" with no combat-log line, most noticeable at high latency.
- On `SMSG_PARTY_KILL_LOG`, if the killed unit is our current auto-attack target and we're in a settled attack state, synthesize the player's `SMSG_ATTACK_STOP` (`NowDead=1`) to the client immediately and clear `CurrentAttackTarget`. The real server stop ~200ms later is then a no-op.

## Why it's safe to preempt
`SMSG_PARTY_KILL_LOG` is **terminal proof**: the victim is already dead server-side, and a dead unit can never be auto-attacked, so the server can never contradict "you stopped attacking it." This is the same class of guaranteed outcome as the existing movement-cancel cast preemption (movement always interrupts a cast-time spell). The preempt only ever asserts a state the server is forced to agree with — never a guess.

## Compatibility with #321 (auto-attack stuck ~30s on a rejected swing)
Disjoint state by construction. `TryClearSettledAttackTargetOnDeath` fires **only** when `!WaitingForAttackStart && !DeferredAttackStop`:
- #321 owns the swing-start handshake (`WaitingForAttackStart == true`, swing rejected because the target died before it started). This guard skips that case — and there's no started swing to "ghost" there anyway.
- This owns the settled case (`WaitingForAttackStart == false`). By the time the real server stop echoes, `CurrentAttackTarget` is already cleared, so it lands on the `!WaitingForAttackStart` branch, never #321's.
- Both clear `CurrentAttackTarget = default` as the safe remedy, so neither can cause or undo the other.

## Edge cases
- Different unit dies (party member's kill / our DoT on another mob): no fire, target untouched.
- Pure caster (never meleed): no settled target, no fire.
- Stale `CurrentAttackTarget` (an earlier swing was rejected): worst case a no-op stop on the client; "not attacking the dead unit" is still true.
- **Known gap:** gray mobs that award no XP send no `SMSG_PARTY_KILL_LOG`, so they aren't preempted. By design — only terminal-proof triggers.

## Test plan
- [x] `AttackStopPreemptOnDeathTests` — full gating truth table (settled-fire, different-victim, WaitingForAttackStart-defer, DeferredAttackStop-defer, not-attacking)
- [x] Full suite green (586/586)
- [ ] PTR: grind XP mobs, confirm no post-death swing/sound and `combat.attack_stop_preempted` fires
- [ ] PTR: target-switch and rapid re-attack still feel correct (no #321 regression)