### PR TITLE
Fix stuck-stunned re-attach logins: normalize the artificial logout-stun state at the first self-create

### DIFF
--- a/HermesProxy.Tests/World/StuckLogoutStunGateTests.cs
+++ b/HermesProxy.Tests/World/StuckLogoutStunGateTests.cs
@@ -1,0 +1,63 @@
+using HermesProxy.World.Client;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (stuck-logout-stun): gate for the artificial-logout-stun login fix. The detector
+// may only trip when the local player's create block carries UNIT_FLAG_STUNNED with ZERO
+// debuff auras — every genuine vanilla stun is a MOD_STUN debuff occupying a debuff slot in
+// the same create block, so a real stun must never open the gate (it would let the synthesized
+// CMSG_LOGOUT_CANCEL free a legitimately stunned player).
+public class StuckLogoutStunGateTests
+{
+    const uint Stunned = (uint)UnitFlagsVanilla.Stunned;
+    const uint InCombat = (uint)UnitFlagsVanilla.InCombat;
+    const uint PlayerControlled = (uint)UnitFlagsVanilla.PlayerControlled;
+
+    [Fact]
+    public void IsArtificialLogoutStun_StunnedFlagNoDebuffs_Trips()
+    {
+        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned, debuffAuraCount: 0));
+    }
+
+    // The 2026-07-17 incident wire state: stunned + in-combat on a player, zero debuffs
+    // (only Battle Stance / Find Minerals in the buff slots).
+    [Fact]
+    public void IsArtificialLogoutStun_IncidentFlagCombination_Trips()
+    {
+        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned | InCombat | PlayerControlled, debuffAuraCount: 0));
+    }
+
+    // Re-attach mid genuine stun: the stun's own debuff (e.g. Kidney Shot, War Stomp) is in
+    // the create block — gate must stay closed.
+    [Fact]
+    public void IsArtificialLogoutStun_StunnedWithDebuffPresent_DoesNotTrip()
+    {
+        Assert.False(WorldClient.IsArtificialLogoutStun(Stunned | InCombat, debuffAuraCount: 1));
+    }
+
+    [Fact]
+    public void IsArtificialLogoutStun_NoStunnedFlag_DoesNotTrip()
+    {
+        Assert.False(WorldClient.IsArtificialLogoutStun(InCombat | PlayerControlled, debuffAuraCount: 0));
+        Assert.False(WorldClient.IsArtificialLogoutStun(0, debuffAuraCount: 0));
+    }
+
+    // Non-stun debuffs (Dazed 1604 was live mid-session in the incident) close the gate too:
+    // a false negative is safe — no cure that login — while a false positive is not.
+    [Fact]
+    public void IsArtificialLogoutStun_StunnedWithHarmlessDebuff_DoesNotTrip()
+    {
+        Assert.False(WorldClient.IsArtificialLogoutStun(Stunned, debuffAuraCount: 2));
+    }
+
+    // Locks the vanilla slot layout the detector's buff/debuff partition assumes:
+    // 32 buffs then 16 debuffs (incident's Dazed landed in slot 32, the first debuff slot).
+    [Fact]
+    public void VanillaAuraSlotLayout_Is32BuffsPlus16Debuffs()
+    {
+        Assert.Equal(48, WorldClient.VanillaAuraSlotCount);
+        Assert.Equal(32, WorldClient.VanillaFirstDebuffSlot);
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -51,6 +51,18 @@ public static class Settings
     // Hard timeout on the reconnect attempt — beyond this, abandon and propagate DC.
     // Clamped to 1000..30000 in LoadAndVerifyFrom.
     public static int UnplannedReconnectTimeoutMs;
+    // JimsProxy (stuck-logout-stun): counter Kronos's incomplete reconnect cleanup. A fast
+    // same-character relogin after an abrupt in-combat disconnect re-attaches the session to
+    // the player object that lingered in-world; Kronos clears the logout root but leaves the
+    // aura-less "artificial" UNIT_FLAG_STUNNED, so the client logs in unable to cast or turn
+    // ("You can't do that while stunned") until a character switch. Detection fires once per
+    // login, on the first self create-block, only when the stunned flag arrives with zero
+    // debuff auras (every real vanilla stun occupies a debuff slot in the same block).
+    // CancelFix synthesizes a legacy CMSG_LOGOUT_CANCEL — the lineage server handler that
+    // removes the artificial stun. ClientStrip clears the bit from the forwarded create
+    // block so input isn't locked client-side even if the server ignores the cancel.
+    public static bool StuckLogoutStunCancelFix;
+    public static bool StuckLogoutStunClientStrip;
     // JimsProxy (clean handshake teardown): bound the realmd auth handshake. If realmd accepts
     // the TCP connection but never sends LOGON_CHALLENGE (half-accepting login server, load-shed,
     // firewall), the login thread would otherwise block forever ("stuck on Connecting..."). On
@@ -177,6 +189,8 @@ public static class Settings
         SpellCastEarlyFireOffsetMs = Math.Clamp(config.GetInt("SpellCastEarlyFireOffsetMs", 0), 0, 50);
         EnableUnplannedReconnect = config.GetBoolean("EnableUnplannedReconnect", false);
         UnplannedReconnectTimeoutMs = Math.Clamp(config.GetInt("UnplannedReconnectTimeoutMs", 5000), 1000, 30000);
+        StuckLogoutStunCancelFix = config.GetBoolean("StuckLogoutStunCancelFix", true);
+        StuckLogoutStunClientStrip = config.GetBoolean("StuckLogoutStunClientStrip", true);
         AuthHandshakeTimeoutMs = Math.Clamp(config.GetInt("AuthHandshakeTimeoutMs", 15000), 1000, 60000);
         EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -89,6 +89,13 @@ public sealed class GameSessionData
     public bool ChannelDisplayList;
     public bool ShowPlayedTime;
     public bool IsInFarSight;
+    // JimsProxy (stuck-logout-stun): state for the artificial-logout-stun login fix; all four
+    // reset at CMSG_PLAYER_LOGIN so every world login runs exactly one fresh detection. See
+    // WorldClient.DetectStuckLogoutStunAtSelfCreate (UpdateHandler.cs) for the mechanism doc.
+    public bool StuckStunLoginCheckDone;        // first-self-create gate: one detection per login
+    public bool StuckStunDetectedThisLogin;     // enables raw CAST_RESULT logging + the server-clear breadcrumb
+    public bool StuckStunCancelArmed;           // detection → end-of-UPDATE_OBJECT synth handoff
+    public bool AwaitingSynthLogoutCancelAck;   // swallow the next SMSG_LOGOUT_CANCEL_ACK (client never asked)
     // JimsProxy (taxi-flight-robustness): IsInTaxiFlight is read on the dismount Task's
     // ThreadPool thread and written on the packet-handler thread. Always access via
     // Volatile.Read/Write so weak-memory-model reorderings can't deliver stale state to

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -514,6 +514,14 @@ public partial class WorldClient
     void HandleLogoutCancelAck(WorldPacket packet)
     {
         GetSession().ClearLogoutIntentional();
+        // JimsProxy (stuck-logout-stun): this ack answers OUR synthesized CMSG_LOGOUT_CANCEL —
+        // the modern client never asked to cancel a logout, so don't surface the unsolicited ack.
+        if (GetSession().GameState.AwaitingSynthLogoutCancelAck)
+        {
+            GetSession().GameState.AwaitingSynthLogoutCancelAck = false;
+            Log.Event("login.stuck_stun.cancel_ack", null);
+            return;
+        }
         LogoutCancelAck logout = new LogoutCancelAck();
         SendPacketToClient(logout);
     }

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -310,6 +310,21 @@ public partial class WorldClient
         ReconcileTalentRankInjection();
     }
 
