### PR TITLE
Tear down the ghost legacy connection when the modern client dies abruptly (gap-A)

### DIFF
--- a/HermesProxy.Tests/World/ModernDeathWatchdogTests.cs
+++ b/HermesProxy.Tests/World/ModernDeathWatchdogTests.cs
@@ -1,0 +1,53 @@
+using HermesProxy.World.Client;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// JimsProxy (gap-A ghost-character teardown): the modern-death watchdog fire/skip truth table.
+/// See <see cref="ModernDeathWatchdog"/>.
+/// </summary>
+public class ModernDeathWatchdogTests
+{
+    // The one case that fires: we saw the client alive, both its sockets are now dead, it was not an
+    // intentional logout, and this WorldClient still owns the slot -> the client died abruptly, tear down.
+    [Fact]
+    public void SeenAlive_BothSocketsDead_NotIntentional_Active_Fires()
+    {
+        Assert.True(ModernDeathWatchdog.ShouldTearDown(
+            wasEverAlive: true, modernGone: true, isLogoutIntentional: false, isActiveWorldClient: true));
+    }
+
+    // Never observed alive yet (login/handshake window, before the sockets are assigned) -> not a death.
+    [Fact]
+    public void NeverSeenAlive_DoesNotFire()
+    {
+        Assert.False(ModernDeathWatchdog.ShouldTearDown(
+            wasEverAlive: false, modernGone: true, isLogoutIntentional: false, isActiveWorldClient: true));
+    }
+
+    // A clean logout / realm-or-char switch sets IsLogoutIntentional -> never treated as a death.
+    // This is the swap-safety gate.
+    [Fact]
+    public void IntentionalLogout_DoesNotFire()
+    {
+        Assert.False(ModernDeathWatchdog.ShouldTearDown(
+            wasEverAlive: true, modernGone: true, isLogoutIntentional: true, isActiveWorldClient: true));
+    }
+
+    // A swapped-out corpse WorldClient no longer owns the session slot -> it must not tear the session down.
+    [Fact]
+    public void NotActiveWorldClient_DoesNotFire()
+    {
+        Assert.False(ModernDeathWatchdog.ShouldTearDown(
+            wasEverAlive: true, modernGone: true, isLogoutIntentional: false, isActiveWorldClient: false));
+    }
+
+    // Modern sockets still alive -> nothing to do.
+    [Fact]
+    public void ModernStillAlive_DoesNotFire()
+    {
+        Assert.False(ModernDeathWatchdog.ShouldTearDown(
+            wasEverAlive: true, modernGone: false, isLogoutIntentional: false, isActiveWorldClient: true));
+    }
+}

--- a/HermesProxy/World/Client/ModernDeathWatchdog.cs
+++ b/HermesProxy/World/Client/ModernDeathWatchdog.cs
@@ -1,0 +1,28 @@
+namespace HermesProxy.World.Client;
+
+/// <summary>
+/// JimsProxy (gap-A ghost-character teardown): pure decision for whether the modern-side death
+/// watchdog (on <see cref="WorldClient"/>'s keepalive tick) should tear the legacy connection down.
+///
+/// The ghost: when the modern client dies abruptly (hard crash / taskkill / network partition) it
+/// never sends CMSG_LOG_DISCONNECT, so nothing disconnects the legacy WorldClient -- it keeps
+/// pinging the server forever and the character lingers in-world (raid slot held, heals wasted)
+/// until the player relogs. The watchdog notices, on the 30s keepalive tick, that both modern
+/// sockets are gone and tears the legacy side down so the server logs the character out.
+///
+/// Extracted as a pure predicate so the fire/skip truth table is unit-testable (see
+/// <c>HermesProxy.Tests/World/ModernDeathWatchdogTests</c>) and decoupled from the socket and
+/// session plumbing at the call site.
+///
+///   wasEverAlive        - both modern sockets have been observed open at least once (guards the
+///                         login/handshake window, before the sockets are assigned to the session)
+///   modernGone          - both modern sockets are now dead (null, or no longer open)
+///   isLogoutIntentional - the player logged out cleanly (CMSG_LOGOUT_REQUEST / CMSG_LOG_DISCONNECT);
+///                         this is also the state during a realm/char switch, so it gates out switches
+///   isActiveWorldClient - this WorldClient still owns the session slot (not a swapped-out corpse)
+/// </summary>
+internal static class ModernDeathWatchdog
+{
+    internal static bool ShouldTearDown(bool wasEverAlive, bool modernGone, bool isLogoutIntentional, bool isActiveWorldClient)
+        => wasEverAlive && modernGone && !isLogoutIntentional && isActiveWorldClient;
+}

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -1040,7 +1040,20 @@ public partial class WorldClient
                         });
                     }
                     StopKeepAliveTimer();
