### PR TITLE
#382: strip PET_IN_COMBAT from player-charmed players (charm+0x800 hybrid removal)

### DIFF
--- a/HermesProxy.Tests/World/PetInCombatCharmStripTests.cs
+++ b/HermesProxy.Tests/World/PetInCombatCharmStripTests.cs
@@ -1,0 +1,133 @@
+using HermesProxy.World;
+using HermesProxy.World.Client;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (#382): a player charmed by ANOTHER PLAYER FPS-locks 1.14 clients in BGs while
+// the charm is active. The suspect state is a HYBRID no modern server produces on one unit:
+// charm control (CHARMEDBY-player, PLAYER_CONTROLLED, shim-POSSESSED) coexisting with
+// UNIT_FLAG_PET_IN_COMBAT (0x800) — vanilla pins that flag on the charmed unit itself
+// (cmangos/vmangos SetInCombatState: any unit with a charmer), while modern TC pins it on
+// the CHARMER. Both severe captured caps delivered the full hybrid to the client; the fix
+// strips 0x800 from a player for exactly the duration of a player-charm.
+//
+// The warlock corner (James, 2026-07-24): a pet-class player LEGITIMATELY carries 0x800
+// (own pet fighting) BEFORE being charmed — and a charm apply can arrive with NO flags
+// update in the block (cap2's apply was CHARMEDBY+faction only). A passive strip never
+// fires there; the client keeps its held 0x800 and enters the hybrid anyway. So the strip
+// must synthesize a flags re-send on the charm edges from the cached last-known raw flags.
+public class PetInCombatCharmStripTests
+{
+    static readonly WowGuid128 Victim = WowGuid128.Create(HighGuidType703.Player, 21654);
+    static readonly WowGuid128 Charmer = WowGuid128.Create(HighGuidType703.Player, 15773);
+    static readonly WowGuid128 NpcCharmer = WowGuid128.Create(HighGuidType703.Creature, 0, 12118, 500); // Lucifron
+    static readonly WowGuid128 NpcVictim = WowGuid128.Create(HighGuidType703.Creature, 0, 100, 501);
+
+    const uint PetInCombat = (uint)UnitFlags.PetInCombat;          // 0x800
+    const uint PlayerControlled = (uint)UnitFlags.PlayerControlled; // 0x8
+    const uint InCombat = (uint)UnitFlags.InCombat;                 // 0x80000
+    const uint Possessed = (uint)UnitFlags.Possessed;               // 0x1000000
+
+    // ---- tracking predicate: ALL perspectives (self/charmer sessions included — the victim
+    // drops too, and the hybrid is wrong from every viewpoint). NPC charmers excluded:
+    // raid MC (Lucifron) is long-stable content.
+
+    [Fact]
+    public void CharmTracking_PlayerCharmedByPlayer_True()
+    {
+        Assert.True(WorldClient.IsPlayerCharmedByPlayer(Victim, Charmer));
+    }
+
+    [Fact]
+    public void CharmTracking_NpcCharmer_False()
+    {
+        Assert.False(WorldClient.IsPlayerCharmedByPlayer(Victim, NpcCharmer));
+    }
+
+    [Fact]
+    public void CharmTracking_NpcVictim_False()
+    {
+        Assert.False(WorldClient.IsPlayerCharmedByPlayer(NpcVictim, Charmer));
+    }
+
+    [Fact]
+    public void CharmTracking_EmptyCharmedBy_False()
+    {
+        Assert.False(WorldClient.IsPlayerCharmedByPlayer(Victim, WowGuid128.Empty));
+    }
+
+    // ---- passive strip (flags update present in the block) ----
+
+    [Fact]
+    public void Strip_TrackedCharm_ClearsOnlyPetInCombat()
+    {
+        uint flags = PlayerControlled | PetInCombat | InCombat | Possessed;
+        uint result = WorldClient.ApplyPetInCombatCharmStrip(flags, leverOn: true, isCharmTracked: true);
+        Assert.Equal(PlayerControlled | InCombat | Possessed, result);
+    }
+
+    [Fact]
+    public void Strip_NotTracked_Untouched()
+    {
+        uint flags = PlayerControlled | PetInCombat | InCombat;
+        Assert.Equal(flags, WorldClient.ApplyPetInCombatCharmStrip(flags, leverOn: true, isCharmTracked: false));
+    }
+
+    [Fact]
+    public void Strip_LeverOff_Untouched()
+    {
+        uint flags = PlayerControlled | PetInCombat;
+        Assert.Equal(flags, WorldClient.ApplyPetInCombatCharmStrip(flags, leverOn: false, isCharmTracked: true));
+    }
+
+    [Fact]
+    public void Strip_NoPetInCombatBit_NoOp()
+    {
+        uint flags = PlayerControlled | InCombat;
+        Assert.Equal(flags, WorldClient.ApplyPetInCombatCharmStrip(flags, leverOn: true, isCharmTracked: true));
+    }
+
+    // ---- proactive flags re-sync on charm edges (THE warlock corner) ----
+
+    // Pet-class player carries 0x800 pre-charm; charm apply block has NO flags write
+    // (cap2 pattern) → must synthesize, or the client holds the hybrid untouched.
+    [Fact]
+    public void SynthResync_CharmEdgeNoFlagsInBlock_CachedHasPetInCombat_Fires()
+    {
+        Assert.True(WorldClient.ShouldSynthPetInCombatFlagsResync(
+            leverOn: true, charmEdgeThisBlock: true, flagsInUpdateMask: false, cachedRawHasPetInCombat: true));
+    }
+
+    // Flags update present in the same block → the passive strip handles it; no synth.
+    [Fact]
+    public void SynthResync_FlagsAlreadyInBlock_DoesNotFire()
+    {
+        Assert.False(WorldClient.ShouldSynthPetInCombatFlagsResync(
+            leverOn: true, charmEdgeThisBlock: true, flagsInUpdateMask: true, cachedRawHasPetInCombat: true));
+    }
+
+    // No cached 0x800 (rogue/mage victim, or pet idle) → nothing to clear/restore; no synth.
+    [Fact]
+    public void SynthResync_CachedFlagsClean_DoesNotFire()
+    {
+        Assert.False(WorldClient.ShouldSynthPetInCombatFlagsResync(
+            leverOn: true, charmEdgeThisBlock: true, flagsInUpdateMask: false, cachedRawHasPetInCombat: false));
+    }
+
+    // Mid-charm update with no flags (heartbeats etc.) — not an edge; no synth spam.
+    [Fact]
+    public void SynthResync_NotACharmEdge_DoesNotFire()
+    {
+        Assert.False(WorldClient.ShouldSynthPetInCombatFlagsResync(
+            leverOn: true, charmEdgeThisBlock: false, flagsInUpdateMask: false, cachedRawHasPetInCombat: true));
+    }
+
+    [Fact]
+    public void SynthResync_LeverOff_DoesNotFire()
+    {
+        Assert.False(WorldClient.ShouldSynthPetInCombatFlagsResync(
+            leverOn: false, charmEdgeThisBlock: true, flagsInUpdateMask: false, cachedRawHasPetInCombat: true));
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -63,6 +63,17 @@ public static class Settings
     // block so input isn't locked client-side even if the server ignores the cancel.
     public static bool StuckLogoutStunCancelFix;
     public static bool StuckLogoutStunClientStrip;
+    // JimsProxy (#382 MC-cap BG FPS drop): strip UNIT_FLAG_PET_IN_COMBAT (0x800) from a
+    // PLAYER for exactly the duration of a player-on-player charm (Gnomish MC Cap 13181,
+    // priest MC 605). Vanilla cores set that flag on the charmed unit itself; modern
+    // servers set it on the CHARMER — so charm state + 0x800 on one player is a hybrid no
+    // modern server produces, and the 1.14 client FPS-locking on charmed players (victim
+    // AND bystanders, BG-scale, native 1.12 clients unaffected) is suspected to be its
+    // cost. Includes a charm-edge flags re-sync for pet-class victims whose legitimate
+    // pet-owner 0x800 predates the charm (a charm apply can carry no flags write at all).
+    // NPC charmers (raid MC — Lucifron) are untouched. Default ON; key = kill switch.
+    // Default-init true so paths that bypass LoadAndVerifyFrom (tests) get the fix.
+    public static bool Charm382StripPetInCombat = true;
     // JimsProxy (clean handshake teardown): bound the realmd auth handshake. If realmd accepts
     // the TCP connection but never sends LOGON_CHALLENGE (half-accepting login server, load-shed,
     // firewall), the login thread would otherwise block forever ("stuck on Connecting..."). On
@@ -191,6 +202,7 @@ public static class Settings
         UnplannedReconnectTimeoutMs = Math.Clamp(config.GetInt("UnplannedReconnectTimeoutMs", 5000), 1000, 30000);
         StuckLogoutStunCancelFix = config.GetBoolean("StuckLogoutStunCancelFix", true);
         StuckLogoutStunClientStrip = config.GetBoolean("StuckLogoutStunClientStrip", true);
+        Charm382StripPetInCombat = config.GetBoolean("Charm382StripPetInCombat", true);
         AuthHandshakeTimeoutMs = Math.Clamp(config.GetInt("AuthHandshakeTimeoutMs", 15000), 1000, 60000);
         EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -899,6 +899,21 @@ public sealed class GameSessionData
     // fresh create block (re-appearance after an out-of-range charm end).
     public HashSet<WowGuid128> ObservedCharmedPlayers = [];
 
+    // JimsProxy (#382 PetInCombat charm strip): players currently charmed by ANOTHER PLAYER,
+    // tracked from ALL perspectives (no self/charmer exclusion — the victim's own client
+    // drops too, and the charm+0x800 hybrid is wrong from every viewpoint). Maintained in
+    // the CHARMEDBY translation; cleared when CHARMEDBY empties or on a create block without
+    // CHARMEDBY (out-of-range charm end). While a guid is in here, UNIT_FLAG_PET_IN_COMBAT
+    // is stripped from its forwarded flags (Charm382StripPetInCombat).
+    public HashSet<WowGuid128> PlayerCharmedByPlayer = [];
+
+    // JimsProxy (#382): last RAW vanilla UNIT_FIELD_FLAGS seen per PLAYER guid — always the
+    // server's value, never the stripped presentation. Feeds the charm-edge flags re-sync:
+    // a pet-class player can enter a charm already carrying a legitimate pet-owner 0x800
+    // while the charm apply block carries no flags write at all, so the re-sync needs the
+    // pre-charm value to strip from (and to restore from at charm end).
+    public Dictionary<WowGuid128, uint> LastKnownPlayerUnitFlags = new();
+
     // JimsProxy (Tallstrider-Fix): per-GUID last-known facing orientation, populated from
     // any MovementInfo we observe (spawn, heartbeat, ObjectUpdate movement block). Used by
     // MovementHandler.HandleMonsterMove to compare the creature's current facing against

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -90,6 +90,40 @@ public partial class WorldClient
         return guid.GetHighType() == HighGuidType.Creature;
     }
 
+    // JimsProxy (#382 PetInCombat charm strip): tracking predicate for a PLAYER charmed by
+    // ANOTHER PLAYER — all perspectives (victim's own session and the charmer's included:
+    // the victim FPS-drops too, and the hybrid state is wrong from every viewpoint). NPC
+    // charmers (Lucifron's Dominate Mind et al.) are excluded — long-stable raid content.
+    internal static bool IsPlayerCharmedByPlayer(WowGuid128 guid, WowGuid128 charmedBy)
+    {
+        return guid.IsPlayer() && charmedBy.IsPlayer();
+    }
+
+    // JimsProxy (#382): strip UNIT_FLAG_PET_IN_COMBAT (0x800) from a player's forwarded
+    // flags for exactly the duration of a player-charm. Vanilla cores pin the flag on the
+    // charmed unit itself (cmangos/vmangos SetInCombatState: any unit with a charmer);
+    // modern servers pin it on the CHARMER — so charm+0x800 on one player is a hybrid no
+    // modern server produces, and the leading #382 suspect. Deliberate concession: a
+    // charmed pet-class player whose own pet keeps fighting loses the (then-legitimate)
+    // flag while charmed — that coexistence IS the suspected trigger, so no exemption.
+    internal static uint ApplyPetInCombatCharmStrip(uint modernFlags, bool leverOn, bool isCharmTracked)
+    {
+        if (!leverOn || !isCharmTracked)
+            return modernFlags;
+        return modernFlags & ~(uint)UnitFlags.PetInCombat;
+    }
+
+    // JimsProxy (#382, the pre-charmed-pet-owner corner): a charm apply can arrive with NO
+    // flags write in the block (capture cap2: CHARMEDBY+faction only) — a passive strip
+    // never fires and the client keeps its held pre-charm 0x800 alongside the new charm
+    // state. On a charm EDGE (apply or clear) with no flags in the update mask and a cached
+    // last-known raw carrying 0x800, synthesize a flags re-send (stripped on apply, restored
+    // on clear) so the client's held state never combines charm + PetInCombat.
+    internal static bool ShouldSynthPetInCombatFlagsResync(bool leverOn, bool charmEdgeThisBlock, bool flagsInUpdateMask, bool cachedRawHasPetInCombat)
+    {
+        return leverOn && charmEdgeThisBlock && !flagsInUpdateMask && cachedRawHasPetInCombat;
+    }
+
     // (DisplayId, wire * 1000 rounded) pairs where Twinstar's bias on top of CMS_v
     // is the deliberate vanilla-intended visible scale, not a pre-scaled sibling.
     // The wirePreScaled heuristic would otherwise catch and shrink these to CMS_v,
@@ -2430,6 +2464,11 @@ public partial class WorldClient
             (objectType == ObjectType.Player) ||
             (objectType == ObjectType.ActivePlayer))
         {
+            // JimsProxy (#382 PetInCombat charm strip): set when THIS update block changes a
+            // player's player-charm state (apply or clear) — arms the charm-edge flags
+            // re-sync below for blocks that carry no flags write of their own.
+            bool charmEdgeThisBlock = false;
+
             int UNIT_FIELD_CHARM = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_CHARM);
             if (UNIT_FIELD_CHARM >= 0 && updateMaskArray[UNIT_FIELD_CHARM])
             {
@@ -2475,12 +2514,39 @@ public partial class WorldClient
                         guid_low = guid.GetCounter(),
                     });
                 }
