### PR TITLE
Fix party pet showing Unknown/vanishing and stale member data for out-of-range members

### DIFF
--- a/HermesProxy.Tests/World/AuraExpiryPersistenceTests.cs
+++ b/HermesProxy.Tests/World/AuraExpiryPersistenceTests.cs
@@ -1,0 +1,141 @@
+using System;
+using HermesProxy;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Covers the wall-clock aura expiry map (UnitAuraExpiryTick) that restores buff
+// timers after relog / unit destroy (PallyPower blessing timers restarting at
+// full duration was the reported bug).
+public class AuraExpiryPersistenceTests
+{
+    private static WowGuid128 MakeUnit(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 12345, counter);
+
+    private const int BlessingOfMight = 25291;
+    private const int FifteenMinutesMs = 15 * 60 * 1000;
+
+    [Fact]
+    public void RecordThenTryGet_ReturnsRemainingWithinRecordedWindow()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var rogue = MakeUnit(1);
+
+        state.RecordAuraExpiry(rogue, BlessingOfMight, FifteenMinutesMs);
+        int? remaining = state.TryGetAuraRemainingMs(rogue, BlessingOfMight);
+
+        Assert.NotNull(remaining);
+        Assert.InRange(remaining!.Value, 1, FifteenMinutesMs);
+    }
+
+    [Fact]
+    public void TryGet_UnknownEntry_ReturnsNull()
+    {
+        var state = GameSessionData.CreateForTesting();
+        Assert.Null(state.TryGetAuraRemainingMs(MakeUnit(1), BlessingOfMight));
+    }
+
+    [Fact]
+    public void RecordAuraExpiry_NonPositiveRemaining_IsIgnored()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var rogue = MakeUnit(1);
+
+        state.RecordAuraExpiry(rogue, BlessingOfMight, 0);
+        state.RecordAuraExpiry(rogue, BlessingOfMight, -5000);
+
+        Assert.Empty(state.UnitAuraExpiryTick);
+    }
+
+    [Fact]
+    public void TryGet_ExpiredEntry_ReturnsNullAndRemovesIt()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var rogue = MakeUnit(1);
+
+        state.UnitAuraExpiryTick[(rogue, BlessingOfMight)] = Environment.TickCount64 - 1;
+
+        Assert.Null(state.TryGetAuraRemainingMs(rogue, BlessingOfMight));
+        Assert.Empty(state.UnitAuraExpiryTick);
+    }
+
+    [Fact]
+    public void ClearAuraExpiry_RemovesOnlyThatSpellOnThatUnit()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var rogue = MakeUnit(1);
+        var mage = MakeUnit(2);
+
+        state.RecordAuraExpiry(rogue, BlessingOfMight, FifteenMinutesMs);
+        state.RecordAuraExpiry(rogue, 1126, FifteenMinutesMs);
+        state.RecordAuraExpiry(mage, BlessingOfMight, FifteenMinutesMs);
+
+        state.ClearAuraExpiry(rogue, BlessingOfMight);
+
+        Assert.Null(state.TryGetAuraRemainingMs(rogue, BlessingOfMight));
+        Assert.NotNull(state.TryGetAuraRemainingMs(rogue, 1126));
+        Assert.NotNull(state.TryGetAuraRemainingMs(mage, BlessingOfMight));
+    }
+
+    [Fact]
+    public void EvictUnitAuraState_DoesNotTouchExpiryMap()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var rogue = MakeUnit(1);
+
+        state.StoreAuraDurationLeft(rogue, slot: 0, duration: 30000, currentTime: 1000);
+        state.RecordAuraExpiry(rogue, BlessingOfMight, FifteenMinutesMs);
+
+        state.EvictUnitAuraState(rogue);
+
+        Assert.False(state.UnitAuraDurationLeft.ContainsKey(rogue));
+        Assert.NotNull(state.TryGetAuraRemainingMs(rogue, BlessingOfMight));
+    }
+
+    [Fact]
+    public void RecordAuraExpiry_Rerecord_OverwritesWithNewExpiry()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var rogue = MakeUnit(1);
+
+        state.RecordAuraExpiry(rogue, BlessingOfMight, 1000);
+        state.RecordAuraExpiry(rogue, BlessingOfMight, FifteenMinutesMs);
+
+        int? remaining = state.TryGetAuraRemainingMs(rogue, BlessingOfMight);
+        Assert.NotNull(remaining);
+        Assert.True(remaining!.Value > 1000, $"rebuff should extend the timer, got {remaining}");
+    }
+
+    [Fact]
+    public void RecordAuraExpiry_OverCapacity_PrunesOnlyExpiredEntries()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var live = MakeUnit(999_999);
+
+        for (ulong i = 0; i < 4200; i++)
+            state.UnitAuraExpiryTick[(MakeUnit(i), (int)i)] = Environment.TickCount64 - 1;
+        state.RecordAuraExpiry(live, BlessingOfMight, FifteenMinutesMs);
+
+        state.RecordAuraExpiry(MakeUnit(5000), 1126, FifteenMinutesMs);
+
+        Assert.NotNull(state.TryGetAuraRemainingMs(live, BlessingOfMight));
+        Assert.True(state.UnitAuraExpiryTick.Count <= 3, $"expired entries should be pruned, count={state.UnitAuraExpiryTick.Count}");
+    }
+
+    // The relog carry-over: a recreated GameSessionData must keep the same expiry
+    // map so buff timers on party members resume instead of restarting at full.
+    [Fact]
+    public void CreateNewGameSessionData_CarriesExpiryMapAcrossRelog()
+    {
+        var before = GameSessionData.CreateForTesting();
+        var rogue = MakeUnit(1);
+        before.RecordAuraExpiry(rogue, BlessingOfMight, FifteenMinutesMs);
+
+        var after = GameSessionData.CreateForTesting(previous: before);
+
+        Assert.NotNull(after.TryGetAuraRemainingMs(rogue, BlessingOfMight));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -755,6 +755,11 @@ public sealed class GameSessionData
     public Dictionary<WowGuid128, Dictionary<byte, int>> UnitAuraDurationLeft = [];
     public Dictionary<WowGuid128, Dictionary<byte, int>> UnitAuraDurationFull = [];
     public Dictionary<WowGuid128, Dictionary<byte, WowGuid128>> UnitAuraCaster = [];
+    // Wall-clock aura expiry per (unit, spell). Unlike the per-slot caches above this
+    // survives unit destroys AND relogs (carried over in CreateNewGameSessionData), so a
+    // buff re-seen on a group member resumes its real remaining time instead of
+    // restarting at full duration (PallyPower blessing timers after relog/stealth).
+    public Dictionary<(WowGuid128, int), long> UnitAuraExpiryTick = [];
 
     // MIRASU (stack-aura-decrement): last AuraDataInfo emitted for each (unit, slot).
     // Used to detect AURAAPPLICATIONS-quad-only updates where a single slot's app
@@ -933,12 +938,18 @@ public sealed class GameSessionData
         // satisfied the unit-frame name without issuing a fresh CMSG_QUERY_PLAYER_NAME —
         // the proxy then had no entry to fill the inspect Name/Class/Race/Sex fields.
         if (previous != null)
-        {
-            self.CachedPlayers = previous.CachedPlayers;
-            self.PlayerGuildIds = previous.PlayerGuildIds;
-            self.IgnoredPlayers = previous.IgnoredPlayers;
-        }
+            CarryOverRealmScopedCaches(previous, self);
         return self;
+    }
+
+    private static void CarryOverRealmScopedCaches(GameSessionData previous, GameSessionData self)
+    {
+        self.CachedPlayers = previous.CachedPlayers;
+        self.PlayerGuildIds = previous.PlayerGuildIds;
+        self.IgnoredPlayers = previous.IgnoredPlayers;
+        // Buff expiries are wall-clock facts about other units — a /camp doesn't
+        // change when the rogue's blessing runs out.
+        self.UnitAuraExpiryTick = previous.UnitAuraExpiryTick;
     }
 
     /// <summary>
