### PR TITLE
Fix breath bar not reappearing after underwater air pocket

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MiscHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MiscHandler.cs
@@ -244,6 +244,16 @@ public partial class WorldClient
         timer.Scale = packet.ReadInt32();
         timer.Paused = packet.ReadBool();
         timer.SpellID = packet.ReadInt32();
+
+        // JimsProxy: the 1.14 client's mirror-timer engine fails to re-show the
+        // breath bar on a START that arrives after a STOP for the same timer
+        // (e.g. leaving an underwater air pocket while still submerged — Kronos
+        // sends a clean depleting START but the bar never reappears). A fresh
+        // dive works because no BREATH timer exists when the START arrives, so
+        // reproduce that clean state by tearing down any lingering timer first.
+        if (timer.Timer == MirrorTimerType.Breath)
+            SendPacketToClient(new StopMirrorTimer { Timer = MirrorTimerType.Breath });
+
         SendPacketToClient(timer);
     }
 


### PR DESCRIPTION
## Summary
Leaving an underwater air pocket (e.g. a bubbling rock) while still submerged left the breath bar hidden until you resurfaced. Kronos correctly sends a fresh depleting START on re-submerge, but the 1.14 client's mirror-timer engine fails to re-show the bar on a START that arrives after a STOP for the same timer.

A normal dive works because no BREATH timer exists when the START arrives. This reproduces that clean state by emitting a `StopMirrorTimer(BREATH)` before forwarding the START, so the client engine tears down any lingering (stopped) timer and rebuilds the bar. Scoped to `BREATH` only.

## Root cause (everything else was clean)
- **Proxy**: forwards every `SMSG_*_MIRROR_TIMER` faithfully (no drop/mistranslate).
- **Server**: decoded modern `.pkt` shows the re-submerge START is valid — `BREATH, value=60000=max, scale=-1`. vmangos drowning logic confirms the bare `STOP -> START` sequence when leaving an air pocket ("as if above water").
- **Client UI Lua** (`MirrorTimer.lua`, Classic Era): re-show logic is correct.
- The failure is in the client's closed C-engine timer state machine (re-START after STOP for the same type). The depleting START always has `value==max` and rendered fine on a normal dive, so the trigger is specifically the re-START-after-STOP, not the value.

## Test plan
- [x] In-game (Twinstar/Kronos, 1.14.2): dive -> air rock until breath tops off (bar hides) -> move away while still submerged -> breath bar reappears and resumes draining.
- [x] No change to non-BREATH timers (fatigue / feign-death) or to the normal dive/surface flow.