### PR TITLE
Add RTT Pre-Fire modes (Timer / Knocker) to Low-Latency mode

### DIFF
--- a/HermesProxy.Tests/World/RttPrefireKnockTests.cs
+++ b/HermesProxy.Tests/World/RttPrefireKnockTests.cs
@@ -114,4 +114,52 @@ public class RttPrefireKnockTests
         session.StartKnockLoop(133, () => { });
         Assert.True(session.IsKnockActiveForSpell(133));
     }
+
+    [Fact]
+    public async Task StartKnockLoop_ExhaustedUnresolved_InvokesOnAbandonedOnce()
+    {
+        var session = NewSession();
+        EnqueueNonStarted(session, 133);
+        int abandoned = 0;
+        session.StartKnockLoop(133, () => { }, _ => Interlocked.Increment(ref abandoned));
+
+        await WaitForLoopExit(session, 133);
+
+        // Entry never started/resolved, so the exhausted loop must hand it to onAbandoned
+        // exactly once — the caller's resolution is what keeps it from blocking the spell.
+        Assert.Equal(1, Volatile.Read(ref abandoned));
+    }
+
+    [Fact]
+    public async Task StartKnockLoop_SupersededWithLiveEntry_InvokesOnAbandoned()
+    {
+        var session = NewSession();
+        EnqueueNonStarted(session, 133);
+        EnqueueNonStarted(session, 2136);
+        int abandonedOld = 0;
+        session.StartKnockLoop(133, () => { }, _ => Interlocked.Increment(ref abandonedOld));
+        session.StartKnockLoop(2136, () => { });
+
+        await WaitForLoopExit(session, 133);
+
+        // The superseded loop exits with its entry still unstarted — it must be abandoned
+        // to the resolver, not silently leaked (the knock-supersede leak from the review).
+        Assert.Equal(1, Volatile.Read(ref abandonedOld));
+    }
+
+    [Fact]
+    public async Task StartKnockLoop_ResolvedMidLoop_DoesNotInvokeOnAbandoned()
+    {
+        var session = NewSession();
+        EnqueueNonStarted(session, 133);
+        int abandoned = 0;
+        session.StartKnockLoop(133, () => { }, _ => Interlocked.Increment(ref abandoned));
+
+        Assert.True(session.TryDequeuePendingNormalCast(133, out _, preferStarted: false));
+        await WaitForLoopExit(session, 133);
+
+        // A properly resolved press has an owner (the dequeuing packet path) — abandoning
+        // it too would double-ack.
+        Assert.Equal(0, Volatile.Read(ref abandoned));
+    }
 }

--- a/HermesProxy.Tests/World/RttPrefireKnockTests.cs
+++ b/HermesProxy.Tests/World/RttPrefireKnockTests.cs
@@ -34,6 +34,16 @@ public class RttPrefireKnockTests
         Assert.False(session.IsKnockActiveForSpell(spellId));
     }
 
+    private static async Task WaitForCounter(Func<int> read, int expected)
+    {
+        // The loop drops the chaff guard BEFORE invoking onAbandoned (deliberate production
+        // ordering), so loop-exit is observable before the callback runs — poll the counter
+        // itself with the same generous ceiling instead of racing that gap.
+        for (int i = 0; i < 100 && read() != expected; i++)
+            await Task.Delay(GameSessionData.KnockIntervalMs);
+        Assert.Equal(expected, read());
+    }
+
     [Fact]
     public async Task StartKnockLoop_UnresolvedPress_SendsExactlyKnockCount()
     {
@@ -127,7 +137,7 @@ public class RttPrefireKnockTests
 
         // Entry never started/resolved, so the exhausted loop must hand it to onAbandoned
         // exactly once — the caller's resolution is what keeps it from blocking the spell.
-        Assert.Equal(1, Volatile.Read(ref abandoned));
+        await WaitForCounter(() => Volatile.Read(ref abandoned), 1);
     }
 
     [Fact]
@@ -144,7 +154,7 @@ public class RttPrefireKnockTests
 
         // The superseded loop exits with its entry still unstarted — it must be abandoned
         // to the resolver, not silently leaked (the knock-supersede leak from the review).
-        Assert.Equal(1, Volatile.Read(ref abandonedOld));
+        await WaitForCounter(() => Volatile.Read(ref abandonedOld), 1);
     }
 
     [Fact]
