### PR TITLE
Serialize pending-cast queue mutations; release forwarded CastID on parse-failure drain

### DIFF
--- a/HermesProxy.Tests/World/PendingCastQueueLockingTests.cs
+++ b/HermesProxy.Tests/World/PendingCastQueueLockingTests.cs
@@ -98,6 +98,11 @@ public class PendingCastQueueLockingTests
         { "ClearNonStartedPetCasts", s => s.ClearNonStartedPetCasts() },
         { "ClearPendingPetCasts", s => s.ClearPendingPetCasts() },
         { "ResetInFlightCastState", s => s.ResetInFlightCastState() },
+        { "ClearPendingNormalCasts", s => s.ClearPendingNormalCasts() },
+        // 13261 = Malfunction Explosion, a known malfunction substitute — anything else
+        // early-outs before the lock (see MalfunctionSubstituteToDevice).
+        { "TryEvictForwardedItemUseCast", s => s.TryEvictForwardedItemUseCast(13261, out _) },
+        { "TryDequeueItemCast", s => s.TryDequeueItemCast(new WowGuid128(1, 2), out _) },
     };
 
     [Theory]

--- a/HermesProxy.Tests/World/PendingCastQueueLockingTests.cs
+++ b/HermesProxy.Tests/World/PendingCastQueueLockingTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using HermesProxy;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (cast-queue lock discipline): PendingNormalCasts / PendingPetCasts are mutated by
+// compound "dequeue-all, filter, re-enqueue-survivors" helpers. ConcurrentQueue makes each
+// individual operation atomic but cannot make a whole drain-rebuild atomic, and the mutators run
+// on three unsynchronized contexts: the modern socket's IOCP receive thread (CMSG_CAST_SPELL —
+// which calls RunWatchdogEviction on EVERY press), WorldClient's ReceiveLoop task (SPELL_START /
+// SPELL_GO / CAST_FAILED), and the ThreadPool GCD hold-release timer.
+//
+// Before this fix DrainExpiredWatchdogCasts ran its drain-rebuild without PendingCastsLock, and
+// the CMSG intake enqueued without it, so a press could interleave with an SMSG-side dequeue and
+// scramble FIFO order — the ordering the START<->GO correspondence machinery depends on.
+//
+// These tests pin: (1) the hot path leaves the queues untouched when nothing is overdue, (2) an
+// eviction preserves the order of survivors, and (3) concurrent enqueue/drain conserves every
+// entry and preserves FIFO order.
+public class PendingCastQueueLockingTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static ClientCastRequest MakeCast(uint spellId, long watchdogDeadlineMs = 0, bool hasStarted = false)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            Timestamp = Environment.TickCount,
+            WatchdogDeadlineMs = watchdogDeadlineMs,
+            HasStarted = hasStarted,
+        };
+    }
+
+    [Fact]
+    public void NothingOverdue_LeavesBothQueuesByReferenceAndOrder()
+    {
+        var session = NewSession();
+        var normal = new[] { MakeCast(101), MakeCast(102), MakeCast(103) };
+        var pet = new[] { MakeCast(201), MakeCast(202) };
+        foreach (var c in normal) session.EnqueuePendingNormalCast(c);
+        foreach (var c in pet) session.EnqueuePendingPetCast(c);
+
+        session.DrainExpiredWatchdogCasts(Environment.TickCount64, out var evictedNormal, out var evictedPet);
+
+        Assert.Empty(evictedNormal);
+        Assert.Empty(evictedPet);
+        // Same instances, same order — the per-press hot path must not churn the queues.
+        Assert.Equal(normal, session.PendingNormalCasts.ToArray());
+        Assert.Equal(pet, session.PendingPetCasts.ToArray());
+    }
+
+    [Fact]
+    public void OverdueEviction_PreservesOrderOfSurvivors()
+    {
+        var session = NewSession();
+        long now = Environment.TickCount64;
+        var keepA = MakeCast(101);
+        var overdue = MakeCast(102, watchdogDeadlineMs: now - 1);
+        var keepB = MakeCast(103, watchdogDeadlineMs: now + 60_000);
+
+        session.EnqueuePendingNormalCast(keepA);
+        session.EnqueuePendingNormalCast(overdue);
+        session.EnqueuePendingNormalCast(keepB);
+
+        session.DrainExpiredWatchdogCasts(now, out var evicted, out _);
+
+        Assert.Equal(new[] { overdue }, evicted);
+        Assert.Equal(new[] { keepA, keepB }, session.PendingNormalCasts.ToArray());
+    }
+
+    // The regression test for the race itself.
+    //
+    // A timing stress test is the wrong tool here: the window between a drain's dequeue-all and
+    // its re-enqueue-all is microseconds, so a racing-threads test passes almost every run even
+    // against the unlocked code, and would be a flaky detector that lulls rather than guards.
+    //
+    // Instead assert the contract directly: every compound mutation of the pending-cast queues
+    // must acquire PendingCastsLock. We hold the lock on this thread, invoke each mutator on
+    // another, and require it to block — which is only true if it takes the lock. Against the old
+    // unlocked DrainExpiredWatchdogCasts / raw Enqueue / pet-queue helpers, each of these fails
+    // immediately.
+    public static TheoryData<string, Action<GameSessionData>> Mutators() => new()
+    {
+        { "DrainExpiredWatchdogCasts", s => s.DrainExpiredWatchdogCasts(Environment.TickCount64, out _, out _) },
+        { "DrainPendingCastsForDestroyedTarget", s => s.DrainPendingCastsForDestroyedTarget(
+            new WowGuid128(1, 2), out _, out _) },
+        { "EnqueuePendingNormalCast", s => s.EnqueuePendingNormalCast(MakeCast(1)) },
+        { "EnqueuePendingPetCast", s => s.EnqueuePendingPetCast(MakeCast(1)) },
+        { "TryDequeuePendingNormalCast", s => s.TryDequeuePendingNormalCast(1, out _) },
+        { "TryDequeuePendingPetCast", s => s.TryDequeuePendingPetCast(1, out _) },
+        { "ClearNonStartedNormalCasts", s => s.ClearNonStartedNormalCasts() },
+        { "ClearNonStartedPetCasts", s => s.ClearNonStartedPetCasts() },
+        { "ClearPendingPetCasts", s => s.ClearPendingPetCasts() },
+        { "ResetInFlightCastState", s => s.ResetInFlightCastState() },
+    };
+
+    [Theory]
+    [MemberData(nameof(Mutators))]
+    public void EveryQueueMutator_AcquiresPendingCastsLock(string name, Action<GameSessionData> mutate)
+    {
+        var session = NewSession();
+        session.EnqueuePendingNormalCast(MakeCast(101));
+        session.EnqueuePendingPetCast(MakeCast(201));
+
+        using var entered = new ManualResetEventSlim(false);
+        var worker = new Thread(() => { entered.Set(); mutate(session); });
+
+        Monitor.Enter(session.PendingCastsLock);
+        try
+        {
+            worker.Start();
+            entered.Wait(TimeSpan.FromSeconds(5));
+            // The mutator must NOT be able to run while we hold the lock.
+            Assert.False(worker.Join(TimeSpan.FromMilliseconds(250)),
+                $"{name} completed while PendingCastsLock was held — it does not take the lock.");
+        }
+        finally
+        {
+            Monitor.Exit(session.PendingCastsLock);
+        }
+
+        // Once released it must complete promptly.
+        Assert.True(worker.Join(TimeSpan.FromSeconds(5)), $"{name} did not complete after the lock was released.");
+    }
+
+    // A force-closed STARTED cast must release its forwarded-START CastID, or the dead cast's id
+    // stays at the head of the per-spell FIFO and the NEXT same-spell SPELL_GO pops it — stamping
+    // the new cast's GO with the dead cast's CastID. The 1.14 client pairs START<->GO by CastID,
+    // so the new cast would never close (stuck cast animation + looping cast sound).
+    // This pins the invariant that RunWatchdogEviction and the SPELL_START/GO parse-failure drain
+    // both rely on.
+    [Fact]
+    public void ReleasingAForceClosedCastId_LeavesTheNextCastsIdAtTheFifoHead()
+    {
+        var session = NewSession();
+        const uint spellId = 13877; // Blade Flurry
+        var deadCastId = new WowGuid128(0x1111111111111111, 0x2222222222222222);
+        var liveCastId = new WowGuid128(0x3333333333333333, 0x4444444444444444);
+
+        session.EnqueueForwardedStartCastId(spellId, deadCastId);
+        session.EnqueueForwardedStartCastId(spellId, liveCastId);
+
+        // The parse-failure drain / watchdog force-closes the first cast: remove BY VALUE.
+        Assert.True(session.RemoveForwardedStartCastId(spellId, deadCastId));
+
+        // The next same-spell GO must recover the LIVE cast's id, not the dead one's.
+        Assert.True(session.TryPopForwardedStartCastId(spellId, out var recovered));
+        Assert.Equal(liveCastId, recovered);
+        Assert.False(session.TryPopForwardedStartCastId(spellId, out _));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -414,13 +414,44 @@ public sealed class GameSessionData
     public ClientCastRequest? CurrentClientNextMeleeCast; // next melee spells (Raptor Strike, Heroic Strike, etc.)
     public ClientCastRequest? CurrentClientAutoRepeatCast; // auto repeat spells (Auto Shot, Shoot, etc.)
     public ConcurrentQueue<ClientCastRequest> PendingPetCasts = new();  // pet spell casts (queue for proper FIFO handling)
-    // JimsProxy (issue #43): serializes the drain-filter-rebuild helpers below with the
-    // ThreadPool-thread Enqueue in WorldSocket.ForwardHeldGcdCast. Without this, the timer
-    // thread can enqueue a held cast mid-drain, causing the drain to observe the new item
-    // out-of-order and possibly return it as a FIFO match for an unrelated SMSG_SPELL_GO.
-    // Pre-existing Enqueues from the network-thread CMSG handlers stay lock-free (same-thread
-    // semantics as before this PR); only the new cross-thread path takes the lock.
+    // JimsProxy (issue #43): serializes EVERY mutation of PendingNormalCasts / PendingPetCasts.
+    //
+    // Both queues are drained and rebuilt by compound "dequeue-all, filter, re-enqueue-survivors"
+    // helpers. ConcurrentQueue makes each individual Enqueue/TryDequeue atomic, but it cannot make
+    // a whole drain-rebuild atomic: a concurrent Enqueue lands in the middle of one, and two
+    // concurrent drain-rebuilds split the queue between their private survivor lists. Either way
+    // FIFO order — which START/GO/CAST_FAILED matching depends on — is not preserved.
+    //
+    // These mutations genuinely run in parallel. CMSG handlers (HandleCastSpell, and the
+    // RunWatchdogEviction it calls on every press) execute on the modern socket's IOCP receive
+    // thread; SMSG handlers (SPELL_START/GO/CAST_FAILED) execute on WorldClient's ReceiveLoop
+    // task; the GCD hold-release timer fires on a ThreadPool thread. Nothing serializes them.
+    //
+    // So: take this lock around any mutation, and prefer the EnqueuePending*Cast helpers below.
+    // Read-only walks (HasStartedNormalCast, TryMarkPendingNormalCastStarted, ...) may stay
+    // lock-free: ConcurrentQueue enumeration is a snapshot and they mutate only entry fields.
     internal readonly object PendingCastsLock = new();
+
+    /// <summary>
+    /// Enqueue a normal cast under <see cref="PendingCastsLock"/>. Always use this rather than
+    /// touching <see cref="PendingNormalCasts"/> directly — a lock-free Enqueue racing a
+    /// drain-rebuild reorders the FIFO the cast-correspondence machinery relies on.
+    /// </summary>
+    public void EnqueuePendingNormalCast(ClientCastRequest cast)
+    {
+        lock (PendingCastsLock)
+            PendingNormalCasts.Enqueue(cast);
+    }
+
+    /// <summary>
+    /// Enqueue a pet cast under <see cref="PendingCastsLock"/>. See
+    /// <see cref="EnqueuePendingNormalCast"/>.
+    /// </summary>
+    public void EnqueuePendingPetCast(ClientCastRequest cast)
+    {
+        lock (PendingCastsLock)
+            PendingPetCasts.Enqueue(cast);
+    }
 
     // JimsProxy (#313): the spell-queue hold-window width is configurable via
     // Framework.Settings.SpellQueueWindowMs (400 retail-accurate / 1000 / 1300 smoothest;
@@ -1726,55 +1757,63 @@ public sealed class GameSessionData
         // DIAGNOSTIC (stuck-spell investigation): hoist toggle read; remove with diagnostics
         bool debugEvents = Framework.Settings.DebugOutput;
 
-        var keepNormal = new List<ClientCastRequest>();
-        while (PendingNormalCasts.TryDequeue(out var cast))
+        // The drain-rebuild is a compound mutation: hold the lock across it. Logging happens
+        // afterwards so no file I/O runs inside the critical section.
+        lock (PendingCastsLock)
         {
-            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            var keepNormal = new List<ClientCastRequest>();
+            while (PendingNormalCasts.TryDequeue(out var cast))
             {
-                normalEvicted.Add(cast);
-                // DIAGNOSTIC (stuck-spell investigation): remove when closed
-                if (debugEvents)
-                    Log.Event("cast.destroy_eviction", new
-                    {
-                        queue = "normal",
-                        spell_id = cast.SpellId,
-                        had_started = cast.HasStarted,
-                        is_channeled = GameData.IsChanneledSpell(cast.SpellId),
-                        destroyed_target_low = destroyedGuid.GetCounter(),
-                        client_cast_id = cast.ClientGUID.ToString(),
-                    });
+                if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+                    normalEvicted.Add(cast);
+                else
+                    keepNormal.Add(cast);
             }
-            else
-                keepNormal.Add(cast);
-        }
-        foreach (var c in keepNormal)
-            PendingNormalCasts.Enqueue(c);
+            foreach (var c in keepNormal)
+                PendingNormalCasts.Enqueue(c);
 
-        var keepPet = new List<ClientCastRequest>();
-        while (PendingPetCasts.TryDequeue(out var cast))
-        {
-            if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+            var keepPet = new List<ClientCastRequest>();
+            while (PendingPetCasts.TryDequeue(out var cast))
             {
-                petEvicted.Add(cast);
-                // DIAGNOSTIC (stuck-spell investigation): remove when closed
-                if (debugEvents)
-                    Log.Event("cast.destroy_eviction", new
-                    {
-                        queue = "pet",
-                        spell_id = cast.SpellId,
-                        had_started = cast.HasStarted,
-                        is_channeled = GameData.IsChanneledSpell(cast.SpellId),
-                        destroyed_target_low = destroyedGuid.GetCounter(),
-                        client_cast_id = cast.ClientGUID.ToString(),
-                    });
+                if (!cast.HasStarted && !cast.TargetGuid.IsEmpty() && cast.TargetGuid == destroyedGuid)
+                    petEvicted.Add(cast);
+                else
+                    keepPet.Add(cast);
             }
-            else
-                keepPet.Add(cast);
+            foreach (var c in keepPet)
+                PendingPetCasts.Enqueue(c);
         }
-        foreach (var c in keepPet)
-            PendingPetCasts.Enqueue(c);
+
+        // DIAGNOSTIC (stuck-spell investigation): remove when closed
+        if (debugEvents)
+        {
+            foreach (var cast in normalEvicted)
+                LogDestroyEviction("normal", cast, destroyedGuid);
+            foreach (var cast in petEvicted)
+                LogDestroyEviction("pet", cast, destroyedGuid);
+        }
     }
 
