### PR TITLE
Fix PallyPower Lua error storm in cross-version raids (COOLDOWNS normalize + addon whisper-echo drop)

### DIFF
--- a/HermesProxy.Tests/World/AddonInteropTranslatorTests.cs
+++ b/HermesProxy.Tests/World/AddonInteropTranslatorTests.cs
@@ -178,6 +178,52 @@ public class AddonInteropTranslatorTests
     }
 
     // -------------------------------------------------------------------
+    // COOLDOWNS normalization (inbound only) — malformed tails half-build
+    // the receiver's CooldownInfo and error every grid OnUpdate.
+    // -------------------------------------------------------------------
+
+    [Theory]
+    // Bare COOLDOWNS with no tail at all (empty cooldown list variants).
+    [InlineData("COOLDOWNS", "COOLDOWNS:n:n:n:n")]
+    [InlineData("FREEASSIGN NO | SYMCOUNT 184 | COOLDOWNS", "FREEASSIGN NO | SYMCOUNT 184 | COOLDOWNS:n:n:n:n")]
+    // Short tail: only one pair sent — pad the second pair.
+    [InlineData("COOLDOWNS:300:180", "COOLDOWNS:300:180:n:n")]
+    // Duration "n" but remaining numeric crashes the receiver — force the pair to n:n.
+    [InlineData("COOLDOWNS:n:300:n:n", "COOLDOWNS:n:n:n:n")]
+    // Garbage tokens become n:n pairs.
+    [InlineData("COOLDOWNS:abc:def:n:n", "COOLDOWNS:n:n:n:n")]
+    // Parseable-by-.NET but not receiver-safe tokens are rejected too.
+    [InlineData("COOLDOWNS:NaN:NaN:n:n", "COOLDOWNS:n:n:n:n")]
+    [InlineData("COOLDOWNS:Infinity:300:n:n", "COOLDOWNS:n:n:n:n")]
+    [InlineData("COOLDOWNS:1e5:300:n:n", "COOLDOWNS:n:n:n:n")]
+    // Space-delimited variant salvages the numeric pair.
+    [InlineData("COOLDOWNS 300 180", "COOLDOWNS:300:180:n:n")]
+    // Trailing segment after the tokens is dropped rather than fed to strsplit.
+    [InlineData("COOLDOWNS:300:180 | EXTRA", "COOLDOWNS:300:n:n:n")]
+    public void TranslateInbound_MalformedCooldowns_NormalizedToSafeTail(string input, string expected)
+    {
+        Assert.Equal(expected, AddonInteropTranslator.TranslateInbound("PLPWR", input));
+    }
+
+    [Theory]
+    // Well-formed tails must pass through byte-identical.
+    [InlineData("FREEASSIGN NO | SYMCOUNT 184 | COOLDOWNS:n:n:n:n")]
+    [InlineData("FREEASSIGN YES | SYMCOUNT 5 | COOLDOWNS:300:180:60:30")]
+    [InlineData("COOLDOWNS:1800:1799.5:n:n")]
+    public void TranslateInbound_WellFormedCooldowns_PassThrough(string body)
+    {
+        Assert.Equal(body, AddonInteropTranslator.TranslateInbound("PLPWR", body));
+    }
+
+    [Fact]
+    public void TranslateOutbound_MalformedCooldowns_NotNormalized()
+    {
+        // Outbound is never rewritten: modern senders are well-formed and the legacy wire stays canonical.
+        const string body = "FREEASSIGN NO | SYMCOUNT 184 | COOLDOWNS";
+        Assert.Equal(body, AddonInteropTranslator.TranslateOutbound("PLPWR", body));
+    }
+
+    // -------------------------------------------------------------------
     // Defensive guards.
     // -------------------------------------------------------------------
 

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -226,6 +226,10 @@ public partial class WorldClient
             return;
         }
 
+        // JimsProxy: never forward the server's echo of our own addon whisper — it carries the TARGET's guid, so addons (and the HealComm bridge below) would parse our message as if the target sent it.
+        if (chatType == ChatMessageTypeVanilla.WhisperInform && DropAddonWhisperInformEcho(language, text))
+            return;
+
         // JimsProxy HealComm bridge: rewrite inbound HealComm-1.0 addon
         // messages from 1.12-native players into LibHealComm-4.0 form so
         // the modern client's LHC40 prefix consumes them. Must run before
@@ -297,6 +301,22 @@ public partial class WorldClient
                 });
                 return $"|Hitem:{itemId}:{enchant}:0:0:0:0:{suffixModern}:0:60:0:0:0|h";
             });