@@ -157,6 +167,8 @@ public class RttPrefireKnockTests
 
         Assert.True(session.TryDequeuePendingNormalCast(133, out _, preferStarted: false));
         await WaitForLoopExit(session, 133);
+        // Give a would-be stray callback the same window the positive tests get.
+        await Task.Delay(GameSessionData.KnockIntervalMs * 3);
 
         // A properly resolved press has an owner (the dequeuing packet path) — abandoning
         // it too would double-ack.

--- a/HermesProxy.Tests/World/RttPrefireKnockTests.cs
+++ b/HermesProxy.Tests/World/RttPrefireKnockTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using HermesProxy;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (rtt-prefire): behavior tests for the Knocker resend loop (StartKnockLoop).
+// Real-time based — the loop uses Task.Delay exactly like production — so assertions
+// use generous waits and only rely on properties the loop guarantees deterministically:
+// knock COUNT is bounded by the loop conditions, not by elapsed time.
+public class RttPrefireKnockTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static ClientCastRequest MakeCast(uint spellId) => new ClientCastRequest
+    {
+        SpellId = spellId,
+        Timestamp = Environment.TickCount,
+    };
+
+    private static void EnqueueNonStarted(GameSessionData session, uint spellId)
+    {
+        lock (session.PendingCastsLock)
+            session.PendingNormalCasts.Enqueue(MakeCast(spellId));
+    }
+
+    private static async Task WaitForLoopExit(GameSessionData session, uint spellId)
+    {
+        // Generous ceiling: 10 knocks × 20ms nominal ≈ 200ms; allow 5× for timer quantum.
+        for (int i = 0; i < 100 && session.IsKnockActiveForSpell(spellId); i++)
+            await Task.Delay(GameSessionData.KnockIntervalMs);
+        Assert.False(session.IsKnockActiveForSpell(spellId));
+    }
+
+    [Fact]
+    public async Task StartKnockLoop_UnresolvedPress_SendsExactlyKnockCount()
+    {
+        var session = NewSession();
+        EnqueueNonStarted(session, 133);
+        int sent = 0;
+        session.StartKnockLoop(133, () => Interlocked.Increment(ref sent));
+
+        await WaitForLoopExit(session, 133);
+
+        // Entry never starts/resolves and no newer knock arms, so every knock fires.
+        Assert.Equal(GameSessionData.KnockCount, Volatile.Read(ref sent));
+    }
+
+    [Fact]
+    public async Task StartKnockLoop_EntryResolvedMidLoop_StopsEarly()
+    {
+        var session = NewSession();
+        EnqueueNonStarted(session, 133);
+        int sent = 0;
+        session.StartKnockLoop(133, () => Interlocked.Increment(ref sent));
+
+        // Resolve the press almost immediately — the GO/CAST_FAILED path's effect on the queue.
+        Assert.True(session.TryDequeuePendingNormalCast(133, out _, preferStarted: false));
+        await WaitForLoopExit(session, 133);
+
+        // The loop re-checks the non-started set before every send; with the entry gone
+        // from (at latest) the second iteration on, it cannot run to exhaustion.
+        Assert.True(Volatile.Read(ref sent) < GameSessionData.KnockCount,
+            $"expected early stop, sent={sent}");
+    }
+
+    [Fact]
+    public async Task StartKnockLoop_MarkedStartedMidLoop_StopsEarly()
+    {
+        var session = NewSession();
+        EnqueueNonStarted(session, 133);
+        int sent = 0;
+        session.StartKnockLoop(133, () => Interlocked.Increment(ref sent));
+
+        // SMSG_SPELL_START's effect: the entry leaves the non-started set without dequeueing.
+        Assert.True(session.TryMarkPendingNormalCastStarted(133, out _));
+        await WaitForLoopExit(session, 133);
+
+        Assert.True(Volatile.Read(ref sent) < GameSessionData.KnockCount,
+            $"expected early stop, sent={sent}");
+    }
+
+    [Fact]
+    public async Task StartKnockLoop_NewerKnockArms_SupersedesOlderLoop()
+    {
+        var session = NewSession();
+        EnqueueNonStarted(session, 133);
+        EnqueueNonStarted(session, 2136);
+        int sentOld = 0, sentNew = 0;
+        session.StartKnockLoop(133, () => Interlocked.Increment(ref sentOld));
+        session.StartKnockLoop(2136, () => Interlocked.Increment(ref sentNew));
+
+        await WaitForLoopExit(session, 133);
+        await WaitForLoopExit(session, 2136);
+
+        // The second arm bumped the shared generation: the older loop must abort before
+        // exhaustion (normally on its very first generation check — sentOld is almost
+        // always 0, but a stalled test thread between the two arms could let one knock
+        // through, so assert the strict correctness property: no exhaustion), while the
+        // newer loop owns the boundary and runs dry.
+        Assert.True(Volatile.Read(ref sentOld) < GameSessionData.KnockCount,
+            $"superseded loop must not exhaust, sentOld={sentOld}");
+        Assert.Equal(GameSessionData.KnockCount, Volatile.Read(ref sentNew));
+    }
+
+    [Fact]
+    public void IsKnockActiveForSpell_FalseWithoutLoop_TrueWhileArmed()
+    {
+        var session = NewSession();
+        Assert.False(session.IsKnockActiveForSpell(133));
+        EnqueueNonStarted(session, 133);
+        session.StartKnockLoop(133, () => { });
+        Assert.True(session.IsKnockActiveForSpell(133));
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -13,6 +13,10 @@ namespace Framework;
 
 public enum ServerFork { Kronos, Generic }
 
+// JimsProxy (rtt-prefire): GCD-boundary chaining strategy under Low-Latency mode. See the
+// RttPrefire setting below for semantics.
+public enum RttPrefireMode { Off, Timer, Knocker }
+
 public static class Settings
 {
     public static byte[] ClientSeed = null!;
@@ -58,6 +62,22 @@ public static class Settings
     // without holding. Eliminates hold-queue race conditions that cause stuck
     // spells for players with <40ms RTT. Most players should leave this OFF.
     public static bool LowLatencyMode;
+    // JimsProxy (rtt-prefire): chain casts across the GCD boundary under Low-Latency mode.
+    //   Off     — pure forward-everything (the plain LL behavior; default).
+    //   Timer   — a press landing inside the SpellQueueWindowMs tail of the GCD is held in
+    //             the existing hold slot and released by the BeginGcd timer at (estimated
+    //             expiry − early-fire offset); SpellCastEarlyFireOffsetMs / OverrideRtt govern
+    //             the offset exactly as in queue mode. Public advanced toggle.
+    //   Knocker — SugarProxy-parity: forward immediately, then re-send the same CMSG every
+    //             20ms (max 10 knocks, ≤200ms) until the cast starts/resolves or a newer
+    //             press supersedes it. Server-rough (each early knock bounces NOT_READY) —
+    //             experimental; the launcher only offers it in Dev Mode.
+    // Read only while LowLatencyMode is on; queue mode ignores it entirely.
+    public static RttPrefireMode RttPrefire;
+    // Effective gates: the sub-mode is live only under LowLatencyMode (mirrors
+    // IdentityPinnedCastIdsActive).
+    public static bool RttPrefireTimerActive => LowLatencyMode && RttPrefire == RttPrefireMode.Timer;
+    public static bool RttPrefireKnockerActive => LowLatencyMode && RttPrefire == RttPrefireMode.Knocker;
     // JimsProxy: suppress transient cast errors (NotReady, SpellInProgress) so
     // the client doesn't show red error text during rapid spam. Independent of
     // LowLatencyMode — useful as a companion setting but not required.
@@ -147,6 +167,10 @@ public static class Settings
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
         RefireSpellGo = config.GetBoolean("RefireSpellGo", false);
+        var rttPrefireStr = config.GetString("RttPrefire", "off");
+        RttPrefire = rttPrefireStr.Equals("timer", StringComparison.OrdinalIgnoreCase) ? RttPrefireMode.Timer
+            : rttPrefireStr.Equals("knocker", StringComparison.OrdinalIgnoreCase) ? RttPrefireMode.Knocker
+            : RttPrefireMode.Off;
         FormExitStartDeferMs = Math.Clamp(config.GetInt("FormExitStartDeferMs", 100), 0, 300);
         SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 1300), 0, 1300);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -442,6 +442,59 @@ public sealed class GameSessionData
     public Action<ClientCastRequest>? OnGcdHeldCastFire; // set by WorldSocket at attach time; invoked on a ThreadPool thread at GCD expiry
     public Action<ClientCastRequest>? OnAutoRepeatRetry; // set by WorldSocket; refires Shoot/Auto Shot after retryable legacy failures
 
