### PR TITLE
Translate six dropped legacy s2c opcodes; KnownBenignOpcodes audit fixes

### DIFF
--- a/DROPPED-S2C-AUDIT.md
+++ b/DROPPED-S2C-AUDIT.md
@@ -147,6 +147,17 @@ worklist): `CMSG_AUCTION_LIST_PENDING_SALES` (1,849), `CMSG_COMMERCE_TOKEN_GET_L
   (0x102). Modern client sends it empty (stop-emote); vanilla expects `u32 emoteId`. Possible translate
   = forward with `ONESHOT_NONE` to clear state-emotes for observers [INFERENCE — verify vanilla
   HandleEmoteOpcode semantics before touching].
+  **RESOLVED 2026-07-21 — translated.** Semantics verified: TC modern = empty CMSG_EMOTE means
+  `SetEmoteState(EMOTE_ONESHOT_NONE)`; vmangos = the 1.12 client only ever sends `ONESHOT_NONE(0)` or
+  `WAVE`, and on 0 the server clears `UNIT_NPC_EMOTESTATE` (`Unit::HandleEmote → HandleEmoteState(0)`),
+  so forwarding `{u32 0}` is byte-authentic vanilla traffic that stops observers from seeing a stuck
+  state emote. Corpus neighborhoods show it fires in the interaction-close burst (same-ms as
+  `CMSG_CLOSE_INTERACTION`, usually double-sent) and at movement moments — never adjacent to own casts.
+  Implemented with two guards: hold while the local channel window is open (mangos-family
+  `HandleEmoteOpcode` interrupts `ANIM_CANCELS`-flagged channels; window tracked from
+  `MSG_CHANNEL_START/UPDATE`, duration-bounded) and a 250 ms same-burst dedupe. Diagnostics:
+  `emote.stop_forwarded` / `emote.stop_skipped_channeling`. **`SMSG_SPELL_MISS_LOG` is now the only
+  deliberate holdout.**
 
 ## 6. KnownBenignOpcodes re-audit
 

--- a/DROPPED-S2C-AUDIT.md
+++ b/DROPPED-S2C-AUDIT.md
@@ -1,0 +1,211 @@
+# Dropped s2c packet audit — JimsProxy log corpus
+
+**Date:** 2026-07-20 · **Code audited at:** beta HEAD `e5a6898` (this worktree) · **Read-only pass — no code changed.**
+
+Goal: find legacy server→client opcodes the proxy drops that the 1.14 client could actually consume
+(generalizing the `MSG_MOVE_TIME_SKIPPED` precedent). Primary discovery channel: the structured JSONL
+drop events (`packet.untranslated`, `packet.ignored`).
+
+---
+
+## 1. Corpus
+
+| | |
+|---|---|
+| Files scanned | **521** JSONL (520 unique sessions; 1 duplicate skipped by name+size) |
+| Volume | **3.50 GB**, 19,027,372 lines, **0 parse errors** |
+| Date span | 2026-05-03 → 2026-07-20 (today) |
+| Proxy versions | 5.1.5-beta.6 → **5.1.9-beta.2** (all recent builds still show every finding below) |
+| Sources | box1 `kronoswow\Hermes\Logs` (176), box2 `kronoswow_box2\Hermes\Logs` (27), 14 test-build folders `Downloads\JimsProxy-*\Logs` (~250), tester-exported logs `Downloads\` root + `drive-download-*` (43, incl. 300 MB raid-day sessions) |
+| Searched, empty | Desktop diagnostics zips (none exist), `Desktop\World of Warcraft`, `proxy-publish-*` |
+
+Schema verified against `Framework/Logging/Log.cs` and the two emit sites
+(`WorldClient.cs:674/691` s2c, `WorldSocket.cs:430/441` c2s). Payload keys are snake_case
+(`direction` = `"s2c"`/`"c2s"`, `opcode_universal`, `opcode_raw`, `size`, `reason`).
+`size` is consistent with **2-byte legacy opcode word + body** across all 12 s2c opcodes.
+`opcode_raw` for s2c is the **legacy** (1.12) opcode value. `guid.legacy.unknown` (1,299 hits)
+confirmed as a separate class — excluded.
+
+**Opcode-table correction to the audit brief:** 1.14.2 builds resolve to the
+**`V2_5_3_41750`** opcode table, not `V1_14_1_40688` (`Opcodes.GetOpcodesDefiningBuild`,
+`Enums/Opcodes.cs:70-76`). All "modern slot" verdicts below are against `V2_5_3_41750`
+(cross-checked against `V1_14_1_40688`; identical presence for every candidate).
+
+## 2. Headline
+
+45 distinct dropped opcodes: **12 s2c** (the target class), 33 c2s.
+**8 of 12 s2c opcodes have a 1.14.2 dispatch slot.** Six are trivially translatable.
+One active misclassification landmine found in an unmerged branch (§6).
+
+## 3. Ranked triage table — s2c drops
+
+Sizes are min/mode/max (incl. 2-byte legacy opcode). "Slot" = present in `V2_5_3_41750`.
+
+| # | Universal opcode | Legacy → 1.14.2 raw | Hits | Sess | Size | Slot | Feasibility | Plausible lost behavior | Value | Conf |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 1 | `MSG_MOVE_TIME_SKIPPED` | 0x319 → `SMSG_MOVE_SKIP_TIME` 0x2E18 | **15,084** | **236** | 8/9/10 | **Y** | **trivial** | Observed players' movement time-base never corrected after their client hitches → jerky/lagging/warping *other* players | **STRONG** | high |
+| 2 | `SMSG_PET_MODE` | 0x17A → 0x258C | 297 | 4 | 14 | **Y** | **trivial** | Pet action-bar react/command state never server-synced (summon restore, charm/possess, server-side changes) | **STRONG** (pet classes; visible impact unconfirmed) | med |
+| 3 | `SMSG_QUEST_LOG_FULL` | 0x195 → 0x2A87 | 14 | 11 | 2 | **Y** | **trivial** (empty body) | Accepting a quest with a full log silently does nothing — no error shown | **STRONG** (per-event UX; classic "impossible to describe" bug) | med-high |
+| 4 | `SMSG_SPELL_OR_DAMAGE_IMMUNE` | 0x263 → 0x2C2F | 48 | 7 | 23 | **Y** | trivial | No "Immune" feedback for spells on immune targets (melee immune comes via ATTACKERSTATEUPDATE, which is translated) | WEAK | high |
+| 5 | `SMSG_PROC_RESIST` | 0x260 → 0x2752 | 557 | 33 | 23 | **Y** | trivial-moderate | Missing combat-log line when a weapon/aura proc is resisted → procs look like they silently did nothing | WEAK | med |
+| 6 | `SMSG_ITEM_TIME_UPDATE` | 0x1EA → 0x274B | 69 | 12 | 14 | **Y** | trivial | Duration-limited items don't tick/expire visibly; item countdown stale until relog | WEAK | high |
+| 7 | `SMSG_SPELL_MISS_LOG` | 0x24B → 0x2C41 | 14 | 7 | 28 | **Y** | moderate (modern shape unverified) | Spell-miss combat-log entries for the log-only miss path | WEAK | low-med |
+| 8 | `SMSG_UPDATE_LAST_INSTANCE` | 0x320 → 0x2681 | 4 | 4 | 6 | **Y** (struct exists, already synthesized at world-transfer, `Client/…/MovementHandler.cs:539`) | trivial | Last-instance hint outside transfers | WEAK→NONE | high |
+| 9 | `SMSG_SET_REST_START` | 0x21E → **none** | 870 | 405 | 6 | **N** | n/a | **None** — rested state is already delivered via `RestInfo` update fields (`UpdateHandler.cs:3774-3830`) | NONE | high |
+| 10 | `SMSG_WARDEN_DATA` | 0x2E6 → (Warden3 family only) | 839 | 414 | 39 | N (semantically) | not feasible/desirable | Anti-cheat bridging out of scope; Kronos demonstrably tolerates unanswered Warden (hours-long sessions) | NONE (class C) | high |
+| 11 | `SMSG_GAMEOBJECT_SPAWN_ANIM` | 0x214 → **none** | 421 | 36 | 10 | **N** | hard/speculative | GO spawn-in animation cosmetic (body = u64 GO guid only) | NONE→WEAK | med |
+| 12 | `SMSG_SPELL_UPDATE_CHAIN_TARGETS` | 0x330 → **none** | 9 | 3 | 26 | **N** | n/a | Chain-visual retargeting; modern chain visuals ride SPELL_GO | NONE | high |
+
+No bimodal size distributions — the only size variance (#1: 8/9/10) is packed-GUID length, not sub-cases.
+
+**High-frequency-everywhere flag (per brief):** `MSG_MOVE_TIME_SKIPPED` is the only s2c opcode
+dropped at high frequency in essentially every *play* session (236/520; absent only in login-only
+or solo-empty sessions; 7,322 hits in a single tester raid day). SET_REST_START/WARDEN appear in
+~80% of sessions but are the NONE class.
+
+## 4. Top translate-next candidates
+
+### 4.1 `MSG_MOVE_TIME_SKIPPED` → `SMSG_MOVE_SKIP_TIME` — the flagship
+- **Mechanism [SOURCED]:** vanilla server relays a nearby player's time skip to observers:
+  vmangos `HandleMoveTimeSkippedOpcode` rebroadcasts `MSG_MOVE_TIME_SKIPPED {PackedGuid mover, uint32 lag}`
+  to the move-set. Modern TrinityCore does the *identical* thing with the *identical* trigger, as
+  `SMSG_MOVE_SKIP_TIME {MoverGUID, uint32 TimeSkipped}` (`WorldSession::HandleMoveTimeSkippedOpcode`,
+  TC master `MovementHandler.cpp`). The 1.14.2 client both **sends** the CMSG (we already forward it,
+  `Server/PacketHandlers/MovementHandler.cs:341`) and **has the dispatch slot** for the SMSG (0x2E18).
+  Retail-era clients receive this packet routinely — it keeps the mover's movement-time base aligned.
+- **What dropping costs [INFERENCE, strong]:** when another player's client hitches (alt-tab, loading,
+  long GC), all their subsequent movement packets carry timestamps advanced by the skipped amount. Our
+  client never learns about the skip → observed-mover interpolation runs on a stale time base → the
+  *other* player appears to lag behind / warp / jitter until something re-syncs. This is squarely in the
+  long-standing "observed players stuck/warping" complaint family (same observed-unit-fidelity bucket
+  as #352's drawn-bow fix). 15k occurrences across every multiplayer session make it the highest-volume
+  untranslated s2c opcode by 18×.
+- **Implementation sketch:** Client handler reads PackedGuid + uint32 → translate GUID legacy→modern →
+  new `MoveSkipTime` ServerPacket (guid128 + uint32; struct doesn't exist yet, pattern = `SuspendToken`,
+  `MovementPackets.cs:773`). Guard: skip if the unit is destroyed/unknown to the client (same rationale
+  as the existing `movement.dropped_stray_after_destroy` guard — 53k such events show stray movement
+  after destroy is common). The MOVEMENT_SYNTH_PATTERN.md deferred-synth trap does **not** apply (this
+  is a peer-mover broadcast, not a self-movement reset) — but see Unknown U1.
+- **Blocker to kill (§6):** `mongrul/alpha` commit `eb31138` silently benign-lists this opcode on the
+  false premise that "the modern 1.14 client doesn't have an equivalent inbound opcode." It must not
+  merge; the correct disposition is translation.
+
+### 4.2 `SMSG_PET_MODE` — pet-bar state sync (hunters/warlocks)
+- **Mechanism:** vanilla sends `{u64 petGuid, u32 packedMode}` (body 12 = observed size 14−2)
+  whenever the pet's react/command state is set server-side (stance clicks are acked this way; charm/
+  possess and summon-restore also emit it) [reference-core knowledge; packing layout to verify against
+  cmangos-classic at impl]. Modern packet [SOURCED, TC master `PetPackets.cpp`]:
+  `PetMode { PetGUID; uint8 CommandState; uint8 Flag; uint8 ReactState }` — same information, unpacked.
+- **Cost of dropping:** every server-side mode change is invisible; the pet bar shows whatever the
+  client last assumed. 242 drops in one tester hunter session (2026-05-26) = the whole session's worth
+  of acks. Self-clicks are probably optimistic client-side, so the visible loss concentrates in
+  desync cases (state restored on summon, feign death, charm) — mechanism solid, user-visible impact
+  **unconfirmed** (no pet-bar bug reports in hand; also nobody has played a pet class in the corpus
+  since May 26, which is why last-seen is old — the gap is live on beta, no handler exists).
+- **Gain:** closes an entire class-family desync channel for two classes, at ~20 lines.
+
+### 4.3 `SMSG_QUEST_LOG_FULL` — un-silence a silent failure
+- Empty-body packet, slot 0x2A87, modern struct is literally
+  `QuestLogFull : ServerPacket(SMSG_QUEST_LOG_FULL, 0)` [SOURCED, TC master `QuestPackets.h`].
+  Translation = forward the opcode. 11 different sessions hit it — real players with full logs clicked
+  "Accept" and got nothing. Only open question is whether the 1.14 client renders the red error from
+  this opcode or expects `SMSG_DISPLAY_GAME_ERROR` (U4) — send-and-see, zero risk.
+
+### 4.4 Combat-log fidelity bundle (one small PR)
+`SMSG_SPELL_OR_DAMAGE_IMMUNE` (body u64+u64+u32+u8 → modern `{CasterGUID, VictimGUID, uint32 SpellID,
+1-bit IsPeriodic}` [SOURCED]) + `SMSG_PROC_RESIST` (→ modern `{Caster, Target, int32 SpellID, optional
+Rolled/Needed}` — send with optionals absent [SOURCED]) + `SMSG_ITEM_TIME_UPDATE` (u64+u32 → identical
+modern shape [SOURCED]). All three are read-N-fields → write-N-fields translations with no state.
+Individually WEAK; bundled they remove ~700 corpus drops of player-visible combat-log/countdown loss.
+
+## 5. Correctly dropped — leave alone (do not re-litigate)
+
+**s2c:**
+- `SMSG_WARDEN_DATA` — class C. Bridging 1.12 Warden modules to a 1.14 client is neither feasible nor
+  desirable; corpus proves Kronos tolerates unanswered Warden. *Housekeeping suggestion (not done):*
+  re-tag to `packet.ignored` with an accurate reason — it is the #3 noisiest `untranslated` and is pure
+  alarm fatigue.
+- `SMSG_SET_REST_START` — correctly benign **in effect** (no 1.14.2 slot), but the entry's comment is
+  wrong in both directions (§6).
+- `SMSG_GAMEOBJECT_SPAWN_ANIM`, `SMSG_SPELL_UPDATE_CHAIN_TARGETS` — no 1.14.2 slot; cosmetic loss only.
+  Benign-list candidates *with correct citations* ("absent from V2_5_3_41750"), not with vibes.
+
+**c2s ignored list (all 34 entries):** mechanically validated — **zero** of them exist in the
+`V1_12_1_5875` table (script in §8). Semantic-twin caveats, all resolved safe:
+`CMSG_GUILD_GET_RANKS` (ranks already push-synthesized, `Client/…/GuildHandler.cs:279` → `SMSG_GUILD_RANKS`),
+`CMSG_REQUEST_FORCED_REACTIONS` (vanilla is push-based, rare content), `CMSG_GM_TICKET_GET_CASE_STATUS`
+(login poll; vanilla ticket family is separate — watch the help UI, low risk).
+
+**c2s untranslated → benign-able** (scoped separately from this audit's s2c target, listed for the
+worklist): `CMSG_AUCTION_LIST_PENDING_SALES` (1,849), `CMSG_COMMERCE_TOKEN_GET_LOG` (1,606),
+`CMSG_SET_ROLE`, `CMSG_REORDER_CHARACTERS`, `CMSG_ENGINE_SURVEY`, `CMSG_SET_ADVANCED_COMBAT_LOGGING`,
+`CMSG_USED_FOLLOW` — all with no 1.12 target. Two that are *not* mere noise:
+- `CMSG_SUSPEND_TOKEN_RESPONSE` (147/60 sessions): the proxy itself **sends** `SuspendToken`
+  (`Client/…/MovementHandler.cs:409`) — the client's ack should be consumed by a no-op handler, not
+  logged as a translation gap.
+- `CMSG_EMOTE` (1,260/216 sessions): the **only** c2s untranslated opcode with a same-name 1.12 opcode
+  (0x102). Modern client sends it empty (stop-emote); vanilla expects `u32 emoteId`. Possible translate
+  = forward with `ONESHOT_NONE` to clear state-emotes for observers [INFERENCE — verify vanilla
+  HandleEmoteOpcode semantics before touching].
+
+## 6. KnownBenignOpcodes re-audit
+
+- **List-level: sound.** All 35 entries hold against the opcode tables (34 c2s absent from 1.12;
+  the 1 s2c entry absent from 1.14.2).
+- **`SMSG_SET_REST_START` inline note is wrong twice** (`KnownBenignOpcodes.cs:96-99`): it claims the
+  modern client "still expects this for rested XP banner" (it *cannot* — no such opcode in 1.14.2) and
+  that not translating loses rested visual feedback (rested state is already translated via
+  `PLAYER_REST_STATE_EXPERIENCE` → `ActivePlayerData.RestInfo`, `UpdateHandler.cs:3774-3830`).
+  The "filed as backlog" item is phantom — delete it. (Quick in-game confirm of the zzz icon closes it.)
+- **Header comment stale** (`:7-9`): cites `SMSG_TRAINER_BUY_SUCCEEDED` as a benign-drop example, but it
+  has since been *translated* (`Client/…/NPCHandler.cs:305`) — which is also the house precedent that
+  benign entries can graduate to real translations.
+- **Landmine: `eb31138` on `mongrul/alpha` (unmerged)** adds `Opcode.MSG_MOVE_TIME_SKIPPED` to the
+  benign list stating "The modern 1.14 client doesn't have an equivalent inbound opcode and handles peer
+  drift via its own movement extrapolation" — **false**: `SMSG_MOVE_SKIP_TIME = 0x2E18` exists in both
+  `V2_5_3_41750` and `V1_14_1_40688`, and modern servers actively send it. This is exactly the
+  misclassification pattern the audit was commissioned to catch. Recommendation: do not merge; translate
+  instead (§4.1). Every corpus build, including the tested `5.1.8-alpha.1+46(b41eb0c)`, predates this
+  commit — the corpus still logs the drop loudly.
+- **Process rule reaffirmed by this audit:** a benign-list addition must cite absence from
+  `V2_5_3_41750` (for s2c) or `V1_12_1_5875` (for c2s). Both existing mistakes were comment/premise
+  errors, not table errors.
+
+## 7. Symptom correlation — honest result
+
+No statistical signal. The six symptom-named sessions ("stuck sunder" ×2, "stuck BS near yetis",
+"Plague cloud not clearing", "stuck at completed window", "late melee swing after death") contain only
+the ambient drop set — no candidate spikes near any of them (the Plague-cloud session notably has
+**zero** `SMSG_GAMEOBJECT_SPAWN_ANIM`, killing the tempting GO-visual link). The correlation case for
+the candidates is therefore **mechanistic, not temporal**:
+
+- `MOVE_SKIP_TIME` ↔ the chronic "observed players lag/warp/rubber-band" family (only candidate with
+  both ubiquity and a direct mechanism).
+- `PET_MODE` ↔ any future "pet bar shows wrong stance" report.
+- `QUEST_LOG_FULL` ↔ "clicked accept, nothing happened".
+- Explicit negative: **none of these drops plausibly feeds the stuck-spell-visual investigation**
+  (lifecycles #1/#2) — the dropped SPELL_* opcodes are combat-log-only. That question is closed here.
+
+## 8. Explicit unknowns & capture asks
+
+| # | Unknown | How to resolve |
+|---|---|---|
+| U1 | Does the proxy rebase observed-mover movement times anywhere (which would partially mask or interact with SKIP_TIME)? | Implementation-time review of the movement translation path before wiring §4.1. |
+| U2 | 1.14.2 wire layout of `MoveSkipTime`/`PetMode`/`ProcResist` etc. — TC **master** (retail) shapes are sourced; classic-era 2.5.3 could differ in bit-packing. | Check WowPacketParser classic-era modules (or a .pkt) per packet at impl time. These are simple packets; risk is low. |
+| U3 | Vanilla `SMSG_PET_MODE` u32 packing (react/command/flags bit order). | cmangos-classic/vmangos source read at impl; 30 seconds. |
+| U4 | Does the 1.14 client render the "quest log is full" red error from `SMSG_QUEST_LOG_FULL`, or only via `SMSG_DISPLAY_GAME_ERROR`? | Send-and-see with a full log (12-quest character, accept a 13th). |
+| U5 | `SMSG_PET_MODE` visible impact on current build. | Capture ask: one hunter/warlock session on 5.1.9+, toggle pet stances, feign death, note any pet-bar mismatch; the JSONL will show the drops regardless. |
+| U6 | What content triggers `SMSG_GAMEOBJECT_SPAWN_ANIM` bursts (120/session peaks)? Payload GUID isn't logged. | Only if someone wants the cosmetic: a vanilla-side .pkt capture, or temporarily log the guid at the drop site. Not worth a slot otherwise. |
+| U7 | Post-fix validation for §4.1. | Two-box capture: box A alt-tabs 10 s while moving in view of box B; compare box B's view of A before/after the translation. |
+
+## 9. Method appendix
+
+- Aggregator: `aggregate_drops.py` (session scratchpad), one pass over all files; per-opcode
+  count / session set / size histogram / raws / first-last timestamps / per-session counts; full
+  output in `agg_summary.json`.
+- Direction values are lowercase `s2c`/`c2s`; s2c `opcode_raw` is the legacy wire value (decimal).
+- Universal↔version mapping: `Enums/Opcodes.cs` (`GetOpcodeValueForVersion` = name-based lookup into
+  the per-build enum; presence in `V2_5_3_41750/Opcode.cs` ⇒ the 1.14.2 client has a dispatch slot).
+- Modern packet shapes quoted from TrinityCore master (`MovementHandler.cpp`, `PetPackets.cpp`,
+  `CombatLogPackets.cpp`, `ItemPackets.cpp`, `QuestPackets.h`); legacy relay behavior from vmangos
+  (`MovementHandler.cpp`). Legacy body sizes corroborated against the corpus size column for all 12.

--- a/HermesProxy.Tests/World/DroppedS2CTranslationPacketTests.cs
+++ b/HermesProxy.Tests/World/DroppedS2CTranslationPacketTests.cs
@@ -1,0 +1,128 @@
+using System;
+using Framework.IO;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Byte-layout tests for the ServerPacket structs added by the dropped-s2c
+// translation pass (DROPPED-S2C-AUDIT.md): write via the ISpanWritable fast
+// path, read back with WorldPacket (the modern-side reader), and assert the
+// field order/types match the sourced wire shapes (WPP 3.4-classic parsers /
+// TrinityCore master Write() implementations).
+public class DroppedS2CTranslationPacketTests
+{
+    static DroppedS2CTranslationPacketTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    private static WowGuid128 PlayerGuid => WowGuid128.Create(HighGuidType703.Player, 4242);
+    private static WowGuid128 CreatureGuid => WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 777);
+
+    private static WorldPacket WriteViaSpan(ISpanWritable packet)
+    {
+        byte[] buffer = new byte[Math.Max(packet.MaxSize, 1)];
+        int written = packet.WriteToSpan(buffer);
+        Assert.InRange(written, 0, packet.MaxSize);
+        return new WorldPacket(0, buffer.AsSpan(0, written).ToArray());
+    }
+
+    [Fact]
+    public void PetMode_Layout_GuidThenCommandFlagReact()
+    {
+        var packet = new PetMode
+        {
+            PetGUID = CreatureGuid,
+            CommandState = CommandStates.Follow,
+            Flag = 0x8,
+            ReactState = ReactStates.Aggressive,
+        };
+
+        WorldPacket reader = WriteViaSpan(packet);
+
+        Assert.Equal(CreatureGuid, reader.ReadPackedGuid128());
+        Assert.Equal((byte)CommandStates.Follow, reader.ReadUInt8());
+        Assert.Equal((byte)0x8, reader.ReadUInt8());
+        Assert.Equal((byte)ReactStates.Aggressive, reader.ReadUInt8());
+        Assert.False(reader.CanRead());
+    }
+
+    [Fact]
+    public void QuestLogFull_Layout_EmptyBody()
+    {
+        var packet = new QuestLogFull();
+
+        byte[] buffer = new byte[1];
+        Assert.Equal(0, packet.WriteToSpan(buffer));
+        Assert.Equal(0, packet.MaxSize);
+    }
+
+    [Fact]
+    public void ItemTimeUpdate_Layout_GuidThenDuration()
+    {
+        var packet = new ItemTimeUpdate { ItemGuid = PlayerGuid, DurationLeft = 900 };
+
+        WorldPacket reader = WriteViaSpan(packet);
+
+        Assert.Equal(PlayerGuid, reader.ReadPackedGuid128());
+        Assert.Equal(900u, reader.ReadUInt32());
+        Assert.False(reader.CanRead());
+    }
+
+    [Fact]
+    public void SpellOrDamageImmune_Layout_GuidsSpellThenPeriodicBit()
+    {
+        var packet = new SpellOrDamageImmune
+        {
+            CasterGUID = CreatureGuid,
+            VictimGUID = PlayerGuid,
+            SpellID = 25990,
+            IsPeriodic = false,
+        };
+
+        WorldPacket reader = WriteViaSpan(packet);
+
+        Assert.Equal(CreatureGuid, reader.ReadPackedGuid128());
+        Assert.Equal(PlayerGuid, reader.ReadPackedGuid128());
+        Assert.Equal(25990u, reader.ReadUInt32());
+        Assert.False(reader.ReadBit());
+        Assert.False(reader.CanRead());
+    }
+
+    [Fact]
+    public void ProcResist_Layout_GuidsSpellThenTwoFalseOptionalBits()
+    {
+        var packet = new ProcResist
+        {
+            Caster = PlayerGuid,
+            Target = CreatureGuid,
+            SpellID = 21992,
+        };
+
+        WorldPacket reader = WriteViaSpan(packet);
+
+        Assert.Equal(PlayerGuid, reader.ReadPackedGuid128());
+        Assert.Equal(CreatureGuid, reader.ReadPackedGuid128());
+        Assert.Equal(21992u, reader.ReadUInt32());
+        Assert.False(reader.ReadBit()); // HasRolled
+        Assert.False(reader.ReadBit()); // HasNeeded
+        Assert.False(reader.CanRead());
+    }
+
+    [Fact]
+    public void UpdateLastInstance_Layout_MapIdOnly()
+    {
+        var packet = new UpdateLastInstance { MapID = 409 };
+
+        WorldPacket reader = WriteViaSpan(packet);
+
+        Assert.Equal(409u, reader.ReadUInt32());
+        Assert.False(reader.CanRead());
+    }
+}

--- a/HermesProxy.Tests/World/RecentlyDestroyedSuppressionTests.cs
+++ b/HermesProxy.Tests/World/RecentlyDestroyedSuppressionTests.cs
@@ -21,10 +21,12 @@ public class RecentlyDestroyedSuppressionTests
     {
         var state = WowGuidTestHelper.CreateMockGameSessionData();
         // The mock is built via GetUninitializedObject, which skips field initializers —
-        // initialize the one private field this suite exercises.
+        // initialize the fields this suite's code paths touch.
         typeof(GameSessionData)
             .GetField("_recentlyDestroyedObjects", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .SetValue(state, new System.Collections.Concurrent.ConcurrentDictionary<WowGuid128, long>());
+        // MarkObjectRecentlyDestroyed also drops the unit's observed-emote latch.
+        state.ObservedLoopingEmoteByUnit = new();
         return state;
     }
 

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -142,6 +142,26 @@ public sealed class GameSessionData
     // JimsProxy (emote-stop double-send collapse): the modern client emits
     // CMSG_EMOTE twice within the same interaction-close burst; forward one.
     public long LastEmoteStopForwardMs;
+    // JimsProxy (observed-dance loop): per-unit looping-emote latch for OTHER
+    // units — the 1.14 client loops EMOTE_ONESHOT_DANCE for any unit until
+    // another SMSG_EMOTE arrives for it, and the 1.12 server never sends a
+    // stop (corpus: 27 of 30 dance broadcasts were for other units, zero
+    // player emote-state field activity in 526 sessions). Self stays on the
+    // c2s move-start latch above (the server never echoes our own moves);
+    // observed units break on their s2c translational move-start — the same
+    // rule the 1.12 client applies locally. Entries are replaced/cleared by
+    // any newer SMSG_EMOTE for the unit and dropped on unit destroy.
+    public ConcurrentDictionary<WowGuid128, uint> ObservedLoopingEmoteByUnit = new();
+
+    /// <summary>True while the local player's channel window (tracked from
+    /// MSG_CHANNEL_START/UPDATE) is open, with a small grace margin. Used to
+    /// hold c2s emote forwards — mangos-family emote handlers interrupt
+    /// channels and strip auras flagged ANIM_CANCELS (#244).</summary>
+    public bool IsLocalChannelWindowOpen()
+    {
+        return LocalChannelSpellId != 0 &&
+               Environment.TickCount64 < LocalChannelEndTickMs + 2000;
+    }
     public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;
@@ -370,6 +390,9 @@ public sealed class GameSessionData
         if (guid.IsEmpty())
             return;
         _recentlyDestroyedObjects[guid] = Environment.TickCount64;
+        // A destroyed unit can't end its looping emote anymore — drop any latch
+        // so a later re-appearance can't trigger a stale stop synth.
+        ObservedLoopingEmoteByUnit.TryRemove(guid, out _);
         // Opportunistic hygiene sweep so a long session of spawns/despawns can't grow this
         // unbounded. Only long-stale entries go; recent marks are never evicted for size —
         // evicting a live mark would reopen the leak in exactly the crowded scenes that grow it.

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -131,6 +131,17 @@ public sealed class GameSessionData
     // a stop SMSG_EMOTE on the first movement-start packet.
     public uint LastLoopingEmoteId; // 0 means no active loop
     public long LastLoopingEmoteTickMs;
+    // JimsProxy (emote-stop channel guard): the local player's active channel
+    // window, tracked from MSG_CHANNEL_START / MSG_CHANNEL_UPDATE (vanilla
+    // sends both only to the caster). The CMSG_EMOTE(0) stop-forward must not
+    // fire mid-channel — mangos-family HandleEmoteOpcode interrupts channels
+    // flagged ANIM_CANCELS. End-time bounded by the start's own duration so a
+    // missed 0-update can never wedge the guard permanently.
+    public uint LocalChannelSpellId; // 0 means not channeling
+    public long LocalChannelEndTickMs;
+    // JimsProxy (emote-stop double-send collapse): the modern client emits
+    // CMSG_EMOTE twice within the same interaction-close burst; forward one.
+    public long LastEmoteStopForwardMs;
     public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -738,6 +738,17 @@ public partial class WorldClient
                 GetSession().GameState.LastLoopingEmoteId = 0;
             }
         }
+        else
+        {
+            // JimsProxy (observed-dance loop): same latch for OTHER units — their
+            // looping emote breaks on their next translational move-start
+            // (Client MovementHandler) since the 1.12 server never sends a stop
+            // for them either. A newer emote replaces/clears, mirroring the client.
+            if (IsClientLoopingEmote(emote.EmoteID))
+                GetSession().GameState.ObservedLoopingEmoteByUnit[emote.Guid] = emote.EmoteID;
+            else
+                GetSession().GameState.ObservedLoopingEmoteByUnit.TryRemove(emote.Guid, out _);
+        }
         SendPacketToClient(emote);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/InstanceHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/InstanceHandler.cs
@@ -18,6 +18,18 @@ public partial class WorldClient
         SendPacketToClient(instance);
     }
 
+    // JimsProxy: vanilla SMSG_UPDATE_LAST_INSTANCE { mapId u32 }. The proxy
+    // already synthesizes this packet on world-transfer (MovementHandler);
+    // also forward the server-initiated sends so the client's last-instance
+    // hint stays current outside transfers (DROPPED-S2C-AUDIT.md).
+    [PacketHandler(Opcode.SMSG_UPDATE_LAST_INSTANCE)]
+    void HandleUpdateLastInstance(WorldPacket packet)
+    {
+        UpdateLastInstance instance = new UpdateLastInstance();
+        instance.MapID = packet.ReadUInt32();
+        SendPacketToClient(instance);
+    }
+
     [PacketHandler(Opcode.SMSG_INSTANCE_RESET)]
     void HandleInstanceReset(WorldPacket packet)
     {

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -379,6 +379,19 @@ public partial class WorldClient
         SendPacketToClient(enchant);
     }
 
+    // JimsProxy: forward remaining-duration ticks for timed items (vanilla
+    // sends one per duration item on login and as time elapses). Without it,
+    // item countdowns on the modern client stay stale until relog
+    // (DROPPED-S2C-AUDIT.md).
+    [PacketHandler(Opcode.SMSG_ITEM_TIME_UPDATE)]
+    void HandleItemTimeUpdate(WorldPacket packet)
+    {
+        ItemTimeUpdate item = new ItemTimeUpdate();
+        item.ItemGuid = packet.ReadGuid().To128(GetSession().GameState);
+        item.DurationLeft = packet.ReadUInt32();
+        SendPacketToClient(item);
+    }
+
     [PacketHandler(Opcode.SMSG_ENCHANTMENT_LOG)]
     void HandleEnchantmentLog(WorldPacket packet)
     {

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -159,6 +159,26 @@ public partial class WorldClient
             IsAutoRepeatStoppingMove(packet.GetUniversalOpcode(false)))
         {
             RetractObservedShooterOnStop(moveUpdate.MoverGUID);
+
+            // JimsProxy (observed-dance loop): the same translational move-start
+            // also breaks a latched looping emote on an observed unit — the rule
+            // the 1.12 client applies locally, which the 1.14 client lacks. The
+            // server never sends the stop (zero player emote-state field activity
+            // across 526 corpus sessions), so synthesize the SMSG_EMOTE(0) the
+            // client is waiting for. TryRemove gives exactly-one stop per loop.
+            if (GetSession().GameState.ObservedLoopingEmoteByUnit.TryRemove(moveUpdate.MoverGUID, out uint loopingEmoteId))
+            {
+                EmoteMessage stopEmote = new EmoteMessage();
+                stopEmote.EmoteID = 0; // EMOTE_ONESHOT_NONE — clears the looping animation
+                stopEmote.Guid = moveUpdate.MoverGUID;
+                SendPacketToClient(stopEmote);
+                Framework.Logging.Log.Event("emote.loop.broken_by_observed_move", new
+                {
+                    guid = moveUpdate.MoverGUID.GetCounter(),
+                    emote_id = loopingEmoteId,
+                    trigger_opcode = packet.GetUniversalOpcode(false).ToString(),
+                });
+            }
         }
         moveUpdate.MoveInfo = new();
         moveUpdate.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);

--- a/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
@@ -226,6 +226,32 @@ public partial class WorldClient
         SendPacketToClient(sound);
     }
 
+    // JimsProxy: server-side pet mode sync (vanilla SMSG_PET_MODE
+    // { petGuid u64, react u8, command u8, flag1 u8 (always 0), enabledFlags
+    // u8 (0x0 enabled / 0x8 actions-disabled) } per vmangos Pet.cpp — same
+    // react/command byte order the PET_SPELLS handler above reads). Without
+    // the forward, the modern pet bar only ever shows its own optimistic
+    // click state; server-initiated react/command changes (summon restore,
+    // charm/possess, stance acks) desynced silently (DROPPED-S2C-AUDIT.md).
+    [PacketHandler(Opcode.SMSG_PET_MODE)]
+    void HandlePetMode(WorldPacket packet)
+    {
+        PetMode mode = new PetMode();
+        mode.PetGUID = packet.ReadGuid().To128(GetSession().GameState);
+        mode.ReactState = (ReactStates)packet.ReadUInt8();
+        mode.CommandState = (CommandStates)packet.ReadUInt8();
+        packet.ReadUInt8(); // flag1, always 0
+        mode.Flag = packet.ReadUInt8(); // enabledFlags: 0x8 = actions disabled (same bit modern-side)
+        Log.Event("pet.mode", new
+        {
+            pet_guid = mode.PetGUID.ToString(),
+            react_state = mode.ReactState.ToString(),
+            command_state = mode.CommandState.ToString(),
+            flag = mode.Flag,
+        });
+        SendPacketToClient(mode);
+    }
+
     [PacketHandler(Opcode.SMSG_PET_BROKEN)]
     void HandlePetBroken(WorldPacket packet)
     {

--- a/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
@@ -405,6 +405,16 @@ public partial class WorldClient
         SendPacketToClient(quest);
     }
 
+    // JimsProxy: vanilla sends SMSG_QUEST_LOG_FULL (empty body) when the
+    // player accepts a quest with a full log. Forward it so the modern client
+    // shows the "Your quest log is full." error instead of Accept silently
+    // doing nothing (hit in 11 corpus sessions, DROPPED-S2C-AUDIT.md).
+    [PacketHandler(Opcode.SMSG_QUEST_LOG_FULL)]
+    void HandleQuestLogFull(WorldPacket packet)
+    {
+        SendPacketToClient(new QuestLogFull());
+    }
+
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_COMPLETE)]
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_FAILED)]
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_FAILED_TIMER)]

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -2996,6 +2996,34 @@ public partial class WorldClient
         GetSession().ThreatTracker.OnDamage(spell.CasterGUID, spell.TargetGUID, (int)spell.SpellID, spell.Damage);
     }
 
+    // JimsProxy: combat-log fidelity forwards (DROPPED-S2C-AUDIT.md). Both
+    // vanilla packets share the shape { caster u64, target u64, spellId u32,
+    // logFormat u8 } (vmangos Spell.h); the trailing logFormat byte is a
+    // 0=default/1=debug formatting hint with no modern equivalent — discard
+    // it, do NOT map it onto IsPeriodic.
+    [PacketHandler(Opcode.SMSG_SPELL_OR_DAMAGE_IMMUNE)]
+    void HandleSpellOrDamageImmune(WorldPacket packet)
+    {
+        SpellOrDamageImmune immune = new SpellOrDamageImmune();
+        immune.CasterGUID = packet.ReadGuid().To128(GetSession().GameState);
+        immune.VictimGUID = packet.ReadGuid().To128(GetSession().GameState);
+        immune.SpellID = packet.ReadUInt32();
+        packet.ReadUInt8(); // logFormat
+        immune.IsPeriodic = false; // vanilla doesn't distinguish; don't guess
+        SendPacketToClient(immune);
+    }
+
+    [PacketHandler(Opcode.SMSG_PROC_RESIST)]
+    void HandleProcResist(WorldPacket packet)
+    {
+        ProcResist resist = new ProcResist();
+        resist.Caster = packet.ReadGuid().To128(GetSession().GameState);
+        resist.Target = packet.ReadGuid().To128(GetSession().GameState);
+        resist.SpellID = packet.ReadUInt32();
+        packet.ReadUInt8(); // logFormat
+        SendPacketToClient(resist);
+    }
+
     [PacketHandler(Opcode.SMSG_SPELL_EXECUTE_LOG)]
     void HandleSpellExecuteLog(WorldPacket packet)
     {

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3419,6 +3419,13 @@ public partial class WorldClient
         channel.SpellID = packet.ReadUInt32();
         channel.SpellXSpellVisualID = GameData.GetSpellVisual(channel.SpellID);
         channel.Duration = packet.ReadUInt32();
+        // JimsProxy (emote-stop channel guard): record our own channel window
+        // so the CMSG_EMOTE(0) stop-forward holds off while it is open.
+        if (channel.CasterGUID == GetSession().GameState.CurrentPlayerGuid)
+        {
+            GetSession().GameState.LocalChannelSpellId = channel.Duration > 0 ? channel.SpellID : 0;
+            GetSession().GameState.LocalChannelEndTickMs = Environment.TickCount64 + channel.Duration;
+        }
         SendPacketToClient(channel);
     }
 
@@ -3431,6 +3438,10 @@ public partial class WorldClient
         else
             channel.CasterGUID = GetSession().GameState.CurrentPlayerGuid;
         channel.TimeRemaining = packet.ReadInt32();
+        // JimsProxy (emote-stop channel guard): the server ends a channel by
+        // sending an update with no time remaining — close our window early.
+        if (channel.TimeRemaining <= 0 && channel.CasterGUID == GetSession().GameState.CurrentPlayerGuid)
+            GetSession().GameState.LocalChannelSpellId = 0;
         SendPacketToClient(channel);
     }
 

--- a/HermesProxy/World/KnownBenignOpcodes.cs
+++ b/HermesProxy/World/KnownBenignOpcodes.cs
@@ -3,10 +3,10 @@
 //   (1) Modern client sends c2s for a subsystem that never existed in 1.12
 //       (Battle Pay, Calendar v2, etc.) -- the legacy server would ignore it
 //       if we forwarded it.
-//   (2) Legacy server sends s2c for a 1.12-only opcode the modern client
-//       doesn't expect (SMSG_TRAINER_BUY_SUCCEEDED, SMSG_SET_REST_START) --
-//       the modern client gets equivalent UX via a different packet
-//       (SMSG_LEARNED_SPELL for the trainer case).
+//   (2) Legacy server sends s2c for a 1.12-only opcode with no dispatch slot
+//       in the 1.14.2 client (SMSG_SET_REST_START) -- the modern client gets
+//       the equivalent UX via a different channel (update fields), or the
+//       concept has no modern rendering at all.
 // Silencing these in the console + downgrading the JSONL event from
 // "packet.untranslated" (implies bug) to "packet.ignored" (implies
 // intentional no-op) lets real translation gaps stand out when reading logs.
@@ -15,6 +15,16 @@
 // side. Grow this list cautiously;
 // when in doubt, leave the opcode in the untranslated pile so we at least get
 // a warning for it.
+//
+// PROCESS RULE (2026-07-20 audit): before adding an s2c opcode here, verify it
+// has NO entry in Enums/V2_5_3_41750/Opcode.cs — the table 1.14.2 builds
+// dispatch from (per Opcodes.GetOpcodesDefiningBuild; NOT V1_14_1_40688). An
+// entry there means the client CAN consume it and the right fix is a
+// translation, not a drop. Cautionary tale: "MSG_MOVE_TIME_SKIPPED has no
+// modern equivalent" was false (SMSG_MOVE_SKIP_TIME 0x2E18 exists) — it is
+// translated, not benign-listed (PR #434), and must never appear in this
+// list. For c2s entries the check is V1_12_1_5875/Opcode.cs absence.
+// Full triage: DROPPED-S2C-AUDIT.md.
 
 using System.Collections.Generic;
 using HermesProxy.World.Enums;
@@ -93,11 +103,59 @@ public static class KnownBenignOpcodes
         // Added 2026-04-17 from Block 1 Test 1.2 (20-min AFK session):
         Opcode.CMSG_GET_ACCOUNT_NOTIFICATIONS,     // Modern account notification poll (MoP+)
 
-        // Rest-XP notification packet — post-Wrath server→client
-        // (Note: the modern client still expects this for rested XP banner
-        //  in the player frame. Not translating means no visual feedback
-        //  for rested state, but gameplay is unaffected. Filed as backlog.)
+        // Vanilla rest-state timer packet (0x21E, u32 restStart). No dispatch
+        // slot in the 1.14.2 table (absent from V2_5_3_41750), and nothing is
+        // lost: rested/resting UI on the modern client is driven by the
+        // RestInfo update fields, which UpdateHandler already translates from
+        // PLAYER_REST_STATE_EXPERIENCE / PLAYER_BYTES_2 (UpdateHandler.cs
+        // ~3774). An earlier note here claimed the modern client "still
+        // expects this for the rested banner" — wrong on both counts.
         Opcode.SMSG_SET_REST_START,
+
+        // ── Added 2026-07-20 from the corpus-wide dropped-s2c audit ──
+        // (DROPPED-S2C-AUDIT.md; every entry mechanically verified: s2c
+        // absent from V2_5_3_41750, c2s absent from V1_12_1_5875.)
+
+        // Kronos sends 1.12 Warden module data (~2×/session, 39 bytes, seen
+        // in 414/520 corpus sessions). There is no bridge: the 1.14 client
+        // speaks Warden3 (a different module system), and anti-cheat
+        // bridging is out of scope. The corpus shows Kronos tolerates the
+        // unanswered handshake (hours-long sessions throughout).
+        Opcode.SMSG_WARDEN_DATA,
+
+        // GO spawn-in animation (0x214, u64 goGuid). No 1.14.2 slot; modern
+        // clients convey spawn animation via GO create/update state.
+        // Cosmetic-only loss.
+        Opcode.SMSG_GAMEOBJECT_SPAWN_ANIM,
+
+        // Chain-visual retarget list (0x330). No 1.14.2 slot; modern chain
+        // visuals ride SPELL_GO hit targets.
+        Opcode.SMSG_SPELL_UPDATE_CHAIN_TARGETS,
+
+        // Ack for the proxy-synthesized SMSG_SUSPEND_TOKEN
+        // (Client/PacketHandlers/MovementHandler.cs sends it fire-and-forget;
+        // nothing gates on the response).
+        Opcode.CMSG_SUSPEND_TOKEN_RESPONSE,
+
+        // Modern AH "pending sales" poll; vanilla delivers sale results as
+        // mail — there is no queryable pending-sales list to answer with.
+        Opcode.CMSG_AUCTION_LIST_PENDING_SALES,
+
+        // WoW Token purchase-log poll (retail shop subsystem).
+        Opcode.CMSG_COMMERCE_TOKEN_GET_LOG,
+
+        // Party role (tank/heal/dps) assignment — vanilla has no relay
+        // channel; role icons stay client-local.
+        Opcode.CMSG_SET_ROLE,
+
+        // Character-list reorder persistence (modern account feature).
+        Opcode.CMSG_REORDER_CHARACTERS,
+
+        // Hardware survey / advanced-combat-logging toggle / follow-usage
+        // telemetry — no legacy destination.
+        Opcode.CMSG_ENGINE_SURVEY,
+        Opcode.CMSG_SET_ADVANCED_COMBAT_LOGGING,
+        Opcode.CMSG_USED_FOLLOW,
 
     };
 

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -363,6 +363,25 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SEND_TEXT_EMOTE)]
     void HandleSendTextEmote(CTextEmote emote)
     {
+        // JimsProxy (#244): vanilla HandleTextEmoteOpcode interrupts channels
+        // and strips auras flagged ANIM_CANCELS for every anim-bearing text
+        // emote (vmangos ChatHandler.cpp — only sleep/sit/kneel/none are
+        // exempt). Modern servers dropped that interrupt, so the 1.14 client
+        // happily sends /clap mid-channel; forwarding it cancels
+        // bandage-class channels on Kronos. Hold text emotes while our
+        // channel window is open — the proxy can't tell anim-bearing from
+        // chat-only (no EmotesText anim mapping loaded), and a seconds-long
+        // hold beats a canceled channel.
+        if (GetSession().GameState.IsLocalChannelWindowOpen())
+        {
+            Log.Event("emote.text.dropped_channeling", new
+            {
+                text_emote_id = emote.EmoteID,
+                channel_spell = GetSession().GameState.LocalChannelSpellId,
+            });
+            return;
+        }
+
         var target = emote.Target;
 
         if (emote.EmoteID == TEXTEMOTE_SPIT && target.IsEmpty())
@@ -402,8 +421,7 @@ public partial class WorldSocket
     {
         var gameState = GetSession().GameState;
 
-        if (gameState.LocalChannelSpellId != 0 &&
-            Environment.TickCount64 < gameState.LocalChannelEndTickMs + 2000)
+        if (gameState.IsLocalChannelWindowOpen())
         {
             Log.Event("emote.stop_skipped_channeling", new
             {

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -379,6 +379,50 @@ public partial class WorldSocket
         SendPacketToServer(packet);
     }
 
+    // JimsProxy: the modern client sends an empty CMSG_EMOTE meaning "clear my
+    // emote state" (TC master HandleEmoteOpcode → SetEmoteState(ONESHOT_NONE)).
+    // Corpus shows it firing in the interaction-close burst (same-ms as
+    // CMSG_CLOSE_INTERACTION, usually double-sent) and when movement ends a
+    // state emote. The vanilla client sends the same opcode with a u32 id —
+    // per vmangos the 1.12 client only ever sends ONESHOT_NONE(0) or WAVE,
+    // and on 0 the server clears UNIT_NPC_EMOTESTATE (Unit::HandleEmote →
+    // HandleEmoteState(0)). Forwarding the 0 is therefore byte-authentic
+    // vanilla traffic and stops observers from seeing our state emote
+    // (/read, /sleep, ...) forever after we move. Previously dropped as
+    // packet.untranslated (1,260 hits / 216 sessions, DROPPED-S2C-AUDIT.md).
+    // Complements the looping-emote tracker (Client ChatHandler + move-start
+    // synth), which only fixes the local player's own view.
+    //
+    // Guards: mangos-family HandleEmoteOpcode also interrupts channels
+    // flagged ANIM_CANCELS, and a real vanilla client never emits this
+    // mid-channel — hold it while our channel window is open. Collapse the
+    // same-burst double-send so the server sees one clear per burst.
+    [PacketHandler(Opcode.CMSG_EMOTE)]
+    void HandleEmoteStop(EmptyClientPacket emote)
+    {
+        var gameState = GetSession().GameState;
+
+        if (gameState.LocalChannelSpellId != 0 &&
+            Environment.TickCount64 < gameState.LocalChannelEndTickMs + 2000)
+        {
+            Log.Event("emote.stop_skipped_channeling", new
+            {
+                channel_spell = gameState.LocalChannelSpellId,
+            });
+            return;
+        }
+
+        long now = Environment.TickCount64;
+        if (now - gameState.LastEmoteStopForwardMs < 250)
+            return; // same-burst duplicate
+        gameState.LastEmoteStopForwardMs = now;
+
+        Log.Event("emote.stop_forwarded", null);
+        WorldPacket packet = new WorldPacket(Opcode.CMSG_EMOTE);
+        packet.WriteUInt32(0); // EMOTE_ONESHOT_NONE — clear emote state
+        SendPacketToServer(packet);
+    }
+
     [PacketHandler(Opcode.CMSG_CHAT_REGISTER_ADDON_PREFIXES)]
     void HandleChatRegisterAddonPrefixes(ChatRegisterAddonPrefixes addons)
     {

--- a/HermesProxy/World/Server/Packets/ItemPackets.cs
+++ b/HermesProxy/World/Server/Packets/ItemPackets.cs
@@ -829,6 +829,34 @@ class ItemEnchantTimeUpdate : ServerPacket, ISpanWritable
     public WowGuid128 OwnerGuid;
 }
 
+// JimsProxy: remaining-duration tick for a timed item. Vanilla
+// SMSG_ITEM_TIME_UPDATE { itemGuid u64, duration u32 } (vmangos
+// Item::SendTimeUpdate) maps 1:1 to the modern { GUID, DurationLeft } shape
+// per WPP 3.4-classic HandleItemTimeUpdate and TC master.
+class ItemTimeUpdate : ServerPacket, ISpanWritable
+{
+    public ItemTimeUpdate() : base(Opcode.SMSG_ITEM_TIME_UPDATE, ConnectionType.Instance) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(ItemGuid);
+        _worldPacket.WriteUInt32(DurationLeft);
+    }
+
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + uint
+
+    public int WriteToSpan(Span<byte> buffer)
+    {
+        var writer = new SpanPacketWriter(buffer);
+        writer.WritePackedGuid128(ItemGuid.Low, ItemGuid.High);
+        writer.WriteUInt32(DurationLeft);
+        return writer.Position;
+    }
+
+    public WowGuid128 ItemGuid;
+    public uint DurationLeft;
+}
+
 class EnchantmentLog : ServerPacket, ISpanWritable
 {
     public EnchantmentLog() : base(Opcode.SMSG_ENCHANTMENT_LOG) { }

--- a/HermesProxy/World/Server/Packets/PetPackets.cs
+++ b/HermesProxy/World/Server/Packets/PetPackets.cs
@@ -113,6 +113,41 @@ public class PetClearSpells : ServerPacket, ISpanWritable
     public int WriteToSpan(Span<byte> buffer) => 0;
 }
 
+// JimsProxy: server-side pet react/command state sync. Vanilla SMSG_PET_MODE
+// carries { petGuid u64, react u8, command u8, flag1 u8, enabledFlags u8 }
+// (vmangos Pet.cpp); the modern body is { PetGUID, CommandState u8, Flag u8,
+// ReactState u8 } per WPP 3.4-classic ReadPetFlags344 and TC master
+// PetMode::Write — same trio PetSpells above already encodes.
+public class PetMode : ServerPacket, ISpanWritable
+{
+    public PetMode() : base(Opcode.SMSG_PET_MODE, ConnectionType.Instance) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(PetGUID);
+        _worldPacket.WriteUInt8((byte)CommandState);
+        _worldPacket.WriteUInt8(Flag);
+        _worldPacket.WriteUInt8((byte)ReactState);
+    }
+
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 3; // GUID + 3 bytes
+
+    public int WriteToSpan(Span<byte> buffer)
+    {
+        var writer = new SpanPacketWriter(buffer);
+        writer.WritePackedGuid128(PetGUID.Low, PetGUID.High);
+        writer.WriteUInt8((byte)CommandState);
+        writer.WriteUInt8(Flag);
+        writer.WriteUInt8((byte)ReactState);
+        return writer.Position;
+    }
+
+    public WowGuid128 PetGUID;
+    public CommandStates CommandState;
+    public byte Flag;
+    public ReactStates ReactState;
+}
+
 class PetAction : ClientPacket
 {
     public PetAction(WorldPacket packet) : base(packet) { }

--- a/HermesProxy/World/Server/Packets/QuestPackets.cs
+++ b/HermesProxy/World/Server/Packets/QuestPackets.cs
@@ -684,6 +684,21 @@ public class QuestGiverCompleteQuest : ClientPacket
     public bool FromScript; // 0 - standart complete quest mode with npc, 1 - auto-complete mode
 }
 
+// JimsProxy: "Your quest log is full." error notification. Empty body on both
+// sides (vanilla SMSG_QUEST_LOG_FULL and TC master QuestLogFull, size 0);
+// without the forward, accepting a quest with a full log silently does
+// nothing on the modern client.
+class QuestLogFull : ServerPacket, ISpanWritable
+{
+    public QuestLogFull() : base(Opcode.SMSG_QUEST_LOG_FULL, ConnectionType.Instance) { }
+
+    public override void Write() { }
+
+    public int MaxSize => 0;
+
+    public int WriteToSpan(Span<byte> buffer) => 0;
+}
+
 class QuestGiverQuestFailed : ServerPacket, ISpanWritable
 {
     public QuestGiverQuestFailed() : base(Opcode.SMSG_QUEST_GIVER_QUEST_FAILED) { }

--- a/HermesProxy/World/Server/Packets/SpellPackets.cs
+++ b/HermesProxy/World/Server/Packets/SpellPackets.cs
@@ -1579,6 +1579,80 @@ class SpellNonMeleeDamageLog : ServerPacket, ISpanWritable
     public ContentTuningParams ContentTuning = null!;
 }
 
+// JimsProxy: combat-log "Immune" feedback for spells. Vanilla
+// SMSG_SPELLORDAMAGE_IMMUNE { caster u64, target u64, spellId u32,
+// logFormat u8 } (vmangos Spell.h); modern shape per WPP 3.4-classic
+// HandleSpellOrDamageImmune and TC master SpellOrDamageImmune::Write.
+class SpellOrDamageImmune : ServerPacket, ISpanWritable
+{
+    public SpellOrDamageImmune() : base(Opcode.SMSG_SPELL_OR_DAMAGE_IMMUNE, ConnectionType.Instance) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(CasterGUID);
+        _worldPacket.WritePackedGuid128(VictimGUID);
+        _worldPacket.WriteUInt32(SpellID);
+        _worldPacket.WriteBit(IsPeriodic);
+        _worldPacket.FlushBits();
+    }
+
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 5; // 2 GUIDs + uint + bit byte
+
+    public int WriteToSpan(Span<byte> buffer)
+    {
+        var writer = new SpanPacketWriter(buffer);
+        writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+        writer.WritePackedGuid128(VictimGUID.Low, VictimGUID.High);
+        writer.WriteUInt32(SpellID);
+        writer.WriteBit(IsPeriodic);
+        writer.FlushBits();
+        return writer.Position;
+    }
+
+    public WowGuid128 CasterGUID;
+    public WowGuid128 VictimGUID;
+    public uint SpellID;
+    public bool IsPeriodic;
+}
+
+// JimsProxy: combat-log proc-resist feedback. Vanilla SMSG_PROCRESIST
+// { caster u64, target u64, spellId u32, logFormat u8 } (vmangos Spell.h);
+// modern shape per WPP 3.4-classic HandleProcResist and TC master
+// ProcResist::Write — the optional Rolled/Needed floats are omitted
+// (vanilla has no equivalent data).
+class ProcResist : ServerPacket, ISpanWritable
+{
+    public ProcResist() : base(Opcode.SMSG_PROC_RESIST, ConnectionType.Instance) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(Caster);
+        _worldPacket.WritePackedGuid128(Target);
+        _worldPacket.WriteUInt32(SpellID);
+        _worldPacket.WriteBit(false); // HasRolled
+        _worldPacket.WriteBit(false); // HasNeeded
+        _worldPacket.FlushBits();
+    }
+
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 5; // 2 GUIDs + uint + bit byte
+
+    public int WriteToSpan(Span<byte> buffer)
+    {
+        var writer = new SpanPacketWriter(buffer);
+        writer.WritePackedGuid128(Caster.Low, Caster.High);
+        writer.WritePackedGuid128(Target.Low, Target.High);
+        writer.WriteUInt32(SpellID);
+        writer.WriteBit(false); // HasRolled
+        writer.WriteBit(false); // HasNeeded
+        writer.FlushBits();
+        return writer.Position;
+    }
+
+    public WowGuid128 Caster;
+    public WowGuid128 Target;
+    public uint SpellID;
+}
+
 class SpellHealLog : ServerPacket, ISpanWritable
 {
     private const int MaxPowerDataEntries = 10;


### PR DESCRIPTION
## What

Implements the DROPPED-S2C-AUDIT.md worklist (521 JSONL / 3.5 GB corpus, first commit), **minus the flagship `MSG_MOVE_TIME_SKIPPED` translation, which is split into #434** for independent validation. Plus the emote-lifecycle follow-ups that grew out of the audit.

### s2c translations (each had a 1.14.2 dispatch slot but was dropped)

| Legacy opcode | → Modern | Corpus drops | What the client was denied |
|---|---|---|---|
| `SMSG_PET_MODE` 0x17A | 0x258C | 297 / 4 sessions | Server-side pet react/command state (summon restore, charm/possess, stance acks); emits `pet.mode` |
| `SMSG_QUEST_LOG_FULL` 0x195 | 0x2A87 | 14 / 11 sessions | The "Your quest log is full." error — Accept previously did nothing, silently |
| `SMSG_SPELL_OR_DAMAGE_IMMUNE` 0x263 | 0x2C2F | 48 / 7 | "Immune" combat-log feedback for spells |
| `SMSG_PROC_RESIST` 0x260 | 0x2752 | 557 / 33 | Proc-resist combat-log line |
| `SMSG_ITEM_TIME_UPDATE` 0x1EA | 0x274B | 69 / 12 | Timed-item duration countdown ticks |
| `SMSG_UPDATE_LAST_INSTANCE` 0x320 | 0x2681 | 4 / 4 | Wires the legacy send into the already-existing synth struct |

Wire shapes sourced from vmangos (legacy) + WPP 3.4-classic parsers and TrinityCore master (modern); corpus size histograms corroborate every legacy body. The vanilla trailing `u8` on both combat-log packets is a `logFormat` debug flag — discarded, **not** mapped onto `IsPeriodic`.

> **Flagship split out:** `MSG_MOVE_TIME_SKIPPED → SMSG_MOVE_SKIP_TIME` (15,084 drops / 236 sessions) now lives in **#434** so it can be validated and reverted on its own. This branch was rebased to remove it; the two PRs no longer overlap.

### c2s: `CMSG_EMOTE` stop-forward

The modern client sends an **empty `CMSG_EMOTE`** meaning "clear my emote state" (TC: `SetEmoteState(ONESHOT_NONE)`) — 1,260 drops / 216 sessions. Per vmangos the 1.12 client only ever sends `ONESHOT_NONE(0)`/`WAVE`; on 0 the server clears `UNIT_NPC_EMOTESTATE`. Forwarding `{u32 0}` is byte-authentic vanilla traffic and stops 1.12 observers from seeing our state emote (/read, /sleep…) forever after we move. Guards: **channel hold** + **250 ms same-burst dedupe**. Diagnostics: `emote.stop_forwarded` / `emote.stop_skipped_channeling`.

### Emote lifecycle fixes from the open-issue sweep

- **Fixes #244** (/clap stops channels, e.g. bandage): vanilla `HandleTextEmoteOpcode` interrupts channels + strips `ANIM_CANCELS` auras for every anim-bearing text emote. Text-emote forwards now **hold while the local channel window is open** (`GameState.IsLocalChannelWindowOpen()`, tracked from `MSG_CHANNEL_START/UPDATE`). Event: `emote.text.dropped_channeling`.
- **Observed looping-emote stop**: the shipped dance fix only covered the local player; corpus shows **27 of 30 dance broadcasts target OTHER units** with no server stop edge. New per-unit latch + synthesized `SMSG_EMOTE(0)` on the unit's next translational move-start (observed-bow-retract pattern). Event: `emote.loop.broken_by_observed_move`.
- Not this PR: #135 / #401 (1.14 client needs anim-driving calls 1.12 never sends — different class).

### KnownBenignOpcodes housekeeping

Corrected the wrong `SMSG_SET_REST_START` note; added a **PROCESS RULE** header (verify s2c absent from `V2_5_3_41750`, c2s from `V1_12_1_5875`; the `MSG_MOVE_TIME_SKIPPED` false-premise near-miss documented, now translated in #434); added 10 mechanically-verified benign entries. Sole deliberate holdout: `SMSG_SPELL_MISS_LOG`.

## Testing

`dotnet test`: **737 passed / 0 failed**. Behavioral validation for the beta build is in `VALIDATION-GUIDE.md` (backbone: these opcodes vanish from the drop log; plus per-fix repro + JSONL events). Time-skip validation lives with #434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)