### PR TITLE
Threat: raid-wide gear/enchants, BG gate, aggro-swap calibration logger, Life Tap fix

### DIFF
--- a/HermesProxy.Tests/World/KtmThreatBridgeTests.cs
+++ b/HermesProxy.Tests/World/KtmThreatBridgeTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Pins the KTM (KLHThreatMeter) outbound interop — the half that makes our
+// engine's threat number win on the 1.12 "KLHTM" wire when a 1.14 player also
+// runs a KTM addon. Two surfaces:
+//   RewriteOutbound            — the pure string wire-rewrite contract
+//   ComputeKtmBroadcastThreat  — the value source (target selection / floor /
+//                                untracked-pair lookup) the rewrite is fed. The
+//                                engine-off / battleground gate lives in the
+//                                GetKtmBroadcastThreat caller via the shared
+//                                ThreatDisabled property, exercised elsewhere.
+public class KtmThreatBridgeTests
+{
+    // ---- RewriteOutbound: the wire-rewrite contract ----------------------
+
+    [Fact]
+    public void RewriteOutbound_ThreatLine_ReplacedWithOurNumber()
+    {
+        Assert.Equal("t 12345", KtmThreatBridge.RewriteOutbound("KLHTM", "t 5000", 12345));
+    }
+
+    [Fact]
+    public void RewriteOutbound_AddonReportsZero_OurPositiveNumberStillWins()
+    {
+        // The addon broadcasting "t 0" (its own estimate hasn't spun up) must
+        // not stop our real number reaching the raid — our data wins.
+        Assert.Equal("t 8200", KtmThreatBridge.RewriteOutbound("KLHTM", "t 0", 8200));
+    }
+
+    [Theory]
+    // Officer coordination grammar — never a value we own; must pass through
+    // even though the engine has a live number to broadcast.
+    [InlineData("target Thrall")]
+    [InlineData("cleartarget")]
+    [InlineData("clear")]
+    public void RewriteOutbound_OfficerCommand_PassesThrough(string body)
+    {
+        Assert.Equal(body, KtmThreatBridge.RewriteOutbound("KLHTM", body, 12345));
+    }
+
+    [Theory]
+    // A PallyPower / HealComm / DBM body that happens to look like a threat
+    // line must be untouched — we only own the KLHTM prefix.
+    [InlineData("PLPWR")]
+    [InlineData("LHC40")]
+    [InlineData("D4")]
+    public void RewriteOutbound_NonKtmPrefix_PassesThrough(string prefix)
+    {
+        Assert.Equal("t 5000", KtmThreatBridge.RewriteOutbound(prefix, "t 5000", 12345));
+    }
+
+    [Fact]
+    public void RewriteOutbound_NoData_PassesAddonNumberThrough()
+    {
+        // ourThreat == 0 means engine-off / no-data: defer to the addon's own
+        // number rather than blanking the raider's meter with a 0.
+        Assert.Equal("t 5000", KtmThreatBridge.RewriteOutbound("KLHTM", "t 5000", 0));
+    }
+
+    [Theory]
+    // "t" without the trailing space is the "target" family, not a threat line;
+    // anything whose value token isn't a bare non-negative integer is a shape we
+    // don't fully understand and must not mangle.
+    [InlineData("t")]
+    [InlineData("t abc")]
+    [InlineData("t 50 60")]
+    [InlineData("t -5")]
+    [InlineData("")]
+    public void RewriteOutbound_MalformedOrNonThreat_PassesThrough(string body)
+    {
+        Assert.Equal(body, KtmThreatBridge.RewriteOutbound("KLHTM", body, 12345));
+    }
+
+    [Fact]
+    public void RewriteOutbound_ThreatLineTrailingSpace_NormalizesAndRewrites()
+    {
+        // AceComm shouldn't frame short messages, but tolerate a trailing space
+        // defensively — the value token is trimmed and we emit the canonical form.
+        Assert.Equal("t 12345", KtmThreatBridge.RewriteOutbound("KLHTM", "t 5000 ", 12345));
+    }
+
+    // ---- ComputeKtmBroadcastThreat: target selection / floor / lookup -----
+
+    // Distinct player-type GUIDs; the lookup keys the threat list by GUID and
+    // never inspects the high-guid type, so a second player-type GUID stands in
+    // for the targeted mob without needing a creature high-guid enum.
+    private static WowGuid128 Guid(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Player, 0, 0, counter);
+
+    private static Dictionary<WowGuid128, Dictionary<WowGuid128, double>> Lists(
+        WowGuid128 mob, WowGuid128 threater, double threat) =>
+        new() { [mob] = new() { [threater] = threat } };
+
+    [Fact]
+    public void ComputeKtmBroadcastThreat_TargetTracked_ReturnsFlooredThreat()
+    {
+        var player = Guid(1);
+        var mob = Guid(100);
+        // floor(), not round() — KTM's getThreatStringKTM floors.
+        Assert.Equal(5000, ThreatTracker.ComputeKtmBroadcastThreat(Lists(mob, player, 5000.9), mob, player));
+    }
+
+    [Fact]
+    public void ComputeKtmBroadcastThreat_NoTarget_ReturnsZero()
+    {
+        var player = Guid(1);
+        var mob = Guid(100);
+        // Player has threat on the mob, but isn't targeting anything — KTM only
+        // broadcasts current-target threat.
+        Assert.Equal(0, ThreatTracker.ComputeKtmBroadcastThreat(Lists(mob, player, 5000.0), WowGuid128.Empty, player));
+    }
+
+    [Fact]
+    public void ComputeKtmBroadcastThreat_TargetWeAreNotTracking_ReturnsZero()
+    {
+        var player = Guid(1);
+        var trackedMob = Guid(100);
+        var otherMob = Guid(200);
+        // Targeting a mob we hold no threat list for.
+        Assert.Equal(0, ThreatTracker.ComputeKtmBroadcastThreat(Lists(trackedMob, player, 5000.0), otherMob, player));
+    }
+
+    [Fact]
+    public void ComputeKtmBroadcastThreat_PlayerNotOnTargetList_ReturnsZero()
+    {
+        var player = Guid(1);
+        var otherRaider = Guid(2);
+        var mob = Guid(100);
+        // We track the mob, but only another raider's threat — not the local player's.
+        Assert.Equal(0, ThreatTracker.ComputeKtmBroadcastThreat(Lists(mob, otherRaider, 5000.0), mob, player));
+    }
+
+    [Fact]
+    public void ComputeKtmBroadcastThreat_ZeroThreat_ReturnsZero()
+    {
+        var player = Guid(1);
+        var mob = Guid(100);
+        // A tracked-but-zero entry is "no data", not a broadcastable value.
+        Assert.Equal(0, ThreatTracker.ComputeKtmBroadcastThreat(Lists(mob, player, 0.0), mob, player));
+    }
+}

