### PR TITLE
Harden completed_quests.csv against corrupt lines and dedupe on load

### DIFF
--- a/HermesProxy.Tests/World/CompletedQuestParseTests.cs
+++ b/HermesProxy.Tests/World/CompletedQuestParseTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Pins the defensive parsing of completed_quests.csv. The old code called uint.Parse on every
+// line's first field, so a single corrupt line (a crash/kill mid-append can leave NUL bytes)
+// threw FormatException from inside HandlePlayerLogin and terminated the whole proxy on login.
+// The parser now skips corrupt lines and collapses duplicate quest IDs (repeatable turn-ins,
+// e.g. Argent Dawn Scourgestone quests, append a row every completion).
+public class CompletedQuestParseTests
+{
+    [Fact]
+    public void ParseCompletedQuestLines_NulByteLine_SkippedAndFlaggedForRewrite()
+    {
+        var lines = new List<string> { "411,1780220603", "435,1780245929", new string('\0', 17) };
+
+        var ids = AccountMetaDataManager.ParseCompletedQuestLines(lines, out var compact, out var needsRewrite);
+
+        Assert.Equal(new uint[] { 411, 435 }, ids);
+        Assert.Equal(new[] { "411,1780220603", "435,1780245929" }, compact);
+        Assert.True(needsRewrite);
+    }
+
+    [Fact]
+    public void ParseCompletedQuestLines_AllValidDistinct_NoRewrite()
+    {
+        var lines = new List<string> { "411,1", "435,2" };
+
+        var ids = AccountMetaDataManager.ParseCompletedQuestLines(lines, out var compact, out var needsRewrite);
+
+        Assert.Equal(new uint[] { 411, 435 }, ids);
+        Assert.Equal(2, compact.Count);
+        Assert.False(needsRewrite);
+    }
+
+    [Fact]
+    public void ParseCompletedQuestLines_Duplicates_CollapsedToFirstSeen()
+    {
+        // Repeatable turn-in (Argent Dawn "Minion's Scourgestones" 5510) appended many times.
+        var lines = new List<string> { "5510,100", "5510,101", "5510,102", "5508,103", "5510,104" };
+
+        var ids = AccountMetaDataManager.ParseCompletedQuestLines(lines, out var compact, out var needsRewrite);
+
+        Assert.Equal(new uint[] { 5510, 5508 }, ids);
+        Assert.Equal(new[] { "5510,100", "5508,103" }, compact);
+        Assert.True(needsRewrite);
+    }
+
+    [Fact]
+    public void ParseCompletedQuestLines_BlankLines_NotTreatedAsCorruption()
+    {
+        var lines = new List<string> { "411,1", "", "  " };
+
+        var ids = AccountMetaDataManager.ParseCompletedQuestLines(lines, out _, out var needsRewrite);
+
+        Assert.Equal(new uint[] { 411 }, ids);
+        Assert.False(needsRewrite);
+    }
+}

--- a/HermesProxy/World/Server/AccountDataManager.cs
+++ b/HermesProxy/World/Server/AccountDataManager.cs
@@ -95,10 +95,69 @@ public class AccountMetaDataManager
         if (!File.Exists(path))
             return new List<uint>();
 
-        List<string> lines = File.ReadAllLines(path).ToList();
+        var completedQuestIds = ParseCompletedQuestLines(File.ReadAllLines(path), out var compactLines, out var needsRewrite);
 