+    // JimsProxy (stuck-logout-stun): drain and hex-dump whatever the server appended beyond the
+    // fields we parse — the 2026-07-17 incident's CAST_RESULTs were 7 bytes on the wire, one more
+    // than the vanilla spellId+status+reason layout accounts for. Only called from the
+    // cast.result.while_stuck_stun captures, after all regular fields are consumed.
+    private static string ReadTrailingBytesHex(WorldPacket packet)
+    {
+        if (!packet.CanRead())
+            return "";
+        var sb = new System.Text.StringBuilder();
+        int guard = 0;
+        while (packet.CanRead() && guard++ < 16)
+            sb.Append(packet.ReadUInt8().ToString("X2"));
+        return sb.ToString();
+    }
+
     [PacketHandler(Opcode.SMSG_CAST_FAILED)]
     void HandleCastFailed(WorldPacket packet)
     {
@@ -327,6 +342,19 @@ public partial class WorldClient
             var status = packet.ReadUInt8();
             if (status != 2)
             {
+                // JimsProxy (stuck-logout-stun): while an artificial logout stun is live the
+                // server emits unsolicited own-cast CAST_RESULTs (2026-07-17 incident: one per
+                // Defensive State proc, ~2 s cadence) that the drop paths in this handler swallow
+                // silently. Their raw decode is the only record of WHAT the server refuses and
+                // WHY — capture while the condition is active. Twin below for status==2.
+                if (GetSession().GameState.StuckStunDetectedThisLogin)
+                    Log.Event("cast.result.while_stuck_stun", new
+                    {
+                        spell_id = spellId,
+                        status = status,
+                        trailing_hex = ReadTrailingBytesHex(packet),
+                    });
+
                 // JimsProxy (engineering-malfunction jam): a discarded CAST_FAILED can be a
                 // server-side substitute (e.g. Goblin Mortar -> Malfunction Explosion 13261) that
                 // preempted a forwarded item-use cast (13237). The item-use then never starts and
@@ -351,6 +379,19 @@ public partial class WorldClient
             arg1 = packet.ReadInt32();
         if (packet.CanRead())
             arg2 = packet.ReadInt32();
+
+        // JimsProxy (stuck-logout-stun): twin of the status!=2 capture above — a failed-status
+        // result's reason names the server's enforcement (e.g. 100 = vanilla Stunned).
+        if (GetSession().GameState.StuckStunDetectedThisLogin)
+            Log.Event("cast.result.while_stuck_stun", new
+            {
+                spell_id = spellId,
+                status = 2,
+                reason_id = reason,
+                arg1 = arg1,
+                arg2 = arg2,
+                trailing_hex = ReadTrailingBytesHex(packet),
+            });
 
         // JimsProxy (H7): NotReady / SpellInProgress is a duplicate-rejection — the press the
         // server bounced because another cast of the same spell is already in progress. Its

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2086,6 +2086,30 @@ public partial class WorldClient
             Log.Event("login.stuck_stun.client_strip", new { forwarded_flags = updateData.UnitData.Flags.Value });
         }
 
+        // JimsProxy (stuck-logout-stun, layer 4 — the ACTUAL latch, 2026-07-19 byte-diff):
+        // the re-attach create is serialized while the zombie still carries the logout
+        // root, so its movement block ships MovementFlagModern.Root as the client's BASE
+        // move state (stuck login create Flags=0x400 vs clean login 0x0, all else equal).
+        // Kronos fires the matching FORCE_MOVE_ROOT before the create — the client
+        // discards force ops for a mover it hasn't created — so the later
+        // FORCE_MOVE_UNROOT has no force-root to cancel and the mover is left in a
+        // contradictory half-rooted state: fwd/back/strafe work, facing input and the
+        // spell system stay locked for the whole session. Empirically the acked unroot
+        // does NOT lift the latch, and stripping the unit-flags stun bit alone did not
+        // unlock the client — the create's movement flags are the load-bearing byte.
+        // Clear the root from the forwarded create; the server's own unroot ~1 s later
+        // is then a no-op (the clean login shows unroot-while-unrooted is harmless).
+        if (Framework.Settings.StuckLogoutStunClientStrip &&
+            updateData.CreateData?.MoveInfo != null &&
+            (updateData.CreateData.MoveInfo.Flags & (uint)MovementFlagModern.Root) != 0)
+        {
+            updateData.CreateData.MoveInfo.Flags &= ~(uint)MovementFlagModern.Root;
+            Log.Event("login.stuck_stun.create_root_strip", new
+            {
+                forwarded_move_flags = updateData.CreateData.MoveInfo.Flags,
+            });
+        }
+
         if (Framework.Settings.StuckLogoutStunCancelFix)
             GetSession().GameState.StuckStunCancelArmed = true;
     }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -601,6 +601,18 @@ public partial class WorldClient
         // MIRASU (mc-rune-dousing): after the packet's own updates are out, push rune targetability for any boss life-state edges seen in it, and hide respawned circles around doused runes.
         FlushPendingMcRuneResyncs();
         SuppressMcCirclesOnDousedRunes();