@@ -946,9 +957,12 @@ public sealed class GameSessionData
     /// the GCD hold state machine (issue #43) can construct a bare GameSessionData without
     /// standing up a full GlobalSessionData graph.
     /// </summary>
-    internal static GameSessionData CreateForTesting()
+    internal static GameSessionData CreateForTesting(GameSessionData? previous = null)
     {
-        return new GameSessionData();
+        var self = new GameSessionData();
+        if (previous != null)
+            CarryOverRealmScopedCaches(previous, self);
+        return self;
     }
     
     public uint GetCurrentGroupSize()
@@ -1430,7 +1444,55 @@ public sealed class GameSessionData
         UnitAuraDurationFull.Remove(guid);
         UnitAuraCaster.Remove(guid);
         UnitAuraLastEmitted.Remove(guid);
+        // UnitAuraExpiryTick deliberately survives — it restores remaining buff time
+        // when the unit re-enters view.
         return evicted;
+    }
+
+    public void RecordAuraExpiry(WowGuid128 guid, int spellId, int remainingMs)
+    {
+        if (remainingMs <= 0)
+            return;
+        if (UnitAuraExpiryTick.Count > 4096)
+        {
+            long now = Environment.TickCount64;
+            List<(WowGuid128, int)> expired = [];
+            foreach (var kvp in UnitAuraExpiryTick)
+                if (kvp.Value <= now)
+                    expired.Add(kvp.Key);
+            foreach (var key in expired)
+                UnitAuraExpiryTick.Remove(key);
+        }
+        UnitAuraExpiryTick[(guid, spellId)] = Environment.TickCount64 + remainingMs;
+    }
+
+    public int? TryGetAuraRemainingMs(WowGuid128 guid, int spellId)
+    {
+        if (!UnitAuraExpiryTick.TryGetValue((guid, spellId), out var expiry))
+            return null;
+        long remaining = expiry - Environment.TickCount64;
+        if (remaining <= 0)
+        {
+            UnitAuraExpiryTick.Remove((guid, spellId));
+            return null;
+        }
+        return (int)Math.Min(remaining, int.MaxValue);
+    }
+
+    public void ClearAuraExpiry(WowGuid128 guid, int spellId)
+    {
+        UnitAuraExpiryTick.Remove((guid, spellId));
+    }
+    // A single values update can move an aura to a lower free slot (set at B, clear at
+    // old A, B < A). The clear must not delete the expiry the set just recorded.
+    public bool IsSpellEmittedInAnotherSlot(WowGuid128 guid, byte exceptSlot, uint spellId)
+    {
+        if (!UnitAuraLastEmitted.TryGetValue(guid, out var dict))
+            return false;
+        foreach (var kvp in dict)
+            if (kvp.Key != exceptSlot && kvp.Value.SpellID == spellId)
+                return true;
+        return false;
     }
     public void StoreLastEmittedAura(WowGuid128 guid, byte slot, AuraDataInfo data)
     {

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -297,6 +297,14 @@ public sealed class GameSessionData
     // so we always send a valid family, cleared only on explicit pet dismiss.
     public ConcurrentDictionary<WowGuid128, ushort> CachedPetCreatureFamily = new();
     public Dictionary<uint, WowGuid128> CachedPetNumbers = new();
+    // Pet names learned from party member stats, keyed by pet number — lets us answer
+    // pet name queries for out-of-range party pets the legacy server returns empty for.
+    public Dictionary<uint, string> PartyPetNames = new();
+    // Last known pet stats / member level per party member guid. The legacy server only
+    // re-sends fields when they change, but the modern client expires party data it
+    // hasn't seen refreshed — these snapshots get re-attached to forwarded updates.
+    public Dictionary<WowGuid128, World.Server.Packets.PartyMemberPetStats> PartyPetStats = new();
+    public Dictionary<WowGuid128, ushort> PartyMemberLevels = new();
     // Tracks quest ids the proxy has issued its own CMSG_QUERY_QUEST_INFO for.
     public HashSet<uint> ProxyIssuedQuestInfoQueries = new();
     // JimsProxy: client-originated CMSG_QUERY_QUEST_INFO gating. Questie's filter-toggle

--- a/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
@@ -684,7 +684,111 @@ public partial class WorldClient
             }); //MIRASU
         } //MIRASU
 
