### PR TITLE
Fix mid-life hover transitions: Onyxia stands/bounces while flying and keeps hover anim after landing

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -732,6 +732,19 @@ public partial class WorldClient
                 Framework.Logging.Log.Event("hover.registry.cleared", new { guid = spline.MoverGUID.ToString() });
         }
         SendPacketToClient(spline);
+        // MIRASU (onyxia-parked-hover-anim): mirror hover toggles as PlayHoverAnim + gravity, else a parked flyer stands and bounces once its spline ends.
+        if (universalOpcode is Opcode.SMSG_MOVE_SPLINE_SET_HOVER or Opcode.SMSG_MOVE_SPLINE_UNSET_HOVER)
+        {
+            bool hovering = universalOpcode == Opcode.SMSG_MOVE_SPLINE_SET_HOVER;
+            SetPlayHoverAnim hoverAnim = new SetPlayHoverAnim();
+            hoverAnim.UnitGUID = spline.MoverGUID;
+            hoverAnim.PlayHoverAnim = hovering;
+            SendPacketToClient(hoverAnim);
+            MoveSplineSetFlag gravity = new MoveSplineSetFlag(hovering ? Opcode.SMSG_MOVE_SPLINE_DISABLE_GRAVITY : Opcode.SMSG_MOVE_SPLINE_ENABLE_GRAVITY);
+            gravity.MoverGUID = spline.MoverGUID;
+            SendPacketToClient(gravity);
+            Framework.Logging.Log.Event("hover.anim_synth", new { guid = spline.MoverGUID.ToString(), hovering });
+        }
     }
 
     [PacketHandler(Opcode.SMSG_MOVE_ROOT)]

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -27,6 +27,29 @@ public partial class WorldClient
         return GetSession().GameState.KnownSwimmingMobs.Contains(guid);
     }
 
+    // MIRASU (onyxia-parked-hover-anim): single entry point for hover registry transitions; real changes synth PlayHoverAnim + gravity (vanilla legacy only — later cores drive hover/gravity natively).
+    internal void SetHoverState(WowGuid128 guid, bool hovering, string source, bool synthesize = true)
+    {
+        if (guid == GetSession().GameState.CurrentPlayerGuid)
+            return;
+        bool changed = hovering
+            ? GetSession().GameState.KnownHoveringMobs.Add(guid)
+            : GetSession().GameState.KnownHoveringMobs.Remove(guid);
+        if (!changed)
+            return;
+        Framework.Logging.Log.Event(hovering ? "hover.registry.set" : "hover.registry.cleared", new { guid = guid.ToString(), source });
+        if (!synthesize || !LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+            return;
+        SetPlayHoverAnim hoverAnim = new SetPlayHoverAnim();
+        hoverAnim.UnitGUID = guid;
+        hoverAnim.PlayHoverAnim = hovering;
+        SendPacketToClient(hoverAnim);
+        MoveSplineSetFlag gravity = new MoveSplineSetFlag(hovering ? Opcode.SMSG_MOVE_SPLINE_DISABLE_GRAVITY : Opcode.SMSG_MOVE_SPLINE_ENABLE_GRAVITY);
+        gravity.MoverGUID = guid;
+        SendPacketToClient(gravity);
+        Framework.Logging.Log.Event("hover.anim_synth", new { guid = guid.ToString(), hovering });
+    }
+
     // Strips Falling/FallingFar and forces DisableGravity on a hovering mob's movement
     // flags. Call BEFORE casting WotLK flags to Modern. Vanilla servers don't have
     // AnimTier/HoverHeight in their movement protocol, so hovering mobs bleed Falling
@@ -720,31 +743,10 @@ public partial class WorldClient
         Opcode universalOpcode = packet.GetUniversalOpcode(false);
         MoveSplineSetFlag spline = new MoveSplineSetFlag(universalOpcode);
         spline.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
-        // MIRASU (onyxia-landed-still-hovering): explicit hover toggles drive the registry, else a landed mob keeps hover anim forever.
-        if (universalOpcode == Opcode.SMSG_MOVE_SPLINE_SET_HOVER)
-        {
-            if (GetSession().GameState.KnownHoveringMobs.Add(spline.MoverGUID))
-                Framework.Logging.Log.Event("hover.registry.set", new { guid = spline.MoverGUID.ToString() });
-        }
-        else if (universalOpcode == Opcode.SMSG_MOVE_SPLINE_UNSET_HOVER)
-        {
-            if (GetSession().GameState.KnownHoveringMobs.Remove(spline.MoverGUID))
-                Framework.Logging.Log.Event("hover.registry.cleared", new { guid = spline.MoverGUID.ToString() });
-        }
         SendPacketToClient(spline);
-        // MIRASU (onyxia-parked-hover-anim): mirror hover toggles as PlayHoverAnim + gravity, else a parked flyer stands and bounces once its spline ends.
+        // MIRASU (onyxia-landed-still-hovering): explicit hover toggles drive the registry + anim/gravity synth, else a landed mob keeps hover anim forever and a parked flyer stands and bounces.
         if (universalOpcode is Opcode.SMSG_MOVE_SPLINE_SET_HOVER or Opcode.SMSG_MOVE_SPLINE_UNSET_HOVER)
-        {
-            bool hovering = universalOpcode == Opcode.SMSG_MOVE_SPLINE_SET_HOVER;
-            SetPlayHoverAnim hoverAnim = new SetPlayHoverAnim();
-            hoverAnim.UnitGUID = spline.MoverGUID;
-            hoverAnim.PlayHoverAnim = hovering;
-            SendPacketToClient(hoverAnim);
-            MoveSplineSetFlag gravity = new MoveSplineSetFlag(hovering ? Opcode.SMSG_MOVE_SPLINE_DISABLE_GRAVITY : Opcode.SMSG_MOVE_SPLINE_ENABLE_GRAVITY);
-            gravity.MoverGUID = spline.MoverGUID;
-            SendPacketToClient(gravity);
-            Framework.Logging.Log.Event("hover.anim_synth", new { guid = spline.MoverGUID.ToString(), hovering });
-        }
+            SetHoverState(spline.MoverGUID, universalOpcode == Opcode.SMSG_MOVE_SPLINE_SET_HOVER, "explicit_toggle");
     }
 
     [PacketHandler(Opcode.SMSG_MOVE_ROOT)]
