### PR TITLE
Make forwarded-START CastID recovery FIFO-backed by default (drop lossy single-slot)

### DIFF
--- a/HermesProxy.Tests/World/IdentityPinnedCastIdsTests.cs
+++ b/HermesProxy.Tests/World/IdentityPinnedCastIdsTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace HermesProxy.Tests.World;
 
-// JimsProxy (T1 identity-pinned cast correspondence): the 1.12 server strips the client's
-// CastID, so the proxy must re-derive which press a server event belongs to. T1 makes that
-// deterministic — every local-player terminating event (SPELL_GO / CAST_FAILED / SPELL_FAILURE)
-// and the watchdog's synthetic closure is stamped with the CastID recorded at SPELL_START,
-// drawn from a per-spell FIFO in START order, instead of depending on which queue entry the
-// dequeue heuristic picked. These tests pin the FIFO's ordering/lifecycle and the watchdog
-// data-path closure. The packet-handler wiring is gated behind Settings.IdentityPinnedCastIdsActive
-// (LowLatencyMode && IdentityPinnedCastIds); the last test guards that OFF can't activate it.
+// JimsProxy (cast-go-castid-recovery): the 1.12 server strips the client's CastID, so the proxy
+// must re-derive which press a server event belongs to. It makes that deterministic — every
+// local-player terminating event (SPELL_GO / CAST_FAILED / SPELL_FAILURE) and the watchdog's
+// synthetic closure is stamped with the CastID recorded at SPELL_START, drawn from a per-spell
+// FIFO in START order, instead of depending on which queue entry the dequeue heuristic picked.
+// The FIFO recovery is unconditional (the default path); the Settings.IdentityPinnedCastIdsActive
+// property survives only to gate the keepalive watchdog pump. These tests pin the FIFO's
+// ordering/lifecycle, the watchdog data-path closure, and that property's truth table.
 public class IdentityPinnedCastIdsTests
 {
     private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
@@ -54,45 +54,53 @@ public class IdentityPinnedCastIdsTests
         Assert.False(session.TryPopForwardedStartCastId(13877, out _));
     }
 
-    // --- Divergence proof: the ONLY by-construction evidence T1 does something the pre-T1 path
-    //     cannot. T1's per-spell FIFO replaces #362's single-slot PlayerForwardedCastIds recovery
-    //     (spellId -> one CastID). Under a CONCURRENT same-spell double-START whose GOs both reach
-    //     the orphan-GO recovery, the single slot is OVERWRITTEN — it collapses both casts onto the
-    //     latest CastID and loses the first, so START 1's cast never gets a matching GO and loops.
-    //     The FIFO keeps both in START order and pairs each GO correctly.
-    //     SCOPE (honest): this proves T1 is strictly more correct *when that interleaving occurs*.
-    //     It does NOT prove the Blade Flurry loop reaches it — the documented BF mechanism (a single
-    //     keypress's off-GCD double-send: START -> CAST_FAILED(dup) -> GO) is resolved by #372's
-    //     off-GCD collapse + prefer-started dequeue WITHOUT reaching this recovery path. Whether a
-    //     genuine concurrent double-START occurs in the wild is a field/log question, not a unit one.
+    // --- Default-path fix: the FIFO now backs GO recovery UNCONDITIONALLY (no longer gated behind
+    //     LowLatencyMode + IdentityPinnedCastIds). The pre-fix default path used a single
+    //     spellId -> CastID slot; under a CONCURRENT same-spell double-START whose GOs both reach the
+    //     orphan-GO recovery, that slot was OVERWRITTEN — it collapsed both casts onto the latest
+    //     CastID and lost the first, so START 1's cast never got a matching GO and looped. The FIFO
+    //     keeps both in START order and pairs each GO correctly, and it does so with the identity-
+    //     pinned flag OFF (default), which is what this test proves.
+    //     SCOPE (honest): this proves the recovery is strictly more correct *when that interleaving
+    //     occurs*. It does NOT prove the Blade Flurry loop reaches it — the documented BF mechanism (a
+    //     single keypress's off-GCD double-send: START -> CAST_FAILED(dup) -> GO) is resolved by #372's
+    //     off-GCD collapse + prefer-started dequeue WITHOUT reaching this recovery path, and the primary
+    //     looping-cast bug is client-side. Whether a genuine concurrent double-START occurs in the wild
+    //     is a field/log question, not a unit one.
     [Fact]
