### PR TITLE
Fix queued instant firing a full cast-time late (GCD held_pending race)

### DIFF
--- a/HermesProxy.Tests/World/GcdHoldTests.cs
+++ b/HermesProxy.Tests/World/GcdHoldTests.cs
@@ -175,6 +175,80 @@ public class GcdHoldTests
         Assert.Equal(200u, fired?.SpellId);
     }
 
+    // JimsProxy (GCD held_pending race): a press parked by ForceHoldCast (the
+    // HasForwardedPendingCast guard) has no timer/deadline of its own. When the cast that
+    // blocked it is a CAST-TIME spell, TakeForcedHoldOrphanedByCastTimeStart releases it at
+    // that cast's SPELL_START so it doesn't ride the whole cast and fire a full cast-time late.
+
+    [Fact]
+    public void TakeForcedHoldOrphanedByCastTimeStart_CastTimeStart_NoActiveTimer_ReleasesParkedCast()
+    {
+        var session = NewSession();
+        var parked = MakeCast(10202); // Arcane Explosion (instant), parked behind the cast-time spell
+        session.ForceHoldCast(parked);
+
+        // Frostbolt (3000ms cast-time) reaches SPELL_START; no GCD timer is armed for it, and its
+        // next SPELL_GO is 3s away at completion. Without release here the press rides the cast.
+        var released = session.TakeForcedHoldOrphanedByCastTimeStart(startedCastTimeMs: 3000);
+
+        Assert.Same(parked, released);
+        Assert.Null(session.PeekHeldGcdCast());
+    }
+
+    [Fact]
+    public void TakeForcedHoldOrphanedByCastTimeStart_InstantStart_LeavesParkedCast()
+    {
+        var session = NewSession();
+        var parked = MakeCast(10202);
+        session.ForceHoldCast(parked);
+
+        // An instant START (CastTime == 0) is left to the existing GO/BeginGcd timer path,
+        // which correctly queues an instant-after-instant press for the next GCD expiry.
+        var released = session.TakeForcedHoldOrphanedByCastTimeStart(startedCastTimeMs: 0);
+
+        Assert.Null(released);
+        Assert.Same(parked, session.PeekHeldGcdCast());
+    }
+
+    [Fact]
+    public void TakeForcedHoldOrphanedByCastTimeStart_GcdTimerStillPending_LeavesParkedCast()
+    {
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        session.BeginGcd(now + 5000, now + 5000); // GCD active — its timer will release the hold
+        var parked = MakeCast(10202);
+        session.ForceHoldCast(parked);
+
+        var released = session.TakeForcedHoldOrphanedByCastTimeStart(startedCastTimeMs: 3000);
+
+        Assert.Null(released);
+        Assert.Same(parked, session.PeekHeldGcdCast());
+
+        session.CancelGcdHold(); // dispose the pending timer
+    }
+
+    [Fact]
+    public void TakeForcedHoldOrphanedByCastTimeStart_AnotherForwardedCastUnstarted_LeavesParkedCast()
+    {
+        var session = NewSession();
+        var forwarded = MakeCast(10181); // a still-unstarted forwarded cast — keep waiting for it
+        session.PendingNormalCasts.Enqueue(forwarded);
+        var parked = MakeCast(10202);
+        session.ForceHoldCast(parked);
+
+        var released = session.TakeForcedHoldOrphanedByCastTimeStart(startedCastTimeMs: 3000);
+
+        Assert.Null(released);
+        Assert.Same(parked, session.PeekHeldGcdCast());
+    }
+
+    [Fact]
+    public void TakeForcedHoldOrphanedByCastTimeStart_NothingParked_ReturnsNull()
+    {
+        var session = NewSession();
+        Assert.Null(session.TakeForcedHoldOrphanedByCastTimeStart(startedCastTimeMs: 3000));
+    }
+
     // JimsProxy issue #43 post-review hardening tests:
 
     [Fact]

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1781,6 +1781,36 @@ public sealed class GameSessionData
         }
     }
 