+    // JimsProxy (rtt-prefire, Knocker): SugarProxy-parity resend loop. The caller has already
+    // enqueued and forwarded the press once (LL forward-everything unchanged); this re-sends the
+    // SAME wire packet every 20ms, up to 10 knocks (Sugar's exact constants: time.Sleep(20ms),
+    // N=10 flat), so the first knock after the server-side GCD expires lands ≤~20ms late with
+    // zero GCD prediction — the server is the timing authority. Resends are wire-only: the FIFO
+    // entry is NOT re-enqueued (Sugar re-Adds into a per-spell map, which is idempotent; our
+    // FIFO is not). The loop self-terminates when the press starts/resolves (it leaves the
+    // non-started set — our equivalent of Sugar's per-entry cancel flag set at START/GO/FAILED),
+    // when ANY newer knock arms (global generation counter — Sugar's session-atomic semantics),
+    // or when knocks run out. Early-knock NOT_READY / SpellInProgress bounces are swallowed by
+    // HandleCastFailed's knock-chaff guard while IsKnockActiveForSpell is true; the final bounce
+    // (arriving after the guard drops) resolves the press through the normal transient path.
+    public const int KnockIntervalMs = 20;
+    public const int KnockCount = 10;
+    private long _knockGeneration;
+    public readonly ConcurrentDictionary<uint, long> ActiveKnocks = new();
+
+    public bool IsKnockActiveForSpell(uint spellId) => ActiveKnocks.ContainsKey(spellId);
+
+    public void StartKnockLoop(uint spellId, Action resendToServer)
+    {
+        long myGen = Interlocked.Increment(ref _knockGeneration);
+        ActiveKnocks[spellId] = myGen;
+        _ = System.Threading.Tasks.Task.Run(async () =>
+        {
+            int sent = 0;
+            try
+            {
+                for (int i = 0; i < KnockCount; i++)
+                {
+                    await System.Threading.Tasks.Task.Delay(KnockIntervalMs);
+                    if (Interlocked.Read(ref _knockGeneration) != myGen)
+                        break; // a newer press armed its own loop — it owns the GCD boundary now
+                    if (!HasNonStartedPendingCastForSpell(spellId))
+                        break; // started or resolved — the cast landed (or terminally failed)
+                    resendToServer();
+                    sent++;
+                }
+            }
+            catch
+            {
+                // Session teardown mid-loop (socket gone) — the knock is moot; never surface an
+                // unhandled exception on the ThreadPool (would crash the process).
+            }
+            finally
+            {
+                ActiveKnocks.TryRemove(new KeyValuePair<uint, long>(spellId, myGen));
+                if (Framework.Settings.DebugOutput)
+                    Log.Event("cast.knock_loop_done", new { spell_id = spellId, knocks_sent = sent });
+            }
+        });
+    }
+
     // JimsProxy (observed-bow retract): an observed (non-local) unit auto-repeating — Auto Shot 75 / wand Shoot 5019 — latches the 1.14 client's intrinsic ranged-aim the moment we forward its SPELL_START, and vanilla never broadcasts a stop for other units, so once the shooter quits nothing lowers the weapon (your own char is fine — SMSG_SPELL_FAILURE retracts the local aim). Hybrid retract: DETERMINISTIC stop edges — the target dies (PARTY_KILL_LOG / health->0), or the shooter itself dies, moves, or retargets — lower the bow instantly, AND a quiescence timer is the catch-all for the case no edge covers: the shooter stops with its target still alive and stands still (out of ammo, /stopattack, LoS, target dummy). Each latched shooter tracks its current target (for the death/retarget edges) and its last-shot time (for the sweep). The sweep fires SMSG_CANCEL_AUTO_REPEAT carrying THAT unit's GUID once it goes quiet past ObservedAutoRepeatQuietMs (the modern packet is per-GUID; the legacy handler only ever cancels the local player); the threshold sits above the slowest bow cadence + jitter so a steady shooter never flickers, and a premature retract self-heals — the next shot's START re-raises the aim.
     private readonly object _observedAutoRepeatLock = new();
     private readonly Dictionary<WowGuid128, ObservedShooterState> _observedShooterTargets = new();

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -461,22 +461,34 @@ public sealed class GameSessionData
 
     public bool IsKnockActiveForSpell(uint spellId) => ActiveKnocks.ContainsKey(spellId);
 