--- a/HermesProxy.Tests/World/KtmThreatOriginatorTests.cs
+++ b/HermesProxy.Tests/World/KtmThreatOriginatorTests.cs
@@ -1,0 +1,82 @@
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Pins KtmThreatOriginator.ShouldEmit — the change-gate / throttle / gap-suppress
+// decision for proxy-originated KLHTM broadcasts (used when the local client has
+// no KTM addon of its own). Pure static, so it needs no GlobalSessionData graph.
+public class KtmThreatOriginatorTests
+{
+    private const long Now = 100_000;
+    private const long LongAgo = Now - 10_000;   // outside the 5s client-KTM window
+    private const long Recent = Now - 1_000;     // inside the 5s client-KTM window
+    private const long Interval = 2_000;
+
+    [Fact]
+    public void ShouldEmit_FreshPositiveThreat_Emits()
+    {
+        // lastEmitMs 0 (never emitted) bypasses the throttle; value changed; no client KTM.
+        Assert.True(KtmThreatOriginator.ShouldEmit(
+            threat: 5000, now: Now, lastClientKtmMs: LongAgo,
+            lastEmittedValue: -1, lastEmitMs: 0, interval: Interval));
+    }
+
+    [Fact]
+    public void ShouldEmit_ClientKtmActive_Suppressed()
+    {
+        // The local client emitted its own KLHTM recently → the rewrite owns the stream.
+        Assert.False(KtmThreatOriginator.ShouldEmit(
+            threat: 5000, now: Now, lastClientKtmMs: Recent,
+            lastEmittedValue: -1, lastEmitMs: 0, interval: Interval));
+    }
+
+    [Fact]
+    public void ShouldEmit_ValueUnchanged_ChangeGated()
+    {
+        Assert.False(KtmThreatOriginator.ShouldEmit(
+            threat: 5000, now: Now, lastClientKtmMs: LongAgo,
+            lastEmittedValue: 5000, lastEmitMs: Now - 10_000, interval: Interval));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public void ShouldEmit_NoPositiveThreat_Suppressed(long threat)
+    {
+        Assert.False(KtmThreatOriginator.ShouldEmit(
+            threat: threat, now: Now, lastClientKtmMs: LongAgo,
+            lastEmittedValue: -1, lastEmitMs: 0, interval: Interval));
+    }
+
+    [Fact]
+    public void ShouldEmit_WithinThrottle_Suppressed()
+    {
+        // 1.5s since last emit < 2s interval → throttled, even though the value changed.
+        Assert.False(KtmThreatOriginator.ShouldEmit(
+            threat: 5200, now: Now, lastClientKtmMs: LongAgo,
+            lastEmittedValue: 5000, lastEmitMs: Now - 1_500, interval: Interval));
+    }
+
+    [Fact]
+    public void ShouldEmit_PastThrottle_Emits()
+    {
+        // 2.1s since last emit >= 2s interval and the value changed → emit.
+        Assert.True(KtmThreatOriginator.ShouldEmit(
+            threat: 5200, now: Now, lastClientKtmMs: LongAgo,
+            lastEmittedValue: 5000, lastEmitMs: Now - 2_100, interval: Interval));
+    }
+
+    [Fact]
+    public void ShouldEmit_WarriorIntervalShorter_EmitsWhereBaseWouldNot()
+    {
+        // 1.5s since last emit: past the 1s warrior interval but not the 2s base.
+        long lastEmit = Now - 1_500;
+        Assert.True(KtmThreatOriginator.ShouldEmit(
+            threat: 5200, now: Now, lastClientKtmMs: LongAgo,
+            lastEmittedValue: 5000, lastEmitMs: lastEmit, interval: 1_000));   // warrior
+        Assert.False(KtmThreatOriginator.ShouldEmit(
+            threat: 5200, now: Now, lastClientKtmMs: LongAgo,
+            lastEmittedValue: 5000, lastEmitMs: lastEmit, interval: 2_000));   // non-warrior
+    }
+}

--- a/HermesProxy.Tests/World/ThreatEnchantTests.cs
+++ b/HermesProxy.Tests/World/ThreatEnchantTests.cs
@@ -1,0 +1,82 @@
+using HermesProxy;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Pins the raid-wide threat-enchant read (ThreatSetBonuses.GetGearEnchantMultiplier).
+// Threat enchants ride in the public per-GUID permanent-enchant cache
+// (CachedPlayerEnchants, populated for the inspect UI from the visible-item
+// enchant field), so they resolve for EVERY raider, not just the local player —
+// which is the point of the raid-wide gear/enchant pass. Enchant ids and their
+// factors match LibThreatClassic2 (cloak Subtlety 2621 = -2%, gloves Threat
+// 2613 = +2%), so the proxy's SMSG_THREAT_UPDATE agrees with the 1.12 KTM meters.
+public class ThreatEnchantTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    // A non-local raider GUID (distinct from the empty CurrentPlayerGuid a fresh
+    // test session carries), so these exercise the OTHER-player path specifically.
+    private static WowGuid128 Raider(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Player, 0, 0, counter);
+
+    [Fact]
+    public void GetGearEnchantMultiplier_UnknownGuid_ReturnsNeutral()
+    {
+        var session = NewSession();
+        Assert.Equal(1.0, ThreatSetBonuses.GetGearEnchantMultiplier(session, Raider(1)), 6);
+    }
+
+    [Fact]
+    public void GetGearEnchantMultiplier_NoThreatEnchants_ReturnsNeutral()
+    {
+        var session = NewSession();
+        var g = Raider(2);
+        session.CachedPlayerEnchants[g] = new uint[19]; // all zero
+        Assert.Equal(1.0, ThreatSetBonuses.GetGearEnchantMultiplier(session, g), 6);
+    }
+
+    [Fact]
+    public void GetGearEnchantMultiplier_CloakSubtlety_ReducesTwoPercent()
+    {
+        var session = NewSession();
+        var g = Raider(3);
+        session.CachedPlayerEnchants[g] = new uint[19];
+        session.CachedPlayerEnchants[g][14] = 2621; // EQUIPMENT_SLOT_BACK, Subtlety
+        Assert.Equal(0.98, ThreatSetBonuses.GetGearEnchantMultiplier(session, g), 6);
+    }
+
+    [Fact]
+    public void GetGearEnchantMultiplier_GlovesThreat_AddsTwoPercent()
+    {
+        var session = NewSession();
+        var g = Raider(4);
+        session.CachedPlayerEnchants[g] = new uint[19];
+        session.CachedPlayerEnchants[g][9] = 2613; // EQUIPMENT_SLOT_HANDS, Threat
+        Assert.Equal(1.02, ThreatSetBonuses.GetGearEnchantMultiplier(session, g), 6);
+    }
+
+    [Fact]
+    public void GetGearEnchantMultiplier_BothEnchants_StackMultiplicatively()
+    {
+        var session = NewSession();
+        var g = Raider(5);
+        session.CachedPlayerEnchants[g] = new uint[19];
+        session.CachedPlayerEnchants[g][14] = 2621;
+        session.CachedPlayerEnchants[g][9] = 2613;
+        Assert.Equal(0.98 * 1.02, ThreatSetBonuses.GetGearEnchantMultiplier(session, g), 6);
+    }
+
+    [Fact]
+    public void GetGearEnchantMultiplier_OtherEnchant_Ignored()
+    {
+        var session = NewSession();
+        var g = Raider(6);
+        session.CachedPlayerEnchants[g] = new uint[19];
+        session.CachedPlayerEnchants[g][14] = 1888; // Greater Agility — not a threat enchant
+        Assert.Equal(1.0, ThreatSetBonuses.GetGearEnchantMultiplier(session, g), 6);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2950,12 +2950,18 @@ public class GlobalSessionData
     // (vanilla 1.12), so mixed-population raids see each other's predictions.
     public HealCommBridge HealCommBridge = null!;
 
+    // JimsProxy KTM originator: broadcasts our engine's threat on the 1.12 KLHTM
+    // channel for KLHThreatMeter raiders when the local client has no KTM addon
+    // of its own (the addon case is handled by KtmThreatBridge.RewriteOutbound).
+    public KtmThreatOriginator KtmThreatOriginator = null!;
+
     public GlobalSessionData()
     {
         GameState = GameSessionData.CreateNewGameSessionData(this);
         AuthClient = new AuthClient(this);
         ThreatTracker = new ThreatTracker(this);
         HealCommBridge = new HealCommBridge(this);
+        KtmThreatOriginator = new KtmThreatOriginator(this);
     }
 
     /// <summary>
@@ -3755,6 +3761,7 @@ public class GlobalSessionData
         // Threat lists are tied to the previous character's mob/unit GUIDs;
         // wipe so the new login starts clean.
         ThreatTracker.Reset();
+        KtmThreatOriginator.Reset();
     }
 
     public void SendHermesTextMessage(string message, bool isError = false)

--- a/HermesProxy/World/KtmThreatOriginator.cs
+++ b/HermesProxy/World/KtmThreatOriginator.cs
@@ -10,8 +10,9 @@ namespace HermesProxy.World;
 //
 // The rewrite half (KtmThreatBridge.RewriteOutbound) makes our number win when
 // the local client ALSO runs a KTM addon: it rewrites that addon's outbound
-// KLHTM "t <n>" to our value. But the launcher disables KTM addons when the
-// threat engine is on, so the common case is a 1.14 player with our engine and
+// KLHTM "t <n>" to our value. But the launcher is slated to disable KTM addons
+// when the threat engine is on (launcher-side follow-up, not yet shipped), so
+// the common case is a 1.14 player with our engine and
 // NO KTM addon — nothing on the wire for the rewrite to catch, and 1.12
 // KLHThreatMeter raiders would see nothing from that player.
 //

--- a/HermesProxy/World/KtmThreatOriginator.cs
+++ b/HermesProxy/World/KtmThreatOriginator.cs
@@ -1,0 +1,172 @@
+using HermesProxy.Enums;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Server;
+using System;
+using System.Globalization;
+
+namespace HermesProxy.World;
+
+// JimsProxy KTM (KLHThreatMeter) threat interop — origination half.
+//
+// The rewrite half (KtmThreatBridge.RewriteOutbound) makes our number win when
+// the local client ALSO runs a KTM addon: it rewrites that addon's outbound
+// KLHTM "t <n>" to our value. But the launcher disables KTM addons when the
+// threat engine is on, so the common case is a 1.14 player with our engine and
+// NO KTM addon — nothing on the wire for the rewrite to catch, and 1.12
+// KLHThreatMeter raiders would see nothing from that player.
+//
+// This originator fills that gap: when our engine has a current-target threat
+// value and the local client is NOT emitting its own KLHTM, we broadcast the
+// KLHTM "t <n>" ourselves so 1.12 raiders see our number. Exactly one KLHTM
+// stream per player either way (rewrite XOR originate), carrying our data.
+//
+// Cadence mirrors KTMClassic's LibThreatClassic2 fork: current-target threat,
+// floor()'d, CHANGE-GATED, throttled to 2s (1s for warriors — its warrior /
+// tanking-module x0.5). Rather than a heartbeat timer, we drive it off the
+// engine's own EmitDirty flush (ThreatTracker calls MaybeBroadcast after each
+// threat recompute): during combat that fires many times a second, so the
+// throttle paces real sends to the KTM cadence, and when combat stops the sends
+// stop too — matching KTMClassic (change-gated) and letting the 1.12 receiver
+// age the entry out on its own.
+public sealed class KtmThreatOriginator
+{
+    // KTMClassic GetPublishInterval: base 2s, x0.5 (1s) for warrior / tanking.
+    // "Tanking module" is addon-internal and unobservable from the wire, so we
+    // approximate it with warrior class — the dominant vanilla main tank.
+    private const long BaseIntervalMs = 2000;
+    private const long WarriorIntervalMs = 1000;
+
+    // How long after the local client's last own KLHTM message we treat it as
+    // "running a KTM addon" and suppress origination (the rewrite owns that
+    // stream). KTMClassic publishes every 1-2s, so a 5s window comfortably spans
+    // its cadence without latching stale after the addon goes away.
+    private const long ClientKtmActiveWindowMs = 5000;
+
+    private readonly GlobalSessionData _session;
+
+    private long _lastEmitMs;                                  // Environment.TickCount64 of our last KLHTM send (0 = none yet)
+    private long _lastEmittedValue = -1;
+    private long _lastClientKtmMs = -ClientKtmActiveWindowMs;  // "never seen" sentinel — starts outside the window
+
+    public KtmThreatOriginator(GlobalSessionData session)
+    {
+        _session = session;
+    }
+
+    // Stamp: the local client just sent its OWN KLHTM message (it runs a KTM
+    // addon). While recent, MaybeBroadcast suppresses origination so we don't
+    // double up on the rewrite. Called from the HandleAddonMessage chokepoint.
+    public void NoteClientKtmActivity()
+    {
+        _lastClientKtmMs = Environment.TickCount64;
+    }
+
+    // Clear per-character throttle / change state (relog / character switch), so
+    // the next fight broadcasts fresh. Called alongside ThreatTracker.Reset.
+    public void Reset()
+    {
+        _lastEmitMs = 0;
+        _lastEmittedValue = -1;
+        _lastClientKtmMs = -ClientKtmActiveWindowMs;
+    }
+
+    // Called from ThreatTracker.EmitDirty after each threat flush. Broadcasts our
+    // current-target threat on KLHTM when: we have a world connection, we're
+    // grouped, the local client isn't already emitting its own KLHTM, and the
+    // value is positive, changed, and past the per-class throttle. Any miss is a
+    // cheap no-op — this runs on the combat hot path.
+    public void MaybeBroadcast()
+    {
+        if (_session.WorldClient == null)
+            return;
+
+        // Solo → no RAID/PARTY channel to broadcast on (and threat is non-zero
+        // solo too). Skip rather than have the server reject "no group".
+        if (!TryGetGroupContext(out bool isRaid))
+            return;
+
+        long threat = _session.ThreatTracker.GetKtmBroadcastThreat();
+        long now = Environment.TickCount64;
+        long interval = LocalPlayerIsWarrior() ? WarriorIntervalMs : BaseIntervalMs;
+
+        if (!ShouldEmit(threat, now, _lastClientKtmMs, _lastEmittedValue, _lastEmitMs, interval))
+            return;
+
+        Emit(threat, isRaid);
+        _lastEmittedValue = threat;
+        _lastEmitMs = now;
+    }
+
+    // Pure decision — the change-gate / throttle / gap-suppress logic, split out
+    // so it's unit-testable without a GlobalSessionData graph. Grouped-ness and
+    // the world connection are checked by the caller (they need session state).
+    internal static bool ShouldEmit(long threat, long now, long lastClientKtmMs,
+        long lastEmittedValue, long lastEmitMs, long interval)
+    {
+        // Local client runs a KTM addon → its (rewritten) stream already carries
+        // our number; don't add a second one.
+        if (now - lastClientKtmMs < ClientKtmActiveWindowMs)
+            return false;
+        // No data (engine off / in BG / no target / untracked). Never broadcast a
+        // 0 — a 1.12 receiver would show us dropped off the meter.
+        if (threat <= 0)
+            return false;
+        // Change-gated: KTMClassic only publishes when the value differs.
+        if (threat == lastEmittedValue)
+            return false;
+        // Throttle to the KTM cadence (1s warrior / 2s otherwise). The first emit
+        // (lastEmitMs == 0) bypasses the throttle so a fresh fight broadcasts at once.
+        if (lastEmitMs != 0 && now - lastEmitMs < interval)
+            return false;
+        return true;
+    }
+
+    // Reuse HealCommBridge's group read: CurrentGroups[0] is the home group; raid
+    // vs party is encoded in its PartyFlags, not which slot is populated. Returns
+    // false when ungrouped.
+    private bool TryGetGroupContext(out bool isRaid)
+    {
+        isRaid = false;
+        var groups = _session.GameState.CurrentGroups;
+        if (groups == null || groups.Length == 0)
+            return false;
+        var home = groups[0];
+        if (home == null)
+            return false;
+        isRaid = (home.PartyFlags & GroupFlags.MaskBgRaid) != 0;
+        return true;
+    }
+
+    private bool LocalPlayerIsWarrior()
+    {
+        var guid = _session.GameState.CurrentPlayerGuid;
+        if (guid.IsEmpty())
+            return false;
+        if (_session.GameState.CachedPlayers.TryGetValue(guid, out var cached))
+            return cached.ClassId == Class.Warrior;
+        return false;
+    }
+
+    // Emit our KLHTM broadcast to the legacy server, mirroring HealCommBridge's
+    // EmitToServer: prefix/body joined by '\t', Language.Addon, RAID or PARTY.
+    private void Emit(long threat, bool isRaid)
+    {
+        var worldClient = _session.WorldClient;
+        if (worldClient == null)
+            return;
+
+        string text = KtmThreatBridge.KtmPrefix + '\t' + "t " + threat.ToString(CultureInfo.InvariantCulture);
+        uint addonLanguage = (uint)Language.Addon;
+
+        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
+        {
+            ChatMessageTypeWotLK chatType = isRaid ? ChatMessageTypeWotLK.Raid : ChatMessageTypeWotLK.Party;
+            worldClient.SendMessageChatWotLK(chatType, addonLanguage, text, "", "");
+        }
+        else
+        {
+            ChatMessageTypeVanilla chatType = isRaid ? ChatMessageTypeVanilla.Raid : ChatMessageTypeVanilla.Party;
+            worldClient.SendMessageChatVanilla(chatType, addonLanguage, text, "", "");
+        }
+    }
+}

--- a/HermesProxy/World/Server/KtmThreatBridge.cs
+++ b/HermesProxy/World/Server/KtmThreatBridge.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Globalization;
+
+namespace HermesProxy.World.Server;
+
+// JimsProxy KTM (KLHThreatMeter) threat interop — outbound rewrite half.
+//
+// When our built-in threat engine is active it computes better, Kronos-
+// calibrated threat than the client-side LibThreatClassic2 estimate that the
+// KTMClassic / KTM addons run. Both the addon and our engine want to feed the
+// 1.12 "KLHTM" wire protocol that 1.12 KLHThreatMeter raiders listen on, so a
+// 1.14 player running a KTM addon would otherwise broadcast the addon's weaker
+// number to the raid.
+//
+// This bridge makes OUR number win by rewriting the local client's outbound
+// KLHTM "t <n>" threat line to our engine's value at the HandleAddonMessage
+// chokepoint — the same rewrite pattern as HealCommBridge / AddonInteropTranslator.
+// Result: exactly one KLHTM stream per player, carrying our data. The
+// complementary ORIGINATION path (proxy emits KLHTM itself when NO KTM addon is
+// present) is a separate follow-up.
+//
+// KTM wire grammar (from KTMClassic's LibThreatClassic2 fork, ktm_prefix
+// "KLHTM"):
+//   "t <int>"        current-target threat, floor()'d   ← the only line we rewrite
+//   "target <name>"  officer set-master-target          ← passthrough
+//   "cleartarget"    officer clear-master-target        ← passthrough
+//   "clear"          officer clear-all-threat           ← passthrough
+// Only the "t " threat line carries a value that's ours to correct; the officer
+// commands are coordination grammar and must pass through untouched. "target"
+// starts with 't' but not "t " (t + space), so the strict "t " prefix cleanly
+// isolates the threat line from the set-master-target command.
+public static class KtmThreatBridge
+{
+    public const string KtmPrefix = "KLHTM";
+
+    // KTM threat line: "t " followed by a base-10 integer.
+    private const string ThreatLinePrefix = "t ";
+
+    // Rewrite an outbound KTM threat broadcast to our engine's number.
+    //
+    //   prefix     the addon message prefix; only "KLHTM" is touched
+    //   body       the addon message body (e.g. "t 12345")
+    //   ourThreat  our engine's floored current-target threat for the local
+    //              player, or 0 when we have no number (engine off / in a
+    //              battleground / no target / untracked mob)
+    //
+    // Returns the body to forward. Non-KLHTM prefixes, non-threat KLHTM lines
+    // (officer commands), malformed threat lines, and ourThreat <= 0 all pass
+    // the body through UNCHANGED — we never blank a raider's meter or corrupt
+    // the addon's coordination grammar. Only a well-formed "t <n>" combined
+    // with a positive ourThreat is rewritten to "t <ourThreat>".
+    //
+    // Passing the addon's own number through when ourThreat is 0 is deliberate:
+    // 0 means "engine off or no data yet", not "genuinely zero threat", so
+    // deferring to the addon's estimate during the observation gap is strictly
+    // better than broadcasting a 0 that would blank the 1.12 raider's meter.
+    public static string RewriteOutbound(string prefix, string body, long ourThreat)
+    {
+        if (prefix != KtmPrefix)
+            return body;
+        if (ourThreat <= 0)
+            return body;
+        if (string.IsNullOrEmpty(body) || !body.StartsWith(ThreatLinePrefix, StringComparison.Ordinal))
+            return body;
+
+        // Everything after "t " must be a single non-negative integer for this
+        // to be the threat line. Parse strictly; anything else (e.g. a future
+        // addon variant that appends fields) passes through untouched so we
+        // never mangle a message shape we don't fully understand.
+        string valueToken = body.Substring(ThreatLinePrefix.Length).Trim();
+        if (!IsNonNegativeInteger(valueToken))
+            return body;
+
+        return ThreatLinePrefix + ourThreat.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsNonNegativeInteger(string s)
+    {
+        if (string.IsNullOrEmpty(s))
+            return false;
+        foreach (char c in s)
+        {
+            if (c < '0' || c > '9')
+                return false;
+        }
+        return true;
+    }
+}

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -274,6 +274,15 @@ public partial class WorldSocket
         // JimsProxy PallyPower: rewrite outbound PLPWR class/skill fields from
         // modern numbering to legacy. Pass-through for non-PallyPower prefixes.
         body = AddonInteropTranslator.TranslateOutbound(prefix, body);
+
+        // JimsProxy KTM threat bridge: when our threat engine is active, replace
+        // the local client's outbound KTM (KLHTM) "t <n>" broadcast with our
+        // computed threat so 1.12 KLHThreatMeter raiders see our number, not the
+        // addon's LTC2 estimate. Only compute our threat for KLHTM traffic; every
+        // other addon prefix skips the lookup and passes straight through.
+        if (prefix == KtmThreatBridge.KtmPrefix)
+            body = KtmThreatBridge.RewriteOutbound(prefix, body, GetSession().ThreatTracker.GetKtmBroadcastThreat());
+
         if (string.IsNullOrEmpty(body)) return;
         string text = prefix + '\t' + body;
 
@@ -311,6 +320,11 @@ public partial class WorldSocket
 
         // JimsProxy PallyPower: see HandleAddonMessage above.
         body = AddonInteropTranslator.TranslateOutbound(prefix, body);
+
+        // JimsProxy KTM threat bridge: see HandleAddonMessage above.
+        if (prefix == KtmThreatBridge.KtmPrefix)
+            body = KtmThreatBridge.RewriteOutbound(prefix, body, GetSession().ThreatTracker.GetKtmBroadcastThreat());
+
         if (string.IsNullOrEmpty(body)) return;
         string text = prefix + '\t' + body;
         string channelName = packet.ChannelGuid.IsEmpty() ? "" :

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -281,7 +281,13 @@ public partial class WorldSocket
         // addon's LTC2 estimate. Only compute our threat for KLHTM traffic; every
         // other addon prefix skips the lookup and passes straight through.
         if (prefix == KtmThreatBridge.KtmPrefix)
+        {
+            // The local client is sending its own KLHTM → note it so our origination
+            // suppresses (that rewritten stream already carries our number), then
+            // rewrite the addon's value to ours.
+            GetSession().KtmThreatOriginator.NoteClientKtmActivity();
             body = KtmThreatBridge.RewriteOutbound(prefix, body, GetSession().ThreatTracker.GetKtmBroadcastThreat());
+        }
 
         if (string.IsNullOrEmpty(body)) return;
         string text = prefix + '\t' + body;
@@ -323,7 +329,13 @@ public partial class WorldSocket
 
         // JimsProxy KTM threat bridge: see HandleAddonMessage above.
         if (prefix == KtmThreatBridge.KtmPrefix)
+        {
+            // The local client is sending its own KLHTM → note it so our origination
+            // suppresses (that rewritten stream already carries our number), then
+            // rewrite the addon's value to ours.
+            GetSession().KtmThreatOriginator.NoteClientKtmActivity();
             body = KtmThreatBridge.RewriteOutbound(prefix, body, GetSession().ThreatTracker.GetKtmBroadcastThreat());
+        }
 
         if (string.IsNullOrEmpty(body)) return;
         string text = prefix + '\t' + body;

--- a/HermesProxy/World/ThreatModules.cs
+++ b/HermesProxy/World/ThreatModules.cs
@@ -363,8 +363,10 @@ internal static class ThreatModules
             // Rogue Bloodfang 5-set: Feint x1.25). Returns 1.0 for spells
             // outside the gated list, so non-set-affected flats pass through
             // unchanged.
+            // This flat-ability handler is local-player-only (guarded above), so
+            // caster == CurrentPlayerGuid — pass it as the gear-read GUID.
             var playerClass = (Class)session.GameState.CurrentPlayerClass;
-            double gearMult = ThreatSetBonuses.GetGearSpellMultiplier(session.GameState, playerClass, spellId);
+            double gearMult = ThreatSetBonuses.GetGearSpellMultiplier(session.GameState, playerClass, caster, spellId);
             double finalAmount = amount * gearMult;
 
             var target = hitTargets[0];

--- a/HermesProxy/World/ThreatSetBonuses.cs
+++ b/HermesProxy/World/ThreatSetBonuses.cs
@@ -212,6 +212,12 @@ internal static class ThreatSetBonuses
     // — caller multiplies the two together.
     public static double GetGearDamageMultiplier(GameSessionData state, Class playerClass, WowGuid128 guid, int spellId)
     {
+        // Only these three classes have a damage-threat set bonus. Early-out
+        // before the (now per-raider, per-event) equipment scan so every other
+        // class's swings don't pay a 19-slot walk to always get 1.0.
+        if (playerClass != Class.Mage && playerClass != Class.Warlock && playerClass != Class.Rogue)
+            return 1.0;
+
         var counts = CountEquippedSetPieces(state, guid);
         double mult = 1.0;
 
@@ -289,6 +295,11 @@ internal static class ThreatSetBonuses
     // per-rank table — caller multiplies the flat amount by this scalar.
     public static double GetGearSpellMultiplier(GameSessionData state, Class playerClass, WowGuid128 guid, int spellId)
     {
+        // Only Warrior (Might→Sunder) and Rogue (Bloodfang→Feint) have a
+        // spell-flat set bonus — early-out before the equipment scan otherwise.
+        if (playerClass != Class.Warrior && playerClass != Class.Rogue)
+            return 1.0;
+
         var counts = CountEquippedSetPieces(state, guid);
 
         // Warrior Might 8-set: Sunder Armor x1.15

--- a/HermesProxy/World/ThreatSetBonuses.cs
+++ b/HermesProxy/World/ThreatSetBonuses.cs
@@ -1,3 +1,4 @@
+using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Frozen;
@@ -77,11 +78,24 @@ internal static class ThreatSetBonuses
         return map;
     }
 
-    // Count equipped pieces per set the player has on right now. Iterates
-    // slots 0..18 (head..feet + tabard + rings + trinkets) reading the
-    // cached OBJECT_FIELD_ENTRY for each item GUID. Skips empty slots and
-    // items whose entries aren't in any tracked set.
-    public static Dictionary<int, int> CountEquippedSetPieces(GameSessionData state)
+    // Count equipped set pieces for ANY raider (per-GUID). The LOCAL player is
+    // read the private, authoritative way — from their real inventory-slot item
+    // objects (immune to client-side iMorph, which only edits the local rendered
+    // view and never the wire). Every OTHER raider is read from their PUBLIC
+    // visible-item fields, which the server broadcasts for all players in view
+    // and which we already cache — so a groupmate's tier bonuses count exactly,
+    // no addon, no new packets. Vanilla has no transmog, so a visible item entry
+    // IS the equipped item. Only a server-side .morph could diverge, and that
+    // degrades gracefully (a morphed display id matches no set → 0 pieces).
+    public static Dictionary<int, int> CountEquippedSetPieces(GameSessionData state, WowGuid128 guid)
+    {
+        if (guid == state.CurrentPlayerGuid)
+            return CountEquippedSetPiecesLocal(state);
+        return CountEquippedSetPiecesVisible(state, guid);
+    }
+
+    // Local player — real equipped item entries via the private inventory slots.
+    private static Dictionary<int, int> CountEquippedSetPiecesLocal(GameSessionData state)
     {
         var counts = new Dictionary<int, int>();
         int entryIdx = LegacyVersion.GetUpdateField(ObjectField.OBJECT_FIELD_ENTRY);
@@ -106,6 +120,59 @@ internal static class ThreatSetBonuses
                 counts[setId] = counts.GetValueOrDefault(setId) + 1;
         }
         return counts;
+    }
+
+    // Other raiders — set piece entries from their public visible-item fields.
+    // Layout mirrors UpdateHandler's parse: PLAYER_VISIBLE_ITEM_1_0 is the base,
+    // each slot's entry sits at base + slot*offset (offset 12 vanilla / 16 tbc).
+    // Mask to the low 16 bits to recover the raw item entry (all vanilla tier
+    // items are < 65536); we only need armor slots but scan all 19 harmlessly.
+    private static Dictionary<int, int> CountEquippedSetPiecesVisible(GameSessionData state, WowGuid128 guid)
+    {
+        var counts = new Dictionary<int, int>();
+        var fields = state.GetCachedObjectFieldsLegacy(guid);
+        if (fields == null) return counts;
+
+        int baseIdx = LegacyVersion.GetUpdateField(PlayerField.PLAYER_VISIBLE_ITEM_1_0);
+        if (baseIdx < 0) return counts;
+        int offset = LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180) ? 16 : 12;
+
+        for (int slot = 0; slot < 19; slot++)
+        {
+            if (!fields.TryGetValue(baseIdx + slot * offset, out var entryField)) continue;
+            uint itemEntry = (uint)(entryField.Int32Value & 0xFFFF);
+            if (itemEntry == 0) continue;
+
+            if (ItemToSet.TryGetValue(itemEntry, out int setId))
+                counts[setId] = counts.GetValueOrDefault(setId) + 1;
+        }
+        return counts;
+    }
+
+    // Threat-modifying weapon/armor enchants, readable for ALL raiders from the
+    // per-GUID permanent-enchant cache (populated for the inspect UI from the
+    // public visible-item enchant field). Cloak "Subtlety" (2621) shaves 2% off
+    // all threat; gloves "Threat" (2613) adds 2%. Both are common tank enchants.
+    // Returns the combined multiplier (1.0 if neither present).
+    private const uint ENCHANT_CLOAK_SUBTLETY = 2621;
+    private const uint ENCHANT_GLOVES_THREAT  = 2613;
+
+    public static double GetGearEnchantMultiplier(GameSessionData state, WowGuid128 guid)
+    {
+        if (!state.CachedPlayerEnchants.TryGetValue(guid, out var enchants) || enchants == null)
+            return 1.0;
+
+        bool hasSubtlety = false, hasThreat = false;
+        for (int i = 0; i < enchants.Length; i++)
+        {
+            if (enchants[i] == ENCHANT_CLOAK_SUBTLETY) hasSubtlety = true;
+            else if (enchants[i] == ENCHANT_GLOVES_THREAT) hasThreat = true;
+        }
+
+        double mult = 1.0;
+        if (hasSubtlety) mult *= 0.98;
+        if (hasThreat)   mult *= 1.02;
+        return mult;
     }
 
     // Per-spell damage multipliers conditional on set bonuses. Combined with
@@ -143,9 +210,9 @@ internal static class ThreatSetBonuses
     // Returns the gear-derived damage multiplier for this spell (1.0 = no
     // adjustment). Applied alongside the base ThreatModules.DamageMultipliers
     // — caller multiplies the two together.
-    public static double GetGearDamageMultiplier(GameSessionData state, Class playerClass, int spellId)
+    public static double GetGearDamageMultiplier(GameSessionData state, Class playerClass, WowGuid128 guid, int spellId)
     {
-        var counts = CountEquippedSetPieces(state);
+        var counts = CountEquippedSetPieces(state, guid);
         double mult = 1.0;
 
         switch (playerClass)
@@ -177,20 +244,20 @@ internal static class ThreatSetBonuses
 
     // Heal-side multiplier (Vestments of Faith 8-set on Priest: x0.9 to
     // every heal threat event).
-    public static double GetGearHealMultiplier(GameSessionData state, Class playerClass)
+    public static double GetGearHealMultiplier(GameSessionData state, Class playerClass, WowGuid128 guid)
     {
         if (playerClass != Class.Priest) return 1.0;
-        var counts = CountEquippedSetPieces(state);
+        var counts = CountEquippedSetPieces(state, guid);
         return counts.GetValueOrDefault(SET_PRIEST_VESTMENTS_OF_FAITH) >= 8 ? 0.9 : 1.0;
     }
 
     // Per-spell flat threat ADD (not multiplier) for specific set effects.
     // Mage Netherwind 3-set: -100 flat on Scorch/Fireball/Frostbolt, -20 on
     // Arcane Missiles tick. Applied additively to the per-event threat.
-    public static double GetGearDamageFlatAdjust(GameSessionData state, Class playerClass, int spellId)
+    public static double GetGearDamageFlatAdjust(GameSessionData state, Class playerClass, WowGuid128 guid, int spellId)
     {
         if (playerClass != Class.Mage) return 0.0;
-        var counts = CountEquippedSetPieces(state);
+        var counts = CountEquippedSetPieces(state, guid);
         if (counts.GetValueOrDefault(SET_MAGE_NETHERWIND) < 3) return 0.0;
 
         // Scorch R1..9
@@ -220,9 +287,9 @@ internal static class ThreatSetBonuses
     // Spell-specific MULTIPLIER set bonuses (Bloodfang Feint, Might Sunder).
     // These wrap flat-threat spells where the value lives in ThreatModules'
     // per-rank table — caller multiplies the flat amount by this scalar.
-    public static double GetGearSpellMultiplier(GameSessionData state, Class playerClass, int spellId)
+    public static double GetGearSpellMultiplier(GameSessionData state, Class playerClass, WowGuid128 guid, int spellId)
     {
-        var counts = CountEquippedSetPieces(state);
+        var counts = CountEquippedSetPieces(state, guid);
 
         // Warrior Might 8-set: Sunder Armor x1.15
         if (playerClass == Class.Warrior && counts.GetValueOrDefault(SET_WARRIOR_MIGHT) >= 8 &&

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -792,11 +792,25 @@ public sealed class ThreatTracker
         EmitDirty();
     }
 
-    // LTC2 ExemptGains: spells that should NOT generate energize threat.
+    // Spells whose power gain must NOT generate threat.
+    //   Warlock Life Tap (all ranks) — converts HP to mana; its threat was
+    //     removed in patch 0.8 (2004), so 0 is correct blizzlike, and both KTM
+    //     and LibThreatClassic2 exempt every rank. We were fabricating threat
+    //     from every tap — the one over-credit all three sources agree on
+    //     (Kronos research 2026-07-13). CAVEAT: vmangos-lineage cores have had
+    //     gain-threat bugs (vmangos #2589, Atlantiss #4978); if THIS fork
+    //     regenerates Life Tap threat, the threat.aggro_unexpected logger will
+    //     show warlocks over-credited and we revisit — but 0 is the grounded
+    //     default.
     //   34299 — Improved Leader of the Pack (heal-side, no threat)
     //   33778 — Lifebloom final bloom (overheal-like effect)
+    private static readonly HashSet<int> LifeTapRanks = new()
+    {
+        1454, 1455, 1456, 11687, 11688, 11689,
+    };
+
     private static bool IsEnergizeExempt(int spellId) =>
-        spellId == 34299 || spellId == 33778;
+        spellId == 34299 || spellId == 33778 || LifeTapRanks.Contains(spellId);
 
     // Per-challenger aggro flip margin, matching LibThreatClassic2's
     // GetPullAggroRangeModifier (LibThreatClassic2.lua line 1679-1713).

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -483,6 +483,15 @@ public sealed class ThreatTracker
                 SendToClient(highest);
             }
         }
+
+        // JimsProxy KTM origination: after pushing SMSG threat to our own client,
+        // consider broadcasting our current-target threat on the 1.12 "KLHTM"
+        // channel so KLHThreatMeter raiders see it too. No-op unless grouped, the
+        // local client isn't already emitting its own KLHTM (that stream is
+        // handled by KtmThreatBridge.RewriteOutbound), and the value changed since
+        // the last throttled emit. Event-driven off this flush — no heartbeat
+        // timer — which reproduces KTMClassic's change-gated cadence.
+        _session.KtmThreatOriginator.MaybeBroadcast();
     }
 
     // Wipe everything — used on session disconnect / character switch. Doesn't

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -496,6 +496,60 @@ public sealed class ThreatTracker
         _lastInCombat.Clear();
     }
 