+        MergeAndRefreshPartyStats(state, updateFlags.HasFlag(GroupUpdateFlagVanilla.PetGuid));
+        CachePartyPetName(state.Pet);
+        Log.Event("party.partial_state.translated", new
+        {
+            member_guid = state.AffectedGUID.ToString(),
+            update_flags = (uint)updateFlags,
+            level = state.Level,
+            aura_count = state.Auras?.Count,
+            has_pet = state.Pet != null,
+            pet_guid = state.Pet != null ? state.Pet.NewPetGuid.ToString() : null,
+            pet_name = state.Pet?.NewPetName,
+            pet_health = state.Pet?.Health,
+        });
         SendPacketToClient(state);
+    }
+
+    // The legacy server only re-sends party fields when they change, but the modern
+    // client expires member/pet data it hasn't seen refreshed — merge each delta into
+    // a per-member snapshot and re-attach it to every forwarded partial update.
+    void MergeAndRefreshPartyStats(PartyMemberPartialState state, bool petGuidInPacket)
+    {
+        var gameState = GetSession().GameState;
+        if (state.Level.HasValue)
+            gameState.PartyMemberLevels[state.AffectedGUID] = state.Level.Value;
+        else if (gameState.PartyMemberLevels.TryGetValue(state.AffectedGUID, out var level))
+            state.Level = level;
+
+        var pets = gameState.PartyPetStats;
+        if (petGuidInPacket && (state.Pet == null || state.Pet.NewPetGuid == default))
+        {
+            // guid arrived as zero — the pet was dismissed, drop the snapshot
+            pets.Remove(state.AffectedGUID);
+            if (state.Pet != null)
+                state.Pet.ExplicitClear = true;
+            return;
+        }
+        pets.TryGetValue(state.AffectedGUID, out var cached);
+        if (state.Pet != null)
+        {
+            cached ??= new PartyMemberPetStats();
+            if (state.Pet.NewPetGuid != default)
+                cached.NewPetGuid = state.Pet.NewPetGuid;
+            if (!string.IsNullOrEmpty(state.Pet.NewPetName))
+                cached.NewPetName = state.Pet.NewPetName;
+            if (state.Pet.DisplayID.HasValue)
+                cached.DisplayID = state.Pet.DisplayID;
+            if (state.Pet.Health.HasValue)
+                cached.Health = state.Pet.Health;
+            if (state.Pet.MaxHealth.HasValue)
+                cached.MaxHealth = state.Pet.MaxHealth;
+            pets[state.AffectedGUID] = cached;
+        }
+        if (cached == null || cached.NewPetGuid == default)
+            return;
+        state.Pet ??= new PartyMemberPetStats();
+        if (state.Pet.NewPetGuid == default)
+            state.Pet.NewPetGuid = cached.NewPetGuid;
+        if (string.IsNullOrEmpty(state.Pet.NewPetName))
+            state.Pet.NewPetName = cached.NewPetName;
+        state.Pet.DisplayID ??= cached.DisplayID;
+        state.Pet.Health ??= cached.Health;
+        state.Pet.MaxHealth ??= cached.MaxHealth;
+    }
+
+    // Full-state counterpart: refresh the snapshots and backfill level if the legacy
+    // full state omitted it (a full state would otherwise zero it client-side).
+    void SnapshotPartyStatsFromFull(PartyMemberFullState state, bool petGuidInPacket, bool levelInPacket)
+    {
+        var gameState = GetSession().GameState;
+        if (levelInPacket)
+            gameState.PartyMemberLevels[state.MemberGuid] = state.Level;
+        else if (gameState.PartyMemberLevels.TryGetValue(state.MemberGuid, out var level))
+            state.Level = level;
+
+        if (state.Pet != null && state.Pet.NewPetGuid != default)
+        {
+            gameState.PartyPetStats[state.MemberGuid] = new PartyMemberPetStats
+            {
+                NewPetGuid = state.Pet.NewPetGuid,
+                NewPetName = state.Pet.NewPetName,
+                DisplayID = state.Pet.DisplayID,
+                Health = state.Pet.Health,
+                MaxHealth = state.Pet.MaxHealth,
+            };
+        }
+        else if (petGuidInPacket)
+            gameState.PartyPetStats.Remove(state.MemberGuid);
+    }
+
+    // Remember party pet names so pet name queries can be answered even when the
+    // legacy server returns an empty name for an out-of-range pet.
+    void CachePartyPetName(PartyMemberPetStats? pet)
+    {
+        if (pet == null || pet.NewPetGuid == default || pet.NewPetGuid == WowGuid128.Empty || string.IsNullOrEmpty(pet.NewPetName))
+            return;
+        var gameState = GetSession().GameState;
+        uint petNumber = pet.NewPetGuid.GetEntry();
+        gameState.CachedPetNumbers[petNumber] = pet.NewPetGuid;
+        gameState.PartyPetNames[petNumber] = pet.NewPetName;
+        Log.Event("pet.name.party_stats_cached", new
+        {
+            pet_guid = pet.NewPetGuid.ToString(),
+            pet_number = petNumber,
+            name = pet.NewPetName,
+        });
     }
 
     [PacketHandler(Opcode.SMSG_PARTY_MEMBER_PARTIAL_STATE, ClientVersionBuild.V2_0_1_6180)]