+
+        // JimsProxy (stuck-logout-stun): fire the cure only after the whole update packet is
+        // processed and forwarded. Armed exclusively by DetectStuckLogoutStunAtSelfCreate;
+        // one shot per login.
+        if (GetSession().GameState.StuckStunCancelArmed)
+        {
+            GetSession().GameState.StuckStunCancelArmed = false;
+            GetSession().GameState.AwaitingSynthLogoutCancelAck = true;
+            WorldPacket cancel = new WorldPacket(Opcode.CMSG_LOGOUT_CANCEL);
+            SendPacketToServer(cancel);
+            Log.Event("login.stuck_stun.cancel_synthesized", null);
+        }
     }
 
     public void ReadNearObjectsBlock(WorldPacket packet, object index)
@@ -1884,6 +1896,8 @@ public partial class WorldClient
 
     private void AfterStoreObjectUpdateHook(WowGuid128 guid, ObjectType objectType, BitArray updateMaskArray, Dictionary<int, UpdateField> updates, AuraUpdate auraUpdate, PowerUpdate? powerUpdate, bool isCreate, ObjectUpdate updateData, BitArray changedValuesMask)
     {
+        DetectStuckLogoutStunAtSelfCreate(guid, updates, isCreate, updateData);
+
         // JimsProxy: comprehensive pet diagnostics for the Hunter-Pet-Stealth-Stuck
         // investigation. Fires on every UPDATE_OBJECT block targeting a pet GUID
         // OR the current pet (covers quest-tamed creatures which have a Creature/
@@ -1985,6 +1999,107 @@ public partial class WorldClient
                 SendPacketToClient(height, Opcode.SMSG_UPDATE_OBJECT);
             }
         }
