### PR TITLE
JimsPlus Performance Mode + proxy sideband handshake expiry

### DIFF
--- a/Addons/JimsPlus/Core.lua
+++ b/Addons/JimsPlus/Core.lua
@@ -12,6 +12,21 @@ function namespace:RegisterModule(name, initFunc)
     self.modules[name] = { init = initFunc, enabled = true }
 end
 
+-- JimsProxy (Performance Mode): suspend/restore the cast-bar engine (the one heavy, per-frame
+-- module) for crowded fights. This is more than the per-unit castbar checkboxes: it also stops
+-- the proxy sideband and the per-event tracking. All other JimsPlus fixes stay active.
+function namespace:SetPerformanceMode(on)
+    on = on and true or false
+    if self.db then self.db.performanceMode = on end
+    local cb = JimsPlusCastbars
+    if cb then
+        if on then cb:SuspendCastbars() else cb:ResumeCastbars() end
+    end
+    print("|cFF00FF00[JimsPlus]|r Performance Mode " ..
+        (on and "|cFFFFD100ON|r — cast bars suspended (other fixes stay active)"
+             or "|cFF00FF00OFF|r — cast bars restored") .. ".")
+end
+
 local f = CreateFrame("Frame")
 f:RegisterEvent("ADDON_LOADED")
 f:SetScript("OnEvent", function(_, _, addon)
@@ -20,5 +35,6 @@ f:SetScript("OnEvent", function(_, _, addon)
     if JimsPlusDB.petFix == nil then JimsPlusDB.petFix = true end
     if JimsPlusDB.taxiFix == nil then JimsPlusDB.taxiFix = true end
     if JimsPlusDB.bagSortOrder == nil then JimsPlusDB.bagSortOrder = false end
+    if JimsPlusDB.performanceMode == nil then JimsPlusDB.performanceMode = false end
     namespace.db = JimsPlusDB
 end)

--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -188,6 +188,12 @@ for _, info in ipairs(castbarUnits) do
     y = y - 28
 end
 
+y = y - 4
+local cbPerf = CreateCheckbox(panel, y,
+    "Performance Mode  |cFFFFD100(suspends cast bars)|r",
+    "For crowded fights (battlegrounds, big pulls) where FPS tanks: fully suspends the\ncast-bar engine — stops rendering, stops per-event tracking, and tells the proxy to\nstop sending cast data entirely. Toggle on when it's a zerg, off when it clears.\n\nAll other JimsPlus fixes stay active. Shortcut: /jp perf")
+y = y - 32
+
 ---------------------------------------------------------------------------
 -- Tools
 ---------------------------------------------------------------------------
@@ -222,6 +228,8 @@ local function RefreshCheckboxes()
             castbarCBs[info.key]:SetChecked(unitDB and unitDB.enabled and true or false)
         end
     end
+
+    cbPerf:SetChecked((namespace.db and namespace.db.performanceMode) and true or false)
 end
 panel:SetScript("OnShow", RefreshCheckboxes)
 panel.refresh = RefreshCheckboxes
@@ -262,6 +270,10 @@ cbBagSort:SetScript("OnClick", function(self)
     print("|cFF00FF00[JimsPlus]|r Custom bag sort order " .. (enabled and "enabled" or "disabled") .. ".")
 end)
 
+cbPerf:SetScript("OnClick", function(self)
+    namespace:SetPerformanceMode(self:GetChecked() and true or false)
+end)
+
 for _, info in ipairs(castbarUnits) do
     local key = info.key
     castbarCBs[key]:SetScript("OnClick", function(self)
@@ -284,7 +296,13 @@ InterfaceOptions_AddCategory(panel)
 
 SLASH_JIMSPLUS1 = "/jimsplus"
 SLASH_JIMSPLUS2 = "/jp"
-SlashCmdList["JIMSPLUS"] = function()
+SlashCmdList["JIMSPLUS"] = function(msg)
+    msg = (msg or ""):lower():gsub("%s+", "")
+    if msg == "perf" or msg == "performance" then
+        namespace:SetPerformanceMode(not (namespace.db and namespace.db.performanceMode))
+        if panel.refresh then panel.refresh() end
+        return
+    end
     InterfaceOptionsFrame_OpenToCategory(panel)
     InterfaceOptionsFrame_OpenToCategory(panel)
 end

--- a/Addons/JimsPlus/castbars/CastBars.lua
+++ b/Addons/JimsPlus/castbars/CastBars.lua
@@ -348,15 +348,72 @@ function addon:ToggleUnitEvents(shouldReset)
     end
 end
 
+-- JimsProxy (Performance Mode): announce the JP sideband handshake reflecting current state.
+-- "1" enables the proxy's cast-time/channel sideband; "0" tells it to STOP. Not-listening
+-- client-side is NOT enough — the proxy keeps streaming JP_ chat until it receives "0"
+-- (ChatHandler.HandleJimsPlusSideband). Also doubles as the heartbeat the proxy expires on.
+function addon:SendSidebandHandshake()
+    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
+        C_ChatInfo.SendAddonMessage("JP", self.suspended and "0" or "1", "WHISPER", UnitName("player"))
+    end
+end
+
+-- JimsProxy (Performance Mode): fully suspend the cast-bar engine for crowded fights.
+-- Unchecking the per-unit boxes only stops DISPLAY; this also stops the proxy sideband,
+-- unregisters the high-volume inbound streams (CLEU, nameplate, chat), drops all tracked
+-- casts, and nils the per-frame OnUpdate — so the client pays neither the render cost nor
+-- the per-event tracking cost. Every other JimsPlus fix is left untouched.
+function addon:SuspendCastbars()
+    if self.suspended then return end
+    self.suspended = true
+
+    self:SendSidebandHandshake() -- "0": proxy stops emitting the sideband
+
+    self:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+    self:UnregisterEvent("CHAT_MSG_SYSTEM")
+    self:UnregisterEvent("PLAYER_TARGET_CHANGED")
+    self:UnregisterEvent("UNIT_AURA")
+    self:UnregisterEvent("NAME_PLATE_UNIT_ADDED")
+    self:UnregisterEvent("NAME_PLATE_UNIT_REMOVED")
+    self:UnregisterEvent("GROUP_ROSTER_UPDATE")
+    self:UnregisterEvent("GROUP_JOINED")
+    -- PLAYER_ENTERING_WORLD / ZONE_CHANGED_NEW_AREA stay registered so we re-affirm "0"
+    -- across loading screens (a reconnect resets the proxy to off, but re-affirming keeps
+    -- intent explicit and survives a mid-suspend session change).
+
+    wipe(activeGUIDs)
+    wipe(activeTimers)
+    wipe(activeFrames)
+    PoolManager:GetFramePool():ReleaseAll()
+    self:SetFocusDisplay(nil)
+    self:SetScript("OnUpdate", nil)
+end
+
+-- JimsProxy (Performance Mode): restore the cast-bar engine.
+function addon:ResumeCastbars()
+    if not self.suspended then return end
+    self.suspended = false
+
+    self:SetScript("OnUpdate", self.CastbarOnUpdate)
+    self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+    self:RegisterEvent("CHAT_MSG_SYSTEM")
+    self:ToggleUnitEvents() -- restores NAME_PLATE / target / party per db.enabled
+
+    self:SendSidebandHandshake() -- "1": proxy resumes the sideband
+    if self.db and self.db.party and self.db.party.enabled and IsInGroup() then
+        self:GROUP_ROSTER_UPDATE()
+    end
+end
+
 function addon:PLAYER_ENTERING_WORLD(isInitialLogin)
     if isInitialLogin then return end
 
     -- Re-announce the JP sideband handshake. A reconnect (or any loading screen) gives the
     -- proxy a fresh session with JimsPlusSideband=false, so without re-sending "1" the cast-time
     -- and channel sidebands silently stop until /reload. Idempotent on same-session zone changes.
-    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
-        C_ChatInfo.SendAddonMessage("JP", "1", "WHISPER", UnitName("player"))
-    end
+    -- While suspended (Performance Mode) this re-affirms "0" instead, and skips the rebuild below.
+    self:SendSidebandHandshake()
+    if self.suspended then return end
 
     -- Reset all data on loading screens
     wipe(activeGUIDs)
@@ -512,7 +569,7 @@ function addon:PLAYER_LOGIN()
     self:UnregisterEvent("PLAYER_LOGIN")
     self.PLAYER_LOGIN = nil
 
-    C_ChatInfo.SendAddonMessage("JP", "1", "WHISPER", UnitName("player"))
+    self:SendSidebandHandshake()
 
     ChatFrame_AddMessageEventFilter("CHAT_MSG_SYSTEM", function(_, _, msg)
         local p = msg:sub(1, 3)
@@ -520,6 +577,19 @@ function addon:PLAYER_LOGIN()
             return true
         end
     end)
+
+    -- JimsProxy (Performance Mode): heartbeat the handshake so the proxy can expire it if the
+    -- addon is disabled or crashes. A gone addon can't send "0", so without this the proxy keeps
+    -- streaming raw JP_ lines that the (now-absent) chat filter no longer swallows — the reported
+    -- "JP_CS:Player-..." chat spam. Re-affirms "1" while active / "0" while suspended.
+    if C_Timer and C_Timer.NewTicker then
+        C_Timer.NewTicker(30, function() addon:SendSidebandHandshake() end)
+    end
+
+    -- Apply a persisted Performance Mode toggle on login.
+    if namespace.db and namespace.db.performanceMode then
+        self:SuspendCastbars()
+    end
 end
 
 local auraRows = 0
@@ -798,7 +868,9 @@ end
 
 local refresh = 0
 local castStopBlacklist = namespace.castStopBlacklist
-addon:SetScript("OnUpdate", function(self, elapsed)
+-- JimsProxy (Performance Mode): stored as a named ref so SuspendCastbars can detach it
+-- (SetScript("OnUpdate", nil)) and ResumeCastbars can reattach it.
+addon.CastbarOnUpdate = function(self, elapsed)
 
     if not next(activeTimers) then return end
     local currTime = GetTime()
@@ -878,4 +950,5 @@ addon:SetScript("OnUpdate", function(self, elapsed)
             end
         end
     end
-end)
+end
+addon:SetScript("OnUpdate", addon.CastbarOnUpdate)

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -86,6 +86,11 @@ public sealed class GameSessionData
     // haven't forwarded one yet this session — first request always passes.
     public long LastForwardedPvpLogDataTickMs;
     public bool JimsPlusSideband;
+    // JimsProxy (Performance Mode / handshake expiry): Environment.TickCount64 of the last "JP"/"1"
+    // affirmation from the addon (0 = never). The JimsPlus addon heartbeats the handshake every
+    // ~30s; if we stop hearing it (addon disabled or crashed) the sideband expires, so we don't
+    // keep streaming raw JP_ chat that the now-absent client-side filter can no longer suppress.
+    public long JimsPlusSidebandAffirmedMs;
     public bool ChannelDisplayList;
     public bool ShowPlayedTime;
     public bool IsInFarSight;
@@ -353,6 +358,15 @@ public sealed class GameSessionData
     private readonly ConcurrentDictionary<WowGuid128, long> _recentlyDestroyedObjects = new();
     private const long RecentlyDestroyedSweepAgeMs = 600_000;
     private const int RecentlyDestroyedSweepThreshold = 4096;
+
+    // JimsProxy (Performance Mode / handshake expiry): the sideband is live only while the addon
+    // keeps re-affirming "1" (it heartbeats every ~30s). A disabled/crashed addon can't send "0",
+    // so we time the handshake out — otherwise the proxy would keep emitting raw JP_ chat that the
+    // now-absent addon filter no longer suppresses (the reported "JP_CS:Player-..." spam).
+    public const long JimsPlusSidebandExpiryMs = 100_000;
+    public bool IsJimsPlusSidebandActive()
+        => JimsPlusSideband
+           && (Environment.TickCount64 - JimsPlusSidebandAffirmedMs) <= JimsPlusSidebandExpiryMs;
 
     public void MarkObjectRecentlyDestroyed(WowGuid128 guid)
     {

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1868,7 +1868,7 @@ public partial class WorldClient
         // Send cast-time sideband for non-self casters so the addon gets
         // the server-reported cast time instead of GetSpellInfo() which
         // returns the observer's own modified value (wrong rank/talents).
-        if (GetSession().GameState.JimsPlusSideband &&
+        if (GetSession().GameState.IsJimsPlusSidebandActive() &&
             spell.Cast.CasterUnit != GetSession().GameState.CurrentPlayerGuid &&
             spell.Cast.CasterUnit != GetSession().GameState.CurrentPetGuid &&
             spell.Cast.CastTime > 0)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -3093,7 +3093,7 @@ public partial class WorldClient
                         if (spellId != 0)
                         {
                             channelSpells[guid] = spellId;
-                            if (GetSession().GameState.JimsPlusSideband)
+                            if (GetSession().GameState.IsJimsPlusSidebandActive())
                             {
                                 var chatPkt = new ChatPkt(GetSession(), ChatMessageTypeModern.System,
                                     $"JP_CH:S:{guidStr}:{spellId}");
@@ -3104,7 +3104,7 @@ public partial class WorldClient
                         {
                             channelSpells.TryRemove(guid, out _);
                             GetSession().GameState.ChannelSourceObjectByUnit.TryRemove(guid, out _); // #383
-                            if (GetSession().GameState.JimsPlusSideband)
+                            if (GetSession().GameState.IsJimsPlusSidebandActive())
                             {
                                 var chatPkt = new ChatPkt(GetSession(), ChatMessageTypeModern.System,
                                     $"JP_CH:X:{guidStr}");

--- a/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ChatHandler.cs
@@ -533,7 +533,10 @@ public partial class WorldSocket
 
         if (body == "0" || body == "1")
         {
-            GetSession().GameState.JimsPlusSideband = body == "1";
+            var gs = GetSession().GameState;
+            gs.JimsPlusSideband = body == "1";
+            if (body == "1")
+                gs.JimsPlusSidebandAffirmedMs = Environment.TickCount64;
             return;
         }
 


### PR DESCRIPTION
Adds a **Performance Mode** toggle to JimsPlus and the **proxy-side handshake expiry** followup, in one PR (both live in `Addons/JimsPlus/` and `HermesProxy/`).

## Performance Mode (addon) — default OFF
One toggle to collapse JimsPlus's per-frame/per-event cost in crowded fights (BGs, big pulls). The heavy module is the cast-bar engine (`castbars/`) — multiple per-frame `OnUpdate` loops, nameplate hooks, CLEU, and the `JP_` sideband consumer. Performance Mode does a **full** teardown, not just the per-unit display toggles:
- unregisters the high-volume streams: `COMBAT_LOG_EVENT_UNFILTERED`, `CHAT_MSG_SYSTEM`, `NAME_PLATE_*`, target/party events
- drops all tracked casts + releases the frame pool, and nils the per-frame `OnUpdate`
- **sends `JP`/`0`** so the proxy stops emitting the sideband entirely

Every other JimsPlus fix (tooltip, pet, taxi, mail, zone-sync, …) stays active. Toggle via the Options panel checkbox or `/jp perf`; persisted in `JimsPlusDB.performanceMode` and re-applied on login. The world-enter re-handshake now reflects suspended state (`0`) instead of always sending `1`, so entering a BG (a loading screen) can't silently re-enable it.

**Why display-off wasn't enough:** the proxy streams `JP_CS`/`JP_CH` until it receives `0` (`ChatHandler.HandleJimsPlusSideband`), so the client keeps paying the `SMSG_MESSAGECHAT` cost regardless of whether the addon renders. Unchecking the per-unit boxes only stopped rendering — this stops the source.

## Handshake expiry (proxy) — the followup
The addon now heartbeats the handshake every ~30s; the proxy expires `JimsPlusSideband` after 100s without a re-affirm (`GameState.IsJimsPlusSidebandActive()`, gating all three emit sites). This fixes the **`JP_CS:Player-…` chat spam** that appears when the addon is disabled mid-session: a gone addon can't send `0` or run its `CHAT_MSG_SYSTEM` filter, so without expiry the proxy kept streaming raw `JP_` lines with nothing to suppress them.

## Status / honesty
Candidate mitigation for the MC-cap BG FPS drop (#382). Suspending the cast-bar **display** alone already **measurably reduced** the drop in reporter testing ("less brutal, but still there") — this PR is the complete form (display + events + sideband), **pending a clean reporter confirmation** (they'll re-test with a fresh session, addon fully off, to size any residual). The expiry fix is a real bug fix worth shipping regardless. **Default OFF**, so the normal experience is unchanged.

Proxy: build clean, **731/731 tests pass**. Addon: structurally reviewed (no Lua interpreter in CI); Performance Mode is opt-in so blast radius on the default path is nil.