@@ -831,6 +935,8 @@ public partial class WorldClient
             }
         }
 
+        MergeAndRefreshPartyStats(state, updateFlags.HasFlag(GroupUpdateFlagTBC.PetGuid));
+        CachePartyPetName(state.Pet);
         SendPacketToClient(state);
     }
 
@@ -893,6 +999,7 @@ public partial class WorldClient
             statusOnlyM.AffectedGUID = state.MemberGuid; //MIRASU
             if (updateFlags.HasFlag(GroupUpdateFlagVanilla.Status)) //MIRASU
                 statusOnlyM.StatusFlags = (ushort)(GroupMemberOnlineStatus)packet.ReadUInt8(); //MIRASU
+            MergeAndRefreshPartyStats(statusOnlyM, false);
             SendPacketToClient(statusOnlyM); //MIRASU
             return; //MIRASU - skip the full-state build entirely
         } //MIRASU  
@@ -1074,6 +1181,23 @@ public partial class WorldClient
                 state.Pet.Auras.Add(aura);
             }
         }
+        SnapshotPartyStatsFromFull(state, updateFlags.HasFlag(GroupUpdateFlagVanilla.PetGuid), updateFlags.HasFlag(GroupUpdateFlagVanilla.Level));
+        CachePartyPetName(state.Pet);
+        Log.Event("party.full_state.translated", new
+        {
+            member_guid = state.MemberGuid.ToString(),
+            update_flags = (uint)updateFlags,
+            status = (ushort)state.StatusFlags,
+            level = state.Level,
+            zone = state.ZoneID,
+            current_health = state.CurrentHealth,
+            max_health = state.MaxHealth,
+            aura_count = state.Auras?.Count ?? 0,
+            has_pet = state.Pet != null,
+            pet_guid = state.Pet != null ? state.Pet.NewPetGuid.ToString() : null,
+            pet_name = state.Pet?.NewPetName,
+            pet_health = state.Pet?.Health,
+        });
         SendPacketToClient(state); //MIRASU: Restore missing call — was lost during earlier brace-rearrangement edits. Without this the modern client never gets the initial full-state on party join, so members show as offline/unknown until a PARTIAL_STATE delta arrives (which may never include Status+Health together).     
     }
 