-                    deathSession.AuthClient?.Disconnect();                                // stop pinging Kronos -> server logs the char out
+                    // Guarded like the Disconnect() above: AuthClient.Disconnect does a raw
+                    // Shutdown/Disconnect behind a stale Socket.Connected check, so a socket
+                    // concurrently reset/disposed by another teardown path throws — and an
+                    // unhandled exception on this Timer ThreadPool callback would kill the
+                    // whole process instead of logging one ghost character out.
+                    try { deathSession.AuthClient?.Disconnect(); }                        // stop pinging Kronos -> server logs the char out
+                    catch (Exception ex)
+                    {
+                        Log.Event("session.modern_client_death.auth_disconnect_error", new
+                        {
+                            exception_type = ex.GetType().Name,
+                            message = ex.Message,
+                        });
+                    }
                     return;                                                               // do NOT fall through to the silent-stall reconnect
                 }
             }

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -61,6 +61,12 @@ public partial class WorldClient
     uint _lastInboundOpcodeRaw;
     volatile int _lastInboundOpcodeTick;
 
+    // JimsProxy (gap-A modern-death watchdog): flips true the first keepalive tick both modern
+    // sockets (RealmSocket + InstanceSocket) are observed open. Guards the login/handshake window
+    // (before the sockets are assigned to the session) so the death check never false-fires
+    // mid-login -- the mirror of the silent-stall watchdog's `_lastInboundOpcodeTick != 0` guard.
+    bool _modernClientWasAlive;
+
     // packet order is not always the same as new client, sometimes we need to delay packet until another one
     Dictionary<Opcode, List<WorldPacket>> _delayedPacketsToServer = null!;
     Dictionary<Opcode, List<ServerPacket>> _delayedPacketsToClient = null!;
@@ -958,6 +964,17 @@ public partial class WorldClient
         _keepAliveTimer = null;
     }
 
