### PR TITLE
#382 diagnostic: charm-presentation A/B levers (Charm382*, all default off)

### DIFF
--- a/HermesProxy.Tests/World/CharmPresentationLeverTests.cs
+++ b/HermesProxy.Tests/World/CharmPresentationLeverTests.cs
@@ -1,0 +1,142 @@
+using HermesProxy.World;
+using HermesProxy.World.Client;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (#382 charm-presentation levers): a player charmed by ANOTHER PLAYER in a BG
+// FPS-locks 1.14 clients (victim and bystanders) for the charm's duration. Capture analysis
+// (2026-07-23) exonerated the flags lane wholesale (PET_IN_COMBAT = routine pet-owner state;
+// cap1/cap2 charm windows carried no flags updates at all) and narrowed the held observer
+// state to three legs: CHARMEDBY(player), the faction flip, and the charm aura itself.
+// These tests lock the scope predicates of the config levers that let a reporter A/B each
+// leg independently. NPC charmers (Lucifron's Dominate Mind 20604) must never be touched —
+// raid MC is long-stable content.
+public class CharmPresentationLeverTests
+{
+    static readonly WowGuid128 Victim = WowGuid128.Create(HighGuidType703.Player, 21654);
+    static readonly WowGuid128 Charmer = WowGuid128.Create(HighGuidType703.Player, 15773);
+    static readonly WowGuid128 LocalPlayer = WowGuid128.Create(HighGuidType703.Player, 28648);
+    static readonly WowGuid128 NpcCharmer = WowGuid128.Create(HighGuidType703.Creature, 0, 12118, 500); // Lucifron
+    static readonly WowGuid128 NpcVictim = WowGuid128.Create(HighGuidType703.Creature, 0, 100, 501);
+
+    const uint GnomishMindControlCap = 13181; // MOD_CHARM
+    const uint PriestMindControl = 605;       // MOD_POSSESS
+    const uint DominateMind = 20604;          // Lucifron (NPC charmer)
+    const uint UnrelatedAura = 1833;          // Cheap Shot
+
+    // ---- scope predicate (shared by the shim and levers L1/L2) ----
+
+    [Fact]
+    public void ObservedPredicate_PlayerCharmedByPlayer_Bystander_True()
+    {
+        Assert.True(WorldClient.IsObservedPlayerCharmedByPlayer(Victim, Charmer, LocalPlayer));
+    }
+
+    [Fact]
+    public void ObservedPredicate_LocalPlayerIsVictim_False()
+    {
+        Assert.False(WorldClient.IsObservedPlayerCharmedByPlayer(LocalPlayer, Charmer, LocalPlayer));
+    }
+
+    [Fact]
+    public void ObservedPredicate_LocalPlayerIsCharmer_False()
+    {
+        Assert.False(WorldClient.IsObservedPlayerCharmedByPlayer(Victim, LocalPlayer, LocalPlayer));
+    }
+
+    [Fact]
+    public void ObservedPredicate_NpcCharmer_False()
+    {
+        Assert.False(WorldClient.IsObservedPlayerCharmedByPlayer(Victim, NpcCharmer, LocalPlayer));
+    }
+
+    [Fact]
+    public void ObservedPredicate_NpcVictim_False()
+    {
+        Assert.False(WorldClient.IsObservedPlayerCharmedByPlayer(NpcVictim, Charmer, LocalPlayer));
+    }
+
+    // Charm end: CHARMEDBY empties — predicate must go false so the clear is forwarded
+    // and the tracking set drops the guid.
+    [Fact]
+    public void ObservedPredicate_EmptyCharmedBy_False()
+    {
+        Assert.False(WorldClient.IsObservedPlayerCharmedByPlayer(Victim, WowGuid128.Empty, LocalPlayer));
+    }
+
+    // ---- L3: charm-aura suppression (spell-id gated — ordering-proof vs the CHARMEDBY packet) ----
+
+    [Fact]
+    public void AuraSuppress_LeverOn_GnomishCapOnObservedPlayer_Suppressed()
+    {
+        Assert.True(WorldClient.ShouldSuppressCharmAuraForObserver(true, Victim, LocalPlayer, GnomishMindControlCap));
+    }
+
+    [Fact]
+    public void AuraSuppress_LeverOn_PriestMcOnObservedPlayer_Suppressed()
+    {
+        Assert.True(WorldClient.ShouldSuppressCharmAuraForObserver(true, Victim, LocalPlayer, PriestMindControl));
+    }
+
+    // Lucifron's Dominate Mind: NPC-charmer aura — never suppressed, raid MC is stable content.
+    [Fact]
+    public void AuraSuppress_LeverOn_DominateMind_NotSuppressed()
+    {
+        Assert.False(WorldClient.ShouldSuppressCharmAuraForObserver(true, Victim, LocalPlayer, DominateMind));
+    }
+
+    [Fact]
+    public void AuraSuppress_LeverOn_UnrelatedAura_NotSuppressed()
+    {
+        Assert.False(WorldClient.ShouldSuppressCharmAuraForObserver(true, Victim, LocalPlayer, UnrelatedAura));
+    }
+
+    // Victim path is deliberately untouched (deferred): self keeps its own charm aura.
+    [Fact]
+    public void AuraSuppress_LeverOn_SelfIsVictim_NotSuppressed()
+    {
+        Assert.False(WorldClient.ShouldSuppressCharmAuraForObserver(true, LocalPlayer, LocalPlayer, GnomishMindControlCap));
+    }
+
+    [Fact]
+    public void AuraSuppress_LeverOn_CreatureUnit_NotSuppressed()
+    {
+        Assert.False(WorldClient.ShouldSuppressCharmAuraForObserver(true, NpcVictim, LocalPlayer, GnomishMindControlCap));
+    }
+
+    [Fact]
+    public void AuraSuppress_LeverOff_NotSuppressed()
+    {
+        Assert.False(WorldClient.ShouldSuppressCharmAuraForObserver(false, Victim, LocalPlayer, GnomishMindControlCap));
+    }
+
+    // ---- L2: faction hold (hold only when tracked AND a pre-charm faction was seen) ----
+
+    [Fact]
+    public void FactionHold_LeverOnTrackedCached_Holds()
+    {
+        Assert.True(WorldClient.ShouldHoldFactionForCharm(leverOn: true, isTrackedObservedCharm: true, hasCachedFaction: true));
+    }
+
+    // No cached pre-charm faction (unit walked into range mid-charm): forward raw — we
+    // cannot hold a value we never saw.
+    [Fact]
+    public void FactionHold_NoCachedFaction_ForwardsRaw()
+    {
+        Assert.False(WorldClient.ShouldHoldFactionForCharm(leverOn: true, isTrackedObservedCharm: true, hasCachedFaction: false));
+    }
+
+    [Fact]
+    public void FactionHold_NotTracked_ForwardsRaw()
+    {
+        Assert.False(WorldClient.ShouldHoldFactionForCharm(leverOn: true, isTrackedObservedCharm: false, hasCachedFaction: true));
+    }
+
+    [Fact]
+    public void FactionHold_LeverOff_ForwardsRaw()
+    {
+        Assert.False(WorldClient.ShouldHoldFactionForCharm(leverOn: false, isTrackedObservedCharm: true, hasCachedFaction: true));
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -63,6 +63,25 @@ public static class Settings
     // block so input isn't locked client-side even if the server ignores the cancel.
     public static bool StuckLogoutStunCancelFix;
     public static bool StuckLogoutStunClientStrip;
+    // JimsProxy (#382 charm-presentation A/B levers, 2026-07-23): a player charmed by
+    // ANOTHER PLAYER (Gnomish MC Cap 13181 / priest MC 605) FPS-locks 1.14 clients in BGs
+    // for the charm's duration — victim and bystanders alike; native 1.12 clients and NPC
+    // charmers (Lucifron) are fine. Capture analysis exonerated the flags lane (PET_IN_COMBAT
+    // is routine pet-owner state; two of three captured charm windows carried no flags
+    // updates at all) and narrowed the held observer-side state to three legs: the
+    // CHARMEDBY relationship, the faction flip, and the charm aura itself. Each lever
+    // hides ONE leg from bystander sessions so a reporter can isolate the costly one.
+    // All default OFF (= current behavior); diagnostic use only — no lever ships enabled
+    // without A/B confirmation. Scope: observed player-charmed-by-player only; the victim's
+    // own session, the charmer's session, and all NPC-charmer content are untouched.
+    public static bool Charm382SuppressCharmedBy;
+    public static bool Charm382FactionHold;
+    public static bool Charm382SuppressCharmAura;
+    // Gate for the pre-existing #399 possess shim (OR UNIT_FLAG_POSSESSED onto observed
+    // charmed players). Default TRUE = current beta behavior; set false to A/B dropping
+    // the shim's synthetic possess bit. Default-init true so paths that bypass
+    // LoadAndVerifyFrom (tests) keep today's behavior.
+    public static bool Charm382ObserverPossess = true;
     // JimsProxy (clean handshake teardown): bound the realmd auth handshake. If realmd accepts
     // the TCP connection but never sends LOGON_CHALLENGE (half-accepting login server, load-shed,
     // firewall), the login thread would otherwise block forever ("stuck on Connecting..."). On
@@ -191,6 +210,10 @@ public static class Settings
         UnplannedReconnectTimeoutMs = Math.Clamp(config.GetInt("UnplannedReconnectTimeoutMs", 5000), 1000, 30000);
         StuckLogoutStunCancelFix = config.GetBoolean("StuckLogoutStunCancelFix", true);
         StuckLogoutStunClientStrip = config.GetBoolean("StuckLogoutStunClientStrip", true);
+        Charm382SuppressCharmedBy = config.GetBoolean("Charm382SuppressCharmedBy", false);
+        Charm382FactionHold = config.GetBoolean("Charm382FactionHold", false);
+        Charm382SuppressCharmAura = config.GetBoolean("Charm382SuppressCharmAura", false);
+        Charm382ObserverPossess = config.GetBoolean("Charm382ObserverPossess", true);
         AuthHandshakeTimeoutMs = Math.Clamp(config.GetInt("AuthHandshakeTimeoutMs", 15000), 1000, 60000);
         EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -899,6 +899,13 @@ public sealed class GameSessionData
     // fresh create block (re-appearance after an out-of-range charm end).
     public HashSet<WowGuid128> ObservedCharmedPlayers = [];
 
+    // JimsProxy (#382, lever L2 Charm382FactionHold): last RAW-forwarded UNIT_FIELD_FACTIONTEMPLATE
+    // per PLAYER guid. Only written when a faction value is forwarded unmodified — never while a
+    // hold is active — so during an observed charm it retains the pre-charm faction. The charm-end
+    // restore equals the held value, making the whole charm faction-invisible to this client when
+    // the lever is on. Player guids only (bounded by players seen this session).
+    public Dictionary<WowGuid128, int> LastForwardedPlayerFaction = new();
+
     // JimsProxy (Tallstrider-Fix): per-GUID last-known facing orientation, populated from
     // any MovementInfo we observe (spawn, heartbeat, ObjectUpdate movement block). Used by
     // MovementHandler.HandleMonsterMove to compare the creature's current facing against

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3738,6 +3738,22 @@ public partial class WorldClient
             return;
         }
 
+        // JimsProxy (#382, lever L3 Charm382SuppressCharmAura): this flicker-refresh path
+        // re-emits an existing aura when it's re-cast onto the target — without this gate a
+        // re-cap would leak the suppressed charm aura back to bystanders through here.
+        if (ShouldSuppressCharmAuraForObserver(Settings.Charm382SuppressCharmAura, target,
+                GetSession().GameState.CurrentPlayerGuid, spellId))
+        {
+            Framework.Logging.Log.Event("aura.slot.dropped_charm_observer", new
+            {
+                target_low = target.GetCounter(),
+                slot,
+                spell_id = spellId,
+                source = "refresh_update",
+            });
+            return;
+        }
+
         auraData.CastUnit = caster;
 
         // For the current player, SMSG_UPDATE_AURA_DURATION will follow with the

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -90,6 +90,43 @@ public partial class WorldClient
         return guid.GetHighType() == HighGuidType.Creature;
     }
 
+    // JimsProxy (#382 charm-presentation levers): scope predicate shared by the possess-shim
+    // tracking and the Charm382* A/B levers — a PLAYER charmed by ANOTHER PLAYER, seen from a
+    // bystander session. The victim (guid == self) and the charmer (charmedBy == self) keep
+    // the raw presentation; NPC charmers (Lucifron's Dominate Mind et al.) are long-stable
+    // raid content and stay untouched.
+    internal static bool IsObservedPlayerCharmedByPlayer(WowGuid128 guid, WowGuid128 charmedBy, WowGuid128 localPlayerGuid)
+    {
+        return guid.IsPlayer() &&
+            charmedBy.IsPlayer() &&
+            guid != localPlayerGuid &&
+            charmedBy != localPlayerGuid;
+    }
+
+    // JimsProxy (#382, lever L3 Charm382SuppressCharmAura): drop the charm aura itself
+    // (Gnomish MC Cap 13181 / priest MC 605) from a bystander's view of a charmed player.
+    // Spell-id gated rather than tracking-set gated so it holds even if the aura slot update
+    // arrives in a packet before the CHARMEDBY write — both spells are player-only casts, so
+    // spell id alone implies a player charmer. 20604 (Lucifron) is deliberately NOT listed.
+    internal static bool ShouldSuppressCharmAuraForObserver(bool leverOn, WowGuid128 guid, WowGuid128 localPlayerGuid, uint spellId)
+    {
+        if (!leverOn)
+            return false;
+        if (spellId != 13181 && spellId != 605) // Gnomish MC Cap / priest Mind Control
+            return false;
+        return guid.IsPlayer() && guid != localPlayerGuid;
+    }
+
+    // JimsProxy (#382, lever L2 Charm382FactionHold): hold a charmed player's pre-charm
+    // faction for bystanders instead of forwarding the server's flip to the charmer's
+    // faction. Only when the unit is tracked as an observed player-charmed-player AND we
+    // actually saw a pre-charm faction to hold (a unit walking into range mid-charm has no
+    // cached value — forward raw, same as today).
+    internal static bool ShouldHoldFactionForCharm(bool leverOn, bool isTrackedObservedCharm, bool hasCachedFaction)
+    {
+        return leverOn && isTrackedObservedCharm && hasCachedFaction;
+    }
+
     // (DisplayId, wire * 1000 rounded) pairs where Twinstar's bias on top of CMS_v
     // is the deliberate vanilla-intended visible scale, not a pre-scaled sibling.
     // The wirePreScaled heuristic would otherwise catch and shrink these to CMS_v,
@@ -2444,7 +2481,6 @@ public partial class WorldClient
             if (UNIT_FIELD_CHARMEDBY >= 0 && updateMaskArray[UNIT_FIELD_CHARMEDBY])
             {
                 WowGuid128 charmedBy = GetGuidValue(updates, UnitField.UNIT_FIELD_CHARMEDBY).To128(GetSession().GameState);
-                updateData.UnitData.CharmedBy = charmedBy;
 
                 // JimsProxy (#382 observer lockup): track players charmed by ANOTHER PLAYER,
                 // so the flags translation below can present them as possessed (see
@@ -2455,10 +2491,26 @@ public partial class WorldClient
                 // years of raid MCs have produced no observer-lockup reports, so that
                 // long-stable content stays untouched.
                 var gameState = GetSession().GameState;
-                bool observedCharmedPlayer = guid.IsPlayer() &&
-                    charmedBy.IsPlayer() &&
-                    guid != gameState.CurrentPlayerGuid &&
-                    charmedBy != gameState.CurrentPlayerGuid;
+                bool observedCharmedPlayer = IsObservedPlayerCharmedByPlayer(guid, charmedBy, gameState.CurrentPlayerGuid);
+
+                // JimsProxy (#382, lever L1 Charm382SuppressCharmedBy): hide the charm
+                // relationship itself from bystander sessions — the modern client's charm
+                // bookkeeping keys off CHARMEDBY, and the 07-23 capture narrowed the held
+                // observer state during a drop to CHARMEDBY + faction flip + charm aura.
+                // Charm-end clears (empty charmedBy → predicate false) always forward, which
+                // writes Empty over the Empty the client already holds — harmless.
+                if (Settings.Charm382SuppressCharmedBy && observedCharmedPlayer)
+                {
+                    Log.Event("charm.observed_player.charmedby_suppressed", new
+                    {
+                        guid_low = guid.GetCounter(),
+                        charmed_by_low = charmedBy.GetCounter(),
+                    });
+                }
+                else
+                {
+                    updateData.UnitData.CharmedBy = charmedBy;
+                }
                 if (observedCharmedPlayer)
                 {
                     if (gameState.ObservedCharmedPlayers.Add(guid))
@@ -2548,7 +2600,35 @@ public partial class WorldClient
             int UNIT_FIELD_FACTIONTEMPLATE = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_FACTIONTEMPLATE);
             if (UNIT_FIELD_FACTIONTEMPLATE >= 0 && updateMaskArray[UNIT_FIELD_FACTIONTEMPLATE])
             {
-                updateData.UnitData.FactionTemplate = updates[UNIT_FIELD_FACTIONTEMPLATE].Int32Value;
+                int newFaction = updates[UNIT_FIELD_FACTIONTEMPLATE].Int32Value;
+
+                // JimsProxy (#382, lever L2 Charm382FactionHold): for a tracked observed
+                // player-charmed-by-player, keep presenting the pre-charm faction instead of
+                // the server's flip to the charmer's faction. CHARMEDBY is processed above
+                // before this block, so within the charm-apply update the tracking set is
+                // already populated (hold applies) and within the charm-end update the set is
+                // already emptied (restore forwards raw — and equals the held value anyway).
+                // A unit first seen mid-charm has no cached pre-charm faction: forward raw,
+                // identical to today.
+                bool hasCachedFaction = GetSession().GameState.LastForwardedPlayerFaction.TryGetValue(guid, out int preCharmFaction);
+                if (ShouldHoldFactionForCharm(Settings.Charm382FactionHold,
+                        GetSession().GameState.ObservedCharmedPlayers.Contains(guid),
+                        hasCachedFaction))
+                {
+                    updateData.UnitData.FactionTemplate = preCharmFaction;
+                    Log.Event("charm.observed_player.faction_held", new
+                    {
+                        guid_low = guid.GetCounter(),
+                        held_faction = preCharmFaction,
+                        suppressed_faction = newFaction,
+                    });
+                }
+                else
+                {
+                    updateData.UnitData.FactionTemplate = newFaction;
+                    if (guid.IsPlayer())
+                        GetSession().GameState.LastForwardedPlayerFaction[guid] = newFaction;
+                }
             }
 
             int UNIT_FIELD_BYTES_0 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_BYTES_0);
@@ -2742,7 +2822,12 @@ public partial class WorldClient
                 // 1.14 client (BG bystanders FPS-lock rendering it), while possess (priest
                 // MC 605) renders fine. CHARMEDBY is processed above before this flags block,
                 // so apply/clear ordering within a single update is already correct.
-                if (Session.GameState.ObservedCharmedPlayers.Contains(guid))
+                // Lever L4 (Charm382ObserverPossess, default true = shipped behavior): the
+                // shim did NOT fix #382 (07-22 capture: fired 3×, drops persisted) — the
+                // toggle lets a reporter A/B dropping the synthetic possess bit alongside
+                // the other Charm382* levers. Retirement tracked separately (PR #436).
+                if (Settings.Charm382ObserverPossess &&
+                    Session.GameState.ObservedCharmedPlayers.Contains(guid))
                     updateData.UnitData.Flags |= (uint)UnitFlags.Possessed;
 
                 // Here because of this bullshit in cmangos:
@@ -3524,6 +3609,16 @@ public partial class WorldClient
                                 is_player_target = guid == GetSession().GameState.CurrentPlayerGuid,
                             });
                         }