-    public void Divergence_ConcurrentSameSpellStarts_PreT1SingleSlotCollapses_FifoPairsCorrectly()
+    public void ConcurrentSameSpellStarts_FlagOff_FifoPairsEachGoInStartOrder()
     {
-        var startA = CastId(0xA);
-        var startB = CastId(0xB);
+        bool savedLowLatency = global::Framework.Settings.LowLatencyMode;
+        bool savedSubToggle = global::Framework.Settings.IdentityPinnedCastIds;
+        try
+        {
+            // Default config: the identity-pinned flag is OFF. The FIFO recovery must still work —
+            // that's the whole point of making it unconditional.
+            global::Framework.Settings.LowLatencyMode = false;
+            global::Framework.Settings.IdentityPinnedCastIds = false;
+            Assert.False(global::Framework.Settings.IdentityPinnedCastIdsActive);
 
-        // PRE-T1 (#362 single-slot recovery): the second START overwrites the first — A is lost.
-        var preT1 = NewSession();
-        preT1.PlayerForwardedCastIds[13877] = startA;
-        preT1.PlayerForwardedCastIds[13877] = startB;   // overwrite
+            var startA = CastId(0xA);
+            var startB = CastId(0xB);
 
-        // GO 1's orphan recovery reads B (WRONG — it should pair with START A), and GO 2 finds
-        // nothing. START A's CastID is never recovered -> the client's cast A never closes -> loop.
-        Assert.True(preT1.PlayerForwardedCastIds.TryRemove(13877, out var preGo1));
-        Assert.Equal(startB, preGo1);                   // GO 1 mis-stamped with B
-        Assert.NotEqual(startA, preGo1);                // START A collapsed away
-        Assert.False(preT1.PlayerForwardedCastIds.TryRemove(13877, out _)); // nothing left for GO 2
+            var session = NewSession();
+            session.EnqueueForwardedStartCastId(13877, startA);
+            session.EnqueueForwardedStartCastId(13877, startB);
 
-        // T1 (per-spell FIFO): both retained in START order — GO 1 pops A, GO 2 pops B. No collapse.
-        var t1 = NewSession();
-        t1.EnqueueForwardedStartCastId(13877, startA);
-        t1.EnqueueForwardedStartCastId(13877, startB);
-
-        Assert.True(t1.TryPopForwardedStartCastId(13877, out var t1Go1));
-        Assert.Equal(startA, t1Go1);                    // GO 1 ↔ START A
-        Assert.True(t1.TryPopForwardedStartCastId(13877, out var t1Go2));
-        Assert.Equal(startB, t1Go2);                    // GO 2 ↔ START B
-        Assert.False(t1.TryPopForwardedStartCastId(13877, out _));
+            // GO 1 pops the OLDER CastID (A), not the newer (B): the single-slot overwrite bug is
+            // fixed on the default path. GO 2 pops B. Neither collapses onto the newest.
+            Assert.True(session.TryPopForwardedStartCastId(13877, out var go1));
+            Assert.Equal(startA, go1);                  // GO 1 ↔ START A (older)
+            Assert.NotEqual(startB, go1);               // NOT collapsed onto the newest
+            Assert.True(session.TryPopForwardedStartCastId(13877, out var go2));
+            Assert.Equal(startB, go2);                  // GO 2 ↔ START B
+            Assert.False(session.TryPopForwardedStartCastId(13877, out _));
+        }
+        finally
+        {
+            global::Framework.Settings.LowLatencyMode = savedLowLatency;
+            global::Framework.Settings.IdentityPinnedCastIds = savedSubToggle;
+        }
     }
 
     [Fact]