-        var completedQuestIds = lines.Select(x => uint.Parse(x.Split(',').FirstOrDefault() ?? "0")).ToList();
+        // Self-heal: the old code called uint.Parse on every line, so a single corrupt line (a
+        // crash/kill mid-append can leave NUL bytes) threw FormatException and terminated the
+        // whole proxy on login. We now skip corrupt lines and de-duplicate repeated quest IDs
+        // (repeatable turn-ins append a line each completion; the file is only meaningful as a
+        // set). When anything was dropped, atomically rewrite the file so it can't recur or grow.
+        if (needsRewrite)
+        {
+            Log.Print(LogType.Warn, $"Compacting completed_quests.csv for '{charName}@{realmName}': " +
+                                    $"kept {compactLines.Count} distinct quest(s), dropped corrupt/duplicate line(s).");
+            try
+            {
+                var tmp = path + ".tmp";
+                File.WriteAllLines(tmp, compactLines);
+                File.Move(tmp, path, overwrite: true);
+            }
+            catch (Exception ex)
+            {
+                Log.Print(LogType.Error, $"Failed to rewrite completed_quests.csv at '{path}': {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
         return completedQuestIds;
+    }
+
+    // Parses completed_quests.csv content. A valid line is "<questId>,<unixSeconds>"; only the
+    // first field is used. Lines whose first field isn't a uint are skipped (corruption, e.g. a
+    // crash-truncated append that left NUL bytes) and repeated quest IDs collapse to their first
+    // occurrence. Returns the distinct quest IDs in first-seen order; compactLines is the matching
+    // raw lines to rewrite the file with. needsRewrite is true when any non-empty line was dropped
+    // (corruption) or any duplicate was collapsed.
+    internal static List<uint> ParseCompletedQuestLines(IReadOnlyList<string> lines,
+                                                        out List<string> compactLines, out bool needsRewrite)
+    {
+        var ids = new List<uint>(lines.Count);
+        compactLines = new List<string>(lines.Count);
+        var seen = new HashSet<uint>();
+        bool droppedCorrupt = false;
+        bool droppedDuplicate = false;
+
+        foreach (var line in lines)
+        {
+            if (uint.TryParse(line.Split(',').FirstOrDefault(), out var questId))
+            {
+                if (seen.Add(questId))
+                {
+                    ids.Add(questId);
+                    compactLines.Add(line);
+                }
+                else
+                {
+                    droppedDuplicate = true;
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(line))
+            {
+                droppedCorrupt = true;
+            }
+        }
+
+        needsRewrite = droppedCorrupt || droppedDuplicate;
+        return ids;
     }
 
     public void MarkQuestAsCompleted(string realmName, string charName, uint questId)

--- a/HermesProxy/World/Server/CurrentPlayerStorage.cs
+++ b/HermesProxy/World/Server/CurrentPlayerStorage.cs
@@ -89,6 +89,11 @@ public class CompletedQuestTracker
 {
     private Dictionary<int, ulong> _cachedQuestCompleted = new();
 
+    // Every completed quest ID currently on disk. Used to avoid appending a duplicate line for a
+    // repeatable turn-in -- the file is only read back as a set of IDs, so without this it grew
+    // unbounded (e.g. Argent Dawn Scourgestone grinds add hundreds of rows for the same quest).
+    private readonly HashSet<uint> _completedQuestIds = new();
+
     public GlobalSessionData Session { get; }
 
     public CompletedQuestTracker(GlobalSessionData globalSession)
@@ -98,6 +103,7 @@ public class CompletedQuestTracker
 
     public void MarkQuestAsNotCompleted(uint questQuestId)
     {
+        _completedQuestIds.Remove(questQuestId);
         Session.AccountMetaDataMgr.MarkQuestAsNotCompleted(Session.GameState.CurrentPlayerInfo!.Realm.Name, Session.GameState.CurrentPlayerInfo!.Name!, questQuestId);
 
         var questBit = GameData.GetUniqueQuestBit(questQuestId);
@@ -109,7 +115,12 @@ public class CompletedQuestTracker
 
     public void MarkQuestAsCompleted(uint questQuestId)
     {
-        Session.AccountMetaDataMgr.MarkQuestAsCompleted(Session.GameState.CurrentPlayerInfo!.Realm.Name, Session.GameState.CurrentPlayerInfo!.Name!, questQuestId);
+        // Only persist the first completion of a (possibly repeatable) quest -- re-appending a
+        // repeatable turn-in just bloats the file, which is only read back as a set of IDs.
+        if (_completedQuestIds.Add(questQuestId))
+        {
+            Session.AccountMetaDataMgr.MarkQuestAsCompleted(Session.GameState.CurrentPlayerInfo!.Realm.Name, Session.GameState.CurrentPlayerInfo!.Name!, questQuestId);
+        }
 
         var questBit = GameData.GetUniqueQuestBit(questQuestId);
         if (questBit.HasValue)
@@ -123,8 +134,11 @@ public class CompletedQuestTracker
         var questIds = Session.AccountMetaDataMgr.GetAllCompletedQuests(Session.GameState.CurrentPlayerInfo!.Realm.Name, Session.GameState.CurrentPlayerInfo!.Name!);
 
         _cachedQuestCompleted = new Dictionary<int, ulong>();
+        _completedQuestIds.Clear();
         foreach (uint questId in questIds)
         {
+            _completedQuestIds.Add(questId);
+
             uint? questBit = GameData.GetUniqueQuestBit(questId);
             if (!questBit.HasValue)
                 continue;


### PR DESCRIPTION
## Summary

A corrupt line in `completed_quests.csv` deterministically crashed the **whole proxy on player login**. This hardens the parser so corruption can never crash login again, self-heals the file, and stops it growing unbounded for repeatable quests.

## Root cause

`AccountMetaDataManager.GetAllCompletedQuests` parsed every line with `uint.Parse` and no guard:

```csharp
lines.Select(x => uint.Parse(x.Split(',').FirstOrDefault() ?? "0"))
```

A crash/kill mid-`AppendAllLines` can leave a NUL-filled or partial line on disk. On the next login `uint.Parse` throws `FormatException` from inside `HandlePlayerLogin` → `LoadCurrentPlayer` → `CompletedQuestTracker.Reload`, which is unhandled and terminates the process. It is **self-perpetuating**: the bad line stays on disk, so every subsequent login for that character crashes the proxy until the file is fixed by hand.

Captured crash (input string was 17 NUL bytes):

```
System.FormatException: The input string '<17x NUL>' was not in a correct format.
   at System.UInt32.Parse(String s)
   at HermesProxy.World.Server.AccountMetaDataManager...GetAllCompletedQuests
   at HermesProxy.World.Server.CompletedQuestTracker.Reload()
   at HermesProxy.World.Server.CurrentPlayerStorage.LoadCurrentPlayer()
   at HermesProxy.World.Server.WorldSocket.HandlePlayerLogin(PlayerLogin playerLogin)
```

The crash fires inside `LoadCurrentPlayer`, i.e. **before** the login is even forwarded to the legacy server — matching the reported symptom of a character stuck at the loading screen.

## The fix

- **Tolerate corruption** — parse with `uint.TryParse` and skip any line whose first field isn't a uint. Login can no longer crash on a bad line.
- **Self-heal** — when corrupt or duplicate lines are found, atomically rewrite (`.tmp` + `File.Move`) the file with only the distinct valid entries, so an already-corrupt file auto-repairs on next login (no manual intervention needed).
- **Dedupe** — repeatable turn-ins (e.g. the Argent Dawn Scourgestone quests **5508 / 5509 / 5510**) append a row every completion and the file never deduped, growing unbounded — one report had quest 5510 recorded **~150 times**. The file is only meaningful as a *set* of completed IDs, so we keep the first occurrence per ID on load (`CompletedQuestTracker` now holds an in-memory set) and skip the disk append when the quest is already recorded.

## Repro & verification

- New `CompletedQuestParseTests` pins the NUL-byte line, blank lines, all-valid, and duplicate-collapse cases.
- `dotnet test --filter CompletedQuestParse` → **4/4 pass**.
- Verified against the affected player's real 328-line file: it parses cleanly once the NUL line is dropped.

## Risk / notes

- The non-atomic append in `MarkQuestAsCompleted` is intentionally left as-is (making appends atomic means a full rewrite per turn-in); the read-side tolerance + self-heal is the mitigation, and the write-side set prevents new duplicates.
- Timestamps in the file are written but never read back, so collapsing duplicate rows loses nothing functional.
- Not yet PTR-verified end-to-end; the affected player was given a manually repaired file in the meantime, so this **should** stop the crash recurring for anyone else once shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
