### PR TITLE
Forward channeled SPELL_START immediately during form-exit (#379 channel brick)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1759,9 +1759,20 @@ public partial class WorldClient
             if (casterIsLocalPlayer && Settings.FormExitStartDeferMs > 0 &&
                 GetSession().GameState.TryConsumeFormExitWindow())
             {
-                // Channeled casts report CastTime == 0 on the wire but never emit a SPELL_GO —
-                // stashing their START would orphan the channel bar. Defer them like cast-time.
-                if (spell.Cast.CastTime > 0 || isChanneled)
+                // #379 channel-brick: a channeled cast emits its SPELL_GO immediately after the START
+                // (not seconds later like a cast-time spell), so deferring the START lands it AFTER its
+                // own GO — the START-crosses-GO case that bricks the client cast state machine (stuck
+                // cast pose, Escape stops opening the game menu, no new cast animation until logout).
+                // Forward channeled STARTs immediately; the minor model-swap sound glitch beats the brick.
+                if (isChanneled)
+                {
+                    SendPacketToClient(spell);
+                    Log.Event("spell.start.form_exit_channel_immediate", new
+                    {
+                        spell_id = spell.Cast.SpellID,
+                    });
+                }
+                else if (spell.Cast.CastTime > 0)
                 {
                     var deferred = new FormExitDeferredStart { SpellId = spell.Cast.SpellID };
                     _formExitDeferredStart = deferred;


### PR DESCRIPTION
## Problem
Casting a **channeled** spell that auto-shifts the player **out of a form** bricks the client's cast state machine. After the channel ends: the casting pose sticks, no new cast animations show, and **Escape stops opening the game menu** (it's consumed cancelling a phantom cast) — until logout. Repro: **Tranquility from Moonkin form.**

## Root cause
The #379 form-exit path defers the local player's `SPELL_START` by `FormExitStartDeferMs` so the model swap renders before the cast visual, and it lumped channeled casts in with cast-time spells:

```
if (spell.Cast.CastTime > 0 || isChanneled) { /* defer START */ }
```

The comment there assumed channeled casts "never emit a SPELL_GO" so deferring their START was safe. But on Kronos a channeled cast emits its `SPELL_GO` **immediately** after the START (`SPELL_START → MSG_CHANNEL_START → SPELL_GO` within ~3ms — verified in JSONL). So the 100ms-deferred START lands **after its own GO** — the exact START-crosses-GO case the same code elsewhere warns "bricks the client cast state machine" (ice-92 / #379). For a cast-time spell the defer is harmless (its GO is seconds away); only channels hit this.

The server side closes the channel cleanly (`MSG_CHANNEL_UPDATE` forwarded, aura slot cleared) — the brick is purely the orphaned late START.

## Fix
Forward channeled `SPELL_START`s **immediately** during form-exit instead of deferring them (new `isChanneled` branch before the cast-time-defer / instant-stash branches). The minor model-swap sound glitch is far preferable to the brick. Cast-time (defer) and instant (stash) form-exit paths are unchanged. Logs `spell.start.form_exit_channel_immediate`.

## Testing
Validated in-game: Tranquility from Moonkin form — channel completes, Escape opens the menu afterward, new casts animate. Cast-time spells shifted out of a form (Wrath/Healing Touch from Moonkin) and normal non-form casts unchanged.