@@ -266,9 +274,9 @@ public class IdentityPinnedCastIdsTests
     [InlineData(true, true, true)]     // both — active
     public void IdentityPinnedCastIdsActive_RequiresBothToggles(bool lowLatency, bool subToggle, bool expectedActive)
     {
-        // The entire T1 mechanism (FIFO stamping + the keepalive watchdog pump + watchdog FIFO
-        // removal) is gated on this property. With it false, none of the new code paths run, so
-        // the Hold-and-Fire path stays byte-identical — the default-OFF regression guarantee.
+        // The property still exists but now gates ONLY the keepalive watchdog pump
+        // (WorldClient.cs) — the FIFO stamping and watchdog FIFO removal are unconditional. This
+        // pins the property's truth table (both toggles required) for that remaining consumer.
         bool savedLowLatency = global::Framework.Settings.LowLatencyMode;
         bool savedSubToggle = global::Framework.Settings.IdentityPinnedCastIds;
         try

--- a/HermesProxy.Tests/World/PlayerForwardedCastIdsTests.cs
+++ b/HermesProxy.Tests/World/PlayerForwardedCastIdsTests.cs
@@ -4,9 +4,9 @@ using Xunit;
 
 namespace HermesProxy.Tests.World;
 
-// JimsProxy (cast-go-castid-recovery): PlayerForwardedCastIds records the client-facing
-// CastID forwarded for the local player's SMSG_SPELL_START so HandleSpellGo can re-stamp
-// the GO with the SAME id when no PendingNormalCast / melee / auto-repeat entry matches.
+// JimsProxy (cast-go-castid-recovery): the per-spell forwarded-START CastID FIFO records the
+// client-facing CastID forwarded for the local player's SMSG_SPELL_START so HandleSpellGo can
+// re-stamp the GO with the SAME id when no PendingNormalCast / melee / auto-repeat entry matches.
 // This is the deterministic fix for the orphaned-cast family (stuck casting animation +
 // looping cast sound): the 1.14 client pairs START<->GO by CastID, and a mismatch leaves
 // the cast un-terminated. It hits server-initiated player casts with no CMSG (GO loot
@@ -17,7 +17,7 @@ namespace HermesProxy.Tests.World;
 // The full handler wiring (store at forward-time, recall as the last-resort GO fallback)
 // needs a live WorldSocket and isn't reachable from this harness. These tests pin the two
 // GameState invariants the fix relies on: the store/recall round-trip is exact and
-// single-shot, and a world transfer clears the map so a stale CastID can't leak across a
+// single-shot, and a world transfer clears the FIFO so a stale CastID can't leak across a
 // zone/realm change onto an unrelated later cast.
 public class PlayerForwardedCastIdsTests
 {
@@ -29,26 +29,27 @@ public class PlayerForwardedCastIdsTests
         var session = NewSession();
         var forwardedCastId = new WowGuid128(0x123456789ABCDEF0, 0x0FEDCBA987654321);
 
-        session.PlayerForwardedCastIds[13877] = forwardedCastId; // Blade Flurry
+        session.EnqueueForwardedStartCastId(13877, forwardedCastId); // Blade Flurry
 
-        // HandleSpellGo recalls via TryRemove: the GO gets the exact CastID the START forwarded.
-        Assert.True(session.PlayerForwardedCastIds.TryRemove(13877, out var recovered));
+        // HandleSpellGo recalls via TryPop: the GO gets the exact CastID the START forwarded.
+        Assert.True(session.TryPopForwardedStartCastId(13877, out var recovered));
         Assert.Equal(forwardedCastId, recovered);
 
         // Single-shot: a second GO (or a later proc GO of the same spell) must NOT reuse it.
-        Assert.False(session.PlayerForwardedCastIds.TryRemove(13877, out _));
+        Assert.False(session.TryPopForwardedStartCastId(13877, out _));
     }
 
     [Fact]
     public void ResetInFlightCastState_ClearsForwardedCastIds()
     {
         var session = NewSession();
-        session.PlayerForwardedCastIds[15343] = new WowGuid128(1, 2); // Create Whipper Root Tubers
-        session.PlayerForwardedCastIds[13877] = new WowGuid128(3, 4); // Blade Flurry
+        session.EnqueueForwardedStartCastId(15343, new WowGuid128(1, 2)); // Create Whipper Root Tubers
+        session.EnqueueForwardedStartCastId(13877, new WowGuid128(3, 4)); // Blade Flurry
 
         // World transfer (BG entry, instance change, realm swap) must not carry CastIDs over.
         session.ResetInFlightCastState();
 
-        Assert.Empty(session.PlayerForwardedCastIds);
+        Assert.False(session.TryPopForwardedStartCastId(15343, out _));
+        Assert.False(session.TryPopForwardedStartCastId(13877, out _));
     }
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -534,29 +534,24 @@ public sealed class GameSessionData
     // overridden with ServerGUID downstream → the auto-cast map entry is a harmless
     // orphan in that case.
     public ConcurrentDictionary<(WowGuid128 caster, uint spellId), WowGuid128> PetAutoCastActiveCastIds = new();
-    // JimsProxy (cast-go-castid-recovery): client-facing CastID forwarded for the LOCAL
-    // PLAYER's SMSG_SPELL_START, keyed by spellId. HandleSpellGo recalls it when no
-    // PendingNormalCast / melee / auto-repeat entry matches at SPELL_GO, so START and GO
-    // ship the SAME CastID. The 1.14 client pairs START↔GO by CastID; a mismatch leaves
-    // the cast un-terminated → stuck casting animation + looping cast sound. Covers
-    // server-initiated player casts with no CMSG (GO loot subspells e.g. Whipper Root
-    // "Create Whipper Root Tubers" 15343, weapon/trinket procs) and casts whose pending
-    // entry was consumed by an interleaved duplicate CAST_FAILED before the GO (Blade
-    // Flurry, re-clicked gathers). Fallback ONLY — never consulted when a real pending
-    // cast is dequeued at GO, so normal casts are wire-identical. Cleared on world
-    // transfer alongside the pet/other-caster cast-id maps.
-    public ConcurrentDictionary<uint, WowGuid128> PlayerForwardedCastIds = new();
-    // JimsProxy (T1 identity-pinned cast correspondence): per-spell FIFO of the CastIDs
-    // forwarded to the modern client at the LOCAL PLAYER's SMSG_SPELL_START. Supersedes the
-    // single-slot PlayerForwardedCastIds (above) when Settings.IdentityPinnedCastIdsActive.
-    // A single slot is overwritten when two same-spell casts are in flight at once (the
-    // immediate-forward / Low-Latency path), so a later GO recovers the wrong CastID; the
-    // FIFO preserves START order so each terminating event consumes the matching forwarded
-    // CastID and START↔GO/FAILED pair deterministically, independent of which queue entry
-    // the dequeue heuristic picks. Bounded per spell (oldest dropped past the cap) and
-    // cleared on reconnect so a missed pop can neither leak nor stale-head a future cast.
-    // Lock-guarded plain Dictionary/List (not Concurrent*) so enqueue+bound and the
-    // remove-by-value the watchdog needs are atomic; contention is negligible (cast events).
+    // JimsProxy (cast-go-castid-recovery): per-spell FIFO of the client-facing CastIDs
+    // forwarded to the modern client at the LOCAL PLAYER's SMSG_SPELL_START, keyed by spellId.
+    // HandleSpellGo recalls the oldest when no PendingNormalCast / melee / auto-repeat entry
+    // matches at SPELL_GO, so START and GO ship the SAME CastID. The 1.14 client pairs START↔GO
+    // by CastID; a mismatch leaves the cast un-terminated → stuck casting animation + looping
+    // cast sound. Covers server-initiated player casts with no CMSG (GO loot subspells e.g.
+    // Whipper Root "Create Whipper Root Tubers" 15343, weapon/trinket procs) and casts whose
+    // pending entry was consumed by an interleaved duplicate CAST_FAILED before the GO (Blade
+    // Flurry, re-clicked gathers). A single spellId->CastID slot would be overwritten when two
+    // same-spell casts are in flight at once (the immediate-forward / Low-Latency path), so a
+    // later GO recovers the wrong CastID; the FIFO preserves START order so each terminating
+    // event consumes the matching forwarded CastID and START↔GO/FAILED pair deterministically,
+    // independent of which queue entry the dequeue heuristic picks. Fallback ONLY — never
+    // consulted when a real pending cast is dequeued at GO, so normal casts are wire-identical.
+    // Bounded per spell (oldest dropped past the cap) and cleared on reconnect / world transfer
+    // so a missed pop can neither leak nor stale-head a future cast. Lock-guarded plain
+    // Dictionary/List (not Concurrent*) so enqueue+bound and the remove-by-value the watchdog
+    // needs are atomic; contention is negligible (cast events).
     private readonly Dictionary<uint, List<WowGuid128>> _playerForwardedStartCastIds = new();
     private readonly object _playerForwardedStartCastIdsLock = new();
     private const int MaxForwardedStartCastIdsPerSpell = 8;
@@ -1450,9 +1445,9 @@ public sealed class GameSessionData
         return false;
     }
 
