### PR TITLE
Fix RTT Pre-Fire Timer window at 400 ms; default SpellQueueWindowMs to 400

### DIFF
--- a/HermesProxy.Tests/World/RttPrefireTimerWindowTests.cs
+++ b/HermesProxy.Tests/World/RttPrefireTimerWindowTests.cs
@@ -1,0 +1,93 @@
+using System;
+using HermesProxy;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (rtt-prefire): admission-width tests for the shared GCD hold gate
+// (IsInGcdQueueWindow). Queue mode reads the configurable SpellQueueWindowMs; under
+// RTT Pre-Fire Timer the width is the fixed Settings.RttPrefireTimerWindowMs so the
+// launcher's greyed-out spell-queue dropdown can't silently govern Timer holds.
+// Remaining-time margins are hundreds of ms away from each boundary, far above
+// timer-tick coarseness, so the immediate re-read cannot flake.
+public class RttPrefireTimerWindowTests
+{
+    private static GameSessionData NewSessionWithGcdRemaining(long remainingMs)
+    {
+        var session = GameSessionData.CreateForTesting();
+        long now = Environment.TickCount64;
+        session.BeginGcd(now + remainingMs, now + remainingMs);
+        return session;
+    }
+
+    private static (bool lowLatency, global::Framework.RttPrefireMode prefire, int queueWindow) SaveSettings()
+        => (global::Framework.Settings.LowLatencyMode,
+            global::Framework.Settings.RttPrefire,
+            global::Framework.Settings.SpellQueueWindowMs);
+
+    private static void RestoreSettings((bool lowLatency, global::Framework.RttPrefireMode prefire, int queueWindow) saved)
+    {
+        global::Framework.Settings.LowLatencyMode = saved.lowLatency;
+        global::Framework.Settings.RttPrefire = saved.prefire;
+        global::Framework.Settings.SpellQueueWindowMs = saved.queueWindow;
+    }
+
+    [Fact]
+    public void IsInGcdQueueWindow_TimerActive_IgnoresConfiguredQueueWindow()
+    {
+        var saved = SaveSettings();
+        try
+        {
+            global::Framework.Settings.LowLatencyMode = true;
+            global::Framework.Settings.RttPrefire = global::Framework.RttPrefireMode.Timer;
+            global::Framework.Settings.SpellQueueWindowMs = 1300;
+
+            // 1200 ms out is inside the configured 1300 but outside Timer's fixed 400:
+            // the stored dropdown value must not widen Timer's admission.
+            var session = NewSessionWithGcdRemaining(1200);
+            Assert.False(session.IsInGcdQueueWindow());
+            session.CancelGcdHold();
+        }
+        finally { RestoreSettings(saved); }
+    }
+
+    [Fact]
+    public void IsInGcdQueueWindow_TimerActive_AdmitsInsideFixedWindow()
+    {
+        var saved = SaveSettings();
+        try
+        {
+            global::Framework.Settings.LowLatencyMode = true;
+            global::Framework.Settings.RttPrefire = global::Framework.RttPrefireMode.Timer;
+            // Deliberately hostile config: even 0 must not disable Timer's fixed window.
+            global::Framework.Settings.SpellQueueWindowMs = 0;
+
+            var session = NewSessionWithGcdRemaining(250);
+            Assert.True(session.IsInGcdQueueWindow());
+            session.CancelGcdHold();
+        }
+        finally { RestoreSettings(saved); }
+    }
+
+    [Fact]
+    public void IsInGcdQueueWindow_QueueMode_UsesConfiguredWindow()
+    {
+        var saved = SaveSettings();
+        try
+        {
+            global::Framework.Settings.LowLatencyMode = false;
+            global::Framework.Settings.RttPrefire = global::Framework.RttPrefireMode.Off;
+            global::Framework.Settings.SpellQueueWindowMs = 1300;
+
+            var wide = NewSessionWithGcdRemaining(1200);
+            Assert.True(wide.IsInGcdQueueWindow());
+            wide.CancelGcdHold();
+
+            global::Framework.Settings.SpellQueueWindowMs = 400;
+            var narrow = NewSessionWithGcdRemaining(1200);
+            Assert.False(narrow.IsInGcdQueueWindow());
+            narrow.CancelGcdHold();
+        }
+        finally { RestoreSettings(saved); }
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -70,7 +70,8 @@ public static class Settings
     public static bool LowLatencyMode;
     // JimsProxy (rtt-prefire): chain casts across the GCD boundary under Low-Latency mode.
     //   Off     — pure forward-everything (the plain LL behavior; default).
-    //   Timer   — a press landing inside the SpellQueueWindowMs tail of the GCD is held in
+    //   Timer   — a press landing inside the last RttPrefireTimerWindowMs (fixed 400 ms) of
+    //             the GCD is held in
     //             the existing hold slot and released by the BeginGcd timer at (estimated
     //             expiry − early-fire offset); SpellCastEarlyFireOffsetMs / OverrideRtt govern
     //             the offset exactly as in queue mode. Public advanced toggle.
@@ -84,6 +85,12 @@ public static class Settings
     // IdentityPinnedCastIdsActive).
     public static bool RttPrefireTimerActive => LowLatencyMode && RttPrefire == RttPrefireMode.Timer;
     public static bool RttPrefireKnockerActive => LowLatencyMode && RttPrefire == RttPrefireMode.Knocker;
+    // JimsProxy (rtt-prefire): Timer's hold-admission window is FIXED at the retail-accurate
+    // 400 ms and deliberately does not read SpellQueueWindowMs. The launcher greys the
+    // spell-queue controls under Low-Latency mode, so their stored value must not silently
+    // govern Timer (2026-07-15: a stored 1000 stretched Timer holds to ~500 ms and correlated
+    // with elevated stuck-lit button reports).
+    public const int RttPrefireTimerWindowMs = 400;
     // JimsProxy: suppress transient cast errors (NotReady, SpellInProgress) so
     // the client doesn't show red error text during rapid spam. Independent of
     // LowLatencyMode — useful as a companion setting but not required.
@@ -119,8 +126,10 @@ public static class Settings
     // JimsProxy (#313): width (ms) of the spell-queue hold window. A press arriving in the
     // last SpellQueueWindowMs of an active GCD or cast bar is held and fired at expiry; earlier
     // presses are forwarded and the server arbitrates (NOT_READY / SpellInProgress). Mirrors the
-    // 1.14 SpellQueueWindow contract. The launcher exposes 400 (retail-accurate) / 1000 / 1300
-    // (smoothest, closest to the old full-hold); lower values are allowed, capped at 1300 ms.
+    // 1.14 SpellQueueWindow contract. The launcher exposes 400 (retail-accurate, the default)
+    // / 1000 / 1300 (smoothest, closest to the old full-hold); lower values are allowed,
+    // capped at 1300 ms. Ignored by RTT Pre-Fire Timer, which uses the fixed
+    // RttPrefireTimerWindowMs instead.
     public static int SpellQueueWindowMs;
     // JimsProxy (PR #228 follow-up): synthesize SMSG_THREAT_UPDATE / HIGHEST /
     // CLEAR so the modern client's native threat APIs (UnitDetailedThreatSituation,
@@ -179,7 +188,7 @@ public static class Settings
             : rttPrefireStr.Equals("knocker", StringComparison.OrdinalIgnoreCase) ? RttPrefireMode.Knocker
             : RttPrefireMode.Off;
         FormExitStartDeferMs = Math.Clamp(config.GetInt("FormExitStartDeferMs", 100), 0, 300);
-        SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 1300), 0, 1300);
+        SpellQueueWindowMs = Math.Clamp(config.GetInt("SpellQueueWindowMs", 400), 0, 1300);
         ThreatEngine = config.GetBoolean("ThreatEngine", false);
         var serverTypeStr = config.GetString("ServerType", "Kronos");
         ServerType = serverTypeStr.Equals("Generic", StringComparison.OrdinalIgnoreCase)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -487,10 +487,13 @@ public sealed class GameSessionData
     }
 
     // JimsProxy (#313): the spell-queue hold-window width is configurable via