+    // KTM (KLHThreatMeter) interop: the local player's current-target threat,
+    // floored to an integer, for broadcast on the 1.12 "KLHTM" addon channel.
+    // KTMClassic's getThreatStringKTM emits floor(threat-on-current-target) as
+    // "t <n>"; we mirror that exactly so our engine's number can REPLACE the
+    // addon's LibThreatClassic2 estimate on the wire — see
+    // KtmThreatBridge.RewriteOutbound. Note we return the RAW floored threat,
+    // NOT ToWireThreat's ×100 modern packing: KTM's wire is the plain integer.
+    //
+    // Returns 0 when the engine is disabled or we're in a battleground (via
+    // ThreatDisabled), when the player has no current target, or when we aren't
+    // tracking threat on that target. The rewrite treats 0 as "no data — leave
+    // the addon's own number alone", so a 0 here never blanks a raider's meter
+    // during the observation gap.
+    //
+    // Target = the player's CurrentSelection. In the common case (no KTM master
+    // target set) that matches the addon's own current-target notion. If an
+    // officer has set a KTM master target that differs from the player's
+    // selection, the addon would report master-target threat while we report
+    // selection threat — a bounded, self-correcting mismatch we accept until
+    // the origination path tracks officer master-target state.
+    public long GetKtmBroadcastThreat()
+    {
+        if (ThreatDisabled)
+            return 0;
+
+        return ComputeKtmBroadcastThreat(
+            _threatLists,
+            _session.GameState.CurrentSelection,
+            _session.GameState.CurrentPlayerGuid);
+    }
+
+    // Pure lookup half of GetKtmBroadcastThreat, split out so the target /
+    // floor / untracked-pair logic is unit-testable with a hand-built threat
+    // list, without standing up a full GlobalSessionData graph (its RealmManager
+    // field initializer needs version config a bare test doesn't have). The
+    // ThreatDisabled gate — shared engine infrastructure — stays in the caller.
+    // Returns the player's floored threat on the mob, or 0 when either GUID is
+    // empty (no current target / no player) or we hold no positive threat for
+    // that pair.
+    internal static long ComputeKtmBroadcastThreat(
+        Dictionary<WowGuid128, Dictionary<WowGuid128, double>> lists,
+        WowGuid128 mob, WowGuid128 player)
+    {
+        if (mob.IsEmpty() || player.IsEmpty())
+            return 0;
+
+        if (!lists.TryGetValue(mob, out var list) ||
+            !list.TryGetValue(player, out double threat) ||
+            threat <= 0)
+            return 0;
+
+        return (long)Math.Floor(threat);
+    }
+
     // Called from SMSG_CANCEL_COMBAT — the legacy server told the local player
     // they've left combat. Most vanilla emulators (incl. Kronos) never emit it,
     // so on those servers the per-unit UNIT_FLAG_IN_COMBAT edge in

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -51,6 +51,17 @@ public sealed class ThreatTracker
     // SMSG_HIGHEST_THREAT_UPDATE when the top actually changes.
     private readonly Dictionary<WowGuid128, WowGuid128> _lastHighest = new();
 