-    // JimsProxy (T1 identity-pinned cast correspondence) — per-spell forwarded-START CastID
-    // FIFO helpers. Active only when Settings.IdentityPinnedCastIdsActive; OFF path never
-    // calls these. See _playerForwardedStartCastIds.
+    // JimsProxy (cast-go-castid-recovery) — per-spell forwarded-START CastID FIFO helpers.
+    // The unconditional recovery mechanism for local-player START↔GO/CAST_FAILED pairing.
+    // See _playerForwardedStartCastIds.
 
     /// <summary>
     /// Record the CastID forwarded to the client at the local player's SMSG_SPELL_START.
@@ -2124,7 +2119,6 @@ public sealed class GameSessionData
         int otherCount = OtherCasterActiveCastIds.Count;
         OtherCasterActiveCastIds.Clear();
         PetAutoCastActiveCastIds.Clear();
-        PlayerForwardedCastIds.Clear();
         ClearForwardedStartCastIds();
         // Single-slot trackers for melee + auto-repeat (Auto Shot, Shoot Wand)
         // — same lifecycle as PendingNormalCasts; if a tracker was set when
@@ -3040,7 +3034,7 @@ public class GlobalSessionData
             // terminating event — release its forwarded-START CastID so a later same-spell cast
             // can't pop this evicted cast's stale CastID. Remove by value (it may not be the FIFO
             // head). The synthetic CastFailed below already carries cast.ServerGUID == that CastID.