@@ -896,16 +898,8 @@ public partial class WorldClient
             // Seed hover detection: any vanilla spline with Flying flag means this is a
             // hovering/flying mob. Mark it so all future packets (heartbeats, Stop, etc.)
             // for this guid carry hover state, even if HOVERHEIGHT field is never set.
-            if (splineFlags.HasAnyFlag(SplineFlagVanilla.Flying) && guid != GetSession().GameState.CurrentPlayerGuid)
-            {
-                if (GetSession().GameState.KnownHoveringMobs.Add(guid))
-                {
-                    Framework.Logging.Log.Event("hover.detect_flying_spline", new
-                    {
-                        guid = guid.ToString(),
-                    });
-                }
-            }
+            if (splineFlags.HasAnyFlag(SplineFlagVanilla.Flying))
+                SetHoverState(guid, true, "flying_spline");
 
             if (splineFlags == SplineFlagVanilla.Runmode) // Default spline flags used by Vanilla and TBC servers
             {

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -717,8 +717,20 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_MOVE_SPLINE_UNSET_FLYING)]
     void HandleSplineMovementMessages(WorldPacket packet)
     {
-        MoveSplineSetFlag spline = new MoveSplineSetFlag(packet.GetUniversalOpcode(false));
+        Opcode universalOpcode = packet.GetUniversalOpcode(false);
+        MoveSplineSetFlag spline = new MoveSplineSetFlag(universalOpcode);
         spline.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
+        // MIRASU (onyxia-landed-still-hovering): explicit hover toggles drive the registry, else a landed mob keeps hover anim forever.
+        if (universalOpcode == Opcode.SMSG_MOVE_SPLINE_SET_HOVER)
+        {
+            if (GetSession().GameState.KnownHoveringMobs.Add(spline.MoverGUID))
+                Framework.Logging.Log.Event("hover.registry.set", new { guid = spline.MoverGUID.ToString() });
+        }
+        else if (universalOpcode == Opcode.SMSG_MOVE_SPLINE_UNSET_HOVER)
+        {
+            if (GetSession().GameState.KnownHoveringMobs.Remove(spline.MoverGUID))
+                Framework.Logging.Log.Event("hover.registry.cleared", new { guid = spline.MoverGUID.ToString() });
+        }
         SendPacketToClient(spline);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -208,6 +208,9 @@ public partial class WorldClient
         // JimsProxy (out-of-range-ghost): suppress any stray trailing movement the legacy server broadcasts for this guid after the destroy, until a CreateObject re-creates it.
         GetSession().GameState.MarkObjectRecentlyDestroyed(guid);
 
+        // MIRASU (onyxia-landed-still-hovering): forget hover state on destroy — a missed UNSET_HOVER while out of range must not poison the stable guid; re-approach re-seeds if still airborne.
+        SetHoverState(guid, false, "destroyed", synthesize: false);
+
         UpdateObject updateObject = new UpdateObject(GetSession().GameState);
         updateObject.DestroyedGuids.Add(guid);
         SendPacketToClient(updateObject);
@@ -565,6 +568,9 @@ public partial class WorldClient
             GetSession().ThreatTracker.OnUnitDestroyed(guid);
             // JimsProxy (out-of-range-ghost): suppress stray trailing movement for this guid until it is re-created on re-approach.
             GetSession().GameState.MarkObjectRecentlyDestroyed(guid);
+
+            // MIRASU (onyxia-landed-still-hovering): out-of-range is a visibility loss like destroy — forget hover state so a missed UNSET_HOVER can't poison the guid.
+            SetHoverState(guid, false, "out_of_range", synthesize: false);
 
             updateObject.OutOfRangeGuids.Add(guid);
         }
