### PR TITLE
Clean connection teardown: idempotent Dispose, throw-safe Disconnect, bounded auth handshake, stdin graceful shutdown

### DIFF
--- a/Framework/Networking/SocketBase.cs
+++ b/Framework/Networking/SocketBase.cs
@@ -20,6 +20,7 @@ using System;
 using System.Buffers;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace Framework.Networking;
 
@@ -43,6 +44,9 @@ public abstract class SocketBase : ISocket, IDisposable
     byte[]? _asyncBuffer;
     const int BufferSize = 0x4000;
 
+    // JimsProxy: single-fire guard for Dispose (0 = live). See Dispose().
+    int _disposed;
+
     public delegate void SocketReadCallback(SocketAsyncEventArgs args);
 
     protected SocketBase(Socket socket)
@@ -63,6 +67,13 @@ public abstract class SocketBase : ISocket, IDisposable
 
     public virtual void Dispose()
     {
+        // JimsProxy: idempotent teardown. Two concurrent closers (e.g. a receive-thread RST
+        // and a cross-thread CloseSocket) can both pass the null checks below and return the
+        // SAME pooled buffer twice — handing one array to two future renters, a latent
+        // cross-session packet-corruption bug. Latch so the body runs exactly once.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
         _socket.Dispose();
 
         if (_callbackBuffer != null)

--- a/HermesProxy.Tests/Auth/AuthHandshakeTimeoutTests.cs
+++ b/HermesProxy.Tests/Auth/AuthHandshakeTimeoutTests.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using HermesProxy.Auth;
+using Xunit;
+
+namespace HermesProxy.Tests.Auth;
+
+/// <summary>
+/// JimsProxy (clean handshake teardown): <see cref="AuthClient.AwaitHandshakeResult"/> must bound
+/// the realmd handshake wait. A realmd that accepts the TCP connection but never completes the
+/// handshake must fail the login cleanly (a bounded wait → FAIL) instead of hanging the login
+/// thread forever, while a handshake that completes in time must pass its real result through
+/// unchanged (a genuine bad-password must NOT be masked as a timeout).
+/// </summary>
+public class AuthHandshakeTimeoutTests
+{
+    // Realmd accepted TCP but never sent LOGON_CHALLENGE -> the wait must bound and fail cleanly.
+    [Fact]
+    public void NeverCompletes_TimesOutCleanly()
+    {
+        var handshake = new TaskCompletionSource<AuthResult>(); // never set
+
+        AuthResult result = AuthClient.AwaitHandshakeResult(handshake.Task, timeoutMs: 100, out bool timedOut);
+
+        Assert.True(timedOut);
+        Assert.Equal(AuthResult.FAIL_INTERNAL_ERROR, result);
+    }
+
+    // Handshake succeeded within the window -> return the real success result, not a timeout.
+    [Fact]
+    public void CompletesInTime_ReturnsRealResult()
+    {
+        var handshake = new TaskCompletionSource<AuthResult>();
+        handshake.SetResult(AuthResult.SUCCESS);
+
+        AuthResult result = AuthClient.AwaitHandshakeResult(handshake.Task, timeoutMs: 1000, out bool timedOut);
+
+        Assert.False(timedOut);
+        Assert.Equal(AuthResult.SUCCESS, result);
+    }
+
+    // A real auth failure that arrives in time must be propagated as-is, never reported as a timeout.
+    [Fact]
+    public void CompletesWithFailure_PropagatesThatFailure()
+    {
+        var handshake = new TaskCompletionSource<AuthResult>();
+        handshake.SetResult(AuthResult.FAIL_INCORRECT_PASSWORD);
+
+        AuthResult result = AuthClient.AwaitHandshakeResult(handshake.Task, timeoutMs: 1000, out bool timedOut);
+
+        Assert.False(timedOut);
+        Assert.Equal(AuthResult.FAIL_INCORRECT_PASSWORD, result);
+    }
+}

--- a/HermesProxy/Auth/AuthClient.cs
+++ b/HermesProxy/Auth/AuthClient.cs
@@ -48,6 +48,17 @@ public partial class AuthClient
         return _globalSession;
     }
 