+    // Ground-truth calibration: per mob, the last (server-target, model-top)
+    // pairing we logged as an UNEXPECTED aggro — the server is hitting someone
+    // our model ranked below its predicted top. The server never emits threat,
+    // so its actual UNIT_FIELD_TARGET is the only oracle; Kronos is a custom
+    // vmangos fork with its own threat bugs, so LTC2's numbers can't be trusted
+    // at face value. Logging every such disagreement (once per episode, not per
+    // event) both calibrates our model against Kronos reality over time AND
+    // gives a paper trail if a player disputes a threat reading. Cleared when
+    // the mob's target and our top agree again.
+    private readonly Dictionary<WowGuid128, (WowGuid128 server, WowGuid128 model)> _lastUnexpectedAggro = new();
+
     // Last-observed UNIT_FLAG_IN_COMBAT per unit (any unit whose flags we see).
     // Lets OnUnitCombatStateObserved detect the in-combat -> out-of-combat edge
     // that drops a threater/mob from the fight. We snapshot it here rather than
@@ -186,6 +197,7 @@ public sealed class ThreatTracker
 
         list.Clear();
         _lastHighest.Remove(mob);
+        _lastUnexpectedAggro.Remove(mob);
         _dirty.Add(mob);
     }
 
@@ -248,6 +260,7 @@ public sealed class ThreatTracker
         if (!_threatLists.Remove(mob))
             return;
         _lastHighest.Remove(mob);