@@ -1231,6 +1355,8 @@ public partial class WorldClient
             }
         }
 
+        SnapshotPartyStatsFromFull(state, updateFlags.HasFlag(GroupUpdateFlagTBC.PetGuid), updateFlags.HasFlag(GroupUpdateFlagTBC.Level));
+        CachePartyPetName(state.Pet);
         SendPacketToClient(state);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -905,13 +905,37 @@ public partial class WorldClient
         response.Name = name;
         if (response.Name.Length == 0)
         {
-            // Legacy server returned empty name (typically a petnumber/guid mismatch in
-            // the CMSG). Still forward the response with Allow=false so the modern client
-            // stops retrying — without a response it spins on the query and the unit
-            // frame stays at "Unknown".
+            // Legacy server returns an empty name when the pet isn't in the player's map
+            // context (e.g. an out-of-range party member's pet). Fall back to the name we
+            // learned from party member stats so the party frame doesn't stay "Unknown".
+            if (GetSession().GameState.PartyPetNames.TryGetValue(petNumber, out var partyName))
+            {
+                response.Allow = true;
+                response.Name = partyName;
+                response.Timestamp = (uint)Time.UnixTime;
+                Log.Event("pet.name_query.party_stats_fallback", new
+                {
+                    pet_number = petNumber,
+                    guid = guid.ToString(),
+                    name = partyName,
+                });
+                SendPacketToClient(response);
+                return;
+            }
+            // No cached name either — still respond with Allow=false so the modern client
+            // stops retrying; without a response it spins and the frame stays "Unknown".
             response.Allow = false;
             SendPacketToClient(response);
             return;
+        }
+
+        // A real name response (e.g. after a rename) must win over the party-stats
+        // snapshot, or the keep-alive partials keep reverting the pet to its old name.
+        GetSession().GameState.PartyPetNames[petNumber] = name;
+        foreach (var petStats in GetSession().GameState.PartyPetStats.Values)
+        {
+            if (petStats.NewPetGuid == guid)
+                petStats.NewPetName = name;
         }
 
         response.Allow = true;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3560,6 +3560,9 @@ public partial class WorldClient
         aura.AuraData.Flags |= AuraFlagsModern.Duration;
         aura.AuraData.Duration = duration;
         aura.AuraData.Remaining = duration;
