### PR TITLE
Threat (draft): Kronos boss threat-reset handlers + warlock leech exempts

### DIFF
--- a/HermesProxy/World/ThreatNPCModules.cs
+++ b/HermesProxy/World/ThreatNPCModules.cs
@@ -48,11 +48,29 @@ internal static class ThreatNPCModules
     {
         var map = new Dictionary<(uint, int), NPCThreatAction>();
 
-        // Molten Core — Ragnaros 11502 / Wrath 20566
+        // Molten Core — Ragnaros 11502 / Wrath 20566.
+        // ⚠️ VALIDATION TARGET (Kronos research 2026-07-13): LTC2 wipes raid
+        // threat here, but KTM-Kronos DELETED this wipe (changelog "fixed
+        // Ragnaros threat reset on knockback"). Wrath is a random-target
+        // knockback firing every ~25-45s, so if Kronos doesn't reset, this
+        // zeroes the MC-endboss meter a dozen+ times per fight. Left AS-IS
+        // pending validation against a real Kronos Ragnaros log (the boss's
+        // melee-target sequence around each Wrath tells us whether threat
+        // actually reset). Remove/guard once confirmed — do NOT drop on LTC2's
+        // word alone (LTC2 is tuned for stock vmangos, not this fork).
         map[(11502, 20566)] = NPCThreatAction.WipeRaidOnMob;
 
         // Molten Core — Shazzrah 12264 / Gate 23138
         map[(12264, 23138)] = NPCThreatAction.WipeRaidOnMob;
+
+        // Naxxramas — Noth the Plaguebringer 15954 / Blink 29211 (teleport =
+        // real server threat wipe). LTC2 hooks this as a BUFF-GAIN because the
+        // 1.12 client surfaces it that way, but the proxy sees the raw
+        // SMSG_SPELL_GO for NPC self-casts (same path Ragnaros Wrath / Shazzrah
+        // Gate already use). Registered here speculatively: if Blink emits a
+        // cast this fires; if it's aura-only on this fork it stays inert (no
+        // harm) until a Noth .pkt confirms and we move it to an aura-edge hook.
+        map[(15954, 29211)] = NPCThreatAction.WipeRaidOnMob;
 
         // Naxxramas — Kel'Thuzad 15990 / Chains of Kel'Thuzad 28410
         map[(15990, 28410)] = NPCThreatAction.WipeRaidOnMob;

--- a/HermesProxy/World/ThreatTracker.cs
+++ b/HermesProxy/World/ThreatTracker.cs
@@ -656,12 +656,37 @@ public sealed class ThreatTracker
     // (a future phase) is the proper fix; until then, the limitation is
     // identical to the rest of the system — heal threat works for tanks,
     // off-healers who DPS, and self-heals while in combat.
+    // Heal events whose heal portion generates no threat. Warlock leech
+    // self-heals — Drain Life, Death Coil, Siphon Life (all ranks; LTC2
+    // Warlock.lua ExemptGains). Their DAMAGE still generates threat via
+    // OnDamage; only the self-heal is zeroed. (Holy Nova's heal side is a
+    // known additional gap — its exact heal-spell ids need verifying against
+    // the Priest module before adding.)
+    private static readonly HashSet<int> HealExemptSpells = new()
+    {
+        // Drain Life R1..6
+        689, 699, 709, 7651, 11699, 11700,
+        // Death Coil R1..3
+        6789, 17925, 17926,
+        // Siphon Life R1..4
+        18265, 18879, 18880, 18881,
+    };
+
+    private static bool IsHealExempt(int spellId) => HealExemptSpells.Contains(spellId);
+
     public void OnHeal(WowGuid128 healer, WowGuid128 healTarget, int spellId, double effectiveHeal)
     {
         if (!Settings.ThreatEngine) return;
         if (effectiveHeal <= 0) return;
         if (!IsRelevantThreater(healer)) return;
         if (healTarget == default) return;
+        // Warlock leech self-heals generate NO threat from the heal portion
+        // (their damage still threats normally in OnDamage). LTC2 and KTM both
+        // exempt every rank; blizzlike-correct. Mirrors the Life Tap energize
+        // exemption — same "we were fabricating threat from a leech" class of
+        // bug. Drain Life / Death Coil / Siphon Life heal ranks (LTC2
+        // Warlock.lua ExemptGains).
+        if (IsHealExempt(spellId)) return;
 
         // LTC2 ThreatClassModuleCore.lua line 1148 (prototype:AddThreat):
         //


### PR DESCRIPTION
**DRAFT** — staged pending validation against real Kronos raid logs (an MC combat log + more session JSONL are incoming). The debatable value/behavior calls are deliberately NOT applied yet.

## In this draft (grounded, safe)
- **Warlock leech-heal exemptions** — Drain Life / Death Coil / Siphon Life self-heals generate no threat from the heal portion (their damage still threats normally). Blizzlike + LTC2 + KTM all agree; completes the Life Tap energize fix from #419's line. Exact ranks from LTC2 Warlock.lua ExemptGains.
- **Noth (Naxx) Blink teleport wipe** — registered as a cast handler on the same SMSG_SPELL_GO path Ragnaros/Shazzrah use. Inert (no harm) if Blink turns out aura-only on this fork; a Noth .pkt confirms and, if needed, we move it to an aura-edge hook.

## Flagged, NOT changed — awaiting your MC log
- **Ragnaros Wrath raid-wipe.** KTM-Kronos (a Kronos-tuned meter) *deleted* this wipe; on Kronos it likely zeroes the MC-endboss meter every ~25–45s. But it's a behavior removal on the game's most-raided boss, and a spurious wipe doesn't trip the aggro logger (it zeros everyone; the arrow still tracks). So it's left in with a prominent code flag — **the boss's melee-target sequence in a real Kronos Ragnaros log is what settles it.** That's exactly what the incoming MC combat log provides.

## Deferred (need decisions / more data)
- **Yell-triggered phase resets** (Nefarian P2, Thaddius P2, Onyxia P3): no single packet marks the transition, so it's HP-threshold, an opt-in monster-yell text hook (the one thing this codebase avoids), or leaning on the server-target override that already keeps the aggro arrow correct. Leaning defer.
- **Resist/absorb gap**: LTC2 fires knock-away / sand-blast / wing-buffet threat mods on fully-resisted hits too; our rawDamage>0 gate blocks that — would route SMSG_SPELL_MISS resist/absorb into the NPC handler.
- **Holy Nova heal-side exempt** (ids need verifying vs the Priest module).
- **Not ported (per-GUID no-op):** KTM's engage/pull resets (Sartura, all ZG bosses, Broodlord/Onyxia pull) — our per-mob-GUID model starts empty each pull, so they're redundant.

## Validation plan
The incoming MC combat log gives an offline aggro oracle (the boss's melee target over time). I'll build a replay/compare tool: run the raid's events through our threat model and diff predicted-top vs the boss's actual melee target — settles Ragnaros, and surfaces any other systematic Kronos-specific divergence. Depends on / follows #419 (the accuracy core + the live aggro logger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqgHDvvFXo6JXGvVDsaRDr