-            if (Framework.Settings.IdentityPinnedCastIdsActive && cast.HasStarted)
+            if (cast.HasStarted)
                 GameState.RemoveForwardedStartCastId(cast.SpellId, cast.ServerGUID);
             if (!cast.HasStarted)
             {

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -514,7 +514,7 @@ public partial class WorldClient
             // recorded START CastID (popped FIFO) and consume the FIFO entry so a later same-spell
             // GO can't pop this now-resolved cast's CastID. Transient dup rejections resolve the
             // UNSTARTED dup (HasStarted=false, no FIFO entry) and leave the started cast's entry.
-            if (Settings.IdentityPinnedCastIdsActive && pendingCast.HasStarted &&
+            if (pendingCast.HasStarted &&
                 GetSession().GameState.TryPopForwardedStartCastId(pendingCast.SpellId, out var pinnedFailCastId))
                 failed.CastID = pinnedFailCastId;
             failed.FailedArg1 = arg1;
@@ -1141,7 +1141,7 @@ public partial class WorldClient
             // T1 (identity-pinned): SPELL_FAILURE only PEEKS the pending cast (the trailing
             // CAST_FAILED / GO / watchdog pops it), so stamp the forwarded failure's CastID from
             // the FIFO front WITHOUT consuming it — the later pop stays paired.
-            if (Settings.IdentityPinnedCastIdsActive && pendingNormal.HasStarted &&
+            if (pendingNormal.HasStarted &&
                 GetSession().GameState.TryPeekForwardedStartCastId(pendingNormal.SpellId, out var pinnedFailureCastId))
                 castId = pinnedFailureCastId;
             spellVisual = pendingNormal.SpellXSpellVisualId;
@@ -1720,19 +1720,13 @@ public partial class WorldClient
         else
         {
             // JimsProxy (cast-go-castid-recovery): record the CastID we forward for the
-            // local player's SPELL_START so HandleSpellGo can recover it if the pending
-            // entry is gone by GO time (server-initiated casts with no CMSG, or a
-            // duplicate's CAST_FAILED having consumed the entry). See PlayerForwardedCastIds.
+            // local player's SPELL_START in a per-spell FIFO so HandleSpellGo can recover it
+            // if the pending entry is gone by GO time (server-initiated casts with no CMSG, or
+            // a duplicate's CAST_FAILED having consumed the entry). The FIFO preserves START
+            // order so concurrent same-spell starts each retain their forwarded CastID.
             // Fallback only — normal casts override with ServerGUID at GO and never read it.
             if (casterIsLocalPlayer)
-            {
-                if (Settings.IdentityPinnedCastIdsActive)
-                    // T1: per-spell FIFO supersedes the single-slot recovery so concurrent
-                    // same-spell starts each retain their forwarded CastID in START order.
-                    GetSession().GameState.EnqueueForwardedStartCastId((uint)spell.Cast.SpellID, spell.Cast.CastID);
-                else
-                    GetSession().GameState.PlayerForwardedCastIds[(uint)spell.Cast.SpellID] = spell.Cast.CastID;
-            }
+                GetSession().GameState.EnqueueForwardedStartCastId((uint)spell.Cast.SpellID, spell.Cast.CastID);
 
             // JimsProxy (#379 form-exit): this START belongs to the cast that auto-shifted the
             // player out of a form. The 1.12 server emits it ~20ms BEFORE the form-removal
@@ -1936,7 +1930,7 @@ public partial class WorldClient
             // same-spell entry. Skip-START instants (HasStarted=false, no FIFO entry) keep the
             // dequeued ServerGUID. Belt-and-suspenders over #372's preferStarted dequeue: matches
             // it in the common case, diverges only under concurrent same-spell starts.
-            if (Settings.IdentityPinnedCastIdsActive && pendingCast.HasStarted &&
+            if (pendingCast.HasStarted &&
                 GetSession().GameState.TryPopForwardedStartCastId(pendingCast.SpellId, out var pinnedGoCastId))
                 spell.Cast.CastID = pinnedGoCastId;
             spell.Cast.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
@@ -2144,13 +2138,12 @@ public partial class WorldClient
         // Hits server-initiated player casts with no CMSG (GO loot subspells e.g. Whipper
         // Root 15343, weapon/trinket procs) and casts whose pending entry was consumed by a
         // duplicate's CAST_FAILED before the GO (Blade Flurry, re-clicked gathers).
-        // JimsProxy (T1 identity-pinned cast correspondence): FIFO-backed promotion of the
-        // #362 recovery below to the primary path. When the GO has no pending entry (consumed by
-        // a duplicate's CAST_FAILED, or a server-initiated cast with no CMSG), recover the
-        // forwarded START CastID from the per-spell FIFO so START↔GO still pair. Supersedes the
-        // single-slot recovery (next branch) when active; the single-slot isn't populated then.
-        else if (Settings.IdentityPinnedCastIdsActive &&
-                 GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
+        // JimsProxy (cast-go-castid-recovery, FIFO-backed): when the GO has no pending entry
+        // (consumed by a duplicate's CAST_FAILED, or a server-initiated cast with no CMSG),
+        // recover the forwarded START CastID from the per-spell FIFO so START↔GO still pair.
+        // The FIFO preserves START order, so concurrent same-spell casts each recover their own
+        // forwarded CastID (a single spellId->CastID slot would collapse them onto the newest).
+        else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
                  GetSession().GameState.TryPopForwardedStartCastId((uint)spell.Cast.SpellID, out var pinnedRecoverCastId))
         {
             spell.Cast.CastID = pinnedRecoverCastId;
@@ -2159,18 +2152,6 @@ public partial class WorldClient
                 spell_id = spell.Cast.SpellID,
                 caster_low = spell.Cast.CasterUnit.GetCounter(),
                 recovered_cast_id = pinnedRecoverCastId.ToString(),
-                pinned = true,
-            });
-        }
-        else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
-                 GetSession().GameState.PlayerForwardedCastIds.TryRemove((uint)spell.Cast.SpellID, out var forwardedStartCastId))
-        {
-            spell.Cast.CastID = forwardedStartCastId;
-            Log.Event("cast.go.castid_recovered", new
-            {
-                spell_id = spell.Cast.SpellID,
-                caster_low = spell.Cast.CasterUnit.GetCounter(),
-                recovered_cast_id = forwardedStartCastId.ToString(),
             });
         }
 


### PR DESCRIPTION
## What

The local player's forwarded-`SPELL_START` -> `SPELL_GO` **CastID recovery** had two
implementations gated by `Settings.IdentityPinnedCastIdsActive`
(`= LowLatencyMode && IdentityPinnedCastIds`, both default **OFF**):

- **ON** - a per-spell FIFO (`_playerForwardedStartCastIds`) that keeps each concurrent
  same-spell START's forwarded CastID in START order, so every terminating event
  (GO / CAST_FAILED / SPELL_FAILURE / watchdog) pops the matching one.
- **OFF (default)** - a spellId-keyed **single slot** (`PlayerForwardedCastIds`)
  **overwritten on every same-spell START**. Under same-spell spam, a completed cast's
  orphan-GO recovery then returns the *newest* CastID instead of its own, so the 1.14
  client (which pairs START<->GO by CastID) can't close the cast -> stuck cast.

That overwrite is the unfixed half of Xian55 #5 in the default configuration.

## Change

Make the per-spell FIFO the **unconditional** recovery mechanism and delete the single slot:

- `EnqueueForwardedStartCastId` at `SPELL_START` is now always called (was flag-gated,
  else a single-slot write).
- The CAST_FAILED pop, SPELL_FAILURE peek, GO pop, and orphan-GO recovery each drop their
  `IdentityPinnedCastIdsActive &&` gate.
- The watchdog's remove-by-value drops its gate.
- `PlayerForwardedCastIds` (field, reset `.Clear()`, single-slot recovery branch) is removed.

The FIFO is bounded per spell and cleared on reconnect / world transfer, so
**non-concurrent casts are unchanged**: a single START enqueues one entry the terminating
event pops - identical to the old single slot.

`Settings.IdentityPinnedCastIds` / `IdentityPinnedCastIdsActive` are **kept intact**: they
still gate the Low-Latency keepalive watchdog pump (`WorldClient.cs`). Their meaning simply
narrows to that.

## Scope (honest)

This is a **latent-correctness / hardening** fix for the mis-pair-under-concurrent-same-spell-START
class. It is **NOT** the primary looping-cast bug, which is **client-side** (the 1.14 client
dropping a ~5 ms-coalesced START+GO). It should not be expected to resolve that loop.

## Testing

- Converted the single-slot `PlayerForwardedCastIdsTests` to the FIFO API.
- Replaced the pre-T1-vs-FIFO divergence test with a **flag-OFF concurrent double-START**
  test proving the older cast's GO now recovers the OLDER CastID on the default path.
- `dotnet build` clean; `dotnet test` green - **615 passed, 0 failed**.