+    // DIAGNOSTIC (stuck-spell investigation): remove when closed
+    private static void LogDestroyEviction(string queue, ClientCastRequest cast, WowGuid128 destroyedGuid)
+    {
+        Log.Event("cast.destroy_eviction", new
+        {
+            queue,
+            spell_id = cast.SpellId,
+            had_started = cast.HasStarted,
+            is_channeled = GameData.IsChanneledSpell(cast.SpellId),
+            destroyed_target_low = destroyedGuid.GetCounter(),
+            client_cast_id = cast.ClientGUID.ToString(),
+        });
+    }
+
+    /// <summary>
+    /// Evict pending casts whose watchdog deadline has passed. Called from the top of every spell
+    /// event handler AND from CMSG_CAST_SPELL — i.e. on every single client cast press — so the
+    /// common case (nothing overdue) must not touch the queues at all: a drain-rebuild there would
+    /// churn the FIFO on the hot path and, worse, race the SMSG-thread dequeue.
+    /// </summary>
     public void DrainExpiredWatchdogCasts(long nowMs,
         out List<ClientCastRequest> normalEvicted,
         out List<ClientCastRequest> petEvicted)
@@ -1782,27 +1821,48 @@ public sealed class GameSessionData
         normalEvicted = new List<ClientCastRequest>();
         petEvicted = new List<ClientCastRequest>();
 
