### PR TITLE
Skip synthetic GCD cooldown packet under Low-Latency mode

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2924,6 +2924,14 @@ public class ClientCastRequest
 
     public bool HasSentPrepare;
 
+    // JimsProxy (held-aware GCD anchoring): true once this press was released from the GCD
+    // hold slot by the release timer (ForwardHeldGcdCast) — i.e. the proxy RE-TIMED it.
+    // The synthetic GCD-anchor packets (#124 cooldown synth, bb4bb18 GO.CastTime stamp) exist
+    // to correct drift the client accrues across re-timed casts; their LL gates key on this
+    // flag rather than on mode alone, so a hold path re-admitted under LL (RttPrefire=Timer)
+    // keeps its anchors while never-held LL casts stay packet-trimmed.
+    public bool WasHeld;
+
     // JimsProxy: cast time (ms) reported by SMSG_SPELL_START. 0 means instant.
     // Distinguishes truly cast-time spells (Frostbolt, Polymorph) from instants that
     // *also* emit SMSG_SPELL_START on Kronos 1.12 (Arcane Explosion, Counterspell, etc.).

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1999,15 +1999,18 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
 
-                // JimsProxy (2026-07-10): skip the synthetic SMSG_SPELL_COOLDOWN under Low-Latency mode.
-                // The cooldown exists to stop the 1.14 GCD bar drifting across HELD instant casts (#124) —
-                // a drift the proxy hold-queue's re-timing induces. LL forwards every cast immediately and
-                // never uses the hold-queue, so there is no queue-induced drift to correct; the packet is
+                // JimsProxy (2026-07-10): skip the synthetic SMSG_SPELL_COOLDOWN under Low-Latency mode
+                // for casts that were never held. The cooldown exists to stop the 1.14 GCD bar drifting
+                // across HELD instant casts (#124) — a drift the proxy hold-queue's re-timing induces.
+                // A never-held LL cast forwarded immediately has no re-timing to correct; the packet is
                 // just a gratuitous extra client-bound send in the coalesced cast burst (SugarProxy, the
                 // queue-less analogue, sends none and the client's own GCD anchors fine — user-verified).
-                // Leading suspect for raising the client's per-cast kit-teardown race odds under LL. Queue
-                // mode is unchanged; BeginGcd above still runs (inert in LL).
-                if (!Settings.LowLatencyMode)
+                // Leading suspect for raising the client's per-cast kit-teardown race odds under LL.
+                // Gate on HELD-NESS, not mode alone: RttPrefire=Timer re-admits the hold path under LL,
+                // and a held-and-re-timed cast needs its anchor regardless of mode (alpha review,
+                // cross-PR #409×#412). Queue mode is unchanged (never LL ⇒ first clause fires); BeginGcd
+                // above still runs (inert in LL when nothing is held).
+                if (!Settings.LowLatencyMode || pendingCast.WasHeld)
                 {
                     var gcdCooldown = new SpellCooldownPkt();
                     gcdCooldown.Caster = spell.Cast.CasterUnit;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1999,23 +1999,34 @@ public partial class WorldClient
                     legacy_lookup_id = pendingCast.LegacySpellId,
                 });
 
-                var gcdCooldown = new SpellCooldownPkt();
-                gcdCooldown.Caster = spell.Cast.CasterUnit;
-                gcdCooldown.Flags = 0x01; // SPELL_COOLDOWN_FLAG_INCLUDE_GCD
-                gcdCooldown.SpellCooldowns.Add(new SpellCooldownStruct
+                // JimsProxy (2026-07-10): skip the synthetic SMSG_SPELL_COOLDOWN under Low-Latency mode.
+                // The cooldown exists to stop the 1.14 GCD bar drifting across HELD instant casts (#124) —
+                // a drift the proxy hold-queue's re-timing induces. LL forwards every cast immediately and
+                // never uses the hold-queue, so there is no queue-induced drift to correct; the packet is
+                // just a gratuitous extra client-bound send in the coalesced cast burst (SugarProxy, the
+                // queue-less analogue, sends none and the client's own GCD anchors fine — user-verified).
+                // Leading suspect for raising the client's per-cast kit-teardown race odds under LL. Queue
+                // mode is unchanged; BeginGcd above still runs (inert in LL).
+                if (!Settings.LowLatencyMode)
                 {
-                    SpellID = (uint)spell.Cast.SpellID,
-                    ForcedCooldown = (uint)gcdMs,
-                    ModRate = 1.0f,
-                });
-                SendPacketToClient(gcdCooldown);
+                    var gcdCooldown = new SpellCooldownPkt();
+                    gcdCooldown.Caster = spell.Cast.CasterUnit;
+                    gcdCooldown.Flags = 0x01; // SPELL_COOLDOWN_FLAG_INCLUDE_GCD
+                    gcdCooldown.SpellCooldowns.Add(new SpellCooldownStruct
+                    {
+                        SpellID = (uint)spell.Cast.SpellID,
+                        ForcedCooldown = (uint)gcdMs,
+                        ModRate = 1.0f,
+                    });
+                    SendPacketToClient(gcdCooldown);
 