+                        // JimsProxy (#382, lever L3 Charm382SuppressCharmAura): hide the charm
+                        // aura itself (13181/605) from bystander views of a charmed player —
+                        // the third leg of the held observer state alongside CHARMEDBY and the
+                        // faction flip. The charm-end slot clear still forwards (AuraData null,
+                        // not gated), which removes nothing client-side since the add was
+                        // never seen.
+                        bool charmAuraSuppressed = aura.AuraData != null &&
+                            ShouldSuppressCharmAuraForObserver(Settings.Charm382SuppressCharmAura,
+                                guid, GetSession().GameState.CurrentPlayerGuid, (uint)aura.AuraData.SpellID);
+
                         if (aura.AuraData != null && ShouldDropModScaleAura(guid, (uint)aura.AuraData.SpellID))
                         {
                             Framework.Logging.Log.Event("aura.slot.dropped_mod_scale_npc", new
@@ -3532,6 +3627,16 @@ public partial class WorldClient
                                 high_type = guid.GetHighType().ToString(),
                                 slot = i,
                                 spell_id = aura.AuraData.SpellID,
+                                source = "object_update",
+                            });
+                        }
+                        else if (charmAuraSuppressed)
+                        {
+                            Framework.Logging.Log.Event("aura.slot.dropped_charm_observer", new
+                            {
+                                target_low = guid.GetCounter(),
+                                slot = i,
+                                spell_id = aura.AuraData!.SpellID,
                                 source = "object_update",
                             });
                         }
