### PR TITLE
Restore channel object for Ritual of Summoning participants

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -547,6 +547,11 @@ public sealed class GameSessionData
     // SMSG_SPELL_CHANNEL_START/UPDATE for observers (vanilla only sends
     // MSG_CHANNEL_START to the caster, not to nearby players).
     public ConcurrentDictionary<WowGuid128, int> UnitChannelSpells = new();
+    // #383: maps a channeling unit -> (GameObject that triggered the channel, spellId).
+    // Kronos sends ritual participants UNIT_CHANNEL_SPELL but no channel object, so the
+    // 1.14 client has the channel spell yet no portal to face and never strikes the pose.
+    // We recall the portal from the unit's SPELL_GO cast-source to restore the object.
+    public ConcurrentDictionary<WowGuid128, (WowGuid128 SourceObject, int SpellId)> ChannelSourceObjectByUnit = new();
     public WowGuid64 LastLootTargetGuid;
     //MIRASU - ConcurrentDictionary because abandon-clear runs on the modern-server thread
     //MIRASU   (CMSG_QUEST_LOG_REMOVE_QUEST handler in Server/QuestHandler.cs) while item-credit

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1597,6 +1597,18 @@ public partial class WorldClient
             return;
         }
 
+        // JimsProxy (#383): a Summoning Portal (GameObject) casting a participant's
+        // "Arcane Channeling" appears as the SPELL_GO cast-source. Remember it per
+        // caster so the UNIT_CHANNEL_SPELL handler can restore the channel object
+        // Kronos omits for ritual participants; cleared when the channel ends.
+        if (spell.Cast.CasterGUID.GetObjectType() == ObjectType.GameObject &&
+            spell.Cast.CasterGUID != spell.Cast.CasterUnit &&
+            !spell.Cast.CasterUnit.IsEmpty())
+        {
+            GetSession().GameState.ChannelSourceObjectByUnit[spell.Cast.CasterUnit] =
+                (spell.Cast.CasterGUID, spell.Cast.SpellID);
+        }
+
         // Cannibalize channel (20578): matching the SPELL_START suppression.
         // No pending-cast entry exists for 20578, so all dequeue/GCD paths
         // below are no-ops. GCD is driven by SPELL_GO 20577 (the wrapper).

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2683,6 +2683,19 @@ public partial class WorldClient
                 uint spellVisual = GameData.GetSpellVisual((uint)spellId);
                 updateData.UnitData.ChannelData = new UnitChannel(spellId, (int)spellVisual);
 
+                // #383: ritual participants get UNIT_CHANNEL_SPELL but no channel object
+                // from Kronos, so the client has the channel spell yet no portal to face
+                // and never poses. Restore the object from the GO that cast this same
+                // spell's SPELL_GO. Rides the channel lifecycle (cleared on channel end).
+                if (spellId != 0 &&
+                    updateData.UnitData.ChannelObject == null &&
+                    guid != GetSession().GameState.CurrentPlayerGuid &&
+                    GetSession().GameState.ChannelSourceObjectByUnit.TryGetValue(guid, out var ritualSource) &&
+                    ritualSource.SpellId == spellId)
+                {
+                    updateData.UnitData.ChannelObject = ritualSource.SourceObject;
+                }
+
                 if (guid != GetSession().GameState.CurrentPlayerGuid)
                 {
                     var channelSpells = GetSession().GameState.UnitChannelSpells;
@@ -2704,6 +2717,7 @@ public partial class WorldClient
                         else
                         {
                             channelSpells.TryRemove(guid, out _);
+                            GetSession().GameState.ChannelSourceObjectByUnit.TryRemove(guid, out _); // #383
                             if (GetSession().GameState.JimsPlusSideband)
                             {
                                 var chatPkt = new ChatPkt(GetSession(), ChatMessageTypeModern.System,


### PR DESCRIPTION
## Summary
- Ritual of Summoning participants channel "Arcane Channeling" (23017) toward the Summoning Portal, but Kronos broadcasts observers the participant's `UNIT_CHANNEL_SPELL` **without** a `UNIT_FIELD_CHANNEL_OBJECT`. The 1.14 client then has the channel spell but no portal to face, so it never plays the channel pose -- participants look idle to everyone else.
- The portal is the GameObject that cast the participant's `SPELL_GO`. We remember it per-caster (`ChannelSourceObjectByUnit`) and, when forwarding a non-local unit's channel that carries no object, restore `UNIT_FIELD_CHANNEL_OBJECT` to the portal so the client renders the pose. Cleared deterministically on channel end (`UNIT_CHANNEL_SPELL -> 0`).
- Narrow by construction: only fires when a GameObject cast the channel and the legacy update omitted the object. The warlock's own 698 channel and normal player channels are untouched (their object already arrives / their cast-source is not a GO).

## Diagnosis
An observer-side packet capture of a live ritual showed both the warlock (698) and participants (23017) get `UNIT_FIELD_CHANNEL_DATA` forwarded -- but only the warlock's update also carries the portal as `UNIT_DYNAMIC_FIELD_CHANNEL_OBJECTS`. The participants' channel update has an empty dynamic block, so the channel object is the only channel-relevant field missing.

## Test plan
- [x] 581/581 unit tests pass
- [x] In-game: ritual participants now visibly channel toward the portal for observers (previously idle)

Fixes #383