### PR TITLE
Harden completed_quests.csv I/O against regular-play failures (#414)

### DIFF
--- a/HermesProxy.Tests/World/CompletedQuestParseTests.cs
+++ b/HermesProxy.Tests/World/CompletedQuestParseTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using HermesProxy.World.Server;
 using Xunit;
 
@@ -58,4 +60,76 @@ public class CompletedQuestParseTests
         Assert.Equal(new uint[] { 411 }, ids);
         Assert.False(needsRewrite);
     }
+
+    // --- Torn-append (glued-line) guard: MarkQuestAsCompleted -> EnsureTrailingNewline ---
+    // A kill mid-append (the launcher force-kills the proxy on game close) can leave the file
+    // without a trailing newline; the next append then glues onto the partial last line. The glued
+    // line's first field still parses, so the second quest id is SILENTLY lost and needsRewrite
+    // stays false -- invisible to the self-heal. These pin the vector and the guard.
+
+    [Fact]
+    public void ParseCompletedQuestLines_GluedLine_SilentlyLosesSecondId_DocumentsTheVector()
+    {
+        // "100,1780000000" (no newline) + "200,1780000005" appended -> one glued line.
+        var glued = new List<string> { "100,1780000000200,1780000005" };
+
+        var ids = AccountMetaDataManager.ParseCompletedQuestLines(glued, out _, out var needsRewrite);
+
+        Assert.Equal(new uint[] { 100 }, ids);   // 200 is swallowed into the middle field
+        Assert.False(needsRewrite);              // and the loss is invisible to the self-heal
+    }
+
+    [Fact]
+    public void EnsureTrailingNewline_MissingTrailingNewline_PreventsGluedAppend()
+    {
+        var path = NewTempFile();
+        try
+        {
+            // Simulate a torn prior append: last line has no terminating newline.
+            File.WriteAllText(path, "100,1780000000");
+
+            AccountMetaDataManager.EnsureTrailingNewline(path);
+            File.AppendAllLines(path, new[] { "200,1780000005" });
+
+            var ids = AccountMetaDataManager.ParseCompletedQuestLines(File.ReadAllLines(path), out _, out _);
+            Assert.Equal(new uint[] { 100, 200 }, ids);   // both survive -- no glue
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void EnsureTrailingNewline_AlreadyNewlineTerminated_LeavesContentUnchanged()
+    {
+        var path = NewTempFile();
+        try
+        {
+            var original = "100,1780000000" + Environment.NewLine;
+            File.WriteAllText(path, original);
+
+            AccountMetaDataManager.EnsureTrailingNewline(path);
+
+            Assert.Equal(original, File.ReadAllText(path));   // idempotent: no spurious blank line
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void EnsureTrailingNewline_MissingOrEmptyFile_NoOpNoThrow()
+    {
+        var missing = NewTempFile();
+        AccountMetaDataManager.EnsureTrailingNewline(missing);   // absent -> no-op, no throw
+        Assert.False(File.Exists(missing));
+
+        var empty = NewTempFile();
+        File.Create(empty).Dispose();                           // 0-byte file
+        try
+        {
+            AccountMetaDataManager.EnsureTrailingNewline(empty);
+            Assert.Equal(0, new FileInfo(empty).Length);        // stays empty, no lone newline
+        }
+        finally { File.Delete(empty); }
+    }
+
+    private static string NewTempFile()
+        => Path.Combine(Path.GetTempPath(), $"jimsproxy_cq_{Guid.NewGuid():N}.csv");
 }

--- a/HermesProxy/World/Server/AccountDataManager.cs
+++ b/HermesProxy/World/Server/AccountDataManager.cs
@@ -95,7 +95,26 @@ public class AccountMetaDataManager
         if (!File.Exists(path))
             return new List<uint>();
 
-        var completedQuestIds = ParseCompletedQuestLines(File.ReadAllLines(path), out var compactLines, out var needsRewrite);
+        string[] rawLines;
+        try
+        {
+            rawLines = File.ReadAllLines(path);
+        }
+        catch (Exception ex)
+        {
+            // Degrade gracefully instead of crashing login: this runs on the login path
+            // (CompletedQuestTracker.Reload -> HandlePlayerLogin), so a transient IOException here
+            // -- an AV scan hold or sharing violation on the file -- would otherwise kill the login
+            // outright. Same crash class as #408, which only hardened the parse, not the read
+            // itself. Returning empty means the completed-quest bits aren't restored for this
+            // session; they re-populate as quests are turned in and the file self-heals on the next
+            // clean read.
+            Log.Print(LogType.Error, $"Failed to read completed_quests.csv for '{charName}@{realmName}' " +
+                                     $"({ex.GetType().Name}: {ex.Message}); treating as no completed quests this session.");
+            return new List<uint>();
+        }
+
+        var completedQuestIds = ParseCompletedQuestLines(rawLines, out var compactLines, out var needsRewrite);
 
         // Self-heal: the old code called uint.Parse on every line, so a single corrupt line (a
         // crash/kill mid-append can leave NUL bytes) threw FormatException and terminated the
@@ -165,8 +184,47 @@ public class AccountMetaDataManager
         var dir = GetAccountCharacterMetaDataDirectory(realmName, charName);
         var path = Path.Combine(dir, COMPLETED_QUESTS_FILE);
 
-        var when = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        File.AppendAllLines(path, new[]{$"{questId},{when}"}, Encoding.UTF8);
+        try
+        {
+            // Guard against a glued line: if a prior append was torn by a kill mid-write (the
+            // launcher force-kills the proxy on game close) the file can end without a newline. A
+            // plain AppendAllLines would then concatenate onto that partial last line, yielding a
+            // *parseable* wrong line whose first field is the OLD id -- silently dropping this quest
+            // and evading the corrupt-line self-heal (the glued line parses fine, so needsRewrite
+            // stays false). Normalise the trailing newline first.
+            EnsureTrailingNewline(path);
+
+            var when = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            File.AppendAllLines(path, new[]{$"{questId},{when}"}, Encoding.UTF8);
+        }
+        catch (Exception ex)
+        {
+            // A locked file (AV hold / sharing violation) must not crash the quest turn-in path.
+            // The in-memory CompletedQuestTracker set already reflects this completion for the
+            // session; only cross-restart persistence is lost until the next successful append.
+            Log.Print(LogType.Error, $"Failed to append completed_quests.csv (quest {questId}) for " +
+                                     $"'{charName}@{realmName}': {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    // Ensures the file ends with a newline so the next append starts on its own line. No-op when the
+    // file is absent (the append will create it) or already ends in '\n'. Reads only the final byte.
+    // Internal for unit-testing the torn-append (glued-line) guard.
+    internal static void EnsureTrailingNewline(string path)
+    {
+        if (!File.Exists(path))
+            return;
+
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        if (fs.Length == 0)
+            return;
+
+        fs.Seek(-1, SeekOrigin.End);
+        if (fs.ReadByte() != '\n')
+        {
+            fs.Seek(0, SeekOrigin.End);
+            fs.WriteByte((byte)'\n');
+        }
     }
 
     public void MarkQuestAsNotCompleted(string realmName, string charName, uint questId)
@@ -174,10 +232,31 @@ public class AccountMetaDataManager
         var dir = GetAccountCharacterMetaDataDirectory(realmName, charName);
         var path = Path.Combine(dir, COMPLETED_QUESTS_FILE);
 
-        string needle = questId.ToString();
-        List<string> lines = File.ReadAllLines(path).ToList();
-        lines.RemoveAll(l => l.Split(',').FirstOrDefault()?.Equals(needle) ?? false);
-        File.WriteAllLines(path, lines);
+        // Nothing persisted yet (e.g. a quest abandoned before any completion on a fresh character)
+        // -> nothing to remove. Without this guard File.ReadAllLines throws FileNotFoundException on
+        // the missing file.
+        if (!File.Exists(path))
+            return;
+
+        try
+        {
+            string needle = questId.ToString();
+            List<string> lines = File.ReadAllLines(path).ToList();
+            if (lines.RemoveAll(l => l.Split(',').FirstOrDefault()?.Equals(needle) ?? false) == 0)
+                return; // quest wasn't recorded -- don't rewrite the file needlessly
+
+            // Atomic rewrite (temp + move) so a kill mid-write (launcher force-kill on game close)
+            // can't truncate/corrupt the file -- matches GetAllCompletedQuests' self-heal and
+            // SaveQuestItemProgress. This was the last non-atomic writer of this file.
+            var tmp = path + ".tmp";
+            File.WriteAllLines(tmp, lines);
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            Log.Print(LogType.Error, $"Failed to rewrite completed_quests.csv (unmark {questId}) for " +
+                                     $"'{charName}@{realmName}': {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     public void SaveCharacterSettingsStorage(string realmName, string charName, PlayerSettings.InternalStorage settings)


### PR DESCRIPTION
`#408` hardened the **parsing** of `completed_quests.csv` (skip corrupt lines, dedupe) but left three **regular-play** I/O failure modes, below the parse, that can still crash login or silently lose a quest. This lands the `#408`-group follow-ups from the beta.2 review wave (#414). None of these guard against manual editing — only against what normal play produces: an AV file-lock, the launcher force-killing the proxy on game close, and torn appends.

## 1. Login-path read was unguarded → crash

`GetAllCompletedQuests` runs on the login path (`CompletedQuestTracker.Reload` → `HandlePlayerLogin`), and its `File.ReadAllLines` had no try/catch. A transient `IOException` — an AV scan hold or a sharing violation on the file — throws straight up and kills login. This is the **same crash class as #408**, one layer below the parse it already hardened.

**Fix:** wrap the read; on failure log and degrade to "no completed quests this session". The bits re-populate as quests are turned in, and the file self-heals on the next clean read. A single session of un-restored completion bits is invisible/cosmetic; a login crash is not.

## 2. `MarkQuestAsNotCompleted` — last non-atomic writer + missing-file crash

It did a direct `File.WriteAllLines` after an **unguarded** `File.ReadAllLines`:
- the read threw `FileNotFoundException` when a quest was unmarked before any completion existed (fresh character → no file yet);
- the write was non-atomic, so a kill mid-write (launcher force-kill on game close) could truncate/corrupt the file.

**Fix:** `File.Exists` guard (early-return — nothing to remove), a nothing-removed short-circuit (don't rewrite needlessly), and temp-file + atomic `File.Move` — matching the self-heal path and `SaveQuestItemProgress`. This was the file's last non-atomic writer.

## 3. `MarkQuestAsCompleted` — silent quest loss from a glued line

`AppendAllLines` after a **torn** prior append (a kill mid-write leaves no trailing newline) concatenates onto the partial last line:

```
"100,1780000000"  +  "200,1780000005"  →  "100,1780000000200,1780000005"
```

The glued line's first field (`100`) still parses, so **quest 200 is silently dropped** — and because the line parses fine, `needsRewrite` stays false, so the corrupt-line self-heal never fires. The #408 NUL-byte case already proves torn appends happen in the field; this is its *invisible* sibling.

**Fix:** `EnsureTrailingNewline` normalises the file's final byte before appending, and the append is wrapped so a locked file can't crash the turn-in (the in-memory `CompletedQuestTracker` set already reflects the completion for the session; only cross-restart persistence is briefly at risk).

## Tests

Extends `CompletedQuestParseTests`:
- `GluedLine_SilentlyLosesSecondId_DocumentsTheVector` — pins the loss: a glued line parses to `{100}` with `needsRewrite == false`.
- `EnsureTrailingNewline_MissingTrailingNewline_PreventsGluedAppend` — the fix; **red if the guard is removed** (the append glues and 200 is lost).
- idempotent-when-already-terminated, and no-op/no-throw on missing/empty.

Full suite **645/645**.

## Risk

Low, one-sided. Every change is a *degrade-instead-of-throw* or *make-atomic*; the happy path is unchanged. Worst case of the read-guard is one session without restored completion bits (self-heals next login); the atomic/append guards only remove failure modes. No timing or threading changes.

## Scope

Touches only `AccountDataManager.cs` + its test — no overlap with any open PR. Addresses the three `#408 (completed_quests.csv)` boxes in #414; the `#406` / `#399` / `#413` / `#404` boxes are other subsystems and remain open, so this does **not** close #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