+        // Server-authoritative self duration — keep the durable expiry map in sync so a
+        // later relog doesn't restore a stale CSV-guessed value for our own buffs.
+        GetSession().GameState.RecordAuraExpiry(guid, (int)aura.AuraData.SpellID, duration);
 
         //MIRASU: Populate CastUnit and set NoCaster when caster is unknown — same rule as
         //MIRASU: the UpdateHandler aura loop. SMSG_UPDATE_AURA_DURATION arrives during login
@@ -3784,6 +3787,9 @@ public partial class WorldClient
 
                 GetSession().GameState.StoreAuraDurationLeft(target, slot, durationFull, Environment.TickCount);
                 GetSession().GameState.StoreAuraDurationFull(target, slot, durationFull);
+                // Mirror the cache seed above (recast → duration restarts at full), not the
+                // possibly-decayed Remaining, so the durable map never lags the cache.
+                GetSession().GameState.RecordAuraExpiry(target, (int)spellId, durationFull);
             }
         }
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -3447,6 +3447,12 @@ public partial class WorldClient
                             }
                             else
                             {
+                                // Slot occupant swapped spells without passing through 0 (Y→X in
+                                // one tick) — Y's decayed duration must not be served, or worse
+                                // persisted, under X.
+                                var prevEmitted = GetSession().GameState.GetLastEmittedAura(guid, i);
+                                if (prevEmitted != null && prevEmitted.SpellID != aura.AuraData.SpellID)
+                                    GetSession().GameState.ClearAuraDuration(guid, i);
                                 GetSession().GameState.GetAuraDuration(guid, i, out durationLeft, out durationFull);
                                 // JimsProxy (Cheap-Shot-aura-duration 2026-05-07): mirror the
                                 // SpellHandler refresh path's CSV fallback. On a cold cache (fresh
@@ -3462,6 +3468,25 @@ public partial class WorldClient
                                     int? talentDur = GameData.TryGetTalentDuration(auraSpellId, GetSession().GameState.CurrentPlayerKnownSpells);
                                     durationFull = talentDur ?? GameData.GetAuraSpellDuration(auraSpellId);
                                 }
+                                // Cold per-slot cache on a re-seen unit (relog, stealth
+                                // destroy/recreate) — resume the wall-clock remaining time
+                                // instead of restarting the timer at full duration.
+                                if (durationLeft <= 0 && isCreate &&
+                                    GetSession().GameState.TryGetAuraRemainingMs(guid, (int)aura.AuraData.SpellID) is int persistedMs)
+                                {
+                                    durationLeft = persistedMs;
+                                    if (durationFull < persistedMs)
+                                        durationFull = persistedMs;
+                                    GetSession().GameState.StoreAuraDurationFull(guid, i, durationFull);
+                                    GetSession().GameState.StoreAuraDurationLeft(guid, i, persistedMs, Environment.TickCount);
+                                    Framework.Logging.Log.Event("aura.duration.restored_from_expiry", new
+                                    {
+                                        target_low = guid.GetCounter(),
+                                        slot = i,
+                                        spell_id = aura.AuraData.SpellID,
+                                        remaining_ms = persistedMs,
+                                    });
+                                }
                             }
 
                             if (durationLeft > 0 && durationFull > 0)