+    }
+
+    // JimsProxy: a native modern client never receives its own addon whispers back; returns true when the message is an addon-language whisper-inform echo to discard.
+    private static bool DropAddonWhisperInformEcho(uint language, string text)
+    {
+        if (language != (uint)Language.Addon)
+            return false;
+        int tabIdx = string.IsNullOrEmpty(text) ? -1 : text.IndexOf('\t');
+        string prefix = tabIdx > 0 ? text.Substring(0, tabIdx) : "";
+        // Bodies can be binary and bursty (AceComm-style sync); only log PLPWR bodies, which are the diagnostic target.
+        Log.Event("addon.whisper_inform.dropped", new
+        {
+            prefix,
+            body = prefix == "PLPWR" ? text.Substring(tabIdx + 1) : null,
+        });
+        return true;
     }
 
     private void TryHealCommInboundTranslate(WowGuid128 sender, string senderName, uint language, ref string text)
@@ -438,6 +458,10 @@ public partial class WorldClient
             }
             return;
         }
+
+        // JimsProxy: see HandleServerChatMessageVanilla — never forward addon whisper-inform echoes.
+        if (chatType == ChatMessageTypeWotLK.WhisperInform && DropAddonWhisperInformEcho(language, text))
+            return;
 
         // JimsProxy HealComm bridge: see HandleServerChatMessageVanilla above.
         TryHealCommInboundTranslate(sender, senderName, language, ref text);

--- a/HermesProxy/World/Server/AddonInteropTranslator.cs
+++ b/HermesProxy/World/Server/AddonInteropTranslator.cs
@@ -30,9 +30,10 @@ namespace HermesProxy.World.Server;
 //   - PASSIGN <name>@<assign>           assign chars via lookup (1.14-only,
 //                                          included for completeness)
 //
-// All other PallyPower messages (CLEAR, REQ, SYMCOUNT, COOLDOWNS, FREEASSIGN,
-// PPLEADER, NASSIGN, AASSIGN, ASELF) carry no class/skill IDs that need
-// translation, or they're 1.14-only features that 1.12 silently ignores.
+// All other PallyPower messages (CLEAR, REQ, SYMCOUNT, FREEASSIGN, PPLEADER,
+// NASSIGN, AASSIGN, ASELF) carry no class/skill IDs that need translation,
+// or they're 1.14-only features that 1.12 silently ignores. COOLDOWNS is
+// special-cased inbound only — see NormalizeCooldowns.
 public static class AddonInteropTranslator
 {
     private const string PallyPowerPrefix = "PLPWR";
@@ -103,9 +104,13 @@ public static class AddonInteropTranslator
         if (body.StartsWith("PASSIGN ", StringComparison.Ordinal))
             return TranslatePassign(body, modernToLegacy);
 
-        // Everything else (CLEAR / REQ / SYMCOUNT / COOLDOWNS / FREEASSIGN /
-        // PPLEADER / NASSIGN / AASSIGN / ASELF) carries no fields that need
-        // version remap — pass through untouched.
+        // Inbound only: modern senders always emit a well-formed COOLDOWNS tail.
+        if (!modernToLegacy && body.Contains("COOLDOWNS", StringComparison.Ordinal))
+            return NormalizeCooldowns(body);
+
+        // Everything else (CLEAR / REQ / SYMCOUNT / FREEASSIGN / PPLEADER /
+        // NASSIGN / AASSIGN / ASELF) carries no fields that need version
+        // remap — pass through untouched.
         return body;
     }
 
@@ -238,6 +243,86 @@ public static class AddonInteropTranslator
             }
         }
         return output.ToString();
+    }
+
+    // The 1.14 addon strsplits the whole message on ':' into 4 positional tokens and errors permanently on any malformed tail; rewrite it to 4 receiver-safe tokens.
+    private static string NormalizeCooldowns(string body)
+    {
+        int idx = body.IndexOf("COOLDOWNS", StringComparison.Ordinal);
+        string head = body.Substring(0, idx);
+        string tail = body.Substring(idx + "COOLDOWNS".Length);
+
+        string[] tokens = ExtractCooldownTokens(tail);
+        for (int pair = 0; pair < 2; pair++)
+        {
+            string duration = tokens[pair * 2];
+            string remaining = tokens[pair * 2 + 1];
+            // Mirror the receiver's guard: safe iff remaining is "n" or both numeric.
+            if (remaining != "n" && (!IsNumericToken(duration) || !IsNumericToken(remaining)))
+            {
+                tokens[pair * 2] = "n";
+                tokens[pair * 2 + 1] = "n";
+            }
+        }
+
+        // A colon before COOLDOWNS would shift every strsplit position on the receiver.
+        head = head.Replace(":", "");
+
+        string normalized = $"{head}COOLDOWNS:{tokens[0]}:{tokens[1]}:{tokens[2]}:{tokens[3]}";
+        if (normalized != body)
+        {
+            Log.Event("addon.interop.normalized", new
+            {
+                prefix = PallyPowerPrefix,
+                message_type = "COOLDOWNS",
+                original = body,
+                result = normalized,
+            });
+        }
+        return normalized;
+    }
+
+    // Salvage up to 4 leading valid tokens from the tail; anything else becomes "n".
+    private static string[] ExtractCooldownTokens(string tail)
+    {
+        var tokens = new[] { "n", "n", "n", "n" };
+        if (tail.Length == 0)
+            return tokens;
+        // Well-formed tails are colon-delimited; tolerate a space-delimited variant.
+        char separator = tail[0] == ':' ? ':' : ' ';
+        string[] parts = tail.Split(separator);
+        // parts[0] is the text between "COOLDOWNS" and the first separator — non-empty means an unknown shape.
+        if (parts[0].Length != 0)
+            return tokens;
+        int filled = 0;
+        for (int i = 1; i < parts.Length && filled < 4; i++)
+        {
+            if (parts[i] == "n" || IsNumericToken(parts[i]))
+                tokens[filled++] = parts[i];
+            else
+                break;
+        }
+        return tokens;
+    }
+
+    // Strict plain-decimal check, deliberately narrower than Lua tonumber() so NaN/Infinity/hex/exponent forms can never reach the receiver's arithmetic.
+    private static bool IsNumericToken(string s)
+    {
+        if (string.IsNullOrEmpty(s))
+            return false;
+        int start = s[0] == '-' ? 1 : 0;
+        bool hasDigit = false, hasDot = false;
+        for (int i = start; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c >= '0' && c <= '9')
+                hasDigit = true;
+            else if (c == '.' && !hasDot)
+                hasDot = true;
+            else
+                return false;
+        }
+        return hasDigit;
     }
 
     private static int TranslateSkillId(int skillIdx, bool modernToLegacy)