-    // Framework.Settings.SpellQueueWindowMs (400 retail-accurate / 1000 / 1300 smoothest;
-    // default 1300). The hold gates (IsInGcdQueueWindow / HasStartedCastInQueueWindow) read it
+    // Framework.Settings.SpellQueueWindowMs (default 400 retail-accurate / 1000 / 1300
+    // smoothest). The hold gates (IsInGcdQueueWindow / HasStartedCastInQueueWindow) read it
     // directly: a press in the last SpellQueueWindowMs of an active GCD or cast bar is held and
-    // fired at expiry; earlier presses are forwarded for the server to arbitrate.
+    // fired at expiry; earlier presses are forwarded for the server to arbitrate. Exception:
+    // under RTT Pre-Fire Timer the GCD gate ignores it and uses the fixed
+    // Settings.RttPrefireTimerWindowMs (the launcher greys the queue controls under LL, so
+    // their stored value must not govern Timer).
 
     // JimsProxy (issue #43): GCD hold-and-fire state. While the player is on a GCD (tracked
     // from SMSG_SPELL_GO), new CMSG_CAST_SPELL presses are held in _heldGcdCast instead of
@@ -2430,11 +2433,14 @@ public sealed class GameSessionData
     }
 
     /// <summary>
-    /// JimsProxy: narrow variant of IsGcdHoldActive — returns true only when the GCD has
-    /// at most SpellQueueWindowMs remaining. Mirrors the 1.14 client's SpellQueueWindow
-    /// semantics for the GCD case (instants pressed in the last 400 ms of the previous cast's
-    /// GCD get queued and fire on GCD expiry; earlier presses are forwarded and receive the
-    /// server's NOT_READY). Used by the HandleCastSpell GCD hold gate. The wider
+    /// JimsProxy: narrow variant of IsGcdHoldActive — returns true only when the GCD is inside
+    /// its hold-admission tail. Mirrors the 1.14 client's SpellQueueWindow semantics for the
+    /// GCD case (instants pressed in the tail of the previous cast's GCD get queued and fire
+    /// on GCD expiry; earlier presses are forwarded and receive the server's NOT_READY).
+    /// Queue mode reads the configurable Framework.Settings.SpellQueueWindowMs; under RTT
+    /// Pre-Fire Timer the width is the fixed Settings.RttPrefireTimerWindowMs (400 ms) so the
+    /// launcher's greyed-out spell-queue dropdown can't silently govern Timer holds.
+    /// Used by the HandleCastSpell GCD hold gate. The wider
     /// IsGcdHoldActive() remains for callers that need "is any GCD active at all"
     /// (e.g. the held-cast-on-failure release path in Client/SpellHandler.cs).
     /// </summary>