-        var keepNormal = new List<ClientCastRequest>();
-        while (PendingNormalCasts.TryDequeue(out var cast))
+        lock (PendingCastsLock)
         {
-            if (cast.WatchdogDeadlineMs > 0 && cast.WatchdogDeadlineMs < nowMs)
-                normalEvicted.Add(cast);
-            else
-                keepNormal.Add(cast);
-        }
-        foreach (var c in keepNormal)
-            PendingNormalCasts.Enqueue(c);
+            if (!HasOverdueWatchdogCast(PendingNormalCasts, nowMs) &&
+                !HasOverdueWatchdogCast(PendingPetCasts, nowMs))
+                return;   // hot path: nothing to evict, leave both queues untouched
 
-        var keepPet = new List<ClientCastRequest>();
-        while (PendingPetCasts.TryDequeue(out var cast))
-        {
-            if (cast.WatchdogDeadlineMs > 0 && cast.WatchdogDeadlineMs < nowMs)
-                petEvicted.Add(cast);
-            else
-                keepPet.Add(cast);
+            var keepNormal = new List<ClientCastRequest>();
+            while (PendingNormalCasts.TryDequeue(out var cast))
+            {
+                if (IsWatchdogOverdue(cast, nowMs))
+                    normalEvicted.Add(cast);
+                else
+                    keepNormal.Add(cast);
+            }
+            foreach (var c in keepNormal)
+                PendingNormalCasts.Enqueue(c);
+
+            var keepPet = new List<ClientCastRequest>();
+            while (PendingPetCasts.TryDequeue(out var cast))
+            {
+                if (IsWatchdogOverdue(cast, nowMs))
+                    petEvicted.Add(cast);
+                else
+                    keepPet.Add(cast);
+            }
+            foreach (var c in keepPet)
+                PendingPetCasts.Enqueue(c);
         }