+
+                // JimsProxy (#382 PetInCombat charm strip): all-perspective tracking (no
+                // self/charmer exclusion, unlike the shim set above) — the strip applies to
+                // the victim's own view and the charmer's view too.
+                if (IsPlayerCharmedByPlayer(guid, charmedBy))
+                {
+                    if (gameState.PlayerCharmedByPlayer.Add(guid))
+                    {
+                        charmEdgeThisBlock = true;
+                        Log.Event("charm.petincombat.strip_armed", new
+                        {
+                            guid_low = guid.GetCounter(),
+                            charmed_by_low = charmedBy.GetCounter(),
+                        });
+                    }
+                }
+                else if (gameState.PlayerCharmedByPlayer.Remove(guid))
+                {
+                    charmEdgeThisBlock = true;
+                    Log.Event("charm.petincombat.strip_disarmed", new
+                    {
+                        guid_low = guid.GetCounter(),
+                    });
+                }
             }
             else if (isCreate)
             {
                 // A create block without CHARMEDBY means the unit is not charmed — drop any
                 // stale shim entry from a charm that ended while the unit was out of range.
+                // (Same lifecycle for the strip set: creates always carry flags, so the
+                // normal forwarding below restores the un-stripped value in this block.)
                 GetSession().GameState.ObservedCharmedPlayers.Remove(guid);
+                GetSession().GameState.PlayerCharmedByPlayer.Remove(guid);
             }
             int UNIT_FIELD_SUMMONEDBY = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY);
             if (UNIT_FIELD_SUMMONEDBY >= 0 && updateMaskArray[UNIT_FIELD_SUMMONEDBY])