@@ -2443,7 +2449,10 @@ public sealed class GameSessionData
         lock (_gcdLock)
         {
             long remaining = _gcdExpireTimestampMs - Environment.TickCount64;
-            return remaining > 0 && remaining <= Framework.Settings.SpellQueueWindowMs;
+            long window = Framework.Settings.RttPrefireTimerActive
+                ? Framework.Settings.RttPrefireTimerWindowMs
+                : Framework.Settings.SpellQueueWindowMs;
+            return remaining > 0 && remaining <= window;
         }
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -346,7 +346,8 @@ public partial class WorldSocket
                     }
 
                     // JimsProxy (rtt-prefire, Timer): the single hold path LL re-admits. A press
-                    // landing inside the SpellQueueWindowMs tail of the GCD parks in the existing
+                    // landing inside the fixed RttPrefireTimerWindowMs (400 ms) tail of the GCD
+                    // parks in the existing
                     // hold slot and the BeginGcd timer (already armed at instant GO even under LL,
                     // C-SH:~1997) releases it at
                     // (estimated expiry − adaptive/manual early-fire offset) — the same
@@ -533,8 +534,9 @@ public partial class WorldSocket
                 // set up in SMSG_SPELL_GO will release it at (estimated GCD expiry - early offset).
                 // Mashing during GCD overwrites the held slot so only the most recent press fires.
                 //
