### PR TITLE
Remap hunter-trap lock 12→13 so the 1.14 client allows right-click disarm (#403)

### DIFF
--- a/HermesProxy.Tests/World/GameObjectTemplateShapingTests.cs
+++ b/HermesProxy.Tests/World/GameObjectTemplateShapingTests.cs
@@ -1,0 +1,41 @@
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Pins the #403 hunter-trap disarm fix: the 1.14 client fabricates
+// "Requires Disarm Trap (300)" for lock rows with Skill=0 (vanilla lock 12,
+// carried by every hunter trap) and blocks the right-click disarm pre-send.
+// RemapTrapLock presents lock 13 (explicit Disarm skill 50 — the lowest disarm
+// lock in 1.14.2's Lock.db2) instead, which the client's gate compares honestly.
+// Client-display only; the legacy server arbitrates the actual disarm cast.
+public class GameObjectTemplateShapingTests
+{
+    [Fact]
+    public void RemapTrapLock_TrapWithVanillaDisarmLock_RemapsTo13()
+    {
+        Assert.Equal(13, GameObjectTemplateShaping.RemapTrapLock(6, 12));
+    }
+
+    [Theory]
+    // TRAP-type GOs with any other lock (or no lock) pass through — hazard /
+    // environmental traps and dungeon trip-traps keep their real lock.
+    [InlineData(6, 0)]
+    [InlineData(6, 13)]
+    [InlineData(6, 57)]
+    public void RemapTrapLock_TrapWithOtherLock_PassesThrough(uint type, int lockId)
+    {
+        Assert.Equal(lockId, GameObjectTemplateShaping.RemapTrapLock(type, lockId));
+    }
+
+    [Theory]
+    // Non-TRAP types never touched, even with lock 12 — chests (3), goobers (10,
+    // incl. the #387 Rookery Egg after its TRAP->GOOBER override runs first).
+    [InlineData(3u)]
+    [InlineData(10u)]
+    [InlineData(15u)]
+    public void RemapTrapLock_NonTrapType_PassesThrough(uint type)
+    {
+        Assert.Equal(12, GameObjectTemplateShaping.RemapTrapLock(type, 12));
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -568,6 +568,25 @@ public partial class WorldClient
         for (int i = 0; i < 24; i++)
             gameObject.Data[i] = packet.ReadInt32();
 
+        // JimsProxy (#403): hunter traps carry vanilla lock 12 (Skill=0) and the
+        // 1.14 client fabricates "Requires Disarm Trap (300)" for skill-0 lock
+        // rows, refusing the right-click disarm pre-send. Remap to lock 13
+        // (explicit Disarm 50) so the client's gate compares honestly; the legacy
+        // server still arbitrates the actual disarm cast. See
+        // GameObjectTemplateShaping for the full mechanism and verification.
+        // Cached in gameobjectcache.wdb — players need a one-time cache clear.
+        // Runs after the egg override above, so the Rookery Egg (now GOOBER type)
+        // is never touched.
+        int lockBefore = gameObject.Data[0];
+        gameObject.Data[0] = GameObjectTemplateShaping.RemapTrapLock(gameObject.Type, gameObject.Data[0]);
+        if (gameObject.Data[0] != lockBefore)
+            Log.Event("gameobject.trap.lock_remapped", new
+            {
+                entry = response.GameObjectID,
+                lock_before = lockBefore,
+                lock_after = gameObject.Data[0],
+            });
+
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
             gameObject.Size = packet.ReadFloat();
 

--- a/HermesProxy/World/GameObjectTemplateShaping.cs
+++ b/HermesProxy/World/GameObjectTemplateShaping.cs
@@ -1,0 +1,39 @@
+namespace HermesProxy.World;
+
+// JimsProxy (#403): GameObject template shaping for the modern client.
+//
+// The 1.14 client gates GO right-click interaction on the template's lock row
+// (Lock.db2). For lock rows whose required Skill is 0, the client FABRICATES a
+// requirement instead of treating 0 as "no gate" the way the 1.12 client did —
+// hunter traps (vanilla lock 12, Skill=0) render "Requires Disarm Trap (300)"
+// and the client refuses the right-click auto-cast pre-send (the disarm never
+// reaches the wire; only a CMSG_GAME_OBJ_REPORT_USE ping goes out). Explicitly
+// casting Disarm Trap (1842) from the spellbook bypasses the GO gate and the
+// legacy server happily executes the disarm, proving the gate is client-local.
+//
+// Fix: remap trap lock 12 -> 13. Lock 13 carries an explicit Disarm skill of 50
+// — the lowest disarm lock in 1.14.2's Lock.db2 (the only other is 55 = 200) —
+// which the client compares honestly. In-game verified 2026-07-14 (Kronos PTR,
+// level-60 rogue vs hunter): right-click disarm works end-to-end and the server
+// flips the trap's GO flags to InUse on success.
+//
+// The remap is client-display only: the query response never returns to the
+// legacy server, which arbitrates the actual disarm cast with its own template.
+// Known limitation: the client-side gate under lock 13 needs the player's
+// disarm-relevant skill >= 50; low-skill rogues keep the spellbook workaround.
+public static class GameObjectTemplateShaping
+{
+    public const uint GameObjectTypeTrap = 6;
+    public const int VanillaDisarmLock = 12;      // Skill=0 -> client fabricates "(300)"
+    public const int ModernDisarmLockSkill50 = 13; // explicit Disarm 50, lowest in 1.14.2
+
+    // Returns the lock id (Data[0]) to present to the modern client for a GO
+    // template of the given type. Pass-through for everything except TRAP-type
+    // templates carrying the vanilla disarm lock.
+    public static int RemapTrapLock(uint goType, int lockId)
+    {
+        if (goType == GameObjectTypeTrap && lockId == VanillaDisarmLock)
+            return ModernDisarmLockSkill50;
+        return lockId;
+    }
+}

--- a/HermesProxy/World/Server/Packets/QueryPackets.cs
+++ b/HermesProxy/World/Server/Packets/QueryPackets.cs
@@ -575,7 +575,7 @@ public class QueryGameObjectResponse : ServerPacket
             foreach (uint questItem in Stats.QuestItems)
                 statsData.WriteUInt32(questItem);
 
-            statsData.WriteUInt32(Stats.ContentTuningId);
+            statsData.WriteUInt32(Stats.RequiredLevel);
         }
 
         _worldPacket.WriteUInt32(statsData.GetSize());
@@ -605,7 +605,13 @@ public class GameObjectStats
     public int[] Data = new int[35];
     public float Size = 1;
     public List<uint> QuestItems = new();
-    public uint ContentTuningId;
+    // JimsProxy (#403 decode): retail-lineage layouts call this trailing field
+    // ContentTuningID, but the 1.14.2 client reads it as a plain REQUIRED LEVEL —
+    // feeding a tuning id here renders "Requires Level <id>" on the object and
+    // suppresses interaction (verified in-game 2026-07-14 by writing 2180 and
+    // watching the error text). Keep 0 (no level requirement) unless a template
+    // genuinely carries one.
+    public uint RequiredLevel;
 }
 
 public class QueryPageText : ClientPacket


### PR DESCRIPTION
Fixes the actual #403 mechanism, established by a five-session in-game investigation tonight (Kronos PTR, level-60 rogue + hunter, full .pkt/JSONL captures).

## Mechanism (verified on the wire)

The 1.14 client gates GO right-click interaction on the template's Lock.db2 row. For rows with **Skill = 0** it **fabricates a requirement** — every hunter trap (vanilla lock 12, Skill=0) shows "Requires Disarm Trap (300)" and the client refuses the right-click auto-cast **pre-send** (only a `CMSG_GAME_OBJ_REPORT_USE` ping leaves the client; `CMSG_CAST_SPELL(1842)` never does). Casting Disarm Trap from the spellbook bypasses the GO gate and the server executes the disarm cleanly — the gate is purely client-local.

## Fix

Present **lock 13** (explicit Disarm skill 50 — the lowest disarm lock in 1.14.2's Lock.db2; the only other is 55 = 200). Explicit skills are compared honestly; right-click disarm verified end-to-end in-game, with the server flipping the trap GO to `InUse` on success. Client-display only — the legacy server arbitrates the actual cast with its own template. Scoped to TRAP(6) + lock 12, after the #387 egg override, so eggs and other-lock traps are untouched.

Also renames `GameObjectStats.ContentTuningId` → `RequiredLevel`: in-game A/B proved the 1.14.2 client reads that trailing uint32 as a plain required level ("Requires Level 2180" when fed a tuning id).

## Not bugs (documented in #403)

- Unstealthed disarm is vanilla-correct (stealth requirement was *added* in 2.0).
- "Uninteractable" traps = owner-PvP-flag semantics (unflagged enemy's traps aren't valid hostile targets until the owner flags up) — confirmed by controlled experiment.

## Caveats

- Players need a one-time `gameobjectcache.wdb` clear (cached GO templates).
- Rogues below skill 50 on the client's disarm measure keep the spellbook workaround; escalation path if ever needed is hotfix-injecting a custom Lock row (skill 1) via the DB_REPLY pipeline.

648/648 (7 new pinning the remap predicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqgHDvvFXo6JXGvVDsaRDr