+    /// <summary>
+    /// JimsProxy (GCD held_pending race): release a press parked in _heldGcdCast by the
+    /// HasForwardedPendingCast guard (ForceHoldCast) when the forwarded cast that blocked it
+    /// turns out to be a CAST-TIME spell, learned at its SPELL_START. Cast-time spells arm no
+    /// GCD-expiry timer (BeginGcd is GO-side, instants only) and their next SPELL_GO is at
+    /// completion — so the parked press would otherwise ride the entire cast and fire a full
+    /// cast-time late. Returns the parked cast for the caller to forward (the server answers
+    /// SpellInProgress while the cast occupies the caster). Returns null for an instant START
+    /// (startedCastTimeMs == 0 — left to the GO/BeginGcd path), while a GCD timer is still
+    /// pending (it will release the hold), while another forwarded cast is still unstarted
+    /// (keep waiting for it), or when nothing is parked.
+    /// </summary>
+    public ClientCastRequest? TakeForcedHoldOrphanedByCastTimeStart(uint startedCastTimeMs)
+    {
+        if (startedCastTimeMs == 0)
+            return null;
+        if (HasForwardedPendingCast())
+            return null;
+        lock (_gcdLock)
+        {
+            if (_heldGcdCast == null)
+                return null;
+            if (_gcdExpireTimestampMs > Environment.TickCount64)
+                return null; // GCD timer still pending — it will release the hold
+            var cast = _heldGcdCast;
+            _heldGcdCast = null;
+            return cast;
+        }
+    }
+
     // ── RTT measurement and adaptive GCD offset ───────────────────────
 
     public void RecordPingSent(uint serial)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1385,6 +1385,24 @@ public partial class WorldClient
                         client_cast_id = failed.ClientGUID.ToString(),
                     });
             }
+
+            // JimsProxy (GCD held_pending race): if this START is a cast-time spell, release any
+            // press parked behind it (ForceHoldCast via the HasForwardedPendingCast guard) so it
+            // doesn't ride the whole cast and fire a full cast-time late. Cast-time spells arm no
+            // GCD-expiry timer and their next SPELL_GO is at completion. Forward the released
+            // press so the server returns its real response (SpellInProgress while the cast
+            // occupies the caster); instant starts (CastTime == 0) are left to the GO/BeginGcd
+            // path. Placed after the non-started sweep so the released press isn't swept here.
+            var orphanedHold = GetSession().GameState.TakeForcedHoldOrphanedByCastTimeStart(spell.Cast.CastTime);
+            if (orphanedHold != null)
+            {
+                Log.Event("spell.held_release_on_casttime_start", new
+                {
+                    started_spell_id = spell.Cast.SpellID,
+                    held_spell_id = orphanedHold.SpellId,
+                });
+                GetSession().GameState.OnGcdHeldCastFire?.Invoke(orphanedHold);
+            }
         }
         bool petCastWasPlayerPressed = false;
         if (casterIsLocalPet &&


### PR DESCRIPTION
## Summary
With **LowLatencyMode off** (queue active), mashing a **cast-time spell + an instant** together right at GCD expiry could park the instant in the hidden hold slot for the **entire** duration of the cast-time spell, firing it as a late "ghost" cast on that spell's completion — instead of rejecting it or holding it only within the ~queue window. The race window is ~`fireOffset + ½ RTT` wide, so the hit rate scales with latency and low-ping players rarely see it.

**Severity: low / cosmetic** — the cast fires late; nothing sticks, desyncs, or breaks. Fix is for queue correctness.

## Root cause
The `_heldGcdCast` slot, when written via `ForceHoldCast` on the `HasForwardedPendingCast()` guard (`World/Server/PacketHandlers/SpellHandler.cs`), has **no timer or deadline**. It is released only by a later `SPELL_GO` / `SPELL_FAILURE` once `HasForwardedPendingCast()` clears. When the forwarded cast that triggered the hold is a **cast-time** spell, `BeginGcd` is never called for it (it is GO-side, instants only) so no GCD-expiry timer is armed, and its next `SPELL_GO` is its *completion* — so the parked instant rides the whole cast (`held_for_ms ≈ cast time`). `instant→instant` is unaffected: the forwarded instant's GO re-arms a GCD timer that releases the held press at the next expiry.

## Fix
At a cast-time spell's `SMSG_SPELL_START` (`CastTime > 0`), if a press is parked in `_heldGcdCast` with no other forwarded cast pending and no active GCD timer, **release it by forwarding** — the legacy server returns its real response (`SpellInProgress` while the cast occupies the caster), matching the existing "earlier presses receive the server's actual response" queue semantics. Deterministic and packet-paired (keyed on START + cast-time), no time-based cap. Instant starts (`CastTime == 0`) are left to the GO/`BeginGcd` path; the separate cast-end queue (`_heldCastTimeCast`) is untouched.

New `GameSessionData.TakeForcedHoldOrphanedByCastTimeStart` encapsulates the decision. Rare diagnostic `spell.held_release_on_casttime_start` logs each release.

(Unrelated to the ruled-out `SpellSuccessKitReset` / "B2" work — reproduced with that off.)

## Test plan
- [x] `dotnet test` — **586 pass**, including 5 new `GcdHoldTests` (release on cast-time START, instant-start no-op, pending-timer no-op, other-forwarded-cast no-op, empty-slot).
- [ ] In-game (Mage, in combat, **LowLatencyMode OFF**): mash Frostbolt + Arcane Explosion timed at GCD expiry; AE should no longer fire a full cast-time late — it rejects ("another action in progress") or holds only within the queue window. Easier to repro on a higher-RTT account.