### PR TITLE
Ack the launcher's stdin shutdown sentinel on stdout

### DIFF
--- a/HermesProxy.Tests/ServerStdinShutdownTests.cs
+++ b/HermesProxy.Tests/ServerStdinShutdownTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using HermesProxy;
+using Xunit;
+
+namespace HermesProxy.Tests;
+
+// JimsProxy: contract tests for the launcher stdin shutdown handshake. The wire tokens are
+// hardcoded literals on purpose — they are a cross-repo contract with the launcher's
+// HermesManager::stop (sentinel in on stdin, ack out on stdout); renaming either side
+// must break these tests.
+public class ServerStdinShutdownTests
+{
+    [Fact]
+    public void SentinelLine_AcksOnStdoutBeforeExitAndStops()
+    {
+        var stdout = new StringWriter();
+        var exitReasons = new List<string>();
+        string? stdoutAtExitTime = null;
+
+        Server.ListenForLauncherShutdown(
+            new StringReader("__LAUNCHER_SHUTDOWN__\n"),
+            stdout,
+            reason => { exitReasons.Add(reason); stdoutAtExitTime = stdout.ToString(); });
+
+        Assert.Equal(new[] { "stdin_launcher_shutdown" }, exitReasons);
+        // The ack must already be on stdout when the exit path starts — that ordering is
+        // what upgrades the launcher's wait from the 250 ms silent-grace to the full
+        // 3 s window before its taskkill fallback.
+        Assert.Contains("__PROXY_SHUTDOWN_ACK__", stdoutAtExitTime);
+        // And it must be a full line of its own, not a fragment.
+        Assert.Contains("__PROXY_SHUTDOWN_ACK__" + stdout.NewLine, stdout.ToString());
+    }
+
+    [Fact]
+    public void SentinelSurroundedByWhitespace_StillAcksAndExits()
+    {
+        var stdout = new StringWriter();
+        int exits = 0;
+
+        Server.ListenForLauncherShutdown(
+            new StringReader("   __LAUNCHER_SHUTDOWN__  \n"), stdout, _ => exits++);
+
+        Assert.Equal(1, exits);
+        Assert.Contains("__PROXY_SHUTDOWN_ACK__", stdout.ToString());
+    }
+
+    [Fact]
+    public void NonSentinelLines_AreIgnoredToEof_NoAckNoExit()
+    {
+        var stdout = new StringWriter();
+        int exits = 0;
+
+        // Includes a near-miss token (missing trailing underscores) — must not trigger.
+        Server.ListenForLauncherShutdown(
+            new StringReader("hello\n__LAUNCHER_SHUTDOWN\nnoise\n"), stdout, _ => exits++);
+
+        Assert.Equal(0, exits);
+        Assert.Equal(string.Empty, stdout.ToString());
+    }
+}

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -203,17 +203,29 @@ partial class Server
     // input is ignored.
     private const string LauncherShutdownSentinel = "__LAUNCHER_SHUTDOWN__";
 
+    // JimsProxy: written to stdout (own line, flushed) the moment the sentinel is accepted,
+    // BEFORE any shutdown work, so the launcher upgrades its wait from the 250 ms
+    // silent-grace to the full 3 s window (token contract shared with HermesManager::stop).
+    private const string LauncherShutdownAck = "__PROXY_SHUTDOWN_ACK__";
+
     private static void ListenForLauncherShutdown()
+        => ListenForLauncherShutdown(Console.In, Console.Out, ShutdownHooks.TriggerGracefulExit);
+
+    // JimsProxy: testable core of the stdin listener. Production wires Console.In/Console.Out
+    // and ShutdownHooks.TriggerGracefulExit (which never returns); tests substitute all three.
+    internal static void ListenForLauncherShutdown(TextReader stdin, TextWriter stdout, Action<string> triggerGracefulExit)
     {
         try
         {
             string? line;
-            while ((line = Console.In.ReadLine()) != null)
+            while ((line = stdin.ReadLine()) != null)
             {
                 if (line.Trim() == LauncherShutdownSentinel)
                 {
                     Log.Event("process.shutdown_request", new { source = "stdin", sentinel = LauncherShutdownSentinel });
-                    ShutdownHooks.TriggerGracefulExit("stdin_launcher_shutdown");
+                    stdout.WriteLine(LauncherShutdownAck);
+                    stdout.Flush();
+                    triggerGracefulExit("stdin_launcher_shutdown");
                     return;
                 }
                 // Any other stdin line is ignored.


### PR DESCRIPTION
## What
When the stdin listener accepts the launcher's `__LAUNCHER_SHUTDOWN__` sentinel, the proxy now writes `__PROXY_SHUTDOWN_ACK__` to stdout — its own line, flushed — **before** any shutdown work, then proceeds through the existing graceful-exit path (idempotent final JSONL event + flush + `Environment.Exit(0)`, ShutdownHooks.cs:111). The listener core is extracted to an internal `ListenForLauncherShutdown(TextReader, TextWriter, Action<string>)` overload so the handshake is unit-testable without `Environment.Exit`; the production wrapper wires `Console.In`/`Console.Out`/`ShutdownHooks.TriggerGracefulExit` exactly as before.

## Why
Launcher 2.0.2's Stop writes the sentinel to stdin and waits **ack-gated**: 250 ms silent-grace without an ack, the full 3000 ms window if it sees the ack token, then `taskkill /F`. The token was already coded launcher-side; the proxy never sent it, so every stop today runs on the 250 ms fallback. Surfaced and requested by the launcher session in the 5.1.9-beta.1 × 2.0.2 paired-release handshake.

## Scope / risk
- Ack is emitted only on the sentinel path, and the listener only spawns when stdin is redirected (`Console.IsInputRedirected`, Server.cs:67) — own-console runs are untouched.
- One extra stdout line that the launcher already expects; at worst (older launcher) it appears as a plain line in the Connection Log for the final moments before exit.
- No change to sentinel matching, the graceful-exit path, or any packet code.

## Tests
722/722 on the branch. 3 new contract tests in `ServerStdinShutdownTests`, written red-first against the pre-ack seam: ack-on-stdout-before-exit ordering (red→green), whitespace-padded sentinel still acks and exits (red→green), non-sentinel and near-miss lines ignored to EOF with no ack and no exit (green throughout). Wire tokens are hardcoded literals so a rename on either side breaks the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WbWe4jSQCMRzKeJDvALbL