+    }
+
+    // JimsProxy (stuck-logout-stun 2026-07-17): vanilla cores implement the logout countdown by
+    // writing a raw UNIT_FLAG_STUNNED + root + sit onto the player — no aura carries it (vmangos
+    // calls the state "artificially stunned"). When a session dies abruptly while in combat,
+    // Kronos keeps the body in-world, schedules its internal logout (applying that artificial
+    // stun), and a fast same-character relogin re-attaches the new session to the live object.
+    // vmangos's reconnect path removes the flag, unroots and stands the player back up; Kronos's
+    // demonstrably does only the unroot half (2026-07-17 incident: FORCE_MOVE_ROOT + UNROOT
+    // within 1 s of both re-logins, stunned flag never cleared, no aura beyond Battle Stance +
+    // Find Minerals). The orphaned flag blocks casting and turning client-side ("You can't do
+    // that while stunned") for the rest of the session; only a character switch — which forces
+    // the lingering object out of the world — clears it.
+    //
+    // Detection is one-shot per world login, on the FIRST create block for the local player,
+    // and only when the stunned flag arrives with ZERO debuff auras: every genuine vanilla stun
+    // is a MOD_STUN debuff occupying one of slots 32-47 of the same create block, so an aura-less
+    // stunned flag at login has exactly one producer — the logout machinery. A genuine stun at
+    // re-attach (debuff present) leaves the gate closed: a false negative is safe (no cure this
+    // login), a false positive is structurally impossible.
+    //
+    // Three layers, the last two individually toggleable:
+    //   tripwire — login.self_create_state always logs the raw wire state, gate hit or not
+    //   cure     — synthesize a legacy CMSG_LOGOUT_CANCEL (Settings.StuckLogoutStunCancelFix):
+    //              lineage cores' HandleLogoutCancelOpcode is the one client-reachable path that
+    //              removes the artificial stun (RemoveFlag + unroot + stand) — the same handler
+    //              every ordinary cancelled logout exercises. Armed here, sent after the whole
+    //              UPDATE_OBJECT finishes processing (end of HandleUpdateObject); the unsolicited
+    //              SMSG_LOGOUT_CANCEL_ACK is swallowed (CharacterHandler.HandleLogoutCancelAck).
+    //   strip    — clear the stunned bit from the create block we forward
+    //              (Settings.StuckLogoutStunClientStrip) so turn/cast input isn't locked
+    //              client-side even if the server ignores the cancel. The server still rejects
+    //              real casts until ITS state clears; the strip only restores input.
+    private void DetectStuckLogoutStunAtSelfCreate(WowGuid128 guid, Dictionary<int, UpdateField> updates, bool isCreate, ObjectUpdate updateData)
+    {
+        if (!isCreate || GetSession().GameState.StuckStunLoginCheckDone)
+            return;
+        if (guid != GetSession().GameState.CurrentPlayerGuid)
+            return;
+        // Vanilla-only: the slot layout and the incomplete-reconnect behavior are 1.12 facts.
+        if (!LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+            return;
+
+        int UNIT_FIELD_FLAGS = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_FLAGS);
+        int UNIT_FIELD_AURA = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_AURA);
+        int UNIT_FIELD_BYTES_1 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_BYTES_1);
+        if (UNIT_FIELD_FLAGS < 0 || UNIT_FIELD_AURA < 0)
+            return;
+
+        GetSession().GameState.StuckStunLoginCheckDone = true;
+
+        uint rawFlags = updates.TryGetValue(UNIT_FIELD_FLAGS, out var flagsField) ? flagsField.UInt32Value : 0;
+        uint standState = 0;
+        if (UNIT_FIELD_BYTES_1 >= 0 && updates.TryGetValue(UNIT_FIELD_BYTES_1, out var bytes1))
+            standState = bytes1.UInt32Value & 0xFF;
+
+        List<uint> buffSpellIds = new();
+        List<uint> debuffSpellIds = new();
+        for (int i = 0; i < VanillaAuraSlotCount; i++)
+        {
+            if (updates.TryGetValue(UNIT_FIELD_AURA + i, out var slot) && slot.UInt32Value != 0)
+                (i < VanillaFirstDebuffSlot ? buffSpellIds : debuffSpellIds).Add(slot.UInt32Value);
+        }
+
+        bool artificial = IsArtificialLogoutStun(rawFlags, debuffSpellIds.Count);
+
+        Log.Event("login.self_create_state", new
+        {
+            raw_unit_flags = rawFlags,
+            stunned = (rawFlags & (uint)UnitFlagsVanilla.Stunned) != 0,
+            stand_state = standState,
+            buff_spell_ids = buffSpellIds,
+            debuff_spell_ids = debuffSpellIds,
+            artificial_logout_stun = artificial,
+        });
+
+        if (!artificial)
+            return;
+
+        GetSession().GameState.StuckStunDetectedThisLogin = true;
+
+        if (Framework.Settings.StuckLogoutStunClientStrip && updateData.UnitData.Flags.HasValue)
+        {
+            updateData.UnitData.Flags &= ~(uint)UnitFlags.Stunned;
+            Log.Event("login.stuck_stun.client_strip", new { forwarded_flags = updateData.UnitData.Flags.Value });
+        }
+
+        if (Framework.Settings.StuckLogoutStunCancelFix)
+            GetSession().GameState.StuckStunCancelArmed = true;
+    }
+
+    // Vanilla aura slot layout: 32 buffs then 16 debuffs (the 2026-07-17 incident's Dazed
+    // landed in slot 32, the first debuff slot).
+    internal const int VanillaAuraSlotCount = 48;
+    internal const int VanillaFirstDebuffSlot = 32;
+
+    // Pure gate: the stunned flag with no debuff present cannot be a real stun — every vanilla
+    // MOD_STUN aura occupies a debuff slot in the same create block.
+    internal static bool IsArtificialLogoutStun(uint rawUnitFlags, int debuffAuraCount)
+    {
+        return (rawUnitFlags & (uint)UnitFlagsVanilla.Stunned) != 0 && debuffAuraCount == 0;
     }
 
     private bool ShouldClearMountDisplayOnDeadNonPlayerUnit(WowGuid128 guid, ObjectType objectType, ObjectUpdate updateData, Dictionary<int, UpdateField> updates, int mountDisplayField)
