### PR TITLE
Fix Eggscilloscope on Rookery Egg (#387): present TRAP GO as GOOBER

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -542,6 +542,16 @@ public partial class WorldClient
         GameObjectStats gameObject = response.Stats;
 
         gameObject.Type = packet.ReadUInt32();
+
+        // Rookery Egg (175124): present vanilla TRAP (6) as GOOBER (10) so the 1.14 client lets
+        // the Eggscilloscope target it (see UpdateHandler / #387). This is the value cached in
+        // gameobjectcache.wdb, so players must clear that cache once to pick up the change.
+        if (response.GameObjectID == 175124 && gameObject.Type == 6)
+        {
+            gameObject.Type = 10;
+            Log.Event("gameobject.egg.typeoverride", new { entry = response.GameObjectID, from = 6, to = 10 });
+        }
+
         gameObject.DisplayID = packet.ReadUInt32();
 
         for (int i = 0; i < 4; i++)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -4171,7 +4171,17 @@ public partial class WorldClient
             int GAMEOBJECT_TYPE_ID = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_TYPE_ID);
             if (GAMEOBJECT_TYPE_ID >= 0 && updateMaskArray[GAMEOBJECT_TYPE_ID])
             {
-                updateData.GameObjectData.TypeID = (sbyte)updates[GAMEOBJECT_TYPE_ID].Int32Value;
+                sbyte goType = (sbyte)updates[GAMEOBJECT_TYPE_ID].Int32Value;
+
+                // Rookery Egg (175124): vanilla GO type is TRAP (6), which fires Summon Rookery
+                // Whelp on proximity. The 1.14 client won't let you select/spell-target a TRAP, so
+                // the Eggscilloscope (Freeze Rookery Egg 15748) finds no valid target. Present it
+                // as GOOBER (10) — a selectable "use/activate" quest object — so the client can
+                // target it. The whelp-spawn trap is server-side and unaffected. See #387.
+                if (updateData.ObjectData.EntryID == 175124 && goType == 6)
+                    goType = 10;
+
+                updateData.GameObjectData.TypeID = goType;
             }
             int GAMEOBJECT_LEVEL = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_LEVEL);
             if (GAMEOBJECT_LEVEL >= 0 && updateMaskArray[GAMEOBJECT_LEVEL])


### PR DESCRIPTION
Fixes #387

## Summary
- The Rookery Egg (GameObject **175124**) is type **TRAP** in 1.12 data — it fires Summon Rookery Whelp on proximity. The 1.14 client won't select or spell-target a TRAP GameObject, so the Eggscilloscope (Freeze Rookery Egg **15748/16028**) found **no valid target**: no mouseover highlight, no interaction at any distance, and no `CMSG_USE_ITEM` ever left the client.
- Presents the egg as **GOOBER** (a selectable use/activate quest object) in both the GameObject query response (the value cached in `gameobjectcache.wdb`) and the object-update type field. Entry-scoped to 175124.
- The trap's proximity whelp-spawn is server-side and unaffected by the client-facing type change.

## Deployment note
The stale `TRAP` type is cached in the client's `gameobjectcache.wdb` and persists within the same client build, so this takes effect only after a one-time GO-cache clear. The launcher's auto-clear-cache option covers existing players.

## Test plan
- [x] In-game on Kronos (after cache clear): egg highlights on mouseover; Eggscilloscope targets the egg; freeze fires and quest progresses. Packet-confirmed: `gameobject.egg.typeoverride` (175124, 6→10) → `cast.forwarded` spell 16028 `source:"item"` → `spell.cast` start→go.
- [ ] Sanity: other Blackrock Spire GOs (doors / chests / runes) still interact normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)