+    // JimsProxy (clean handshake teardown): bound the realmd auth handshake. If realmd accepts
+    // the TCP connection but never sends LOGON_CHALLENGE (half-accepting / load-shed / firewall),
+    // the blocking wait in ConnectToAuthServer/Reconnect would hang the login thread forever
+    // ("stuck on Connecting..."). Wait at most timeoutMs, then fail the login cleanly so the
+    // client shows an error and can retry. Pure — unit-tested in AuthHandshakeTimeoutTests.
+    internal static AuthResult AwaitHandshakeResult(Task<AuthResult> handshake, int timeoutMs, out bool timedOut)
+    {
+        timedOut = !handshake.Wait(timeoutMs);
+        return timedOut ? AuthResult.FAIL_INTERNAL_ERROR : handshake.Result;
+    }
+
     public AuthResult ConnectToAuthServer(string username, string password, string locale)
     {
         _username = username;
@@ -84,16 +95,27 @@ public partial class AuthClient
             _response.SetResult(AuthResult.FAIL_INTERNAL_ERROR);
         }
 
-        _response.Task.ConfigureAwait(false).GetAwaiter().GetResult();
+        AuthResult result = AwaitHandshakeResult(_response.Task, Framework.Settings.AuthHandshakeTimeoutMs, out bool timedOut);
+        if (timedOut)
+        {
+            // Realmd accepted the TCP connection but never completed the handshake — give up
+            // cleanly rather than hang the login thread forever.
+            Log.Event("auth.realmd.handshake_timeout", new
+            {
+                username = username,
+                timeout_ms = Framework.Settings.AuthHandshakeTimeoutMs,
+            });
+            try { _clientSocket?.Close(); } catch { /* best-effort */ }
+        }
 
         // JimsProxy: record handshake outcome
         Log.Event("auth.realmd.handshake", new
         {
             username = username,
-            result = _response.Task.Result.ToString(),
+            result = result.ToString(),
         });
 
-        return _response.Task.Result;
+        return result;
     }
 
     public AuthResult Reconnect()
@@ -117,9 +139,18 @@ public partial class AuthClient
             _response.SetResult(AuthResult.FAIL_INTERNAL_ERROR);
         }
 
-        _response.Task.ConfigureAwait(false).GetAwaiter().GetResult();
+        AuthResult result = AwaitHandshakeResult(_response.Task, Framework.Settings.AuthHandshakeTimeoutMs, out bool timedOut);
+        if (timedOut)
+        {
+            Log.Event("auth.realmd.reconnect_handshake_timeout", new
+            {
+                username = _username,
+                timeout_ms = Framework.Settings.AuthHandshakeTimeoutMs,
+            });
+            try { _clientSocket?.Close(); } catch { /* best-effort */ }
+        }
 
-        return _response.Task.Result;
+        return result;
     }
 
     private void SetAuthResponse(AuthResult response)

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -47,6 +47,12 @@ public static class Settings
     // Hard timeout on the reconnect attempt — beyond this, abandon and propagate DC.
     // Clamped to 1000..30000 in LoadAndVerifyFrom.
     public static int UnplannedReconnectTimeoutMs;
+    // JimsProxy (clean handshake teardown): bound the realmd auth handshake. If realmd accepts
+    // the TCP connection but never sends LOGON_CHALLENGE (half-accepting login server, load-shed,
+    // firewall), the login thread would otherwise block forever ("stuck on Connecting..."). On
+    // expiry the login fails cleanly — the client shows an error and can retry — instead of
+    // hanging. Clamped to 1000..60000 in LoadAndVerifyFrom.
+    public static int AuthHandshakeTimeoutMs;
     // JimsProxy (cross-version addon interop): translate PallyPower ASSIGN class
     // index between 1.12 (0-indexed) and 1.14 (1-indexed) at the chat-addon
     // wire boundary so paladins on either client version can party with each
@@ -142,6 +148,7 @@ public static class Settings
         SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
         EnableUnplannedReconnect = config.GetBoolean("EnableUnplannedReconnect", false);
         UnplannedReconnectTimeoutMs = Math.Clamp(config.GetInt("UnplannedReconnectTimeoutMs", 5000), 1000, 30000);
+        AuthHandshakeTimeoutMs = Math.Clamp(config.GetInt("AuthHandshakeTimeoutMs", 15000), 1000, 60000);
         EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -59,6 +59,21 @@ partial class Server
         // rest of startup gets a process.crash event with a flushed JSONL.
         ShutdownHooks.Install();
 