+        _lastUnexpectedAggro.Remove(mob);
         _dirty.Remove(mob);
 
         var pkt = new ThreatClearPkt { UnitGUID = mob };
@@ -283,6 +296,7 @@ public sealed class ThreatTracker
         {
             _threatLists.Remove(mob);
             _lastHighest.Remove(mob);
+        _lastUnexpectedAggro.Remove(mob);
         }
     }
 
@@ -380,8 +394,45 @@ public sealed class ThreatTracker
             if (serverTarget != default && serverTarget != newHighest &&
                 list.TryGetValue(serverTarget, out var serverTargetValue))
             {
+                // Ground-truth calibration + complaint paper trail: the server is
+                // aggroed on serverTarget, but our model ranked them BELOW its
+                // predicted top (newHighest) — i.e. our threat numbers disagree
+                // with what Kronos actually did. Log it once per distinct episode
+                // (dedup on the pairing) with the ratio so systematic model error
+                // (e.g. a class/pet we over- or under-credit on this fork) shows
+                // up as a repeated signature across fights. Always on: aggro
+                // disagreements are infrequent and this is the audit trail.
+                if (serverTargetValue < highestValue)
+                {
+                    var pairing = (serverTarget, newHighest);
+                    if (!_lastUnexpectedAggro.TryGetValue(mob, out var last) || last != pairing)
+                    {
+                        _lastUnexpectedAggro[mob] = pairing;
+                        Log.Event("threat.aggro_unexpected", new
+                        {
+                            mob_low = mob.GetCounter(),
+                            mob_guid = mob.ToString(),
+                            server_target_low = serverTarget.GetCounter(),
+                            server_target_threat = serverTargetValue,
+                            model_top_low = newHighest.GetCounter(),
+                            model_top_threat = highestValue,
+                            // >1 = how much more threat our model gave its top than the
+                            // raider the server actually chose. Large / recurring =
+                            // a value we're getting wrong on Kronos.
+                            model_overcredit_ratio = serverTargetValue > 0 ? highestValue / serverTargetValue : 0.0,
+                            threaters = list.Count,
+                        });
+                    }
+                }
+
                 newHighest = serverTarget;
                 highestValue = serverTargetValue;
+            }
+            else
+            {
+                // Server target and our top agree (or the server target isn't in
+                // our list) — any prior disagreement for this mob is resolved.
+                _lastUnexpectedAggro.Remove(mob);
             }
 
             var update = new ThreatUpdatePkt { UnitGUID = mob };