@@ -2624,6 +2739,21 @@ public partial class WorldClient
                 // set->clear edge. Done for ALL units, not only the local player, so groupmate FD/death is handled too.
                 GetSession().ThreatTracker.OnUnitCombatStateObserved(
                     guid, (updates[UNIT_FIELD_FLAGS].UInt32Value & (uint)UnitFlagsVanilla.InCombat) != 0);
+
+                // JimsProxy (stuck-logout-stun): adjudication breadcrumb — after a detection,
+                // the first self flags write WITHOUT the stunned bit is the server curing the
+                // artificial stun (canonically in response to our synthesized CMSG_LOGOUT_CANCEL).
+                // Also retires the raw CAST_RESULT capture in HandleCastFailed.
+                if (!isCreate && GetSession().GameState.StuckStunDetectedThisLogin &&
+                    guid == GetSession().GameState.CurrentPlayerGuid &&
+                    (updates[UNIT_FIELD_FLAGS].UInt32Value & (uint)UnitFlagsVanilla.Stunned) == 0)
+                {
+                    GetSession().GameState.StuckStunDetectedThisLogin = false;
+                    Log.Event("login.stuck_stun.cleared_by_server", new
+                    {
+                        raw_unit_flags = updates[UNIT_FIELD_FLAGS].UInt32Value,
+                    });
+                }
             }
             int UNIT_FIELD_FLAGS_2 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_FLAGS_2);
             if (UNIT_FIELD_FLAGS_2 >= 0 && updateMaskArray[UNIT_FIELD_FLAGS_2])

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -305,6 +305,11 @@ public partial class WorldSocket
         GetSession().GameState.IsConnectedToInstance = true;
         GetSession().GameState.IsFirstEnterWorld = true;
         GetSession().ClearLogoutIntentional();