-    public void StartKnockLoop(uint spellId, Action resendToServer)
+    // onAbandoned: invoked (once, on the loop's ThreadPool task) when the loop exits with the
+    // press still unstarted and enqueued — i.e. superseded by a newer press, or knocks exhausted
+    // while every bounce was swallowed as chaff. Nothing else reliably pairs that entry: the
+    // chaff guard ate its failures while the loop was live, and the final in-flight bounce can
+    // land inside the guard-teardown window and be swallowed too. The caller resolves the entry
+    // deterministically ON THIS EVENT (dequeue + DontReport ack) — never on a clock — otherwise
+    // it blocks the spell via the LL duplicate guard until the 2.5s watchdog (alpha review,
+    // knock-supersede leak).
+    public void StartKnockLoop(uint spellId, Action resendToServer, Action<uint>? onAbandoned = null)
     {
         long myGen = Interlocked.Increment(ref _knockGeneration);
         ActiveKnocks[spellId] = myGen;
         _ = System.Threading.Tasks.Task.Run(async () =>
         {
             int sent = 0;
+            bool entryLive = true;
             try
             {
                 for (int i = 0; i < KnockCount; i++)
                 {
                     await System.Threading.Tasks.Task.Delay(KnockIntervalMs);
+                    if (!HasNonStartedPendingCastForSpell(spellId))
+                    {
+                        entryLive = false;
+                        break; // started or resolved — the cast landed (or terminally failed)
+                    }
                     if (Interlocked.Read(ref _knockGeneration) != myGen)
                         break; // a newer press armed its own loop — it owns the GCD boundary now
-                    if (!HasNonStartedPendingCastForSpell(spellId))
-                        break; // started or resolved — the cast landed (or terminally failed)
                     resendToServer();
                     sent++;
                 }
@@ -488,7 +500,18 @@ public sealed class GameSessionData
             }
             finally
             {
+                // Drop the chaff guard FIRST: from here on arriving bounces resolve the entry
+                // through the normal transient paths; the abandonment re-check below fires only
+                // if the entry is still there after that ordering.
                 ActiveKnocks.TryRemove(new KeyValuePair<uint, long>(spellId, myGen));
+                if (entryLive && HasNonStartedPendingCastForSpell(spellId))
+                {
+                    try { onAbandoned?.Invoke(spellId); }
+                    catch
+                    {
+                        // Same teardown rationale as above — resolving on a dying session is moot.
+                    }
+                }
                 if (Framework.Settings.DebugOutput)
                     Log.Event("cast.knock_loop_done", new { spell_id = spellId, knocks_sent = sent });
             }

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -366,6 +366,23 @@ public partial class WorldClient
         if (!isTransientReason)
             CancelFormExitDeferredCast(spellId, "cast_failed");
 
+        // JimsProxy (rtt-prefire, Knocker): while a knock loop is live for this spell, transient
+        // rejections are expected chaff — the deliberate early knocks bouncing off the still-armed
+        // server GCD (NOT_READY) or the occupied caster (SpellInProgress). Swallow them WITHOUT
+        // consuming or acking the pending entry: a later knock inside the window is still
+        // eligible to land, and the loop self-terminates on START/GO/real failure (the entry
+        // leaves the non-started set) or on supersession. The loop's final bounce arrives after
+        // IsKnockActiveForSpell drops and resolves the press through the normal transient paths
+        // below. Real failures carry non-transient reasons and flow through unaffected. This is
+        // our-architecture equivalent of SugarProxy's AddFailedPacket chaff buffering —
+        // adjudicated purely by packet pairing, never by clocks.
+        if (isTransientReason && GetSession().GameState.IsKnockActiveForSpell(spellId))
+        {
+            if (Framework.Settings.DebugOutput)
+                Log.Event("cast.knock_chaff_swallowed", new { spell_id = spellId, reason_id = reason });
+            return;
+        }
+
         // JimsProxy (transient-no-dismiss-started): a transient failure (NOT_READY /
         // SpellInProgress) is the server rejecting a DUPLICATE press, never an interrupt of the
         // cast already in progress — the server never starts a cast and then rejects it with a

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -345,6 +345,56 @@ public partial class WorldSocket
                         return;
                     }
 
+                    // JimsProxy (rtt-prefire, Timer): the single hold path LL re-admits. A press
+                    // landing inside the SpellQueueWindowMs tail of the GCD parks in the existing
+                    // hold slot and the BeginGcd timer (already armed at instant GO even under LL,
+                    // C-SH:~1997) releases it at
+                    // (estimated expiry − adaptive/manual early-fire offset) — the same
+                    // #397-supersede-hardened machinery queue mode uses. Presses outside the
+                    // window still forward immediately; no other queue-mode guard is imported
+                    // (deliberately no ShouldDropLateSameSpell — LL philosophy stays
+                    // forward-everything outside the hold window). The held press is NOT enqueued
+                    // here — ForwardHeldGcdCast enqueues on release, so server responses pair
+                    // with the forwarded copy only.
+                    if (Settings.RttPrefireTimerActive && GetSession().GameState.IsInGcdQueueWindow())
+                    {
+                        WorldPacket heldLlPacket = BuildCastSpellPacket(cast);
+                        castRequest.HeldPacketForReplay = heldLlPacket;
+                        castRequest.HeldAtTickMs = Environment.TickCount64;
+                        long llGcdRemainingMs = GetSession().GameState.GetGcdRemainingMs();
+
+                        // Same-spell skip: the held press already yields this exact outcome — ack
+                        // the duplicate keypress and keep the earlier hold (mirrors queue mode).
+                        var llPeeked = GetSession().GameState.PeekHeldGcdCast();
+                        if (llPeeked != null && llPeeked.SpellId == cast.Cast.SpellID)
+                        {
+                            SendCastFailedWithoutPrepare(castRequest);
+                            return;
+                        }
+
+                        if (GetSession().GameState.TryHoldCastDuringGcd(castRequest, out var llDisplaced))
+                        {
+                            Log.Event("spell.held", new
+                            {
+                                spell_id = cast.Cast.SpellID,
+                                gcd_remaining_ms = llGcdRemainingMs,
+                                displaced_spell_id = llDisplaced?.SpellId ?? 0,
+                                client_cast_id = castRequest.ClientGUID.ToString(),
+                                source = "ll_prefire",
+                            });
+                            if (llDisplaced != null)
+                                SendCastFailedWithoutPrepare(llDisplaced);
+                            return;
+                        }
+                        // GCD expired between the window check and the hold (or the timer already
+                        // fired) — fall through and forward immediately, the LL default.
+                        Log.Event("spell.held_race_fallthrough", new
+                        {
+                            spell_id = cast.Cast.SpellID,
+                            gcd_remaining_ms_at_check = llGcdRemainingMs,
+                        });
+                    }
+
                     // DIAGNOSTIC (stuck-spell investigation): remove when closed
                     if (Framework.Settings.DebugOutput)
                         Log.Event("cast.forwarded", new
@@ -365,6 +415,17 @@ public partial class WorldSocket
                     });
                     WorldPacket llPacket = BuildCastSpellPacket(cast);
                     SendPacketToServer(llPacket);
+
+                    // JimsProxy (rtt-prefire, Knocker): SugarProxy-parity resend loop (dev/
+                    // experimental — the launcher offers it only in Dev Mode). Skip while a
+                    // cast-time cast is in progress: every knock would just bounce
+                    // SpellInProgress (Sugar gates the same way via a session flag). See
+                    // GameSessionData.StartKnockLoop for the full mechanism + termination.
+                    if (Settings.RttPrefireKnockerActive && !GetSession().GameState.HasStartedNormalCast())
+                    {
+                        GetSession().GameState.StartKnockLoop((uint)cast.Cast.SpellID,
+                            () => SendPacketToServer(llPacket));
+                    }
                     return;
                 }
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -424,7 +424,34 @@ public partial class WorldSocket
                     if (Settings.RttPrefireKnockerActive && !GetSession().GameState.HasStartedNormalCast())
                     {
                         GetSession().GameState.StartKnockLoop((uint)cast.Cast.SpellID,
-                            () => SendPacketToServer(llPacket));
+                            () => SendPacketToServer(llPacket),
+                            abandonedSpellId =>
+                            {
+                                // The loop ended (superseded/exhausted) with the press still
+                                // unstarted — its bounces were swallowed as chaff and the final
+                                // one may have been swallowed inside the guard-teardown window,
+                                // so nothing else will pair the entry. Resolve it NOW, keyed to
+                                // the loop-exit event: dequeue the unstarted dup and ack it
+                                // silently, exactly like a displaced held press. If a concurrent
+                                // START won the race to the entry, put it back untouched — the
+                                // server owns started casts.
+                                var st = GetSession().GameState;
+                                if (st.TryDequeuePendingNormalCast(abandonedSpellId, out var abandoned, preferStarted: false) && abandoned != null)
+                                {
+                                    if (abandoned.HasStarted)
+                                    {
+                                        lock (st.PendingCastsLock)
+                                            st.PendingNormalCasts.Enqueue(abandoned);
+                                        return;
+                                    }
+                                    SendCastRequestFailed(abandoned, false, SpellCastResultClassic.DontReport);
+                                    Log.Event("cast.knock_abandoned_resolved", new
+                                    {
+                                        spell_id = abandonedSpellId,
+                                        client_cast_id = abandoned.ClientGUID.ToString(),
+                                    });
+                                }
+                            });
                     }
                     return;
                 }