@@ -440,6 +491,7 @@ public sealed class ThreatTracker
     {
         _threatLists.Clear();
         _lastHighest.Clear();
+        _lastUnexpectedAggro.Clear();
         _dirty.Clear();
         _lastInCombat.Clear();
     }

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -18,13 +18,19 @@ namespace HermesProxy.World;
 // default UI target frame) get nothing to display.
 //
 // This class observes combat events forwarded from the legacy server, computes
-// threat per LibThreatClassic2 rules (port-in-progress, see ClassModules/), and
-// emits modern SMSG threat opcodes to the client.
+// threat per LibThreatClassic2 rules (LTC2 is the community model + what the
+// 1.12 KTM meters in the raid compute, so we align to it for raid consistency;
+// the server never emits threat, so live aggro behaviour is the final oracle),
+// and emits modern SMSG threat opcodes to the client.
 //
-// Phase 2 scope: track damage threat for the local player and their pet. Other
-// group members' threat is not yet shown (Phase 6 group sync). Class-specific
-// abilities (Distracting Shot, Feign Death, Sunder Armor flat threat, defensive
-// stance multipliers, etc.) ship in Phase 3+.
+// Scope: tracks threat for the WHOLE in-range group (local player, every party/
+// raid member, and their pets/guardians — see IsRelevantThreater), fed from the
+// combat log which the proxy observes for all units in range. For non-local
+// raiders we read every modifier that's observable on the wire — base damage/
+// heal, class, stance/form, threat auras (Salvation/Tranquil Air), gear set
+// bonuses + threat enchants (public visible-item fields). Only talent-derived
+// modifiers stay local-player-only, because vanilla 1.12 has no talent-inspect
+// opcode; an addon broadcast is the way to recover those (a follow-up).
 //
 // Threading: methods are called from the WorldClient thread (which dispatches
 // SMSG packet handlers). Emission goes back via WorldClient.SendPacketToClient