-                // JimsProxy (1.14 SpellQueueWindow alignment): gate is the LAST 400 ms of the
-                // GCD, not the entire 1500 ms. Presses earlier than that are forwarded to the
+                // JimsProxy (1.14 SpellQueueWindow alignment): gate is the last
+                // SpellQueueWindowMs (default 400 ms) of the GCD, not the entire 1500 ms.
+                // Presses earlier than that are forwarded to the
                 // server, which returns NOT_READY; the client renders that as the standard
                 // "Spell is not ready yet" feedback. Matches what a real 1.14 server does with
                 // default SpellQueueWindow=400.


### PR DESCRIPTION
## What
Two window changes to the GCD hold-admission gate (`IsInGcdQueueWindow`):

- **RTT Pre-Fire Timer now uses a fixed 400 ms admission window** (new `Settings.RttPrefireTimerWindowMs` const). Timer no longer reads `SpellQueueWindowMs` at all — the gate branches on `RttPrefireTimerActive`, which is only true under Low-Latency mode, so queue mode cannot be affected by the branch.
- **`SpellQueueWindowMs` default drops 1300 → 400** (retail-accurate). The 0–1300 clamp is unchanged and explicitly configured values are honored exactly as before. The launcher writes this key on every settings save, so the new default only reaches configs that never had the key (standalone runs, never-saved installs).

Comment sweep: places claiming Timer holds "the `SpellQueueWindowMs` tail" now name the fixed window; stale "default 1300" notes updated.

## Why
The launcher greys the spell-queue controls under Low-Latency mode, but their stored value silently governed Timer's admission width — the 2026-07-15 design trap: a stored 1000 admitted holds up to ~594 ms before GCD expiry and stretched holds to ~500 ms, the timing regime correlated with the elevated stuck-lit-button nights (beta.1 soak verdict: Timer is a frequency amplifier on a pre-existing client glow race). Pinning the width at the retail-accurate 400 kills the hidden coupling and tightens Timer's press→response latency distribution. The queue-mode default moves to 400 for the same retail-accuracy reason, per user direction.

## Scope / risk
- Prefire off (the default) and queue mode with an explicit config value: byte-identical behavior — inert for every current cohort except Timer opt-ins, so the beta.1 soak stays valid.
- Timer opt-ins: max hold drops ~500 → ~375 ms; presses earlier than 400 ms out now forward immediately and the server arbitrates (plain-LL philosophy outside the window).
- Queue-mode users without a stored key (standalone / never-saved-settings): feel shifts from smoothest-1300 to retail-400 — earlier mid-GCD presses draw NOT_READY instead of being held. Launcher-side default alignment (dropdown preselect, read fallback, `SPELL_QUEUE_WINDOW_DEFAULT`) is a 3-line change handed to the launcher branch separately.
- `HasStartedCastInQueueWindow` (cast-bar tail, queue mode only) rides the new 400 default by design; Timer never holds cast-time presses.

## Tests
722/722. 3 new in `RttPrefireTimerWindowTests`, written red-first against the old gate: Timer ignores a configured 1300 at 1200 ms remaining (red→green), Timer admits at 250 ms even with a hostile `SpellQueueWindowMs=0` (red→green), queue mode still honors the configured width (green throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WbWe4jSQCMRzKeJDvALbL