@@ -2745,6 +2811,17 @@ public partial class WorldClient
                 if (Session.GameState.ObservedCharmedPlayers.Contains(guid))
                     updateData.UnitData.Flags |= (uint)UnitFlags.Possessed;
 
+                // JimsProxy (#382 PetInCombat charm strip): cache the RAW server flags for
+                // players (never the stripped presentation — the charm-edge re-sync below
+                // needs the server truth to strip from and restore from), then remove the
+                // vanilla-only charm+0x800 hybrid from the forwarded value while the unit
+                // is player-charmed. See Charm382StripPetInCombat in Settings for rationale.
+                if (guid.IsPlayer())
+                    Session.GameState.LastKnownPlayerUnitFlags[guid] = updates[UNIT_FIELD_FLAGS].UInt32Value;
+                updateData.UnitData.Flags = ApplyPetInCombatCharmStrip(updateData.UnitData.Flags.Value,
+                    Settings.Charm382StripPetInCombat,
+                    Session.GameState.PlayerCharmedByPlayer.Contains(guid));
+
                 // Here because of this bullshit in cmangos:
                 // https://github.com/cmangos/mangos-tbc/blob/fd093b33071b546545cc5973608304bccc5a041b/src/game/Entities/Object.cpp#L544
                 if (updateData.UnitData.Flags.HasAnyFlag(UnitFlags.ServerControlled) && isCreate &&
@@ -2778,6 +2855,35 @@ public partial class WorldClient
                         raw_unit_flags = updates[UNIT_FIELD_FLAGS].UInt32Value,
                     });
                 }