+    // JimsProxy (gap-A): a modern-client socket counts as dead if it's null (already torn out of
+    // the session on close) or no longer open. Defensive try/catch -- a socket disposed in the
+    // close race can throw on the Connected probe; treat that as dead too.
+    private static bool IsModernSocketDead(WorldSocket? socket)
+    {
+        if (socket == null)
+            return true;
+        try { return !socket.IsOpen(); }
+        catch { return true; }
+    }
+
     private void SendKeepAlivePing(object? state)
     {
         // Race guard: the timer's queued callback can still execute briefly
@@ -975,6 +992,59 @@ public partial class WorldClient
         // RunWatchdogEviction is already invoked cross-thread and no-ops when nothing is overdue.
         if (Framework.Settings.IdentityPinnedCastIdsActive)
             GetSession()?.RunWatchdogEviction();
+
+        // JimsProxy (gap-A modern-death watchdog): the exact mirror of the silent-stall watchdog
+        // below, in the opposite direction. If the MODERN client dies abruptly (hard crash /
+        // taskkill / network partition) it never sends CMSG_LOG_DISCONNECT, so nothing tears down
+        // this legacy WorldClient -- it pings Kronos every 30s forever and the character is a ghost
+        // in-world (raid slot held, heals wasted) until the player relogs. Once we've seen the
+        // modern client alive, if BOTH its sockets are gone and it wasn't an intentional logout, we
+        // tear the legacy side down so the server logs the character out.
+        //
+        // Swap-safe by construction: a realm/char switch re-establishes the modern sockets in well
+        // under a second (far inside this 30s tick), so a coarse tick never sees a mid-switch
+        // transient as a death; and a switch always sets IsLogoutIntentional, gating out even a tick
+        // that landed in that sub-second window. Unlike the silent-stall path this does NOT
+        // reconnect -- the player is gone, so we set the intentional flag first to suppress the
+        // auto-reconnect that HandleDisconnect would otherwise trigger.
+        {
+            var deathSession = GetSession();
+            if (deathSession != null)
+            {
+                bool modernGone = IsModernSocketDead(deathSession.RealmSocket)
+                               && IsModernSocketDead(deathSession.InstanceSocket);
+                if (!modernGone)
+                {
+                    _modernClientWasAlive = true;
+                }
+                else if (ModernDeathWatchdog.ShouldTearDown(
+                             _modernClientWasAlive, modernGone,
+                             deathSession.IsLogoutIntentional(),
+                             ReferenceEquals(deathSession.WorldClient, this)))
+                {
+                    Log.Event("session.modern_client_death.detected", new
+                    {
+                        keepalive_serial = _keepAlivePingSerial,
+                        had_realm_socket = deathSession.RealmSocket != null,
+                        had_instance_socket = deathSession.InstanceSocket != null,
+                    });
+                    deathSession.SetLogoutIntentional();                                  // suppress HandleDisconnect's auto-reconnect
+                    Interlocked.CompareExchange(ref deathSession.WorldClient, null, this); // drop the slot (defense in depth)
+                    try { Disconnect(); }
+                    catch (Exception ex)
+                    {
+                        Log.Event("session.modern_client_death.disconnect_error", new
+                        {
+                            exception_type = ex.GetType().Name,
+                            message = ex.Message,
+                        });
+                    }
+                    StopKeepAliveTimer();
+                    deathSession.AuthClient?.Disconnect();                                // stop pinging Kronos -> server logs the char out
+                    return;                                                               // do NOT fall through to the silent-stall reconnect
+                }
+            }
+        }
 
         // JimsProxy silent-stall watchdog: before sending the next keepalive
         // ping, check whether the legacy server has gone silent on us. The


### PR DESCRIPTION
## Problem — the "ghost character"
When the modern client dies **abruptly** — hard crash, `taskkill /F`, PC power-loss, or a network partition to a remote/multibox proxy — it never sends `CMSG_LOG_DISCONNECT`. Nothing then disconnects the legacy `WorldClient`, so it keeps sending `CMSG_PING` to Kronos **every 30s forever**. The server never times the character out, so your body lingers in-world — raid slot held, healers wasting heals, scoreboard still counting you — **until you relog** (which finally trips the login-collision teardown). Clean exits (`/logout`, `/exit`, normal Alt-F4) are fine; this is specifically the abrupt death.

## Fix — a modern-side death watchdog (mirror of the existing legacy silent-stall watchdog)
On the existing 30-second `WorldClient` keepalive tick, add the exact mirror of the legacy silent-stall watchdog, in the opposite direction:

- The legacy watchdog: *"legacy server went silent, player still here → reconnect."*
- This one: *"the player's client is gone, legacy still here → tear down (no reconnect)."*

Once the modern client has been observed alive, if **both** its sockets (`RealmSocket` + `InstanceSocket`) are gone and it **wasn't** an intentional logout, we `SetLogoutIntentional()` (to suppress the auto-reconnect `HandleDisconnect` would otherwise fire), drop the session slot, `Disconnect()` the legacy `WorldClient`, and `Disconnect()` the `AuthClient`. Kronos sees the world connection drop and logs the character out — within one keepalive interval (~30–60s) instead of "until relog."

## Why it's swap-safe by construction
This is the key design choice, and why it needs **no realm-swap capture to verify**:

- **It does not touch the deliberate 2026-04-26 realm-swap decoupling** (`WorldSocket.SendPacket`'s send-on-closed suppression). That code stays exactly as-is; it keeps nulling the dead sockets, and this watchdog just *notices* from a swap-safe place.
- A realm/char switch re-establishes the modern sockets in **well under a second** — far inside the 30s tick — so a coarse tick can't observe a mid-switch transient as a death.
- A switch **always** sets `IsLogoutIntentional`, which gates out even a tick that happened to land in that sub-second window.
- The `_modernClientWasAlive` flag rules out the initial login/handshake window (before the sockets are assigned) — mirroring the silent-stall watchdog's `_lastInboundOpcodeTick != 0` guard.

Three independent reasons it can't false-fire on a legitimate switch.

## Validation
- **Pre-ship:** the fire/skip decision is a pure `ModernDeathWatchdog.ShouldTearDown(...)` predicate with a 5-case truth-table unit test (fires only on the genuine-death case; skips login-window / intentional-logout / swapped-out-corpse / still-alive). Full solution builds clean; **620/620** tests pass.
- **Post-ship:** the fix is swap-safe by construction, so real-world validation is the **absence of "stuck character / ghost / can't relog until it clears" reports** and no new realm-swap-regression reports. Unlike a silent no-op, the *positive* case is also cheaply checkable if wanted: `taskkill /F` the client in-world → a `session.modern_client_death.detected` event fires and the character drops from the world within ≤ one keepalive interval.

## Notes
- Same connection-teardown thread as #405 (clean teardown) but **independent** — no dependency; either can merge first.
- No new config setting (mirrors the always-on legacy silent-stall watchdog); trivially gateable behind one later if a kill-switch is ever wanted.

Base: `beta`. No open issue auto-closed — the ghost seed was dev-discovered (the #229/#157 disconnect lineage), not player-filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