-        foreach (var c in keepPet)
-            PendingPetCasts.Enqueue(c);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsWatchdogOverdue(ClientCastRequest cast, long nowMs)
+        => cast.WatchdogDeadlineMs > 0 && cast.WatchdogDeadlineMs < nowMs;
+
+    private static bool HasOverdueWatchdogCast(ConcurrentQueue<ClientCastRequest> queue, long nowMs)
+    {
+        foreach (var cast in queue)
+        {
+            if (IsWatchdogOverdue(cast, nowMs))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>
@@ -2049,21 +2109,24 @@ public sealed class GameSessionData
         var pending = new List<ClientCastRequest>();
         cast = null;
 
-        while (PendingPetCasts.TryDequeue(out var current))
+        lock (PendingCastsLock)
         {
-            if (cast == null && CastMatchesSpellId(current, spellId))
+            while (PendingPetCasts.TryDequeue(out var current))
             {
-                cast = current;
+                if (cast == null && CastMatchesSpellId(current, spellId))
+                {
+                    cast = current;
+                }
+                else
+                {
+                    pending.Add(current);
+                }
             }
-            else
-            {
-                pending.Add(current);
-            }
-        }
 
-        foreach (var item in pending)
-        {
-            PendingPetCasts.Enqueue(item);
+            foreach (var item in pending)
+            {
+                PendingPetCasts.Enqueue(item);
+            }
         }
 
         return cast != null;
@@ -2095,7 +2158,10 @@ public sealed class GameSessionData
     /// </summary>
     public void ClearPendingPetCasts()
     {
-        while (PendingPetCasts.TryDequeue(out _)) { }
+        lock (PendingCastsLock)
+        {
+            while (PendingPetCasts.TryDequeue(out _)) { }
+        }
     }
 
     /// <summary>
@@ -2114,13 +2180,14 @@ public sealed class GameSessionData
     public (int normalCasts, int petCasts, int otherCasterIds) ResetInFlightCastState()
     {
         int normalCount;
+        int petCount;
         lock (PendingCastsLock)
         {
             normalCount = PendingNormalCasts.Count;
             while (PendingNormalCasts.TryDequeue(out _)) { }
+            petCount = PendingPetCasts.Count;
+            while (PendingPetCasts.TryDequeue(out _)) { }
         }
-        int petCount = PendingPetCasts.Count;
-        while (PendingPetCasts.TryDequeue(out _)) { }
         int otherCount = OtherCasterActiveCastIds.Count;
         OtherCasterActiveCastIds.Clear();
         PetAutoCastActiveCastIds.Clear();
@@ -2161,18 +2228,21 @@ public sealed class GameSessionData
         var cleared = new List<ClientCastRequest>();
         var keep = new List<ClientCastRequest>();
 
-        while (PendingPetCasts.TryDequeue(out var current))
+        lock (PendingCastsLock)
         {
-            if (current.HasStarted)
-                keep.Add(current);
-            else
-                cleared.Add(current);
-        }
+            while (PendingPetCasts.TryDequeue(out var current))
+            {
+                if (current.HasStarted)
+                    keep.Add(current);
+                else
+                    cleared.Add(current);
+            }
 
-        // Re-enqueue started casts
-        foreach (var item in keep)
-        {
-            PendingPetCasts.Enqueue(item);
+            // Re-enqueue started casts
+            foreach (var item in keep)
+            {
+                PendingPetCasts.Enqueue(item);
+            }
         }
 
         return cleared;

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -428,8 +428,14 @@ public sealed class GameSessionData
     // task; the GCD hold-release timer fires on a ThreadPool thread. Nothing serializes them.
     //
     // So: take this lock around any mutation, and prefer the EnqueuePending*Cast helpers below.
-    // Read-only walks (HasStartedNormalCast, TryMarkPendingNormalCastStarted, ...) may stay
-    // lock-free: ConcurrentQueue enumeration is a snapshot and they mutate only entry fields.
+    // Read walks (HasStartedNormalCast, TryMarkPendingNormalCastStarted, ...) take the lock
+    // too: a ConcurrentQueue enumeration IS a consistent snapshot, but a snapshot taken while
+    // another thread holds this lock mid drain-rebuild (every entry dequeued into a private
+    // survivor list, not yet re-enqueued) sees an EMPTY queue and false-misses a live entry —
+    // a SPELL_START landing in that window skips its match, START and GO then ship different
+    // CastIDs, and the client never closes the cast. The queue holds a handful of entries at
+    // most; the lock cost is noise. (This supersedes the earlier "read walks may stay
+    // lock-free" rule — that blessing was unsound during drain-rebuild windows.)
     internal readonly object PendingCastsLock = new();
 
     /// <summary>
@@ -529,13 +535,16 @@ public sealed class GameSessionData
 
     public bool HasNonStartedPendingCastForSpell(uint spellId)
     {
-        foreach (var item in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (!item.HasStarted &&
-                (item.SpellId == spellId || (item.LegacySpellId != 0 && item.LegacySpellId == spellId)))
-                return true;
+            foreach (var item in PendingNormalCasts)
+            {
+                if (!item.HasStarted &&
+                    (item.SpellId == spellId || (item.LegacySpellId != 0 && item.LegacySpellId == spellId)))
+                    return true;
+            }
+            return false;
         }
-        return false;
     }
 
     // JimsProxy: proxy→server RTT measurement for adaptive GCD fire offset.
@@ -1467,18 +1476,21 @@ public sealed class GameSessionData
     {
         cast = null;
 
-        foreach (var item in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (CastMatchesSpellId(item, spellId) && !item.HasStarted)
+            foreach (var item in PendingNormalCasts)
             {
-                item.HasStarted = true;
-                item.StartedAtTickMs = Environment.TickCount64;
-                cast = item;
-                return true;
+                if (CastMatchesSpellId(item, spellId) && !item.HasStarted)
+                {
+                    item.HasStarted = true;
+                    item.StartedAtTickMs = Environment.TickCount64;
+                    cast = item;
+                    return true;
+                }
             }
-        }
 
-        return false;
+            return false;
+        }
     }
 
     // JimsProxy (T1 identity-pinned cast correspondence) — per-spell forwarded-START CastID
@@ -1591,12 +1603,15 @@ public sealed class GameSessionData
     /// </summary>
     public bool HasStartedNormalCast()
     {
-        foreach (var item in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (item.HasStarted)
-                return true;
+            foreach (var item in PendingNormalCasts)
+            {
+                if (item.HasStarted)
+                    return true;
+            }
+            return false;
         }
-        return false;
     }
 
     /// <summary>
@@ -1614,12 +1629,15 @@ public sealed class GameSessionData
             return false;
         if (gameObjectGuid.GetHighType() != HighGuidType.GameObject)
             return false;
-        foreach (var item in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (item.HasStarted && item.TargetGuid == gameObjectGuid)
-                return true;
+            foreach (var item in PendingNormalCasts)
+            {
+                if (item.HasStarted && item.TargetGuid == gameObjectGuid)
+                    return true;
+            }
+            return false;
         }
-        return false;
     }
 
     /// <summary>
@@ -1635,16 +1653,19 @@ public sealed class GameSessionData
     public bool HasStartedCastInQueueWindow()
     {
         long now = Environment.TickCount64;
-        foreach (var item in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (!item.HasStarted || item.StartedAtTickMs == 0 || item.StartedCastTimeMs == 0)
-                continue;
-            long castEnd = item.StartedAtTickMs + item.StartedCastTimeMs;
-            long remaining = castEnd - now;
-            if (remaining > 0 && remaining <= Framework.Settings.SpellQueueWindowMs)
-                return true;
+            foreach (var item in PendingNormalCasts)
+            {
+                if (!item.HasStarted || item.StartedAtTickMs == 0 || item.StartedCastTimeMs == 0)
+                    continue;
+                long castEnd = item.StartedAtTickMs + item.StartedCastTimeMs;
+                long remaining = castEnd - now;
+                if (remaining > 0 && remaining <= Framework.Settings.SpellQueueWindowMs)
+                    return true;
+            }
+            return false;
         }
-        return false;
     }
 
     /// <summary>
@@ -1694,24 +1715,27 @@ public sealed class GameSessionData
         long nowTick = Environment.TickCount64;
         // DIAGNOSTIC (stuck-spell investigation): hoist toggle read; remove with diagnostics
         bool debugEvents = Framework.Settings.DebugOutput;
-        foreach (var cast in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (cast.HasStarted && cast.StartedCastTimeMs > 0
-                && !GameData.IsChanneledSpell(cast.SpellId))
+            foreach (var cast in PendingNormalCasts)
             {
-                cast.MovementCancelled = true;
-                cast.MarkedAtTickMs = nowTick;
-                if (cast.WatchdogDeadlineMs == 0)
-                    cast.WatchdogDeadlineMs = watchdogDeadlineMs;
-                marked++;
-                // DIAGNOSTIC (stuck-spell investigation): remove when closed
-                if (debugEvents)
-                    Log.Event("cast.movement_marked", new
-                    {
-                        spell_id = cast.SpellId,
-                        started_cast_time_ms = cast.StartedCastTimeMs,
-                        client_cast_id = cast.ClientGUID.ToString(),
-                    });
+                if (cast.HasStarted && cast.StartedCastTimeMs > 0
+                    && !GameData.IsChanneledSpell(cast.SpellId))
+                {
+                    cast.MovementCancelled = true;
+                    cast.MarkedAtTickMs = nowTick;
+                    if (cast.WatchdogDeadlineMs == 0)
+                        cast.WatchdogDeadlineMs = watchdogDeadlineMs;
+                    marked++;
+                    // DIAGNOSTIC (stuck-spell investigation): remove when closed
+                    if (debugEvents)
+                        Log.Event("cast.movement_marked", new
+                        {
+                            spell_id = cast.SpellId,
+                            started_cast_time_ms = cast.StartedCastTimeMs,
+                            client_cast_id = cast.ClientGUID.ToString(),
+                        });
+                }
             }
         }
         return marked;
@@ -1872,12 +1896,15 @@ public sealed class GameSessionData
     /// </summary>
     public bool HasInFlightNormalCastForSpell(uint spellId)
     {
-        foreach (var item in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (CastMatchesSpellId(item, spellId))
-                return true;
+            foreach (var item in PendingNormalCasts)
+            {
+                if (CastMatchesSpellId(item, spellId))
+                    return true;
+            }
+            return false;
         }
-        return false;
     }
 
     /// <summary>
@@ -1887,12 +1914,15 @@ public sealed class GameSessionData
     /// </summary>
     public bool HasForwardedPendingCast()
     {
-        foreach (var item in PendingNormalCasts)
+        lock (PendingCastsLock)
         {
-            if (!item.HasStarted)
-                return true;
+            foreach (var item in PendingNormalCasts)
+            {
+                if (!item.HasStarted)
+                    return true;
+            }
+            return false;
         }
-        return false;
     }
 
     /// <summary>

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -2350,35 +2350,55 @@ public partial class WorldClient
     // one cast — a small price to avoid the permanent lock.
     private void DrainOrphanedStartedNormalCastsOnParseFailure(bool isSpellGo)
     {
-        var queue = GetSession().GameState.PendingNormalCasts;
+        var gameState = GetSession().GameState;
+        var queue = gameState.PendingNormalCasts;
         var keep = new List<ClientCastRequest>();
-        int orphaned = 0;
-        while (queue.TryDequeue(out var cast))
-        {
-            if (cast.HasStarted)
-            {
-                CastFailed failed = new();
-                failed.SpellID = cast.SpellId;
-                failed.SpellXSpellVisualID = cast.SpellXSpellVisualId;
-                failed.Reason = (uint)SpellCastResultClassic.DontReport;
-                failed.CastID = cast.ServerGUID;
-                SendPacketToClient(failed);
-                orphaned++;
-            }
-            else
-            {
-                keep.Add(cast);
-            }
-        }
-        foreach (var c in keep)
-            queue.Enqueue(c);
+        var orphanedCasts = new List<ClientCastRequest>();
 
-        if (orphaned > 0)
+        // Compound drain-rebuild: hold PendingCastsLock across it (a concurrent CMSG-thread
+        // Enqueue or watchdog drain would otherwise scramble the FIFO). No packet I/O inside.
+        lock (gameState.PendingCastsLock)
+        {
+            while (queue.TryDequeue(out var cast))
+            {
+                if (cast.HasStarted)
+                    orphanedCasts.Add(cast);
+                else
+                    keep.Add(cast);
+            }
+            foreach (var c in keep)
+                queue.Enqueue(c);
+        }
+
+        foreach (var cast in orphanedCasts)
+        {
+            // Force-closing a STARTED cast without a server terminating event: release its
+            // forwarded-START CastID, exactly as RunWatchdogEviction does. Otherwise the dead
+            // cast's CastID stays at the head of the per-spell FIFO and the NEXT same-spell
+            // SPELL_GO pops it, stamping the new cast's GO with the dead cast's CastID — the
+            // 1.14 client pairs START↔GO by CastID, so the new cast never closes (stuck cast
+            // animation + looping cast sound). The synthetic CastFailed below already carries
+            // cast.ServerGUID, which is the value the FIFO holds.
+            //
+            // Deliberately ungated: a no-op while the FIFO is off (it is empty then), and correct
+            // once the FIFO becomes the unconditional recovery store. RunWatchdogEviction makes the
+            // same call for the same reason.
+            gameState.RemoveForwardedStartCastId(cast.SpellId, cast.ServerGUID);
+
+            CastFailed failed = new();
+            failed.SpellID = cast.SpellId;
+            failed.SpellXSpellVisualID = cast.SpellXSpellVisualId;
+            failed.Reason = (uint)SpellCastResultClassic.DontReport;
+            failed.CastID = cast.ServerGUID;
+            SendPacketToClient(failed);
+        }
+
+        if (orphanedCasts.Count > 0)
         {
             Log.Event("spell.parse_failed.queue_drained", new
             {
                 phase = isSpellGo ? "go" : "start",
-                orphaned_count = orphaned,
+                orphaned_count = orphanedCasts.Count,
             });
         }
     }

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -971,8 +971,9 @@ public partial class WorldClient
         // its synthetic closure when the player goes idle. The existing watchdog otherwise only
         // runs on the next inbound spell packet, so a truly idle orphan leaks until the next cast.
         // The 2.5s per-cast deadline and the eviction logic are unchanged — this only adds a pump
-        // cadence (≤ one keepalive interval late). Gated with the T1 bundle so OFF is byte-identical;
-        // RunWatchdogEviction is already invoked cross-thread and no-ops when nothing is overdue.
+        // cadence (≤ one keepalive interval late). Gated with the T1 bundle so OFF is byte-identical.
+        // RunWatchdogEviction is safe to call cross-thread: it takes PendingCastsLock, and returns
+        // without touching the queues when nothing is overdue.
         if (Framework.Settings.IdentityPinnedCastIdsActive)
             GetSession()?.RunWatchdogEviction();
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -354,10 +354,7 @@ public partial class WorldSocket
                             queue_depth_before = GetSession().GameState.PendingNormalCasts.Count,
                             source = "low_latency",
                         });
