### PR TITLE
Present observed charmed players as possessed (#382 bystander lockup)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -724,6 +724,18 @@ public sealed class GameSessionData
     // synthesize it. Same shape as KnownHoveringMobs above.
     public HashSet<WowGuid128> KnownSwimmingMobs = [];
 
+    // JimsProxy (#382 observer lockup): players we observe being CHARMED by someone other
+    // than the local player (Gnomish Mind Control Cap 13181 = vanilla MOD_CHARM on a player).
+    // Vanilla charm reaches observers as PLAYER_CONTROLLED + CHARMEDBY with no POSSESSED bit,
+    // and the 1.14 client has no representation for a charmed PLAYER (modern can't charm
+    // players; possess — priest MC 605 — renders fine, which is why priest MC never locks
+    // observers). While a guid is in here, the UNIT_FIELD_FLAGS translation forces
+    // UNIT_FLAG_POSSESSED so observing clients render their known possess path instead.
+    // Scoped to third-party observers only: the charmer keeps its real charm/pet bar and
+    // the target is untouched. Self-clears when CHARMEDBY empties (charm end) or on a
+    // fresh create block (re-appearance after an out-of-range charm end).
+    public HashSet<WowGuid128> ObservedCharmedPlayers = [];
+
     // JimsProxy (Tallstrider-Fix): per-GUID last-known facing orientation, populated from
     // any MovementInfo we observe (spawn, heartbeat, ObjectUpdate movement block). Used by
     // MovementHandler.HandleMonsterMove to compare the creature's current facing against

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -724,8 +724,9 @@ public sealed class GameSessionData
     // synthesize it. Same shape as KnownHoveringMobs above.
     public HashSet<WowGuid128> KnownSwimmingMobs = [];
 
-    // JimsProxy (#382 observer lockup): players we observe being CHARMED by someone other
-    // than the local player (Gnomish Mind Control Cap 13181 = vanilla MOD_CHARM on a player).
+    // JimsProxy (#382 observer lockup): players we observe being CHARMED by another PLAYER
+    // (Gnomish Mind Control Cap 13181 = vanilla MOD_CHARM on a player). NPC charmers (raid
+    // MCs like Lucifron's Dominate Mind) are excluded — long-stable content, no lockup reports.
     // Vanilla charm reaches observers as PLAYER_CONTROLLED + CHARMEDBY with no POSSESSED bit,
     // and the 1.14 client has no representation for a charmed PLAYER (modern can't charm
     // players; possess — priest MC 605 — renders fine, which is why priest MC never locks

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2189,14 +2189,17 @@ public partial class WorldClient
                 WowGuid128 charmedBy = GetGuidValue(updates, UnitField.UNIT_FIELD_CHARMEDBY).To128(GetSession().GameState);
                 updateData.UnitData.CharmedBy = charmedBy;
 
-                // JimsProxy (#382 observer lockup): track players charmed by someone other than us,
+                // JimsProxy (#382 observer lockup): track players charmed by ANOTHER PLAYER,
                 // so the flags translation below can present them as possessed (see
                 // GameSessionData.ObservedCharmedPlayers). Excludes the charmer (needs the real
                 // charm/pet bar) and the local player as target (lives the real charm), so the
                 // charm-vs-possess control difference is preserved for the participants.
+                // NPC charmers (Lucifron's Dominate Mind et al.) are deliberately excluded:
+                // years of raid MCs have produced no observer-lockup reports, so that
+                // long-stable content stays untouched.
                 var gameState = GetSession().GameState;
                 bool observedCharmedPlayer = guid.IsPlayer() &&
-                    charmedBy != WowGuid128.Empty &&
+                    charmedBy.IsPlayer() &&
                     guid != gameState.CurrentPlayerGuid &&
                     charmedBy != gameState.CurrentPlayerGuid;
                 if (observedCharmedPlayer)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2186,7 +2186,41 @@ public partial class WorldClient
             int UNIT_FIELD_CHARMEDBY = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_CHARMEDBY);
             if (UNIT_FIELD_CHARMEDBY >= 0 && updateMaskArray[UNIT_FIELD_CHARMEDBY])
             {
-                updateData.UnitData.CharmedBy = GetGuidValue(updates, UnitField.UNIT_FIELD_CHARMEDBY).To128(GetSession().GameState);
+                WowGuid128 charmedBy = GetGuidValue(updates, UnitField.UNIT_FIELD_CHARMEDBY).To128(GetSession().GameState);
+                updateData.UnitData.CharmedBy = charmedBy;
+
+                // JimsProxy (#382 observer lockup): track players charmed by someone other than us,
+                // so the flags translation below can present them as possessed (see
+                // GameSessionData.ObservedCharmedPlayers). Excludes the charmer (needs the real
+                // charm/pet bar) and the local player as target (lives the real charm), so the
+                // charm-vs-possess control difference is preserved for the participants.
+                var gameState = GetSession().GameState;
+                bool observedCharmedPlayer = guid.IsPlayer() &&
+                    charmedBy != WowGuid128.Empty &&
+                    guid != gameState.CurrentPlayerGuid &&
+                    charmedBy != gameState.CurrentPlayerGuid;
+                if (observedCharmedPlayer)
+                {
+                    if (gameState.ObservedCharmedPlayers.Add(guid))
+                        Log.Event("charm.observed_player.possess_shim", new
+                        {
+                            guid_low = guid.GetCounter(),
+                            charmed_by_low = charmedBy.GetCounter(),
+                        });
+                }
+                else if (gameState.ObservedCharmedPlayers.Remove(guid))
+                {
+                    Log.Event("charm.observed_player.possess_shim_cleared", new
+                    {
+                        guid_low = guid.GetCounter(),
+                    });
+                }
+            }
+            else if (isCreate)
+            {
+                // A create block without CHARMEDBY means the unit is not charmed — drop any
+                // stale shim entry from a charm that ended while the unit was out of range.
+                GetSession().GameState.ObservedCharmedPlayers.Remove(guid);
             }
             int UNIT_FIELD_SUMMONEDBY = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY);
             if (UNIT_FIELD_SUMMONEDBY >= 0 && updateMaskArray[UNIT_FIELD_SUMMONEDBY])