@@ -3544,7 +3649,9 @@ public partial class WorldClient
                         // next AURAAPPLICATIONS-quad-only update can detect a per-slot byte
                         // change and re-emit without spuriously refreshing the other three
                         // slots packed into the same uint32.
-                        if (aura.AuraData != null)
+                        // (#382 L3: skip when the charm aura was suppressed — storing it would
+                        // let a later apps-quad change synthesize the hidden aura back in.)
+                        if (aura.AuraData != null && !charmAuraSuppressed)
                             GetSession().GameState.StoreLastEmittedAura(guid, i, aura.AuraData);
 
                         // JimsProxy (vanilla synthesized spell stats): mirror active aura spell


### PR DESCRIPTION
## Problem

#382: a player charmed by ANOTHER PLAYER (Gnomish MC Cap 13181 / priest MC 605) FPS-locks 1.14 clients in BGs for the charm's duration — the victim AND bystanders. Native 1.12 clients are fine; NPC-charmer content (Lucifron's Dominate Mind) is fine. The #399 possess shim did not fix it (07-21 capture: fired 3×, drops persisted). Reporter has now also exonerated the JimsPlus addon (drop persists with it fully disabled).

## Evidence state (2026-07-23 capture analysis, reporter BG .pkt)

Falsified — do not re-litigate:
- **PET_IN_COMBAT (0x800)**: routine pet-owner state on BG players (present 28 min PRE-charm on the cap3 victim via his own warlock pet; near-constant on a hunter charmer). Cap2's victim never carried it all session and still dropped. Modern-legal on owners (TC `UpdatePetCombatState`).
- **POSSESSED / the flags lane wholesale**: cap1's and cap2's charm windows contained ZERO flags updates for the victims — the client never even saw the shim's bit for those caps; both dropped.