@@ -71,6 +77,13 @@ public sealed class ThreatTracker
     {
         _session = session;
     }
+
+    // Threat is a PvE-only stat. Computing it in battlegrounds / arenas spends
+    // per-event work (roster scans, aura reads, list building) on a metric no
+    // PvP encounter needs — AV NPC bosses included, by design. Every threat
+    // entry point gates on this instead of on Settings.ThreatEngine alone.
+    private bool ThreatDisabled =>
+        !Settings.ThreatEngine || _session.GameState.IsInBattleground();
 
     // Adds threat with the local player's stance / form / class passive
     // modifier applied. Use for ability-driven flat threat (Sunder, Distracting
@@ -469,7 +482,7 @@ public sealed class ThreatTracker
     // field cache in place, so the pre-update value can't be read back.
     public void OnUnitCombatStateObserved(WowGuid128 guid, bool inCombat)
     {
-        if (!Settings.ThreatEngine) return;
+        if (ThreatDisabled) return;
         if (guid == default) return;
 
         _lastInCombat.TryGetValue(guid, out bool wasInCombat);
@@ -581,7 +594,7 @@ public sealed class ThreatTracker
 
     public void OnDamage(WowGuid128 attacker, WowGuid128 victim, int spellId, double rawDamage)
     {
-        if (!Settings.ThreatEngine) return;
+        if (ThreatDisabled) return;
         if (rawDamage <= 0) return;
         if (!IsRelevantThreater(attacker))
         {
@@ -621,16 +634,17 @@ public sealed class ThreatTracker
 
         // Set-bonus gear adjustments (Mage Arcanist x0.85, Warlock Nemesis x0.8
         // on Destruction, Warlock Plagueheart x0.75, Rogue Bonescythe x0.92,
-        // Mage Netherwind -100/-20 flat). Player-only; pets / guardians don't
-        // carry sets. Layered on top of ability/passive/talent multipliers.
-        double gearMultiplier = 1.0;
-        double gearFlat = 0.0;
-        if (attacker == _session.GameState.CurrentPlayerGuid)
-        {
-            var playerClass = (Class)_session.GameState.CurrentPlayerClass;
-            gearMultiplier = ThreatSetBonuses.GetGearDamageMultiplier(_session.GameState, playerClass, spellId);
-            gearFlat = ThreatSetBonuses.GetGearDamageFlatAdjust(_session.GameState, playerClass, spellId);
-        }
+        // Mage Netherwind -100/-20 flat) + threat enchants (cloak Subtlety -2%,
+        // gloves Threat +2%). Applied for EVERY raider, not just the local
+        // player: the local player's gear comes from the private inventory
+        // slots (iMorph-immune), every groupmate's from their public visible-item
+        // fields + the per-GUID enchant cache. Pets / guardians (class == None)
+        // carry no sets, so their gear/enchant lookups no-op. Layered on top of
+        // ability/passive/talent multipliers.
+        Class attackerClass = GetThreaterClass(attacker);
+        double gearMultiplier = ThreatSetBonuses.GetGearDamageMultiplier(_session.GameState, attackerClass, attacker, spellId);
+        double gearFlat = ThreatSetBonuses.GetGearDamageFlatAdjust(_session.GameState, attackerClass, attacker, spellId);
+        double enchantMultiplier = ThreatSetBonuses.GetGearEnchantMultiplier(_session.GameState, attacker);
 
         // Aura-based threat multiplier (Blessing of Salvation x0.7, Greater
         // Bless of Salvation x0.7, Tranquil Air totem x0.8). Stacks
@@ -639,7 +653,7 @@ public sealed class ThreatTracker
         // we'd otherwise compute it.
         double auraMultiplier = ScanThreatMultiplierAuras(attacker);
 
-        double scaledThreat = (rawDamage * abilityMultiplier * gearMultiplier + gearFlat) * passiveModifier * talentMultiplier * auraMultiplier;
+        double scaledThreat = (rawDamage * abilityMultiplier * gearMultiplier + gearFlat) * passiveModifier * talentMultiplier * auraMultiplier * enchantMultiplier;
         if (scaledThreat < 0) scaledThreat = 0;
         AddThreat(victim, attacker, scaledThreat);
 
@@ -658,7 +672,7 @@ public sealed class ThreatTracker
     // off-healers who DPS, and self-heals while in combat.
     public void OnHeal(WowGuid128 healer, WowGuid128 healTarget, int spellId, double effectiveHeal)
     {
-        if (!Settings.ThreatEngine) return;
+        if (ThreatDisabled) return;
         if (effectiveHeal <= 0) return;
         if (!IsRelevantThreater(healer)) return;
         if (healTarget == default) return;
@@ -700,20 +714,20 @@ public sealed class ThreatTracker
         // heal threat when RF aura is active. Other classes' heals are no-op.
         double talentMultiplier = GetSpellTalentMultiplier(healer, spellId);
 
-        // Set-bonus heal-threat scalar (Priest Vestments of Faith 8-set: x0.9).
-        double gearHealMultiplier = 1.0;
-        if (healer == _session.GameState.CurrentPlayerGuid)
-        {
-            var playerClass = (Class)_session.GameState.CurrentPlayerClass;
-            gearHealMultiplier = ThreatSetBonuses.GetGearHealMultiplier(_session.GameState, playerClass);
-        }
+        // Set-bonus heal-threat scalar (Priest Vestments of Faith 8-set: x0.9) +
+        // threat enchants. Applied for every healer, not just the local player —
+        // groupmate gear from public visible items, enchants from the per-GUID
+        // cache (see OnDamage).
+        Class healerClass = GetThreaterClass(healer);
+        double gearHealMultiplier = ThreatSetBonuses.GetGearHealMultiplier(_session.GameState, healerClass, healer);
+        double enchantMultiplier = ThreatSetBonuses.GetGearEnchantMultiplier(_session.GameState, healer);
 
         // Aura-based threat multiplier (Salvation x0.7 etc.) applies to heal
         // threat just like damage threat — LTC2 puts it in threatMods() which
         // wraps all threat output regardless of source event.
         double auraMultiplier = ScanThreatMultiplierAuras(healer);
 
-        double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier * gearHealMultiplier * auraMultiplier;
+        double totalThreat = effectiveHeal * 0.5 * passiveModifier * talentMultiplier * gearHealMultiplier * auraMultiplier * enchantMultiplier;
         // LTC2 divides by EncounterMobs() — total mobs in the encounter, not
         // just the caster's combat list. We approximate with the caster's mob
         // count (close enough for solo/small-group; full encounter sync is a
@@ -770,7 +784,7 @@ public sealed class ThreatTracker
     // math needed proxy-side.
     public void OnEnergize(WowGuid128 caster, WowGuid128 recipient, int spellId, PowerType powerType, double amount)
     {
-        if (!Settings.ThreatEngine) return;
+        if (ThreatDisabled) return;
         if (amount <= 0) return;
         if (!IsRelevantThreater(caster)) return;
         if (IsEnergizeExempt(spellId)) return;
@@ -792,7 +806,7 @@ public sealed class ThreatTracker
     // set so the threat-update SMSG goes out alongside the SpellGo packet.
     public void OnSpellCast(WowGuid128 caster, int spellId, IList<WowGuid128> hitTargets)
     {
-        if (!Settings.ThreatEngine) return;
+        if (ThreatDisabled) return;
         if (caster == default) return;
 
         // First try player/pet handlers. If matched, flush + return.
@@ -1064,7 +1078,7 @@ public sealed class ThreatTracker
     // uses the table amount instead of effective-heal × 0.5.
     public void OnPowerWordShield(WowGuid128 caster, WowGuid128 shieldTarget, int spellId, double baseAmount)
     {
-        if (!Settings.ThreatEngine) return;
+        if (ThreatDisabled) return;
         if (baseAmount <= 0) return;
         if (caster != _session.GameState.CurrentPlayerGuid) return;
         if (shieldTarget == default) return;

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -296,7 +296,7 @@ public sealed class ThreatTracker
         {
             _threatLists.Remove(mob);
             _lastHighest.Remove(mob);
-        _lastUnexpectedAggro.Remove(mob);
+            _lastUnexpectedAggro.Remove(mob);
         }
     }
 


### PR DESCRIPTION
## What
A grounded accuracy + instrumentation pass on the proxy threat engine. Five commits, all 647/647, **no threat number changed on LibThreatClassic2's word alone** — the server never emits threat and Kronos is a custom vmangos fork with its own threat bugs, so every value change here is either observable-fact or backed by cross-source consensus, and the rest is left for the new in-game logger to settle.

## Commits
1. **Raid-wide gear set bonuses + threat enchants + BG gate.** Set bonuses and threat enchants (cloak Subtlety −2%, gloves Threat +2%) now apply to **every** raider, not just the local player: your own gear from the private inventory slots (iMorph-immune — client iMorph only edits the local view, never the wire), every groupmate's from their public visible-item entries + the per-GUID enchant cache. No addon, no new packets. Threat also gates OFF in battlegrounds/arenas (a PvE-only stat). Mixed raids: native-1.12 raiders now get gear/enchants exact from us too, only their personal talents stay approximate.
2. **`threat.aggro_unexpected` logger — the ground-truth calibration + complaint paper trail.** The server's real `UNIT_FIELD_TARGET` is the only oracle for whether our model is right. When the server aggros a raider our model ranked below its predicted top, log it (both threat values + overcredit ratio), deduplicated to once per episode. A recurring signature pinpoints exactly which value this fork computes differently; a disputed reading has an instant audit trail.
3. **Gear-scan class early-out** (efficiency). Since the gear read now runs per-raider per-event, classes with no set bonus on that path skip the 19-slot walk. Behavior-preserving.
4. **Life Tap exemption.** Life Tap generates 0 threat (removed patch 0.8/2004; both KTM and LTC2 exempt all ranks). We were fabricating threat from every warlock mana tap — the one over-credit all three references agree on. Exempts all six ranks. If this fork carries a vmangos gain-threat bug and does regenerate Life Tap threat, commit 2's logger surfaces it.

## Deliberately NOT changed (Kronos research reversed these "bugs")
- **Execute stays 1.25×** — the "should be 1.0×" claim was an old LibThreatClassic *typo* (fixed years ago); current LTC2 + classic threat refs both use 1.25×. "Fixing" it would have re-introduced the bug.
- **Pet AP scaling stays** — LTC2 *does* add an AP bonus (the "degenerates to flat" claim was wrong); our approach matches the reference. Magnitude is logger-validated.

## Scope / risk
- Gear/enchant/BG/logger: no formula change, pure observable-fact extensions + instrumentation.
- Life Tap: the single consensus over-credit fix, grounded default with a logger backstop.
- Correctness confirmed by 647/647 + 6 new enchant tests; threat-value correctness is ultimately validated by in-game aggro (the only oracle) via the new logger.

## Follow-ups (not in this PR)
Kronos boss threat-reset handlers (Shadow of Ebonroc=0, Viscidus/Sartura/ZG resets, + the missing Nefarian/Onyxia-P3/Noth/Azuregos); further efficiency (aura-scan memoization, emit coalescing, benchmark harness); the JimsPlus talent broadcast (addon change) for exact remote-raider talents. The logger data from real raids drives the genuinely-unknown values (Execute server-side, Life Tap on this fork, on-miss threat, pet AP magnitude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqgHDvvFXo6JXGvVDsaRDr