### PR DESCRIPTION
## What
New `RttPrefire` config enum (`off` | `timer` | `knocker`), read **only while `LowLatencyMode` is on**. Plain LL (`off`, the default) and queue mode are byte-identical to before.

- **Timer** (public advanced toggle — launcher: "RTT Pre-Fire"): re-admits exactly **one** hold path into LL. A press landing inside the `SpellQueueWindowMs` tail of the GCD parks in the existing hold slot; the `BeginGcd` timer (already armed at instant GO under LL) releases it at estimated expiry − the adaptive/manual early-fire offset (`SpellCastEarlyFireOffsetMs` / `OverrideRtt` now apply under LL too). This is the #397-supersede-hardened, #407-lock-disciplined machinery queue mode uses — same-spell skip and displaced-press acks included. Held presses are **not** enqueued until release, so server responses pair with the forwarded copy only. Deliberately **no** other queue-mode guard is imported (no `ShouldDropLateSameSpell` — LL stays forward-everything outside the window).
- **Knocker** (experimental — launcher offers it **only in Dev Mode**): SugarProxy-parity resend loop, decoded from their binary (their 提前施法 feature): forward immediately, then re-send the same CMSG every **20ms up to 10 knocks** (their exact constants) until the press starts/resolves or a newer press supersedes it (global generation counter — Sugar's session-atomic semantics). The server is the timing authority; zero GCD prediction. Early-knock NOT_READY/SpellInProgress bounces are swallowed by a **knock-chaff guard** in `HandleCastFailed` while the loop is live — our failure-pairing equivalent of Sugar's `AddFailedPacket` buffer, adjudicated purely by packet pairing, never clocks. The loop's final bounce (arriving after the guard drops) resolves the press through the normal transient path. Resends are **wire-only**: the FIFO entry is never re-enqueued (Sugar re-Adds into a per-spellId map, which is idempotent; a FIFO is not).

## Why
LL is our Sugar-(feature-off)-replica and deliberately has no pre-fire — chaining costs ~½RTT vs queue mode. This adds GCD-boundary chaining back as an opt-in layer, two ways: our proven timer-hold (recommended for players) and Sugar's exact knocker (for PTR experiments / A-B against theirs). Full RE + design record in the session memory (`project_ll_rtt_prefire`).

## Scope / risk
- Both modes are LL-only sub-toggles, default off; queue mode untouched; `off` is byte-identical to current LL.
- Timer: reintroduces exactly one (hardened) timer surface into LL; instants-first (BeginGcd is instant-anchored — the cast-time tail window is a possible follow-up).
- Knocker: up to 10× CMSG per press + NOT_READY chaff on the legacy side — deliberately Dev-Mode-gated; a knocked press whose final bounce Kronos drops can leak a non-started entry until the next sweep (same leak class LL already has for dropped terminals).

## Tests
Clean build; **620/620** (5 new knock-loop behavior tests: exhaustion count, early-stop on resolve, early-stop on START, generation supersession, active-flag lifetime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqgHDvvFXo6JXGvVDsaRDr