### PR TITLE
Fix item-proficiency tooltips: deliver SMSG_SET_PROFICIENCY in-world, in order (#410)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -17,7 +17,34 @@ public partial class WorldClient
         SetProficiency proficiency = new SetProficiency();
         proficiency.ProficiencyClass = packet.ReadUInt8();
         proficiency.ProficiencyMask = packet.ReadUInt32();
-        SendPacketToClient(proficiency);
+
+        // #410 (item-proficiency tooltip): Kronos front-loads the whole proficiency burst BEFORE
+        // SMSG_LOGIN_VERIFY_WORLD -- confirmed 2026-07-15 in both the legacy JSONL and the modern
+        // .pkt (9/9 SMSG_SET_PROFICIENCY arrive pre-verify, 0 after), matching twinhead #13649
+        // "item proficiency packet is sent at incorrect time". The 1.14 client isn't in world yet,
+        // so it appears to drop them: items it can't use don't turn red and wearable armor shows a
+        // spurious "Requires <ArmorType>" line. Hold each packet until the client is in world (the
+        // delay queue flushes right after we forward login-verify) so it can actually apply it.
+        //
+        // The !IsInWorld gate is load-bearing: a MID-SESSION proficiency change (training a new
+        // weapon type at a trainer) arrives AFTER login-verify, and there is no future login-verify
+        // to flush a delayed copy against -- delaying it would strand it forever. Relogin is already
+        // safe: the client-bound delay queue is intentionally not migrated across a WorldClient
+        // recreate (#384), and proficiency is re-sent fresh on each login.
+        //
+        // *** UNVERIFIED -- hypothesis test, NOT a confirmed fix. ***
+        // It is not yet established that the 1.14 client applies proficiency delivered AFTER
+        // login-verify. JimsPlus TooltipFix concluded the client "ignores" SMSG_SET_PROFICIENCY --
+        // but that was observed with the packet arriving early (i.e. this very bug); a post-verify
+        // delivery has never been tried. If the client still ignores it once in world, this change
+        // is simply inert (harmless) and the client-side TooltipFix stays necessary. Needs a live
+        // test with TooltipFix DISABLED: do unusable items go red / does the "Requires <ArmorType>"
+        // line disappear on wearable armor? Do NOT retire TooltipFix, and do not call this fixed,
+        // until that test is green.
+        if (!GetSession().GameState.IsInWorld)
+            SendPacketToClient(proficiency, Opcode.SMSG_LOGIN_VERIFY_WORLD);
+        else
+            SendPacketToClient(proficiency);
     }
     [PacketHandler(Opcode.SMSG_BUY_SUCCEEDED)]
     void HandleBuySucceeded(WorldPacket packet)

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -32,15 +32,14 @@ public partial class WorldClient
         // safe: the client-bound delay queue is intentionally not migrated across a WorldClient
         // recreate (#384), and proficiency is re-sent fresh on each login.
         //
