### PR TITLE
Suppress stray movement for destroyed units until re-create (close the 10s TTL ghost leak)

### DIFF
--- a/HermesProxy.Tests/World/RecentlyDestroyedSuppressionTests.cs
+++ b/HermesProxy.Tests/World/RecentlyDestroyedSuppressionTests.cs
@@ -1,0 +1,103 @@
+using HermesProxy;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// JimsProxy (out-of-range-ghost, issue #415): pins the stray-movement suppression contract for
+/// just-destroyed / out-of-ranged units. Movement for a destroyed-and-not-yet-recreated guid is
+/// NEVER legitimate (the modern client cannot render a unit before its CreateObject), so the
+/// suppression mark must persist until the CreateObject clear — not expire on a timer. The old
+/// 10s TTL leaked: units dwelling in the destroyed-but-still-broadcasting annulus past 10s
+/// (lateral boundary-skimming players, patrolling NPCs, trailing pets) had their first post-TTL
+/// movement packet relayed, re-ghosting them frozen at their last spot (289 at-edge encounters
+/// across 67 field sessions).
+/// </summary>
+public class RecentlyDestroyedSuppressionTests
+{
+    private static GameSessionData NewState()
+    {
+        var state = WowGuidTestHelper.CreateMockGameSessionData();
+        // The mock is built via GetUninitializedObject, which skips field initializers —
+        // initialize the one private field this suite exercises.
+        typeof(GameSessionData)
+            .GetField("_recentlyDestroyedObjects", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(state, new System.Collections.Concurrent.ConcurrentDictionary<WowGuid128, long>());
+        return state;
+    }
+
+    private static WowGuid128 Creature(uint low) => WowGuid128.Create(HighGuidType703.Creature, 0, 1, low);
+
+    // The leak regression: a mark far older than the old 10s TTL must STILL suppress.
+    // This test FAILS against the TTL implementation (it evicted the mark and relayed).
+    [Fact]
+    public void Marked_SuppressedRegardlessOfAge()
+    {
+        var state = NewState();
+        var guid = Creature(23594); // the Tanaris patrol NPC that leaked 6x in one evening
+
+        state.MarkObjectRecentlyDestroyedAtTick(guid, System.Environment.TickCount64 - 3_600_000);
+
+        Assert.True(state.WasObjectRecentlyDestroyed(guid, out long agoMs));
+        Assert.True(agoMs >= 3_600_000);
+    }
+
+    // The normal lifecycle: CreateObject clears the mark and movement relays again.
+    [Fact]
+    public void Cleared_NotSuppressed()
+    {
+        var state = NewState();
+        var guid = Creature(9208);
+
+        state.MarkObjectRecentlyDestroyed(guid);
+        Assert.True(state.WasObjectRecentlyDestroyed(guid, out _));
+
+        state.ClearRecentlyDestroyedObject(guid);
+        Assert.False(state.WasObjectRecentlyDestroyed(guid, out _));
+    }
+
+    [Fact]
+    public void EmptyGuid_NeverMarked()
+    {
+        var state = NewState();
+
+        state.MarkObjectRecentlyDestroyed(WowGuid128.Empty);
+
+        Assert.False(state.WasObjectRecentlyDestroyed(WowGuid128.Empty, out _));
+    }
+
+    // Hygiene sweep: stale entries (units that never came back) are dropped once the dict is
+    // large, so a long session can't grow it unbounded — but the sweep age is far above any
+    // legitimate trailing-broadcast horizon and is NOT a relay permission.
+    [Fact]
+    public void Sweep_DropsStaleEntries_KeepsFresh()
+    {
+        var state = NewState();
+        long staleTick = System.Environment.TickCount64 - 3_600_000; // 1h old >> sweep age
+        for (uint i = 1; i <= 4200; i++)
+            state.MarkObjectRecentlyDestroyedAtTick(Creature(i), staleTick);
+
+        // A fresh mark over the threshold triggers the sweep.
+        var fresh = Creature(999_999);
+        state.MarkObjectRecentlyDestroyed(fresh);
+
+        Assert.True(state.WasObjectRecentlyDestroyed(fresh, out _));
+        Assert.True(state.RecentlyDestroyedCountForTest < 4200);
+    }
+
+    // Correctness beats memory: recent entries are never evicted just because the dict is big —
+    // evicting a live mark would reopen the leak for exactly the crowded scenes that grow it.
+    [Fact]
+    public void Sweep_NeverEvictsRecentEntries()
+    {
+        var state = NewState();
+        for (uint i = 1; i <= 5000; i++)
+            state.MarkObjectRecentlyDestroyed(Creature(i));
+
+        Assert.Equal(5000, state.RecentlyDestroyedCountForTest);
+        Assert.True(state.WasObjectRecentlyDestroyed(Creature(1), out _));
+        Assert.True(state.WasObjectRecentlyDestroyed(Creature(5000), out _));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -331,19 +331,33 @@ public sealed class GameSessionData
     // subsequent same-cast failures add no new state.
     public Dictionary<(WowGuid128 Caster, uint SpellId), long> RecentlyForwardedSpellFailedOther = new();
 
-    // JimsProxy (out-of-range-ghost): guids just destroyed / out-of-ranged and not yet re-created. Vanilla broadcasts a moving unit's trailing MSG_MOVE_* at map-level distance AFTER the per-object-visibility destroy; relaying that stray movement re-ghosts the unit "running in place" on the modern client until re-approach. Movement for these guids is dropped until a CreateObject clears the mark.
+    // JimsProxy (out-of-range-ghost, #415): guids just destroyed / out-of-ranged and not yet
+    // re-created. Vanilla broadcasts a moving unit's trailing MSG_MOVE_* / monster-moves at
+    // map-level distance AFTER the per-object-visibility destroy; relaying that stray movement
+    // re-ghosts the unit "running in place" on the modern client until re-approach. Movement for
+    // these guids is dropped until a CreateObject clears the mark — suppression must NOT expire
+    // on a timer: movement for a destroyed-and-not-recreated guid is never legitimate (the modern
+    // client cannot render a unit before its create). The original 10s TTL leaked exactly there —
+    // units dwelling in the destroyed-but-still-broadcasting annulus past 10s (lateral
+    // boundary-skimming, patrol routes, trailing pets: 289 at-edge encounters across 67 field
+    // sessions) had their first post-TTL packet relayed and re-ghosted. The age constant below is
+    // pure dict hygiene for units that never return, far above any trailing-broadcast horizon —
+    // it is not a relay permission.
     private readonly ConcurrentDictionary<WowGuid128, long> _recentlyDestroyedObjects = new();
-    private const long RecentlyDestroyedTtlMs = 10000;
+    private const long RecentlyDestroyedSweepAgeMs = 600_000;
+    private const int RecentlyDestroyedSweepThreshold = 4096;
 
     public void MarkObjectRecentlyDestroyed(WowGuid128 guid)
     {
         if (guid.IsEmpty())
             return;
         _recentlyDestroyedObjects[guid] = Environment.TickCount64;
-        // Opportunistic sweep so a long session of spawns/despawns can't grow this unbounded.
-        if (_recentlyDestroyedObjects.Count > 4096)
+        // Opportunistic hygiene sweep so a long session of spawns/despawns can't grow this
+        // unbounded. Only long-stale entries go; recent marks are never evicted for size —
+        // evicting a live mark would reopen the leak in exactly the crowded scenes that grow it.
+        if (_recentlyDestroyedObjects.Count > RecentlyDestroyedSweepThreshold)
         {
-            long cutoff = Environment.TickCount64 - RecentlyDestroyedTtlMs;
+            long cutoff = Environment.TickCount64 - RecentlyDestroyedSweepAgeMs;
             foreach (var kvp in _recentlyDestroyedObjects)
                 if (kvp.Value < cutoff)
                     _recentlyDestroyedObjects.TryRemove(kvp.Key, out _);
@@ -352,15 +366,28 @@ public sealed class GameSessionData
 
     public void ClearRecentlyDestroyedObject(WowGuid128 guid) => _recentlyDestroyedObjects.TryRemove(guid, out _);
 
+    // Test seams (RecentlyDestroyedSuppressionTests): inject a mark with a chosen timestamp so
+    // age-dependent behavior is testable without wall-clock waits, and expose the entry count
+    // for the hygiene-sweep assertions.
+    internal void MarkObjectRecentlyDestroyedAtTick(WowGuid128 guid, long tickMs)
+    {
+        if (guid.IsEmpty())
+            return;
+        _recentlyDestroyedObjects[guid] = tickMs;
+    }
+
+    internal int RecentlyDestroyedCountForTest => _recentlyDestroyedObjects.Count;
+
     public bool WasObjectRecentlyDestroyed(WowGuid128 guid, out long agoMs)
     {
         agoMs = 0;
         if (_recentlyDestroyedObjects.TryGetValue(guid, out long when))
         {
+            // Suppress for as long as the mark stands — only a CreateObject (re-approach)
+            // clears it. agoMs feeds the drop diagnostics; values beyond the old 10s TTL are
+            // the packets that used to leak and re-ghost (#415).
             agoMs = Environment.TickCount64 - when;
-            if (agoMs < RecentlyDestroyedTtlMs)
-                return true;
-            _recentlyDestroyedObjects.TryRemove(guid, out _);
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
Fixes the residual of the out-of-range ghost fix (b97e338, 5.1.7-beta.1). Addresses #415.

## Symptom
Units that leave visibility range can still re-appear as a **ghost frozen running-in-place at their last spot** — pets most often (reporter: hunter's pet lingering "quite a while" after its owner despawned cleanly), players occasionally. Discriminator from the field report: running **directly away** despawns cleanly; moving **laterally** along the range boundary ghosts.

## Root cause
b97e338 suppresses stray trailing movement for a destroyed guid for only **10 seconds** (`RecentlyDestroyedTtlMs`). The legacy server broadcasts movement at a larger radius than its visibility removal, so a unit dwelling in that destroyed-but-still-broadcasting annulus past 10s gets its first post-TTL packet **relayed** — the modern client re-ghosts it. Radial exits cross the annulus in a few seconds (suppression outlasts the traffic — why running away looked fixed); lateral skimming dwells past the TTL; pets re-path follow-splines constantly so they hit the post-TTL window most reliably.

## Field evidence (67 sessions since the ghost fix, DebugOutput drop events)
- 4,477 suppression encounters; **289 still had live traffic at ≥9s** (52 player-movement, 237 monster-move) — ~4-5 likely leaks per session.
- Drops stop **dead at 9,985ms** across all sessions — the TTL cliff, exactly matching the code bound.
- Three witnesses in one evening (2026-07-11, beta.2): a **voidwalker** with steady 500ms-cadence splines dropped 0→9,641ms (next spline ~+10.1s relayed → observed frozen ghost until its re-create 21s later); a **lateral-strafing player** dropped through 9,610ms across 28 packets; a **patrolling gossip NPC** whose route skims the reporter's visibility radius leaking on a ~59s metronome, six consecutive cycles.

## Fix
Movement for a destroyed-and-not-yet-recreated guid is **never** legitimate — the modern client cannot render a unit before its CreateObject — so `WasObjectRecentlyDestroyed` no longer expires the mark: suppression persists until the existing CreateObject clear (both create paths already clear it, so a visible unit can never be wrongly suppressed). The old constant is demoted to pure dict hygiene (10 min age, swept only above 4,096 entries, and **recent marks are never evicted for size** — evicting a live mark would reopen the leak in exactly the crowded scenes that grow the dict).

Bonus: the existing `movement.dropped_stray_after_destroy` event now reports `ms_since_destroy` values **beyond 10,000** — precisely the packets that used to leak — so any field JSONL doubles as verification. The reporter's local patrol NPC alone should produce them every ~minute standing at that spot.

## Tests
`RecentlyDestroyedSuppressionTests` (5): persistence-regardless-of-age (**verified RED against the old TTL logic before the fix, GREEN after**), clear-on-recreate lifecycle, empty-guid guard, hygiene sweep drops stale + never evicts recent. Full suite **646/646**.

## Risk
Low, one-sided: the change only widens an existing suppression whose clear path is untouched. Worst case for an over-suppressed guid is exactly the pre-fix intended behavior (movement dropped until create). No timer-based despawn synthesis anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)