@@ -2438,6 +2472,15 @@ public partial class WorldClient
                 // force the bit on so the client picks the swim animation.
                 if (Session.GameState.KnownSwimmingMobs.Contains(guid))
                     updateData.UnitData.Flags |= (uint)UnitFlags.CanSwim;
+
+                // JimsProxy (#382 observer lockup): present an observed charmed PLAYER as
+                // possessed. Vanilla MOD_CHARM (Gnomish MC Cap 13181) emits PLAYER_CONTROLLED
+                // + CHARMEDBY without POSSESSED; a charmed player is unrepresentable to the
+                // 1.14 client (BG bystanders FPS-lock rendering it), while possess (priest
+                // MC 605) renders fine. CHARMEDBY is processed above before this flags block,
+                // so apply/clear ordering within a single update is already correct.
+                if (Session.GameState.ObservedCharmedPlayers.Contains(guid))
+                    updateData.UnitData.Flags |= (uint)UnitFlags.Possessed;
 
                 // Here because of this bullshit in cmangos:
                 // https://github.com/cmangos/mangos-tbc/blob/fd093b33071b546545cc5973608304bccc5a041b/src/game/Entities/Object.cpp#L544


### PR DESCRIPTION
Addresses #382 (kept open pending reporter verification in a live BG).

## Symptom
In a BG, when an **enemy** uses a Gnomish Mind Control Cap on a nearby **ally**, a friendly **bystander's** client FPS-drops / locks up. Neither the charmer nor the target is affected, and priest Mind Control never triggers it (reporter-confirmed).

## Evidence trail
- **Flood refuted:** observer/participant captures show the charm arrives as a tiny, clean packet burst (~9 s2c), far below rates the client handles fine elsewhere in the same sessions.
- **Participants unaffected:** confirmed by 2-box capture and by the reporter ("used on me / I used it — no lockup").
- **The discriminator:** priest MC (605) = `Apply Aura: Possess`; the cap's control aura (13181) = `Apply Aura: Charm` (13180 is a dummy trigger). Verified via classic spell data.
- **Field-level difference (vmangos):** possess sets `UNIT_FLAG_POSSESSED` on the target; charm sets `UNIT_FLAG_PLAYER_CONTROLLED` + `CHARMEDBY` + faction flip + pet CharmInfo — **no POSSESSED bit**.
- **Client gap:** modern/1.14 has no concept of a *charmed player* (players are never charm targets in retail; MC there is possess). A friendly bystander rendering "my groupmate is an enemy's charmed pet" hits an unrepresentable state; the cost scales with raid/crowd size, which is why it's BG-only and why a 3-player local rig can't surface it.
- **Precedent:** #173 was the same root class on the proxy side — the pet path expected creature attributes a charmed *player* lacks (`OBJECT_FIELD_ENTRY` KeyNotFound → dropped pet bar).

## Fix
Track players observed being charmed by someone **other than the local player** (`GameSessionData.ObservedCharmedPlayers`) and OR `UNIT_FLAG_POSSESSED` into their `UNIT_FIELD_FLAGS` translation, so observing clients render their known-good possess path.

Scoping (preserves charm-vs-possess gameplay for participants):
- unit must be a **player** → creature charm (Enslave Demon, Eyes of the Beast, mob MC) untouched
- `CHARMEDBY != CurrentPlayerGuid` → the charmer keeps its real charm/pet bar
- `unit != CurrentPlayerGuid` → the target's own experience untouched
- possess targets already carry POSSESSED → no-op for priest MC
- per-session state → multibox-safe (each client session judges independently)

Lifecycle: entry added on observed charm apply, removed when `CHARMEDBY` empties (charm end) or on a fresh create block (re-appearance after out-of-range charm end). `charm.observed_player.possess_shim` / `..._cleared` events mark both edges.

## Known tradeoff
`UNIT_FLAG_POSSESSED` makes the charmed ally unclickable to observers for the ~20s charm (same as possessed units). Accepted vs. the lockup.

## Verification
- Build clean; full suite green (615/615).
- **Cannot be verified locally** — the render cost needs BG-scale raid/crowd. Reporter test steps:
  1. Run a BG on this build with logging on; be near an ally hit by an enemy's Gnomish Mind Control Cap.
  2. Expect: no FPS drop/lockup while the ally is charmed (should no longer occur).
  3. Send the JSONL — the `charm.observed_player.possess_shim` event proves the shim fired on the charmed ally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)