-        // *** UNVERIFIED -- hypothesis test, NOT a confirmed fix. ***
-        // It is not yet established that the 1.14 client applies proficiency delivered AFTER
-        // login-verify. JimsPlus TooltipFix concluded the client "ignores" SMSG_SET_PROFICIENCY --
-        // but that was observed with the packet arriving early (i.e. this very bug); a post-verify
-        // delivery has never been tried. If the client still ignores it once in world, this change
-        // is simply inert (harmless) and the client-side TooltipFix stays necessary. Needs a live
-        // test with TooltipFix DISABLED: do unusable items go red / does the "Requires <ArmorType>"
-        // line disappear on wearable armor? Do NOT retire TooltipFix, and do not call this fixed,
-        // until that test is green.
+        // VERIFIED 2026-07-15 (Kronos V, TooltipFix disabled, Mage + Rogue): delivered in world,
+        // the 1.14 client DOES apply proficiency -- unusable items go red and the spurious
+        // "Requires <ArmorType>" line disappears on wearable armor. The earlier "the client ignores
+        // this packet" belief was an artifact of the pre-verify timing. NOTE: this only holds with
+        // the forward-order flush in SendDelayedPacketsToClientOnOpcode -- SMSG_SET_PROFICIENCY is a
+        // cumulative absolute mask (only the last, full one is correct), and the queue's old reverse
+        // flush collapsed multi-proficiency classes to the smallest mask (a Rogue to Leather-only /
+        // Sword1H-only, wrongly reddening cloth/thrown). Both are needed together.
         if (!GetSession().GameState.IsInWorld)
             SendPacketToClient(proficiency, Opcode.SMSG_LOGIN_VERIFY_WORLD);
         else

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -566,14 +566,19 @@ public partial class WorldClient
 
     private void SendDelayedPacketsToClientOnOpcode(Opcode opcode)
     {
-        if (_delayedPacketsToClient.ContainsKey(opcode))
+        // Flush in FORWARD (arrival) order. The old reverse loop sent last-queued first, which
+        // is fine for order-independent single packets (#384 name query) but CORRUPTS an
+        // order-sensitive multi-packet burst. #410 delays SMSG_SET_PROFICIENCY here: it's an
+        // absolute cumulative mask -- the server emits one packet per proficiency carrying the
+        // running total, so only the LAST (full) mask is correct and the client keeps the last
+        // one it processes. Reversed, a Rogue collapsed to Leather-only armor / Sword1H-only
+        // weapons (final mask = the FIRST, smallest one), wrongly reddening cloth/thrown/misc
+        // items it can use. Detach the list before sending so a re-entrant flush can't double-send.
+        if (_delayedPacketsToClient.TryGetValue(opcode, out var packets))
         {
-            List<ServerPacket> packets = _delayedPacketsToClient[opcode];
-            for (int i = packets.Count - 1; i >= 0; i--)
-            {
-                SendPacketToClientDirect(packets[i]);
-                packets.RemoveAt(i);
-            }
+            _delayedPacketsToClient.Remove(opcode);
+            foreach (var packet in packets)
+                SendPacketToClientDirect(packet);
         }
     }
 

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -567,7 +567,11 @@ public partial class WorldClient
     private void SendDelayedPacketsToClientOnOpcode(Opcode opcode)
     {
         // Flush in FORWARD (arrival) order. The old reverse loop sent last-queued first, which
-        // is fine for order-independent single packets (#384 name query) but CORRUPTS an
+        // this queue's other users happen to tolerate -- the cooldown-histories delay
+        // (SMSG_SEND_UNLEARN_SPELLS key) is always a single packet per flush, and the
+        // collision-height delay (SMSG_UPDATE_OBJECT key) holds packets for distinct movers,
+        // so order across them is irrelevant. (The #384 name-query delay lives on the
+        // SERVER-bound queue, not this one.) But reverse order CORRUPTS an
         // order-sensitive multi-packet burst. #410 delays SMSG_SET_PROFICIENCY here: it's an
         // absolute cumulative mask -- the server emits one packet per proficiency carrying the
         // running total, so only the LAST (full) mask is correct and the client keeps the last


### PR DESCRIPTION
The 1.14 (proxy) client rendered item-proficiency tooltips wrong: wearable cloth showed a spurious **"Requires Cloth"** line, and items a class *can't* use weren't marked red. Reported as #410 ("the client indicates hidden information").

## Root cause — proficiency timing
Kronos front-loads the whole `SMSG_SET_PROFICIENCY` burst **before** `SMSG_LOGIN_VERIFY_WORLD` — confirmed in both the legacy JSONL and the modern `.pkt` (9/9 pre-verify, 0 after). This matches Twinstar's own **twinhead #13649** ("item proficiency packet is sent at incorrect time"; Fixed 2026-07-01, but the early-send still reproduces on Kronos V). The modern client isn't in world yet when it arrives, so it discards it and never learns what the player can use — hence no red on unusable items and the leaked "Requires \<ArmorType\>" line. The old belief that "the 1.14 client ignores this packet" (which motivated the client-side JimsPlus TooltipFix workaround) was an artifact of exactly this mistiming.

This is **not** item data — `RequiredSkill` is untouched.

## Fix — two parts, both required
**1. Deliver proficiency in-world** (`ItemHandler.HandleSetProficiency`). Hold each `SMSG_SET_PROFICIENCY` in the client-bound delay queue keyed on `SMSG_LOGIN_VERIFY_WORLD` (the #384 mechanism) so it flushes the instant we forward login-verify. Gated on `!IsInWorld` — a mid-session proficiency change (training a weapon at a trainer) arrives *after* login-verify and must pass straight through, since there's no future login-verify to flush a delayed copy against. Relogin is already safe: the client-bound queue isn't migrated across a WorldClient recreate, and proficiency is re-sent fresh each login.

**2. Flush the delayed queue in forward (arrival) order** (`SendDelayedPacketsToClientOnOpcode`). `SMSG_SET_PROFICIENCY` is a *cumulative absolute mask* — the server emits one packet per proficiency carrying the running total, so only the **last** (full) mask is correct and the client keeps the last it processes. The queue's old **reverse** flush made the client end on the **first (smallest)** mask. Found via the Rogue test: armor collapsed to Leather-only (`0x04`), weapon to Sword1H-only (`0x80`), wrongly reddening cloth / thrown / dagger / xbow / misc items. (The Mage passed by luck — a mage's only armor proficiency is cloth, which survives every cumulative mask; its weapons were silently broken too, just never hovered.) Forward order is also correct for the queue's other users — the cooldown-histories delay (`SMSG_SEND_UNLEARN_SPELLS` key, always a single packet per flush) and the mount collision-height delay (`SMSG_UPDATE_OBJECT` key, packets for distinct movers). The #384 name-query delay lives on the **server-bound** queue and is untouched. The list is detached before sending so a re-entrant flush can't double-send.

## Verification (wire + visual, two classes)
On Kronos V with **TooltipFix disabled**:
- **Rogue `.pkt` (post-fix):** all 9 proficiency packets now arrive **after** login-verify, in increasing order, ending on the full masks — armor `0x07` (Misc+Cloth+Leather), weapon `0x5C180` (Sword1H/2H + Dagger + Thrown + Xbow). Mirror of the pre-fix `0x04` / `0x80`.
- **Visual:** the exact reported item (Tapered Pants, 6076) and other cloth render clean (no "Requires Cloth"); cloth/thrown/misc normal; an **axe the rogue can't use stays red** (its bit isn't in the mask — correct).
- **Mage:** wearable cloth clean.

## Interaction with JimsPlus TooltipFix
None harmful. TooltipFix only *recolors* existing subclass lines — it never adds the "Requires" text (that's native). With this fix the native client is the correct, authoritative source, and TooltipFix agrees with it (verified: "all addons off" == "JP red-text on", no visible difference), so it is benign redundancy. Retiring the recolor is optional future cleanup, best gated on detecting the fixed proxy so old-proxy users keep it as a fallback — out of scope here.

## Risk
Low. Timing/ordering only — no item data, no new packets; server-authoritative equip is unaffected (the pre-fix corruption was client-side tooltip state, never equip-blocking). The flush-order change is a strict correctness improvement for any multi-packet delayed burst and a no-op for single-packet ones.

## Scope
`ItemHandler.cs` (the delay) + `WorldClient.cs` (`SendDelayedPacketsToClientOnOpcode` forward flush). No open PR touches these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