Surviving minimal held observer state, delivered every cap:
1. `UNIT_FIELD_CHARMEDBY` = player guid (NPC-charmer charms are clean ⇒ player-charmer specific)
2. `UNIT_FIELD_FACTIONTEMPLATE` flipped to the charmer's
3. The charm aura itself in the victim's slots (verified SPELL_GO + AURA_UPDATE pair at each apply)

Severity tracks the victim's cast volume during the charm (37/17 casts = severe, 4 = mild).

## Fix approach

Not a fix — a **diagnostic A/B kit**. Four config levers, each hiding ONE leg of the charm state from bystander sessions, so the reporter can isolate the costly leg live (one lever per BG):

| Key | Default | Effect when enabled |
|---|---|---|
| `Charm382SuppressCharmedBy` | false | omit CHARMEDBY for observed player-charmed-by-player |
| `Charm382FactionHold` | false | keep presenting the pre-charm faction (session cache of last raw-forwarded player faction; forwards raw if the unit was first seen mid-charm) |
| `Charm382SuppressCharmAura` | false | drop 13181/605 from bystander aura updates — object-update path AND the SendAuraRefreshUpdate flicker path; last-emitted cache skipped so an apps-quad change can't synthesize the hidden aura back |
| `Charm382ObserverPossess` | **true** | gate for the existing #399 shim OR (true = shipped behavior) |