+            }
+            else if (ShouldSynthPetInCombatFlagsResync(Settings.Charm382StripPetInCombat,
+                charmEdgeThisBlock,
+                flagsInUpdateMask: false,
+                cachedRawHasPetInCombat: GetSession().GameState.LastKnownPlayerUnitFlags.TryGetValue(guid, out uint lastRawUnitFlags) &&
+                    (lastRawUnitFlags & (uint)UnitFlagsVanilla.PetInCombat) != 0))
+            {
+                // JimsProxy (#382, pre-charmed-pet-owner corner): this block flipped the
+                // unit's player-charm state but carried NO flags write (real pattern — a
+                // charm apply can be CHARMEDBY+faction only), and the client's held flags
+                // include PET_IN_COMBAT (e.g. a warlock whose pet was fighting before the
+                // cap landed). Re-send the last-known flags so the held state never combines
+                // charm + 0x800: stripped while the charm is tracked (apply edge), restored
+                // verbatim once it isn't (clear edge). Same name-map as the real path; the
+                // possess shim's OR is kept consistent while that shim exists so the bit
+                // doesn't flap mid-charm.
+                uint synthFlags = (uint)((UnitFlagsVanilla)lastRawUnitFlags).CastFlags<UnitFlags>();
+                if (Session.GameState.ObservedCharmedPlayers.Contains(guid))
+                    synthFlags |= (uint)UnitFlags.Possessed;
+                synthFlags = ApplyPetInCombatCharmStrip(synthFlags,
+                    Settings.Charm382StripPetInCombat,
+                    Session.GameState.PlayerCharmedByPlayer.Contains(guid));
+                updateData.UnitData.Flags = synthFlags;
+                Log.Event("charm.petincombat.flags_resynced", new
+                {
+                    guid_low = guid.GetCounter(),
+                    raw_flags = lastRawUnitFlags,
+                    synth_flags = synthFlags,
+                });
             }
             int UNIT_FIELD_FLAGS_2 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_FLAGS_2);
             if (UNIT_FIELD_FLAGS_2 >= 0 && updateMaskArray[UNIT_FIELD_FLAGS_2])