@@ -1044,17 +1050,9 @@ public partial class WorldClient
 
             // Vanilla 1.12 carries hover state via MovementFlagVanilla.FixedZ. Seed our
             // hover registry from it, since some 1.12 cores never populate UNIT_FIELD_HOVERHEIGHT.
-            if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180) && moveInfo.Hover &&
-                guid != GetSession().GameState.CurrentPlayerGuid)
-            {
-                if (GetSession().GameState.KnownHoveringMobs.Add(guid))
-                {
-                    Framework.Logging.Log.Event("hover.detect_fixedz_flag", new
-                    {
-                        guid = guid.ToString(),
-                    });
-                }
-            }
+            // No synth: this runs mid-create-parse and the create block already carries the PlayHoverAnim bit.
+            if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180) && moveInfo.Hover)
+                SetHoverState(guid, true, "fixedz", synthesize: false);
 
             // MIRASU (swim-mob basketball-bounce 2026-05-23): vanilla NPCs in water
             // carry MovementFlagVanilla.Swimming on their MovementInfo. Modern 1.14 client
@@ -2718,6 +2716,11 @@ public partial class WorldClient
                 else if (Session.GameState.KnownSwimmingMobs.Contains(guid))
                 {
                     updateData.UnitData.AnimTier = 1; // AnimTier.Swim
+                }
+                // MIRASU (onyxia-landed-still-hovering): vanilla never carries AnimTier, so repaint Ground(0) once no registry matches — else the client's cached Hover(2) survives landing.
+                else if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_4_0_8089))
+                {
+                    updateData.UnitData.AnimTier = 0;
                 }
             }
             int UNIT_FIELD_PETNUMBER = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_PETNUMBER);

--- a/HermesProxy/World/Server/Packets/MovementPackets.cs
+++ b/HermesProxy/World/Server/Packets/MovementPackets.cs
@@ -587,7 +587,7 @@ public class MoveSplineSetFlag : ServerPacket, ISpanWritable
 }
 
 // MIRASU (onyxia-parked-hover-anim): modern hook for the hover-flap animation on a unit that starts/stops hovering mid-life.
-public class SetPlayHoverAnim : ServerPacket
+public class SetPlayHoverAnim : ServerPacket, ISpanWritable
 {
     public SetPlayHoverAnim() : base(Opcode.SMSG_SET_PLAY_HOVER_ANIM, ConnectionType.Instance) { }
 
@@ -596,6 +596,17 @@ public class SetPlayHoverAnim : ServerPacket
         _worldPacket.WritePackedGuid128(UnitGUID);
         _worldPacket.WriteBit(PlayHoverAnim);
         _worldPacket.FlushBits();
+    }
+
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1; // GUID + flushed bit
+
+    public int WriteToSpan(Span<byte> buffer)
+    {
+        var writer = new SpanPacketWriter(buffer);
+        writer.WritePackedGuid128(UnitGUID.Low, UnitGUID.High);
+        writer.WriteBit(PlayHoverAnim);
+        writer.FlushBits();
+        return writer.Position;
     }
 
     public WowGuid128 UnitGUID;