+        // JimsProxy: when launched by the launcher (stdin piped, not an interactive console),
+        // listen for a graceful-shutdown sentinel on stdin so the launcher can stop us cleanly
+        // (flush the JSONL diag log + emit a final event) instead of taskkill /F. Own-console
+        // runs (double-clicked exe) have stdin on the keyboard — skip, so Program.cs's
+        // end-of-run "Press enter to close" prompt stays intact.
+        if (Console.IsInputRedirected)
+        {
+            var stdinShutdownThread = new Thread(ListenForLauncherShutdown)
+            {
+                IsBackground = true,
+                Name = "StdinShutdownListener",
+            };
+            stdinShutdownThread.Start();
+        }
+
         if (Environment.CurrentDirectory != Path.GetDirectoryName(AppContext.BaseDirectory))
         {
             Log.Print(LogType.Storage, "Switching working directory");
@@ -181,6 +196,35 @@ partial class Server
         // JimsProxy: emit session.end and flush JSONL
         Log.Event("session.end", null);
         Log.FlushAndCloseStructuredLog();
+    }
+
+    // JimsProxy: the launcher writes this exact line to the proxy's stdin to request a clean
+    // shutdown (contract shared with the launcher's HermesManager::stop). All other stdin
+    // input is ignored.
+    private const string LauncherShutdownSentinel = "__LAUNCHER_SHUTDOWN__";
+
+    private static void ListenForLauncherShutdown()
+    {
+        try
+        {
+            string? line;
+            while ((line = Console.In.ReadLine()) != null)
+            {
+                if (line.Trim() == LauncherShutdownSentinel)
+                {
+                    Log.Event("process.shutdown_request", new { source = "stdin", sentinel = LauncherShutdownSentinel });
+                    ShutdownHooks.TriggerGracefulExit("stdin_launcher_shutdown");
+                    return;
+                }
+                // Any other stdin line is ignored.
+            }
+        }
+        catch (Exception ex)
+        {
+            // stdin closed / unreadable — nothing to do; the launcher's taskkill fallback
+            // covers a hard close.
+            Log.Event("process.stdin_listener_stopped", new { exception_type = ex.GetType().Name, message = ex.Message });
+        }
     }
 
     private static SocketManager<TSocketType> StartServer<TSocketType>(IPEndPoint bindIp) where TSocketType : ISocket

--- a/HermesProxy/ShutdownHooks.cs
+++ b/HermesProxy/ShutdownHooks.cs
@@ -104,6 +104,16 @@ internal static class ShutdownHooks
         Environment.Exit(0);
     }
 
+    // JimsProxy: invoked by the stdin launcher-shutdown listener (Server.ServerMain) when the
+    // launcher writes the shutdown sentinel to the proxy's stdin. Routes through the same
+    // idempotent final-event/flush path as the console-close and signal hooks, then exits 0 so
+    // the launcher sees a clean shutdown instead of resorting to taskkill /F.
+    public static void TriggerGracefulExit(string reason)
+    {
+        EmitFinalEvent("process.signal", new { reason });
+        Environment.Exit(0);
+    }
+
     private static void EmitFinalEvent(string eventType, object payload)
     {
         if (Interlocked.Exchange(ref _finalEventEmitted, 1) != 0)

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -178,8 +178,23 @@ public partial class WorldClient
         if (!IsConnected())
             return;
 
-        _clientSocket.Shutdown(SocketShutdown.Both);
-        _clientSocket.Disconnect(false);
+        // JimsProxy: teardown must not throw. A real FIN on the receive thread and the
+        // silent-stall watchdog can race into Disconnect() on the same client; the second
+        // Shutdown/Disconnect then throws SocketException/ObjectDisposedException and aborts
+        // the caller's teardown path (matching the silent-stall path's own try/catch).
+        try
+        {
+            _clientSocket.Shutdown(SocketShutdown.Both);
+            _clientSocket.Disconnect(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Event("session.worldclient.disconnect_error", new
+            {
+                exception_type = ex.GetType().Name,
+                message = ex.Message,
+            });
+        }
 
         if (GetSession().WorldClient == this)
             GetSession().WorldClient = null;

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -463,7 +463,13 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
     private void SendPacketToServer(WorldPacket packet, Opcode delayUntilOpcode = Opcode.MSG_NULL_ACTION)
     {
-        if (GetSession().WorldClient != null)
+        // JimsProxy (teardown TOCTOU): read the field ONCE. The teardown paths (silent-stall
+        // watchdog, modern-death watchdog) null session.WorldClient cross-thread, and this
+        // method also runs on ThreadPool callbacks with no try/catch above it (the GCD
+        // hold-release timer via ForwardHeldGcdCast, knock loops) — a null landing between
+        // a re-checked read and the dereference would NRE and kill the whole process.
+        var worldClient = GetSession().WorldClient;
+        if (worldClient != null)
         {
             // Reset the drop-window counter on first successful send after a DC,
             // emit a final summary so the JSONL shows the size of the gap.
@@ -479,7 +485,7 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                     window_ms = firstMs == 0 ? 0 : Environment.TickCount64 - firstMs,
                 });
             }
-            GetSession().WorldClient!.SendPacketToServer(packet, delayUntilOpcode);
+            worldClient.SendPacketToServer(packet, delayUntilOpcode);
             return;
         }
 