+        // JimsProxy (stuck-logout-stun): fresh world login → fresh one-shot detection.
+        GetSession().GameState.StuckStunLoginCheckDone = false;
+        GetSession().GameState.StuckStunDetectedThisLogin = false;
+        GetSession().GameState.StuckStunCancelArmed = false;
+        GetSession().GameState.AwaitingSynthLogoutCancelAck = false;
         GetSession().GameState.CurrentPlayerGuid = playerLogin.Guid;
         GetSession().GameState.CurrentPlayerInfo = GetSession().GameState.OwnCharacters.Single(x => x.CharacterGuid == playerLogin.Guid);
         GetSession().GameState.CurrentPlayerStorage.LoadCurrentPlayer();


### PR DESCRIPTION
### Problem

Disconnecting abruptly while in combat (launcher close, client kill, network drop) leaves the character in-world. Logging back in quickly re-attaches the session to that live body — and the player arrives **unable to cast or turn** ("You can't do that while stunned"), with only forward/back/strafe working, for the entire session. Same-character relogs re-latch every time; historically only a character switch (which evicts the lingering body) escaped it. Original incident 2026-07-17 on Kronos V; reproduced deterministically on PTR (aggro mobs → close launcher mid-combat → relog within ~30 s at a spot where mobs drop combat and re-engage during the linger).