### PR DESCRIPTION
## Symptom

Raiding with a mix of 1.14 (proxy) and 1.12-native paladins, the 1.14 client gets hammered with two PallyPower Lua errors — observed 624x + 943x in one raid night:

- `PallyPower.lua:1796: attempt to perform arithmetic on local 'duration1' (a nil value)` in `ParseMessage`
- `PallyPower.lua:635: attempt to perform arithmetic on field 'start' (a nil value)` in `PallyPowerBlessingsGrid_Update` (every frame while the Blessings window is open)

## Root cause

The 1.14 PallyPower parses any addon message containing `COOLDOWNS` by `strsplit`-ing the **entire message** on `:` and reading 4 positional tokens. A cooldown pair is skipped only when its *remaining* token is literally `"n"`; anything else is `tonumber()`'d and used in arithmetic unconditionally. A message with a malformed tail crashes ParseMessage **after** it has created an empty `CooldownInfo[1] = {}` — and that half-built table then errors the Blessings grid on every OnUpdate. Since every `SELF` from that paladin wipes and rebuilds their record, the cycle repeats all night.

Neither addon can be patched (players run stock CurseForge / vanilla-archive builds), so this is fixed at the proxy wire boundary, same as the original PLPWR interop.

## Fix (2 commits)

**1. Normalize inbound COOLDOWNS tails** (`AddonInteropTranslator`): inbound legacy→modern PLPWR bodies containing `COOLDOWNS` get the tail rewritten to exactly 4 receiver-safe tokens. Well-formed tails pass through byte-identical; salvageable numeric tokens are kept; a pair survives only if remaining is `"n"` or both halves are strictly plain-decimal (narrower than Lua `tonumber` so NaN/Infinity/hex can never reach the receiver's arithmetic). The substring gate deliberately mirrors the receiver's own unanchored `strfind` + whole-message `strsplit`. Outbound is untouched — the legacy wire stays canonical. Every rewrite logs `addon.interop.normalized` with the original body.

**2. Drop addon whisper-inform echoes** (`ChatHandler`, both vanilla and TBC/WotLK inbound handlers): legacy servers echo every whisper back as WHISPER_INFORM carrying the **target's** guid. The proxy forwarded addon-language echoes to the modern client as regular addon messages, so addons parsed our own outbound whisper as if the target sent it — in a normal raid PallyPower answers each REQ by whisper, so every 1.12 paladin's REQ made our own status (free-assign flag, symbol count, cooldowns) land on *their* grid row. A native modern client never receives its own addon whispers back; the drop restores parity. The drop runs before the HealComm inbound translate so no bridge can act on a mis-attributed echo. Normal chat whisper-informs ("To X: ...") are unaffected. Drops log `addon.whisper_inform.dropped` (body only for PLPWR, keeping binary/bursty addon sync out of the JSONL).

## Testing

- 14 new xUnit cases: malformed tail variants (bare, short, space-delimited, garbage, NaN/Infinity/exponent, n-duration+numeric-remaining), well-formed byte-identical passthrough, outbound untouched. Full suite 629/629 passing.
- Existing PLPWR ASSIGN/MASSIGN/SELF/PASSIGN translation and round-trip tests unchanged and passing.
- Verified against the 1.14 addon source (v1.4.2-classic): the pair rule matches the receiver's guard exactly, including the `":n:300"` shape that crashes stock parsing.
- In-game validation scheduled for the next cross-version raid; both diagnostic events will pinpoint the exact sending fork/format in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)