### PR DESCRIPTION
## Theme: clean teardown

Four small, disjoint connection-lifecycle fixes. The unifying invariant: **a failure should *drop or close cleanly*, never hang, corrupt, or get force-retried.** Each commit is independently reviewable.

> **Deliberately excluded: #388 world-connect retry.** It was scoped into this cluster originally, but on review it *contradicts* the theme — it re-forces a connection the server just transiently refused. Our own investigation (the #388 WSD analysis) shows the refusal is a rare, fast, purely server-side RST that **already drops cleanly today** (`AbortLogin(NoWorld)` → char-select → relog works), SugarProxy doesn't retry world connects at all, and it lives in the historically-finicky worldclient-recreate path. Left filed/deferred; would want a fresh reproducible capture before revisiting.

---

### 1. `SocketBase.Dispose` is now idempotent — pooled-buffer double-return guard
Two concurrent closers (a receive-thread RST + a cross-thread `CloseSocket`) could both pass the `_callbackBuffer != null` / `_asyncBuffer != null` checks before either nulled them, returning the **same pooled array twice** → one buffer handed to two future renters → latent cross-session packet corruption. Latched with an `Interlocked` single-fire guard (Dispose is idempotent by contract anyway). `WorldSocket.Dispose` only nulls fields + calls `base`, so the base latch covers it.
**Impact:** kills a latent "baffling packet corruption in an unrelated session" crash class. Invisible on the happy path.

### 2. `WorldClient.Disconnect` is now throw-safe
A real FIN on the receive thread and the silent-stall watchdog can race into `Disconnect()` on the same client; the second `Shutdown`/`Disconnect` throws `SocketException`/`ObjectDisposedException` and aborts the caller's teardown path. Wrapped in try/catch (matching the silent-stall path's own guard) with a structured `session.worldclient.disconnect_error`; the session-ref clear now always runs.
**Impact:** under a disconnect storm, a stray exception no longer aborts teardown half-done.

### 3. Bounded realmd auth handshake — a half-accepting login server can't hang login
If realmd accepts the TCP connection but never sends `LOGON_CHALLENGE` (half-accepting server, load-shed, firewall), `ConnectToAuthServer`/`Reconnect` blocked the login thread **forever** — the client sits on "Connecting…" with no error and never recovers. Now bounded by `AuthHandshakeTimeoutMs` (new setting, default **15 s**, clamp 1–60 s) via a pure `AwaitHandshakeResult` helper: on expiry, log + fail the login cleanly so the client shows an error and can retry. A real result that arrives in time (success **or** a genuine auth failure) is passed through unchanged — never masked as a timeout.
**Impact:** "stuck on Connecting… forever" → a clean, retryable login error in ~15 s.

### 4. stdin graceful-shutdown trigger for the launcher
When launched with stdin piped, a background thread listens for the sentinel line `__LAUNCHER_SHUTDOWN__` and routes it through the **existing** idempotent shutdown path (new `ShutdownHooks.TriggerGracefulExit` → final event + `FlushAndCloseStructuredLog()` → exit 0). Gated on `Console.IsInputRedirected` so own-console runs (and `Program.cs`'s end-of-run prompt) are untouched; all other stdin input is ignored.
**Impact:** the launcher's "Stop" becomes a *clean* exit — JSONL diagnostics flush + a final event is written, instead of `taskkill /F` truncating the log. The launcher side (`HermesManager::stop` writing the sentinel) is a separate change, per repo scope.

---

## Validation
- **Unit tests:** `AuthHandshakeTimeoutTests` — 3-case truth table over `AwaitHandshakeResult` (never-completes → clean FAIL; completes → real result; real failure → propagated, not masked). Build clean, **618/618** tests pass.
- **① / ②** are inspection-justified hardening (the concurrent race isn't cheaply deterministic; the guards are correct by construction).
- **④** is verified end-to-end once the launcher-side half lands.

Base: `beta`. No open issue is auto-closed — these are hardening + the launcher shutdown contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
