### PR TITLE
Revert #399 observed-charmed-player possess shim (no effect on #382)

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -886,19 +886,6 @@ public sealed class GameSessionData
     // circle around already-doused runes on reload; the proxy destroys those client-side (paired rune has InUse). WC only.
     public Dictionary<uint, WowGuid128> McCirclesSeen = new();
 
-    // JimsProxy (#382 observer lockup): players we observe being CHARMED by another PLAYER
-    // (Gnomish Mind Control Cap 13181 = vanilla MOD_CHARM on a player). NPC charmers (raid
-    // MCs like Lucifron's Dominate Mind) are excluded — long-stable content, no lockup reports.
-    // Vanilla charm reaches observers as PLAYER_CONTROLLED + CHARMEDBY with no POSSESSED bit,
-    // and the 1.14 client has no representation for a charmed PLAYER (modern can't charm
-    // players; possess — priest MC 605 — renders fine, which is why priest MC never locks
-    // observers). While a guid is in here, the UNIT_FIELD_FLAGS translation forces
-    // UNIT_FLAG_POSSESSED so observing clients render their known possess path instead.
-    // Scoped to third-party observers only: the charmer keeps its real charm/pet bar and
-    // the target is untouched. Self-clears when CHARMEDBY empties (charm end) or on a
-    // fresh create block (re-appearance after an out-of-range charm end).
-    public HashSet<WowGuid128> ObservedCharmedPlayers = [];
-
     // JimsProxy (Tallstrider-Fix): per-GUID last-known facing orientation, populated from
     // any MovementInfo we observe (spawn, heartbeat, ObjectUpdate movement block). Used by
     // MovementHandler.HandleMonsterMove to compare the creature's current facing against

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2443,44 +2443,7 @@ public partial class WorldClient
             int UNIT_FIELD_CHARMEDBY = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_CHARMEDBY);
             if (UNIT_FIELD_CHARMEDBY >= 0 && updateMaskArray[UNIT_FIELD_CHARMEDBY])
             {
-                WowGuid128 charmedBy = GetGuidValue(updates, UnitField.UNIT_FIELD_CHARMEDBY).To128(GetSession().GameState);
-                updateData.UnitData.CharmedBy = charmedBy;
-
-                // JimsProxy (#382 observer lockup): track players charmed by ANOTHER PLAYER,
-                // so the flags translation below can present them as possessed (see
-                // GameSessionData.ObservedCharmedPlayers). Excludes the charmer (needs the real
-                // charm/pet bar) and the local player as target (lives the real charm), so the
-                // charm-vs-possess control difference is preserved for the participants.
-                // NPC charmers (Lucifron's Dominate Mind et al.) are deliberately excluded:
-                // years of raid MCs have produced no observer-lockup reports, so that
-                // long-stable content stays untouched.
-                var gameState = GetSession().GameState;
-                bool observedCharmedPlayer = guid.IsPlayer() &&
-                    charmedBy.IsPlayer() &&
-                    guid != gameState.CurrentPlayerGuid &&
-                    charmedBy != gameState.CurrentPlayerGuid;
-                if (observedCharmedPlayer)
-                {
-                    if (gameState.ObservedCharmedPlayers.Add(guid))
-                        Log.Event("charm.observed_player.possess_shim", new
-                        {
-                            guid_low = guid.GetCounter(),
-                            charmed_by_low = charmedBy.GetCounter(),
-                        });
-                }
-                else if (gameState.ObservedCharmedPlayers.Remove(guid))
-                {
-                    Log.Event("charm.observed_player.possess_shim_cleared", new
-                    {
-                        guid_low = guid.GetCounter(),
-                    });
-                }
-            }
-            else if (isCreate)
-            {
-                // A create block without CHARMEDBY means the unit is not charmed — drop any
-                // stale shim entry from a charm that ended while the unit was out of range.
-                GetSession().GameState.ObservedCharmedPlayers.Remove(guid);
+                updateData.UnitData.CharmedBy = GetGuidValue(updates, UnitField.UNIT_FIELD_CHARMEDBY).To128(GetSession().GameState);
             }
             int UNIT_FIELD_SUMMONEDBY = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY);
             if (UNIT_FIELD_SUMMONEDBY >= 0 && updateMaskArray[UNIT_FIELD_SUMMONEDBY])
@@ -2735,15 +2698,6 @@ public partial class WorldClient
                 // force the bit on so the client picks the swim animation.
                 if (Session.GameState.KnownSwimmingMobs.Contains(guid))
                     updateData.UnitData.Flags |= (uint)UnitFlags.CanSwim;
-
-                // JimsProxy (#382 observer lockup): present an observed charmed PLAYER as
-                // possessed. Vanilla MOD_CHARM (Gnomish MC Cap 13181) emits PLAYER_CONTROLLED
-                // + CHARMEDBY without POSSESSED; a charmed player is unrepresentable to the
-                // 1.14 client (BG bystanders FPS-lock rendering it), while possess (priest
-                // MC 605) renders fine. CHARMEDBY is processed above before this flags block,
-                // so apply/clear ordering within a single update is already correct.
-                if (Session.GameState.ObservedCharmedPlayers.Contains(guid))
-                    updateData.UnitData.Flags |= (uint)UnitFlags.Possessed;
 
                 // Here because of this bullshit in cmangos:
                 // https://github.com/cmangos/mangos-tbc/blob/fd093b33071b546545cc5973608304bccc5a041b/src/game/Entities/Object.cpp#L544


### PR DESCRIPTION
Reverts 650a238 (#399), which forced `UNIT_FLAG_POSSESSED` onto players observed being charmed by another player, as an attempt at the #382 BG FPS drop.

## Why revert
- **It didn't fix #382.** The FPS drop predates this shim and reproduces identically with it active (reporter- and maintainer-confirmed). POSSESSED-vs-not is not the discriminator.
- **It injects a representation a real server never sends.** Per TrinityCore `Unit::SetCharmedBy`, a player charmed via `CHARM_TYPE_CHARM` (Gnomish Mind Control Cap 13181) gets only faction→charmer + `CHARMEDBY`→charmer; `UNIT_FLAG_POSSESSED` is set *only* for POSSESS/VEHICLE. A `.pkt` capture confirms we already deliver the correct charm set **and** clear, so the shim only added an incorrect flag with no benefit.

Reverting returns to a clean, correct wire representation of a charmed player.

## What this does NOT claim
This does not fix #382. Current **leading but unconfirmed** hypothesis: the drop is a client-side spell-visual teardown/GC leak (vmangos #3227 family) triggered by the rapid cast burst a charmed caster auto-fires — consistent with reporter data (AMD GPU, `/reload` doesn't clear it, render-range-gated, relog clears it) but **not proven**; a single "reproduces on NVIDIA" report would falsify the GPU-masking leg. The revert stands regardless of whether that hypothesis holds.

Build clean; 731/731 tests pass.