### PR DESCRIPTION
## Problem

#382: 1.14 clients FPS-lock in BGs while a player is Mind-Controlled by another player (Gnomish MC Cap 13181 / priest MC 605) — the victim AND bystanders, for the duration of the cap's use. Native 1.12 clients are unaffected; NPC-charmer raid MC (Lucifron) is unaffected; the JimsPlus addon is exonerated (drop persists with it fully disabled). Never reproduced on PTR — ship-and-observe is the test channel.

## Hypothesis (best-supported single candidate)

Vanilla cores set `UNIT_FLAG_PET_IN_COMBAT` (0x800) **on the charmed unit itself** (cmangos `Unit.cpp:7910-12`, vmangos `:6147-50` — any unit with a charmer entering combat). Modern servers set it **on the charmer** (TC `UpdatePetCombatState`, `PetAI` is `Creature*`-only). We forward vanilla flags bit-identical — so during a player-charm the 1.14 client holds a unit that is simultaneously **charm-controlled** (CHARMEDBY-player + PLAYER_CONTROLLED + shim-POSSESSED) **and pet-in-combat**: a hybrid no modern server produces.

Evidence honestly stated:
- **Both severe captured caps delivered the full hybrid** to the reporter's client (cap1 via its charm-apply CREATE block — found by the adversarial re-review after a values-only scan missed it; cap3 via a values update, `0x01081808`).
- **The bit alone is provably harmless in its legitimate context**: a warlock carried pet-owner 0x800 for 28 minutes pre-charm at zero cost. The suspect is the *combination* with charm state — the earlier "falsification" of this fix tested the bit in isolation and was retracted.
- Not proven — no local repro exists. This is a best-guess ship of a change that is Era-correct regardless (modern clients are never shown 0x800 on a charmed player), so being wrong costs nothing.