### Root cause (three server-side facts + one client latch)

1. Vanilla cores implement the logout countdown as an "artificial stun": raw `UNIT_FLAG_STUNNED` + root written onto the player with **no aura** behind them. Kronos applies it to the lingering body's scheduled logout; its re-attach cleanup unroots but never removes the flag (vmangos's reconnect path does — *"if the character had a logout request, then he is artificially stunned"*).
2. On re-attach, Kronos fires `FORCE_MOVE_ROOT` / `CLIENT_CONTROL_UPDATE` **before** the player's create object. The 1.14 client discards force-ops for a mover it hasn't created.
3. The create is serialized while the body still holds the logout root, so its movement block ships **`MovementFlagModern.Root` as the client's base move state**. The later `FORCE_MOVE_UNROOT` (delivered, acked) has no force-root to cancel — and empirically does **not** clear a create-baked root. The client latches: linear movement works, facing input and the spell system lock for the session. Byte-diff proof: stuck vs clean login for the same character in the same client process differ in exactly this field (`0x400` vs `0x0`).

### The fix — four layers, one gate

Gate: first self-create of a world login carrying the stunned flag with **zero debuff auras**. Every genuine stun/root is a debuff in the same create block, so real CC can never open the gate (false positives structurally impossible; a harmless debuff at login means a safe no-op).

1. **Tripwire (always on):** `login.self_create_state` logs raw flags/stand-state/aura slots every login; `cast.result.while_stuck_stun` captures unsolicited legacy CAST_RESULTs while the condition is live.
2. **Unit-flags strip** (`StuckLogoutStunClientStrip`, default on): remove the stunned bit from the forwarded create.
3. **Server cure** (`StuckLogoutStunCancelFix`, default on): synthesize a legacy `CMSG_LOGOUT_CANCEL` after the update packet is processed — the lineage handler that removes the artificial stun server-side; the unsolicited ack is swallowed; `login.stuck_stun.cleared_by_server` adjudicates.
4. **Create-root strip** (same toggle/gate — **the load-bearing fix**): clear `MovementFlagModern.Root` from the forwarded create's movement flags. The server's own unroot ~1 s later becomes a harmless no-op.

### Verification

- **A/B on PTR, same character, same spot, same trigger:** fix off → stuck 3/3 consecutive re-attach logins (client sent zero facing/cast packets; the server's own flag self-clear at +0.9 s did not unlatch it — proving layers 2–3 alone insufficient and the create flag load-bearing). Fix on (layer 4) → **latch never forms**: facing stream 1.5 s after login, keyboard turns, casts, all in the re-attach session (`jimsproxy-20260719-170552.jsonl`).
- **Ordinary logout-cancel regression pass:** two full logout→cancel cycles on the fix build; `SMSG_LOGOUT_CANCEL_ACK` delivered to the client both times, no swallow, no gate activity (`jimsproxy-20260719-171323.jsonl`).
- 6 new unit tests on the gate and slot layout; full suite 731 green; rebased over #426–#428.

### Limitations / follow-ups (not in this PR)

- The CANCEL layer's server-side effect is confirmed-harmless but unproven-necessary on Kronos V (PTR self-heals its flag in ~0.9 s; V's 07-17 incident did not — patch-note wording should stay tentative on that layer until a V-side confirmation).
- A *genuine* root at re-attach (aura present) keeps the gate closed and could still latch — rare; the general cure is the hold-and-replay stage of the world-entry-contract program, along with re-anchoring the login teleport synth to the self-create (deliberately excluded here — one variable per change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VxLJKSMNMcaRj8VZJtgRQ
