### PR TITLE
Translate MSG_MOVE_TIME_SKIPPED (s2c) → SMSG_MOVE_SKIP_TIME

### DIFF
--- a/HermesProxy.Tests/World/MoveSkipTimeTests.cs
+++ b/HermesProxy.Tests/World/MoveSkipTimeTests.cs
@@ -1,0 +1,91 @@
+using Framework.IO;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Covers the write side of the MSG_MOVE_TIME_SKIPPED (s2c) -> SMSG_MOVE_SKIP_TIME
+// translation: that MoveSkipTime serializes as [packed mover guid128][uint32
+// timeSkipped] and that its two write paths (ByteBuffer Write() and span
+// WriteToSpan()) agree byte-for-byte. The handler-side gating (self-guid /
+// recently-destroyed drops) mirrors the already-tested WasObjectRecentlyDestroyed
+// gate and needs a full session, so it is left to integration/A-B testing.
+public class MoveSkipTimeTests
+{
+    static MoveSkipTimeTests()
+    {
+        // SMSG_MOVE_SKIP_TIME resolves to 0x2E18 for the shipped 1.14.2 build
+        // (opcodes-defining build V2_5_3_41750); ServerPacket's ctor asserts the
+        // opcode is non-zero, so ClientBuild must be set before construction.
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    // Exposes the ByteBuffer (Write()) output, which is otherwise unreachable via
+    // the public API because WritePacketData() prefers the span path for any
+    // ISpanWritable packet. Derived access to the protected _worldPacket is legal.
+    private sealed class ProbeMoveSkipTime : MoveSkipTime
+    {
+        public byte[] WriteViaByteBuffer()
+        {
+            Write();
+            return _worldPacket.GetData()!;
+        }
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(1u)]
+    [InlineData(12345u)]
+    [InlineData(uint.MaxValue)]
+    public void WriteToSpan_MatchesByteBufferWrite(uint timeSkipped)
+    {
+        var mover = WowGuid128.Create(HighGuidType703.Player, 22202);
+
+        var probe = new ProbeMoveSkipTime { MoverGUID = mover, TimeSkipped = timeSkipped };
+        byte[] byteBufferBytes = probe.WriteViaByteBuffer();
+
+        var packet = new MoveSkipTime { MoverGUID = mover, TimeSkipped = timeSkipped };
+        byte[] spanBuffer = new byte[packet.MaxSize];
+        int written = packet.WriteToSpan(spanBuffer);
+
+        Assert.True(written > 0);
+        Assert.Equal(byteBufferBytes.Length, written);
+        Assert.Equal(byteBufferBytes, spanBuffer[..written]);
+    }
+
+    [Fact]
+    public void WriteToSpan_EmitsPackedGuidThenTimeSkipped()
+    {
+        var mover = WowGuid128.Create(HighGuidType703.Player, 22202);
+        uint skip = 0xDEADBEEF;
+
+        // Independent reference in the documented wire order (guid, then u32).
+        using var reference = new WorldPacket();
+        reference.WritePackedGuid128(mover);
+        reference.WriteUInt32(skip);
+        byte[] expected = reference.GetData()!;
+
+        var packet = new MoveSkipTime { MoverGUID = mover, TimeSkipped = skip };
+        byte[] spanBuffer = new byte[packet.MaxSize];
+        int written = packet.WriteToSpan(spanBuffer);
+
+        Assert.Equal(expected, spanBuffer[..written]);
+    }
+
+    [Fact]
+    public void WriteToSpan_StaysWithinMaxSize()
+    {
+        var mover = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+        var packet = new MoveSkipTime { MoverGUID = mover, TimeSkipped = uint.MaxValue };
+
+        byte[] spanBuffer = new byte[packet.MaxSize];
+        int written = packet.WriteToSpan(spanBuffer);
+
+        Assert.True(written > 0);
+        Assert.True(written <= packet.MaxSize);
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -224,6 +224,16 @@ public partial class WorldClient
     // it can't fight the client's own movement clock. Also drop for a just-destroyed
     // mover (mirrors the WasObjectRecentlyDestroyed gate in HandleMovementMessages),
     // so a stale skip can't touch a unit we already retired.
+    //
+    // Possible relation to #418 (observed players "move laggy / delayed") — WEAK and
+    // unproven. That investigation exonerated the proxy's outbound leg and pinned the
+    // dominant cause to client-side cross-engine jump-arc reconstruction, not this.
+    // But it flagged one untested residual: "a laggy sender's TIME_SKIPPED path is
+    // code-verified but not field-exercised" (0 skips seen in that low-latency
+    // session). This handler is the observer-side (s2c) half of that path — before
+    // it, a hitching/lagging peer's clock skip was dropped, so observers never
+    // re-based that mover's movement time. Whether that feeds the #418 symptom is
+    // unproven; the peer-hitch-under-lag A/B is exactly the field test #418 lacked.
     [PacketHandler(Opcode.MSG_MOVE_TIME_SKIPPED)]
     void HandleMoveTimeSkipped(WorldPacket packet)
     {

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -211,6 +211,34 @@ public partial class WorldClient
         SendPacketToClient(knockback);
     }
 
+    // JimsProxy (move-time-skipped translation): the legacy server relays
+    // MSG_MOVE_TIME_SKIPPED (vanilla 0x319) as a peer clock-continuity signal — when
+    // *another* nearby player's client hitches/alt-tabs/loads, its movement clock
+    // jumps and the server tells observers so their per-unit movement-time base for
+    // that mover stays aligned with the (now time-jumped) movement packets that
+    // follow. Upstream dropped this as an unknown s2c opcode; the 1.14 client has a
+    // live handler for the modern twin SMSG_MOVE_SKIP_TIME (0x2E18), so we translate
+    // rather than drop. Wire: packed 64-bit guid + uint32 (all reference cores relay
+    // this shape). The relay is observer-only on every core (the server excludes the
+    // originator), so a self-targeted skip shouldn't arrive — drop it defensively so
+    // it can't fight the client's own movement clock. Also drop for a just-destroyed
+    // mover (mirrors the WasObjectRecentlyDestroyed gate in HandleMovementMessages),
+    // so a stale skip can't touch a unit we already retired.
+    [PacketHandler(Opcode.MSG_MOVE_TIME_SKIPPED)]
+    void HandleMoveTimeSkipped(WorldPacket packet)
+    {
+        MoveSkipTime skip = new MoveSkipTime();
+        skip.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
+        skip.TimeSkipped = packet.ReadUInt32();
+
+        if (skip.MoverGUID == GetSession().GameState.CurrentPlayerGuid)
+            return;
+        if (GetSession().GameState.WasObjectRecentlyDestroyed(skip.MoverGUID, out _))
+            return;
+
+        SendPacketToClient(skip);
+    }
+
     [PacketHandler(Opcode.SMSG_CONTROL_UPDATE)]
     void HandleControlUpdate(WorldPacket packet)
     {

--- a/HermesProxy/World/Server/Packets/MovementPackets.cs
+++ b/HermesProxy/World/Server/Packets/MovementPackets.cs
@@ -637,6 +637,37 @@ public class MoveSetFlag : ServerPacket, ISpanWritable
     public uint MoveCounter = 0;
 }
 
+// JimsProxy (move-time-skipped translation): modern s2c SMSG_MOVE_SKIP_TIME (0x2E18).
+// The observer-side twin of CMSG_MOVE_TIME_SKIPPED — the server relays it to nearby
+// clients when a mover's movement clock legitimately jumps (alt-tab / FPS-hitch /
+// load) so their per-unit movement-time base stays aligned. Wire shape mirrors
+// TrinityCore's MoveSkipTime and the vanilla relay: packed mover guid then uint32
+// time-skipped, no bit-packing. Emitted by HandleMoveTimeSkipped on the WorldClient
+// side; upstream had no translation for the legacy relay and dropped it.
+public class MoveSkipTime : ServerPacket, ISpanWritable
+{
+    public MoveSkipTime() : base(Opcode.SMSG_MOVE_SKIP_TIME, ConnectionType.Instance) { }
+
+    public override void Write()
+    {
+        _worldPacket.WritePackedGuid128(MoverGUID);
+        _worldPacket.WriteUInt32(TimeSkipped);
+    }
+
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + uint
+
+    public int WriteToSpan(Span<byte> buffer)
+    {
+        var writer = new SpanPacketWriter(buffer);
+        writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+        writer.WriteUInt32(TimeSkipped);
+        return writer.Position;
+    }
+
+    public WowGuid128 MoverGUID;
+    public uint TimeSkipped;
+}
+
 public class MovementAckMessage : ClientPacket
 {
     public MovementAckMessage(WorldPacket packet) : base(packet) { }


### PR DESCRIPTION
## What

Translates the legacy observer-side relay `MSG_MOVE_TIME_SKIPPED` (vanilla 0x319) to the modern `SMSG_MOVE_SKIP_TIME` (0x2E18), which the proxy previously dropped as an unknown s2c opcode (logging a `No handler for opcode 793` warning on every nearby time-skip).

Carved out of the #433 dropped-s2c corpus audit as the **highest-impact item** (15,084 drops / 236 sessions — an order of magnitude above the other findings) so it gets isolated review and its own test/rollback surface.

- New `MoveSkipTime` ServerPacket (packed guid128 + uint32), modeled on `MoveSetFlag`; `Write()` + zero-alloc `WriteToSpan()` paths.
- `HandleMoveTimeSkipped` reads the legacy relay (packed guid → `To128`, uint32) and forwards it, with defensive drops for a self-targeted skip and a recently-destroyed mover (reuses the `WasObjectRecentlyDestroyed` gate).
- `MoveSkipTimeTests`: `Write`/`WriteToSpan` byte-parity + wire-format pin + `MaxSize` bound. Falsification-checked (a deliberate divergence turns 5/6 red).
- Note: 1.14.2 (`V1_14_2_42597`) dispatches opcodes via the `V2_5_3_41750` table where `SMSG_MOVE_SKIP_TIME` = 0x2E18 (not the `V1_14_1_40688` table).

## Status / what's unverified

Benefit is **not yet proven**. The client-side effect of the skip on observed units is undocumented, and no observer-symptom report is causally tied to the drop. This is the observer-side half of the untested time-skip path flagged in #418 ("a laggy sender's TIME_SKIPPED path is code-verified but not field-exercised").

Before treating this as a fix or shipping publicly:
- **`.pkt` capture** confirming Kronos's relay is packed-guid + uint32 **and** that the forwarded `MoveTime` stream actually jumps by `timeSkipped` (rules out a double-apply that could make an observed hitcher look *worse*).
- **Live A/B** — a peer hitching in view (alt-tab + background-FPS throttle), translation on vs off.

No version bump; not for merge until the A/B lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsqtgZds4tTLmavhgUEJMm