@@ -3470,6 +3495,8 @@ public partial class WorldClient
                                 aura.AuraData.Duration = durationFull;
                                 aura.AuraData.Remaining = durationLeft;
                             }
+                            if (!appsOnlyChanged && aura.AuraData.Remaining is int remainingMs && remainingMs > 0)
+                                GetSession().GameState.RecordAuraExpiry(guid, (int)aura.AuraData.SpellID, remainingMs);
                             Framework.Logging.Log.Event("aura.slot.set", new
                             {
                                 target_low = guid.GetCounter(),
@@ -3510,6 +3537,10 @@ public partial class WorldClient
                             // Forward the empty AuraInfo so the client removes the icon, and drop
                             // the cached per-slot state so a later refresh doesn't inherit stale
                             // duration / caster from the previous occupant.
+                            var clearedAura = GetSession().GameState.GetLastEmittedAura(guid, i);
+                            if (clearedAura != null &&
+                                !GetSession().GameState.IsSpellEmittedInAnotherSlot(guid, i, clearedAura.SpellID))
+                                GetSession().GameState.ClearAuraExpiry(guid, (int)clearedAura.SpellID);
                             GetSession().GameState.ClearAuraDuration(guid, i);
                             GetSession().GameState.ClearAuraCaster(guid, i);
                             GetSession().GameState.ClearLastEmittedAura(guid, i);

--- a/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
@@ -213,6 +213,9 @@ public partial class WorldSocket
         WorldPacket packet = new WorldPacket(Opcode.CMSG_QUERY_PET_NAME);
         packet.WriteUInt32(queryName.UnitGUID.GetEntry());
         packet.WriteGuid(queryName.UnitGUID.To64());
+        // Modern pet guids embed the pet number as their entry — register the mapping now
+        // so the response resolves even for pets we never saw a unit create for.
+        GetSession().GameState.CachedPetNumbers[queryName.UnitGUID.GetEntry()] = queryName.UnitGUID;
         Framework.Logging.Log.Event("pet.name_query.sent", new
         {
             client_guid = queryName.UnitGUID.ToString(),

--- a/HermesProxy/World/Server/Packets/GroupPackets.cs
+++ b/HermesProxy/World/Server/Packets/GroupPackets.cs
@@ -821,7 +821,8 @@ class PartyMemberPartialState : ServerPacket
     public uint? WmoDoodadPlacementID;
     public Vector3_UInt16 Position = null!;
     public uint? VehicleSeatRecID;
-    public List<PartyMemberAuraStates> Auras = new();
+    // Null means "no aura change" — a non-null empty list wipes the member's aura display.
+    public List<PartyMemberAuraStates> Auras = null!;
     public PartyMemberPetStats Pet = null!;
     public PartyMemberPhaseStates Phase = null!;
     public UnkStruct901_2 Unk901_2 = null!;
@@ -993,21 +994,24 @@ public class PartyMemberPetStats
 {
     public void WritePartial(WorldPacket data)
     {
-        data.WriteBit(NewPetGuid != default);
-        data.WriteBit(NewPetName != null);
+        // NewPetName defaults to "" — writing the name bit with an empty string renames
+        // the pet to nothing client-side, so only send it when we actually have a name.
+        // ExplicitClear forces an empty guid on the wire to signal a dismissed pet.
+        data.WriteBit(NewPetGuid != default || ExplicitClear);
+        data.WriteBit(!string.IsNullOrEmpty(NewPetName));
         data.WriteBit(DisplayID.HasValue);
         data.WriteBit(MaxHealth.HasValue);
         data.WriteBit(Health.HasValue);
         data.WriteBit(Auras != null);
         data.FlushBits();
 
-        if (NewPetName != null)
+        if (!string.IsNullOrEmpty(NewPetName))
         {
             data.WriteBits(NewPetName.GetByteCount(), 8);
             data.WriteString(NewPetName);
         }
-        if (NewPetGuid != default)
-            data.WritePackedGuid128(NewPetGuid);
+        if (NewPetGuid != default || ExplicitClear)
+            data.WritePackedGuid128(NewPetGuid == default ? WowGuid128.Empty : NewPetGuid);
         if (DisplayID.HasValue)
             data.WriteUInt32(DisplayID.Value);
         if (MaxHealth.HasValue)
@@ -1054,7 +1058,10 @@ public class PartyMemberPetStats
     public uint? DisplayID;
     public uint? MaxHealth;
     public uint? Health;
-    public List<PartyMemberAuraStates> Auras = new();
+    // Null means "no aura change" — a non-null empty list wipes the pet's aura display.
+    public List<PartyMemberAuraStates> Auras = null!;
+    // Partial-only: write an empty pet guid to tell the client the pet was dismissed.
+    public bool ExplicitClear;
 }
 
 class MinimapPingClient : ClientPacket


### PR DESCRIPTION
﻿Party frames for out-of-range members degraded quickly on the modern client: a hunter's pet showed as "Unknown" when they joined the party, vanished from the party UI after a few seconds, and the member tooltip lost level info - all until a `/reload`.

Root cause is a protocol-cadence mismatch: the legacy server only re-sends party member fields when they change, while the modern client expects member state refreshed every few seconds and expires phantom member/pet data it hasn't seen recently. On top of that, three translation bugs made things worse:

1. Pet name queries for out-of-range pets couldn't be answered - the petNumber->guid mapping only existed for pets we'd seen a unit create for, so the legacy server's response (empty for out-of-range pets) was dropped entirely and the client stuck on "Unknown".
2. Every forwarded `PARTY_MEMBER_PARTIAL_STATE` containing any pet field wrote the pet-name-changed bit with an empty string (renaming the pet to nothing), and the aura list serialized as "replaced with zero auras" on every delta.
3. Explicit pet dismissal was unrepresentable in partial updates (empty guid never hit the wire).

Fixes:
- Register petNumber->guid at query time (modern pet guids embed the pet number as their entry) and answer empty legacy name responses from the name learned via party member stats - matching what a 1.12 client displays from `GROUP_UPDATE_FLAG_PET_NAME`.
- Keep per-member snapshots of pet stats and level, re-attached to every forwarded partial (legacy sends them every 2-8s), so the modern client's cache stays refreshed and pets/levels survive quiet stretches.
- Only write the pet name / aura list when there's actual content; dismissals now write an explicit empty guid.
- Real pet-name query responses (e.g. after a rename) sync back into the snapshots so refreshes don't revert the name.

Validated in-game two-box (hunter + priest, cross-zone both directions): pet appears immediately on invite with correct name, persists, member level stays on the tooltip, and a rename propagates correctly in and out of zone. New JSONL events: `pet.name.party_stats_cached`, `pet.name_query.party_stats_fallback`, `party.full_state.translated`, `party.partial_state.translated`.

Bonus fix confirmed in retest: stealthed group members no longer read as out-of-range. The legacy server destroys a stealthed ally's object even for group members (vmangos-style detection-limited group stealth visibility), and before this PR the phantom member data collapsed immediately, so raid frames greyed them out and PallyPower lost track of them mid-raid. With the keep-alive refreshes the client computes their range from party-stats position and nearby stealthers stay in-range, matching regular-server behavior.

Second commit: buff timers now survive relogs and unit destroys. Vanilla never sends remaining aura time for other units, so the proxy synthesizes durations - but the caches died with the session on relog (and per-unit on destroy), restarting every timer at full duration (PallyPower showed a blessing back at 15:00 after a relog). A wall-clock expiry map keyed (unit, spell) now survives both and restores the real remaining time when an aura is re-seen (`aura.duration.restored_from_expiry`), with correct handling of same-tick slot reshuffles, slot occupant swaps, rebuff refreshes, and authoritative self-aura durations. Validated in-game (blessing timer resumed correctly after relog); unit-tested; adversarially reviewed with all findings fixed and re-verified.
🤖 Generated with [Claude Code](https://claude.com/claude-code)