-                Log.Event("gcd.cooldown_synth", new
-                {
-                    spell_id = spell.Cast.SpellID,
-                    forced_cooldown_ms = gcdMs,
-                    flags = 0x01,
-                });
+                    Log.Event("gcd.cooldown_synth", new
+                    {
+                        spell_id = spell.Cast.SpellID,
+                        forced_cooldown_ms = gcdMs,
+                        flags = 0x01,
+                    });
+                }
             }
 
             // RefireSpellGo: runs on the FIRST SMSG_SPELL_GO the proxy receives from the server (Kronos

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -786,6 +786,10 @@ public partial class WorldSocket
                 queue_depth_before = gameState.PendingNormalCasts.Count,
                 source = "held_gcd_release",
             });
+        // JimsProxy (held-aware GCD anchoring): this press is being released from the hold
+        // slot — the proxy re-timed it. Mark it so the GCD-anchor packet gates (cooldown
+        // synth / GO.CastTime stamp) treat it as held even under LL (RttPrefire=Timer).
+        cast.WasHeld = true;
         gameState.EnqueuePendingNormalCast(cast);
         // JimsProxy: spell.held_fire — captures total hold duration (press → server forward).
         // Compare against gcd_remaining_ms in the matching spell.held to reconstruct GCD timing.


### PR DESCRIPTION
## What
Under **Low-Latency mode**, stop synthesizing the client-bound `SMSG_SPELL_COOLDOWN{INCLUDE_GCD}` on instant on-GCD casts (`Client/PacketHandlers/SpellHandler.cs`). **Queue mode is unchanged.**

## Why
The cooldown synth was added in #124 to keep the 1.14 GCD bar from drifting across **held** instant casts — a drift caused by the proxy hold-queue's re-timing. **LL forwards every cast immediately and never uses the hold-queue**, so there's no queue-induced drift to correct in this mode; the packet is only a gratuitous extra client-bound send in the tightly-coalesced cast-completion burst.

Two supports:
- **SugarProxy** (queue-less, the closest analogue to LL) sends **no** cooldown at all, and its client's GCD bar anchors fine under sustained Arcane Explosion spam (verified in-game). The packet's GCD-bar purpose is redundant here.
- It's the **leading suspect** for the looping-cast bug under LL: an extra same-frame packet in the cast burst plausibly raises the client's per-cast visual-kit-teardown race odds. Every reported instant looper (Blade Flurry, Sunder Armor, Battle Shout, Life Tap, Arcane Explosion) is a spell we fire this on; Sugar fires it on none and shows no loop.

## Scope / risk
- LL is opt-in (default off) — no default-mode users affected. Queue mode untouched. `BeginGcd` still runs (inert in LL).
- Only risk is reintroducing GCD-bar drift **if** the client can't self-anchor its GCD — but Sugar demonstrates it can, sending no cooldown at all.

## Framing
This **should reduce** the LL looping-cast rate and removes a redundant packet plus its GCD-sweep-reset feel. It is **not** a proven fix — the loop is a client-internal race and this is the leading proxy-side amplifier. To be confirmed by field play (run LL, watch for the loop and the GCD bar).

## Tests
Clean build (0 warnings/errors); **615/615** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqgHDvvFXo6JXGvVDsaRDr


## Review addendum (2026-07-15)

The gate as implemented is **held-aware**, not mode-alone: `!Settings.LowLatencyMode || pendingCast.WasHeld`, with `WasHeld` stamped at the hold-release site (`ForwardHeldGcdCast`). A press the proxy re-timed (RttPrefire=Timer under LL, #412) keeps its GCD anchor; only never-held LL casts skip the synth. Queue mode short-circuits on the first clause — byte-identical.