--- a/HermesProxy/World/Server/Packets/MovementPackets.cs
+++ b/HermesProxy/World/Server/Packets/MovementPackets.cs
@@ -586,6 +586,22 @@ public class MoveSplineSetFlag : ServerPacket, ISpanWritable
     public WowGuid128 MoverGUID;
 }
 
+// MIRASU (onyxia-parked-hover-anim): modern hook for the hover-flap animation on a unit that starts/stops hovering mid-life.
+public class SetPlayHoverAnim : ServerPacket
+{
+    public SetPlayHoverAnim() : base(Opcode.SMSG_SET_PLAY_HOVER_ANIM, ConnectionType.Instance) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(UnitGUID);
+        _worldPacket.WriteBit(PlayHoverAnim);
+        _worldPacket.FlushBits();
+    }
+
+    public WowGuid128 UnitGUID;
+    public bool PlayHoverAnim;
+}
+
 public class MoveSetFlag : ServerPacket, ISpanWritable
 {
     public MoveSetFlag(Opcode opcode) : base(opcode, ConnectionType.Instance) { }


### PR DESCRIPTION
## Problem

Two related animation bugs on Onyxia (Kronos), reported and repro'd in raid 2026-07-15:

1. **Phase 2:** when she flies to the rear of the lair and parks at her hover point, she plays the ground stand pose and bounces up and down instead of hovering.
2. **Phase 3:** after landing she kept gliding around in the hover pose instead of walking (pre-fix behavior).

## Root causes

- `KnownHoveringMobs` was **add-only** — seeded from Flying splines / FixedZ but never removed, so a mob that lands mid-life kept getting `Flying|AnimTierHover` forced onto every ground spline forever.
- The modern client's hover-flap hook (`PlayHoverAnim`) only existed as a **create-block bit**, so a unit that lifts off mid-life (spawned grounded) never received it, and nothing disabled client gravity — once her flight spline ended, the client reverted to stand pose and gravity fought her mid-air position.

## Fix (3 commits)

1. `SMSG_MOVE_SPLINE_SET/UNSET_HOVER` now drive the hover registry (add/remove).
2. New `SetPlayHoverAnim` packet (`SMSG_SET_PLAY_HOVER_ANIM`) + `SMSG_MOVE_SPLINE_DISABLE/ENABLE_GRAVITY` synthesized to the modern client on hover transitions.
3. Hardening from a deep review of 1+2:
   - registry cleared on `SMSG_DESTROY_OBJECT` and out-of-range, so a missed `UNSET_HOVER` (player dead/away when the mob lands, or despawn/respawn reusing a stable guid) can't permanently poison a unit;
   - all transitions flow through one `SetHoverState` helper — player guid excluded, synth fires only on real state changes, and Flying-spline-seeded mobs (which never get an explicit `SET_HOVER`) now receive the anim/gravity hook too;
   - synth gated to vanilla-era legacy — TBC+ cores drive hover/gravity natively, so the synthetic `ENABLE_GRAVITY` can't fight genuine server gravity or a populated `UNIT_FIELD_HOVERHEIGHT`;
   - `BYTES_1` updates repaint `AnimTier=Ground(0)` when no registry matches (vanilla only), so a landed mob can't keep a cached Hover tier;
   - `SetPlayHoverAnim` implements `ISpanWritable` like its neighbors.

## Diagnostics

JSONL events: `hover.registry.set` / `hover.registry.cleared` (with a `source` field: `explicit_toggle` / `flying_spline` / `fixedz` / `destroyed` / `out_of_range`) and `hover.anim_synth`.

## Validation

Tested in-game on Kronos across multiple full Onyxia kills: phase 2 liftoff, flight, and parked hover-flap at the rear all correct with no bouncing; phase 3 lands cleanly and walks. JSONL confirms set/clear pairs the phase transitions exactly. All 641 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)