-                    lock (GetSession().GameState.PendingCastsLock)
-                    {
-                        GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
-                    }
+                    GetSession().GameState.EnqueuePendingNormalCast(castRequest);
                     Log.Event("cast.low_latency_forward", new
                     {
                         spell_id = cast.Cast.SpellID,
@@ -557,7 +554,7 @@ public partial class WorldSocket
                         queue_depth_before = GetSession().GameState.PendingNormalCasts.Count,
                         source = "immediate",
                     });
-                GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
+                GetSession().GameState.EnqueuePendingNormalCast(castRequest);
             }
             else
             {
@@ -596,7 +593,7 @@ public partial class WorldSocket
                         queue_depth_before = GetSession().GameState.PendingNormalCasts.Count,
                         source = "off_gcd",
                     });
-                GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
+                GetSession().GameState.EnqueuePendingNormalCast(castRequest);
 
                 // Off-GCD spells bypass the hold system, so SpellPrepare must be sent now
                 // (on-GCD casts defer SpellPrepare to SPELL_START/SPELL_GO time to avoid
@@ -789,10 +786,7 @@ public partial class WorldSocket
                 queue_depth_before = gameState.PendingNormalCasts.Count,
                 source = "held_gcd_release",
             });
-        lock (gameState.PendingCastsLock)
-        {
-            gameState.PendingNormalCasts.Enqueue(cast);
-        }
+        gameState.EnqueuePendingNormalCast(cast);
         // JimsProxy: spell.held_fire — captures total hold duration (press → server forward).
         // Compare against gcd_remaining_ms in the matching spell.held to reconstruct GCD timing.
         Log.Event("spell.held_fire", new
@@ -842,7 +836,7 @@ public partial class WorldSocket
                 queue_depth_before = GetSession().GameState.PendingPetCasts.Count,
                 source = "pet",
             });
