### PR TITLE
Fix GCD-boundary double-forward desync (random looping cast sound, #394)

### DIFF
--- a/HermesProxy.Tests/World/HasNonStartedPendingCastTests.cs
+++ b/HermesProxy.Tests/World/HasNonStartedPendingCastTests.cs
@@ -1,0 +1,75 @@
+using System;
+using HermesProxy;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (#394 GCD-boundary double-forward): HasNonStartedPendingCastForSpell is the
+// decision predicate for BOTH layers of the fix — ForwardHeldGcdCast's supersede skip
+// ("a fresh same-spell press already forwarded ⇒ don't double-forward the stale held press")
+// and HandleCastFailed's transient-stale-drop ("no unstarted dup left ⇒ the transient
+// rejection is stale, drop it before it consumes the STARTED cast").
+public class HasNonStartedPendingCastTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static ClientCastRequest MakeCast(uint spellId, bool started = false)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            HasStarted = started,
+        };
+    }
+
+    [Fact]
+    public void EmptyQueue_ReturnsFalse()
+    {
+        var session = NewSession();
+        Assert.False(session.HasNonStartedPendingCastForSpell(1454));
+    }
+
+    [Fact]
+    public void UnstartedSameSpell_ReturnsTrue()
+    {
+        // The #394 shape: a fresh press forwarded immediately at the GCD boundary sits
+        // unstarted in the queue when the late timer callback fires the held press.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(1454));
+
+        Assert.True(session.HasNonStartedPendingCastForSpell(1454));
+    }
+
+    [Fact]
+    public void StartedSameSpell_ReturnsFalse()
+    {
+        // The stale-drop shape: on-START sweep already consumed the unstarted dup; only the
+        // STARTED cast remains — a transient CAST_FAILED now has nothing legitimate to consume.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(1454, started: true));
+
+        Assert.False(session.HasNonStartedPendingCastForSpell(1454));
+    }
+
+    [Fact]
+    public void UnstartedDifferentSpell_ReturnsFalse()
+    {
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(6222));
+
+        Assert.False(session.HasNonStartedPendingCastForSpell(1454));
+    }
+
+    [Fact]
+    public void LegacySpellIdMatch_ReturnsTrue()
+    {
+        // SoM-renumbered items: the legacy emulator replies with the old id.
+        var session = NewSession();
+        var cast = MakeCast(363880);
+        cast.LegacySpellId = 17626;
+        session.PendingNormalCasts.Enqueue(cast);
+
+        Assert.True(session.HasNonStartedPendingCastForSpell(17626));
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -351,15 +351,24 @@ public partial class WorldClient
         bool isTransientReason = reason == (uint)SpellCastResultVanilla.NotReady ||
                                  reason == (uint)SpellCastResultVanilla.SpellInProgress;
 
-        // JimsProxy (transient-no-dismiss-started): under LowLatencyMode a transient failure
-        // (NOT_READY / SpellInProgress) is the server rejecting a DUPLICATE press, never an
-        // interrupt of the cast already in progress. If no unstarted duplicate is still queued to
-        // consume (the on-START sweep already cleared + acked it), this rejection is stale — drop it
-        // BEFORE the suppression branch and the dequeue below, both of which would otherwise fall
-        // back to the STARTED cast and dismiss its bar (the "interrupted but fired" desync). Normal
-        // mode is unaffected (no dups reach the server); real failures (OOR/LoS/OOM) are non-transient.
-        if (isTransientReason && Settings.LowLatencyMode &&
-            !GetSession().GameState.HasNonStartedPendingCastForSpell(spellId))
+        // JimsProxy (transient-no-dismiss-started): a transient failure (NOT_READY /
+        // SpellInProgress) is the server rejecting a DUPLICATE press, never an interrupt of the
+        // cast already in progress — the server never starts a cast and then rejects it with a
+        // pre-cast reason. If no unstarted duplicate is still queued to consume (the on-START
+        // sweep already cleared + acked it), this rejection is stale — drop it BEFORE the
+        // suppression branch and the dequeue below, both of which would otherwise fall back to
+        // the STARTED cast and dismiss its bar (the "interrupted but fired" desync, and in queue
+        // mode the client-side START→CastFailed→GO one-frame contradiction that orphans the cast
+        // kit — the #394 looping sound). Originally gated to LowLatencyMode on the premise that
+        // queue mode sends no dups; the #394 JSONL disproved that — the GCD-boundary held-release
+        // timer race double-forwards in queue mode too (see ForwardHeldGcdCast's supersede skip).
+        // Real failures (OOR/LoS/OOM) are non-transient and unaffected. Next-melee / auto-repeat
+        // slots live outside PendingNormalCasts — a transient rejection matching one of those
+        // must still flow to the special-cast branch below to resolve and clear its slot.
+        if (isTransientReason &&
+            !GetSession().GameState.HasNonStartedPendingCastForSpell(spellId) &&
+            GetSession().GameState.CurrentClientNextMeleeCast?.SpellId != spellId &&
+            GetSession().GameState.CurrentClientAutoRepeatCast?.SpellId != spellId)
         {
             if (Framework.Settings.DebugOutput)
                 Log.Event("cast.transient_stale_dropped", new { spell_id = spellId });

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -754,6 +754,28 @@ public partial class WorldSocket
             return;
 
         var gameState = GetSession().GameState;
+
+        // JimsProxy (#394 GCD-boundary double-forward): the release timer runs on the Windows
+        // timer quantum (~15.6ms), so it can fire LATE relative to the GCD deadline. A fresh
+        // same-spell press landing in that gap sees the quantized clock as "GCD over" (window
+        // check and ShouldDropLateSameSpell both read expired) and forwards immediately — if we
+        // then still fire the held press, the server gets TWO CMSGs ~ms apart in reversed press
+        // order. The loser's transient CAST_FAILED lands between the winner's START and GO and
+        // desyncs the pairing (START→CastFailed→GO in one client frame = the #394 looping
+        // sound). The fresh press won the race and IS this spell's cast — ack the stale held
+        // press instead of double-forwarding. The reverse ordering (timer first, press after)
+        // is already handled: the press finds HasForwardedPendingCast() true and is parked.
+        if (gameState.HasNonStartedPendingCastForSpell(cast.SpellId))
+        {
+            SendCastRequestFailed(cast, false, SpellCastResultClassic.DontReport);
+            Log.Event("spell.held_fire_superseded", new
+            {
+                spell_id = cast.SpellId,
+                client_cast_id = cast.ClientGUID.ToString(),
+            });
+            return;
+        }
+
         // DIAGNOSTIC (stuck-spell investigation): remove when closed
         if (Framework.Settings.DebugOutput)
             Log.Event("cast.forwarded", new


### PR DESCRIPTION
## Summary

Root cause and fix for #394 (AliziaKaline's random "cast sound and fx loop" — she pinned it to **Life Tap 1454**, and her JSONL confirms it). This is the *second* bug discussed in the #379 thread, distinct from ice-92's form-exit ordering bug (fixed separately in #396).

**Root cause (from the #394 JSONL, queue mode, every step packet-verified):**
1. The GCD held-release timer runs on the Windows timer quantum (~15.6ms) and fired **14ms late**. A fresh same-spell press landed in the gap and passed every guard — `IsInGcdQueueWindow` and `ShouldDropLateSameSpell` both read the quantized clock as "GCD over", the timer hadn't fired, and the held press wasn't enqueued yet — so it forwarded immediately. The late callback then forwarded the stale held press anyway: **two CMSGs, 6ms apart, reversed press order**.
2. The server cast one and rejected the other with a **transient CAST_FAILED that landed between the winner's START and GO**. The on-START sweep had already consumed the unstarted dup, so the CAST_FAILED's dequeue fell back to the **started** entry.
3. The client received **`START → CastFailed → GO` for one CastID inside a single frame** — orphaned cast kit, looping sound. (#362's recovery restored the GO's CastID but can't undo the CastFailed; the recovered-GO path also skips `BeginGcd`, briefly losing GCD tracking.)

Explains her observations: `SpellCastEarlyFireOffsetMs` had no effect (the race is clock-quantization-driven, not offset-driven), `DebugOutput=true` "reduced" it (ms-scale timing perturbation), and `RefireSpellGo=true` didn't prevent it (different mechanism than the coalesced-GO drop).

**Fix — two deterministic, packet-paired layers (no timers, no time-based cleanup):**
- **`ForwardHeldGcdCast` supersede skip:** if an unstarted same-spell cast is already forwarded when the held release fires, the fresh press won the race — ack the stale held press (`CastFailed DontReport`) instead of double-forwarding. Logged as `spell.held_fire_superseded`.
- **Transient-stale-drop un-gated for queue mode** (was LowLatencyMode-only, from #376): a transient reason (NOT_READY/SpellInProgress) is always a *pre-cast* rejection — the server never starts a cast then rejects it with one — so with no unstarted dup left it is stale and dropped before it can consume the started cast. #376's "queue mode sends no dups" premise is what this log disproved. **Hardened over #376:** the drop now defers to a live next-melee / auto-repeat slot (their casts live outside `PendingNormalCasts`), which strengthens the LowLatencyMode path too.

Replaying the #394 capture against this code: held press superseded + acked, server sees one CMSG, clean `START → GO`. If a dup ever slips the supersede check (the immediate-path enqueue is a hair outside the timer's lock), the stale-drop neutralizes its CAST_FAILED and the GO dequeues the started cast normally — no recovery path, no GCD-tracking loss.

Sibling of #391 (same `_heldGcdCast`/timer machinery, different leg: #391 = parked press fires late; this = double-forward). Kept separate per its own repro/log story.

## Test plan

- [x] `dotnet test` — 586 pass (581 existing + 5 new `HasNonStartedPendingCastTests`)
- [ ] PTR queue mode: spam an instant (Life Tap-style) across many GCD boundaries — watch JSONL for `spell.held_fire_superseded` firing and **zero** `cast.non_started_swept`/`cast.go.castid_recovered` around it
- [ ] PTR queue mode: warrior Heroic Strike re-press + hunter Auto Shot toggle — special-cast slots still resolve (no stuck-lit buttons)
- [ ] Regression: cast-time spam (Frostbolt) and off-GCD spam unchanged
- [ ] Ask AliziaKaline to run this build on Stonetavern (her repro: "spam heal yourself")

Closes #394