## Fix

While a player's `CHARMEDBY` is another player, strip 0x800 from their forwarded `UNIT_FIELD_FLAGS` — **all perspectives** (victim's own session and the charmer's included; the victim drops too). Tracking set `PlayerCharmedByPlayer` maintained in the CHARMEDBY translation with the same lifecycle as the shim set (clear on CHARMEDBY-empty, clear on create-without-CHARMEDBY).

**The pre-charmed-pet-owner corner (the field-reported case):** a pet-class player carries a *legitimate* 0x800 before the cap lands, and a charm apply can arrive with **no flags write at all** (capture cap2's apply was CHARMEDBY+faction only) — a passive strip never fires and the client keeps its held 0x800 alongside the new charm state. So charm **edges** with no flags write in the block synthesize a flags re-send from the cached last-known **raw** server flags (`LastKnownPlayerUnitFlags` — always server truth, never the stripped value): stripped on the apply edge, restored verbatim on the clear edge. The synth reuses the same name-map translation and keeps the possess shim's OR consistent while that shim exists (no mid-charm bit flap). Creates never need the synth (they always carry flags → passive path).

Deliberate, documented concession: a charmed warlock/hunter whose own pet keeps fighting loses the then-legitimate flag for the charm's duration — that coexistence **is** the suspected trigger, so there is no pet-owner exemption. The client has no known visible consumer of 0x800 on players, so the cost is nil.

Internal consumers untouched: ThreatTracker's InCombat feed and the stuck-stun breadcrumb read the raw wire value, not the stripped presentation.

## Config

`Charm382StripPetInCombat`, **default ON** (kill switch; default-init true for config-bypassing test paths). NPC charmers (`CHARMEDBY` = creature) are never tracked — Lucifron raid content stays byte-identical.

## Relationship to other PRs

- **Pairs with #436** (retire the #399 possess shim): together they remove both halves of the TC-impossible hybrid — cap-charm becomes a clean TC-charm, priest MC a clean TC-possess. Recommend merging both for the same beta. (This PR keeps the shim's OR consistent in its synth path while the shim exists, so merge order doesn't matter.)
- **#438** (diagnostic lever kit) stays parked — escape hatches if this doesn't move field reports.

## Tests

13 red-first (`PetInCombatCharmStripTests`): stubs proved the 3 positive cases red before implementation. Covers the tracking predicate (NPC charmer/victim and empty-clear excluded), the strip bit-math (clears only 0x800, lever/tracking gates), and the synth truth table — including the warlock case (edge + no flags in block + cached 0x800 → fires) and its guards (flags present → passive path; no edge → no spam; clean cache → no-op). **744/744 green.**

## Diagnostics

`charm.petincombat.strip_armed` / `strip_disarmed` (once per charm edge) + `charm.petincombat.flags_resynced` (only when the synth fires, with raw and synth values) — low-volume, permanent-safe.

## Expected field outcome

If the hybrid is the driver: MC-cap FPS drops stop for 5.1.9-beta.3+ users with no action on their part. If reports persist unchanged: the hybrid is exonerated for real this time (the strip + #436 remove it entirely), and the program moves to the round-2 leads (CastID stability, loss-of-control synthesis, Era ymir capture / client RE).