-        GetSession().GameState.PendingPetCasts.Enqueue(castRequest);
+        GetSession().GameState.EnqueuePendingPetCast(castRequest);
 
         SpellCastTargetFlags targetFlags = ConvertSpellTargetFlags(cast.Cast.Target);
 
@@ -914,7 +908,7 @@ public partial class WorldSocket
                 queue_depth_before = GetSession().GameState.PendingNormalCasts.Count,
                 source = "item",
             });
-        GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
+        GetSession().GameState.EnqueuePendingNormalCast(castRequest);
 
         // MIRASU (cast-while-moving-out-of-range 2026-05-23): sync server position
         // for reticle-targeted item uses (bombs, sapper charge, grenades). See


### PR DESCRIPTION
Two latent correctness defects in the cast-correspondence bookkeeping, found by auditing the pending-cast queue's lock discipline against the proxy's actual thread model.

**Neither is the looping-cast-sound bug** (that is client-internal — see the foundation doc's V3/I13), and neither has telemetry showing it firing in the 164-log corpus. This is hardening, not a symptom fix. Framing it that way on purpose.

## 1. Unsynchronized drain-rebuild of the pending-cast queues

`PendingNormalCasts` / `PendingPetCasts` are mutated by compound *dequeue-all → filter → re-enqueue-survivors* helpers. `ConcurrentQueue` makes each individual operation atomic, but it cannot make a whole drain-rebuild atomic.

Three helpers ran that compound mutation with **no lock at all** — `DrainExpiredWatchdogCasts`, `DrainPendingCastsForDestroyedTarget`, `DrainOrphanedStartedNormalCastsOnParseFailure` — as did the CMSG intake `Enqueue`s and *every* `PendingPetCasts` operation. Meanwhile `TryDequeuePendingNormalCast` and `ClearNonStartedNormalCasts` did take `PendingCastsLock`. A lock only excludes other lock-takers, so it bought nothing against the unlocked half.

These paths genuinely run in parallel:

| Path | Thread |
|---|---|
| `CMSG_CAST_SPELL` → `RunWatchdogEviction` (**every press**) | modern socket IOCP receive thread |
| `SPELL_START` / `SPELL_GO` / `CAST_FAILED` | `WorldClient.ReceiveLoop` task |
| GCD hold-release fire | ThreadPool timer |

Nothing serializes them. The lock's own comment asserted *"same-thread semantics"* for the CMSG enqueues — never true across that boundary.

**Worst case:** a lost GO-side dequeue leaves a phantom `HasStarted` entry. It is never reclaimed — `WatchdogDeadlineMs` is `0` unless `SPELL_FAILURE` or a movement-cancel armed it, and the watchdog only evicts entries *with* a deadline — so `HasStartedNormalCast()` stays true and the item-use gate silently drops **every subsequent `CMSG_USE_ITEM`** until a zone/reconnect reset (potions, trinkets, food stop working). The wire CastID is *not* affected: the forwarded-START CastID FIFO has its own lock and the orphan-GO fallback re-stamps from it.

**Fix:** `PendingCastsLock` guards every mutation of both queues; CMSG enqueues route through new `EnqueuePendingNormalCast` / `EnqueuePendingPetCast` helpers. Packet I/O and JSONL logging hoisted out of the critical sections. `DrainExpiredWatchdogCasts` also returns without touching the queues when nothing is overdue — it runs on every keypress, so the common case must not churn the FIFO. (That also makes `WorldClient`'s *"no-ops when nothing is overdue"* comment true; it was false.)

## 2. Parse-failure drain leaked a forwarded-START CastID

`DrainOrphanedStartedNormalCastsOnParseFailure` force-closes STARTED casts and sends their synthetic `CastFailed`, but never released the CastID recorded for that START. The dead cast's id stayed at the head of the per-spell FIFO, so the **next same-spell `SPELL_GO` popped it** — stamping the new cast's GO with the dead cast's CastID. The 1.14 client pairs START↔GO by CastID, so the new cast never closes: stuck cast animation + looping cast sound.

`RunWatchdogEviction` already honours this invariant via `RemoveForwardedStartCastId`; this path simply did not. The new call is deliberately **ungated** — a no-op while the FIFO is off, correct once #402 makes it the default.

Deterministic, not timing-dependent. `spell.parse_failed` fires once across 164 corpus logs, so it is latent.

## Tests

A `[Theory]` holds `PendingCastsLock` and asserts each of the **thirteen** queue mutators blocks on it. Deterministic, and it fails against the unlocked code (verified by reverting the lock).

A timing stress test was tried first and **rejected**: the natural race window is microseconds wide, and it passed against the broken code on nearly every run. A flaky detector that lulls is worse than no test. (Confirmed the model by artificially widening the window — it fails then.)

Plus guards for the not-overdue hot path, eviction ordering, and the force-closed-CastID FIFO invariant.

`628/628` pass. No new build warnings.

## Notes for review

- Independent of #402 — both defects exist unchanged on `beta`. No textual conflict expected.
- Lock ordering unchanged: the only nesting is `_gcdLock → PendingCastsLock` (via `ForwardHeldGcdCast`), and no new path takes them in reverse.
- Read-only queue walks (`HasStartedNormalCast`, `TryMarkPendingNormalCastStarted`, …) take the lock too. A `ConcurrentQueue` enumeration is a consistent snapshot, but a snapshot taken while another thread holds the lock mid drain-rebuild (every entry dequeued into a private survivor list, none re-enqueued yet) sees an EMPTY queue and false-misses a live entry — a SPELL_START landing in that window skips its match, and START/GO then ship different CastIDs. The queues hold a handful of entries, so the lock cost is noise. (An earlier revision left read walks lock-free; that was unsound and the code corrects it.)