Scope: `IsObservedPlayerCharmedByPlayer` (extracted, now shared with the shim tracking) — player victim + player charmer + bystander session only. The victim's own session, the charmer's session, and all NPC-charmer content are untouched. Charm-end clears always forward (harmless no-ops when the add was suppressed).

**All defaults = current wire behavior byte-for-byte.** Only additions at defaults: the pre-charm faction cache upkeep (player guids only) and three new JSONL events that cannot fire (`charm.observed_player.charmedby_suppressed`, `charm.observed_player.faction_held`, `aura.slot.dropped_charm_observer`).

## Tests

17 new red-first tests (`CharmPresentationLeverTests`): stubs run first proved the 4 positive cases red, then implementation → green. Covers the scope predicate (self-as-victim / self-as-charmer / NPC charmer / NPC victim / empty-clear all excluded), the aura gate (605 + 13181 suppressed, **20604 Lucifron never**, self never, creatures never, lever-off never), and the faction-hold truth table (no cached pre-charm faction ⇒ forward raw). **748/748 green.**

## Reporter protocol

1. Baseline BG on this build, all levers default — confirm the drop still reproduces.
2. One lever per BG: SuppressCharmedBy → FactionHold → SuppressCharmAura (others at default); note per cap: drop y/n, severity vs usual, ends-at-MC-end y/n. `PacketsLog=true` + JSONL.
3. If no single lever helps: combinations (CharmedBy+Faction, then all three).

## Notes

- Shim retirement is tracked separately (PR #436) — `Charm382ObserverPossess=false` covers the A/B need without entangling it.
- Diagnostic build: NO patch-note lines. No lever ships enabled without reporter isolation + sign-off; shipping the winning lever is a separate informed-deviation decision.
- Victim-path (self-scoped) variant deferred until the observer A/B isolates the leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtyPEd43h4LwQGSWhqmhaD