### PR TITLE
Restore TCP_NODELAY on client-facing sockets (dead since upstream 2022-11 refactor)

### DIFF
--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -162,6 +162,21 @@ public static class Settings
     // Default Kronos since this launcher is built for Kronos.
     public static ServerFork ServerType = ServerFork.Kronos;
 
+    // JimsProxy (client-socket delivery restore, 2026-07-25): TCP_NODELAY on the CLIENT-facing world
+    // sockets. TRUE restores the original design: HermesProxy applied NoDelay=true at birth
+    // (WorldSocketManager, ratkosrb 2022-02) until upstream's 2022-11-26 "Cleanup service start
+    // procedure" (55e9fca8) replaced the manager with the generic StartServer<T> — which sets no
+    // socket options — silently flipping every client socket to the .NET default (Nagle ON) for 3.5
+    // years while the dead class kept reading as live configuration. Our 2026-04-29 73ba505d then
+    // "kept TCP_NODELAY=true permanently" — defending a state that no longer existed. Ground truth
+    // was established empirically (runtime probe logged prior=false on accept), and delivery-spread
+    // A/B rounds at peak cast-collision intensity produced zero looping-cast incidents alongside a
+    // better reported cast feel. Config-key-only escape hatch (no launcher UI): set false to return
+    // to the kernel-batched (Nagle) delivery this bug era shipped with. The LEGACY (proxy->server)
+    // socket is unaffected either way — it has its own explicit NoDelay=true (WorldClient).
+    // Default-init true so paths that bypass LoadAndVerifyFrom get the restored behavior.
+    public static bool ClientTcpNoDelay = true;
+
     public static bool LoadAndVerifyFrom(ConfigurationParser config)
     {
         ClientSeed = config.GetByteArray("ClientSeed", "179D3DC3235629D07113A9B3867F97A7".ParseAsByteArray());
@@ -193,6 +208,7 @@ public static class Settings
         StuckLogoutStunClientStrip = config.GetBoolean("StuckLogoutStunClientStrip", true);
         AuthHandshakeTimeoutMs = Math.Clamp(config.GetInt("AuthHandshakeTimeoutMs", 15000), 1000, 60000);
         EnablePallyPowerInterop = config.GetBoolean("EnablePallyPowerInterop", true);
+        ClientTcpNoDelay = config.GetBoolean("ClientTcpNoDelay", true);
         LowLatencyMode = config.GetBoolean("LowLatencyMode", false);
         SuppressSpellCastErrors = config.GetBoolean("SuppressSpellCastErrors", false);
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -366,19 +366,23 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                // CORRECTED 2026-07-25: the previous comment here ("the proxy always needs
-                // TCP_NODELAY=true") described configuration that had been dead since upstream
-                // 55e9fca8 (2022-11) — these sockets actually ran at the .NET default (Nagle ON), so
-                // "ignoring" this request was a client-side no-op. With NoDelay genuinely restored
-                // (ClientTcpNoDelay, applied in the ctor), we now HONOR the request like SugarProxy
-                // and a real 1.14 server do: the client explicitly asked for batched delivery
-                // ("Optimize Network for Speed" unchecked, sent coalesced with AUTH_SESSION —
-                // Xian55 2960e779), so flip THIS client socket back to Nagle. The LEGACY socket is
-                // deliberately NOT touched (the real lesson of 73ba505d: Nagling proxy->server
-                // forwarding adds genuine latency). The packet is still processed either way so the
-                // AES-GCM nonce counter stays in sync.
-                SetNoDelay(false);
-                Log.Event("client_socket.nagle_honored", new { connection = _connectType.ToString() });
+                // Deliberately process-without-obeying — with the CORRECT rationale this time
+                // (2026-07-25). The old comment claimed "the proxy always needs TCP_NODELAY=true",
+                // which described configuration dead since upstream 55e9fca8 (2022-11); ignoring was
+                // then a no-op. But ignore IS the right policy for this leg: the checkbox's intent
+                // ("Optimize Network for Speed" unchecked = trade latency for less traffic on MY
+                // internet link) maps to the WAN leg in our topology — proxy->server, which keeps
+                // its own pinned NODELAY (WorldClient; the preserved half of 73ba505d). This socket
+                // is the LOOPBACK leg: Nagle conserves nothing on 127.0.0.1 and only re-enters the
+                // kernel-batched delivery regime that shipped the 2022-2026 bad era — silently, for
+                // exactly the users fiddling with network settings because something already feels
+                // off. The opcode is advisory (TCP options are not negotiated on the wire), so the
+                // client cannot observe non-compliance. The legitimate "I want batched delivery"
+                // escape hatch is ClientTcpNoDelay=false — explicit and logged — not a client
+                // checkbox that means something else in a proxied setup. The packet still flows
+                // through decryption so the AES-GCM nonce counter stays in sync (Xian55 2960e779),
+                // and receipt is logged for visibility into how many users actually uncheck the box.
+                Log.Event("client_socket.nagle_requested", new { honored = false, connection = _connectType.ToString() });
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -75,6 +75,23 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
     public WorldSocket(Socket socket) : base(socket)
     {
+        // JimsProxy (client-socket delivery restore): apply the NoDelay policy HERE, on the live
+        // accept path — the generic SocketManager<T> accept chain sets no socket options, and
+        // WorldSocketManager (which reads as if it applies NoDelay=true) is dead code that nothing
+        // instantiates since upstream 55e9fca8 (2022-11-26). The prior value is logged so every
+        // session carries runtime proof of the socket state — this exact belief-vs-reality gap went
+        // unnoticed for 3.5 years because nothing ever measured it. See Settings.ClientTcpNoDelay.
+        try
+        {
+            bool prior = socket.NoDelay;
+            socket.NoDelay = Framework.Settings.ClientTcpNoDelay;
+            Framework.Logging.Log.Event("client_socket.nodelay", new { prior, now = socket.NoDelay });
+        }
+        catch (Exception e)
+        {
+            Framework.Logging.Log.Event("client_socket.nodelay_error", new { error = e.Message });
+        }
+
         _connectType = ConnectionType.Realm;
         _serverChallenge = Array.Empty<byte>().GenerateRandomKey(16);
         _worldCrypt = new WorldCrypt();
@@ -349,10 +366,19 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
                 break;
             case Opcode.CMSG_ENABLE_NAGLE:
-                // Ignore: the proxy always needs TCP_NODELAY=true for low-latency
-                // forwarding. The packet is still processed (AES-GCM nonce stays in
-                // sync) but we don't obey the client's request to re-enable Nagle.
-                // Sent when the user unchecks "Optimize Network for Speed" in WoW.
+                // CORRECTED 2026-07-25: the previous comment here ("the proxy always needs
+                // TCP_NODELAY=true") described configuration that had been dead since upstream
+                // 55e9fca8 (2022-11) — these sockets actually ran at the .NET default (Nagle ON), so
+                // "ignoring" this request was a client-side no-op. With NoDelay genuinely restored
+                // (ClientTcpNoDelay, applied in the ctor), we now HONOR the request like SugarProxy
+                // and a real 1.14 server do: the client explicitly asked for batched delivery
+                // ("Optimize Network for Speed" unchecked, sent coalesced with AUTH_SESSION —
+                // Xian55 2960e779), so flip THIS client socket back to Nagle. The LEGACY socket is
+                // deliberately NOT touched (the real lesson of 73ba505d: Nagling proxy->server
+                // forwarding adds genuine latency). The packet is still processed either way so the
+                // AES-GCM nonce counter stays in sync.
+                SetNoDelay(false);
+                Log.Event("client_socket.nagle_honored", new { connection = _connectType.ToString() });
                 break;
             case Opcode.CMSG_CONNECT_TO_FAILED:
                 ConnectToFailed connectToFailed = new(packet);

--- a/HermesProxy/World/Server/WorldSocketManager.cs
+++ b/HermesProxy/World/Server/WorldSocketManager.cs
@@ -64,6 +64,13 @@ public sealed class WorldSocketManager : SocketManager<WorldSocket>
                 sock.SendBufferSize = _socketSendBufferSize;
 
             // Set TCP_NODELAY.
+            // JimsProxy WARNING (2026-07-25): this class is DEAD CODE — nothing has instantiated
+            // WorldSocketManager since upstream 55e9fca8 (2022-11-26) replaced it with the generic
+            // SocketManager<T> in Server.StartServer<T>, which sets no socket options. The
+            // _tcpNoDelay=true below never executes; reading it as live configuration is exactly how
+            // the client sockets ran Nagle for 3.5 years while everyone believed they were NODELAY.
+            // The live client-socket policy is Settings.ClientTcpNoDelay, applied in the WorldSocket
+            // constructor. Candidate for deletion in a cleanup pass.
             sock.NoDelay = _tcpNoDelay;
         }
         catch (SocketException ex)


### PR DESCRIPTION
# Restore TCP_NODELAY on client-facing sockets (dead since upstream's 2022-11 refactor)

## Problem

The client-facing world sockets have delivered with **Nagle ON** (kernel-batched) for 3.5 years while the codebase read as NODELAY. The belief-vs-reality gap was found during the looping-cast-sound investigation and confirmed empirically: a runtime probe logs `prior: false` on every accepted socket.

## Cause — verified commit by commit

| When | What |
|---|---|
| 2022-02 (`We are in world!`) | `WorldSocketManager` applied `NoDelay=true` — live, as designed |
| **2022-11-26 (upstream `55e9fca8`)** | "Cleanup service start procedure" replaced `new WorldSocketManager()` with the generic `StartServer<T>` — **which sets no socket options**. The class kept compiling; every client socket silently fell to the .NET default (Nagle ON) |
| 2026-04-29 (`73ba505d`, PR #87) | "keep TCP_NODELAY=true permanently" — defended a state dead for years. The ~200 ms coalescing it observed was the **legacy** socket being Nagled by the honor-handler; that half was a real fix and is preserved |
| 2026-07-25 | Ground truth established by runtime probe; this PR |

## Fix (surgical)

- `Settings.ClientTcpNoDelay`, **default TRUE** — config-key-only escape hatch (set `false` to return to batched delivery). No launcher UI by design.
- `WorldSocket` ctor applies the policy on the **live** accept path and logs the prior socket state on every accept — each session carries runtime proof, so this class of rot can't recur silently.
- `CMSG_ENABLE_NAGLE` stays **process-without-obeying — now with the correct rationale** (second commit, review amendment): the checkbox's intent ("trade latency for less traffic on my internet link") maps to the WAN leg, which in our topology is proxy→server and keeps its own pinned `NoDelay=true` (`WorldClient` — the preserved half of #87). Honoring could only toggle the **loopback** leg, where Nagle conserves nothing and would silently re-enter the batched-delivery regime for exactly the users fiddling with network settings. The opcode is advisory (not wire-negotiated), the packet still flows through decryption for AES-GCM nonce sync, and receipt is logged (`client_socket.nagle_requested`). The legitimate batched-delivery escape hatch is `ClientTcpNoDelay=false`.
- `WorldSocketManager` annotated as dead code; deletion left for a cleanup pass.

## Testing

- Build 0 warnings / 0 errors; **731/731 tests green**.
- Empirical probe on this branch, no flags: `client_socket.nodelay { prior: false, now: true }` ×2 (realm + instance).
- Delivery-spread A/B rounds at the **highest cast-collision intensity of the looping-cast investigation** (7 swallowed presses, 11 contested GOs, 13 routed failures; priest Lesser Heal chains + mage Frostbolt including the instant-proc spell that looped under batched delivery): **zero looping-cast incidents**, and better reported cast feel. Live-play hours continuing on spread delivery.

## Notes

- **Not claimed as the loop fix** — claimed as restoring the intended delivery design. Loop-rate impact continues to be measured; patch note should stay tentative (suggested: *"Improved network packet delivery to the game client."*).
- **Sugar parity (decode-backed, the stronger justification):** SugarProxy's client socket runs at Go's default `NoDelay=true` with **zero application-level pacing or batching** (one `conn.Write` per packet; its single `SetNoDelay` call in the entire binary is the `CMSG_ENABLE_NAGLE` handler) — and this client population sends **zero** `CMSG_ENABLE_NAGLE` (verified across every captured session). NODELAY-on is therefore unambiguous Sugar parity for our users, independent of the design-intent archaeology above.
- **Scoping (deliberate non-citation):** the HoneyProxy single-actor experiment's negative loop result predates this change — it ran under the Nagle-ON delivery this PR removes — so it is evidence neither for this PR nor against that architecture, and is cited nowhere here. The only A/B evidence cited is the delivery-spread testing above.
- Mechanism candor — now **wire-measured** (pktmon loopback capture, deduped, matched cast-recipe sessions): Nagle→NoDelay drops the mid-size coalesced-segment share (200–1400 B) from **19.3% → 13.9%** and MSS-full segments from **5.3% → 2.8%** (p90 payload 375 B → 248 B). So kernel-level packing under Nagle is real but **moderate** — 75% of Nagle segments were still single small packets (near-zero loopback RTT shrinks the hold window), and tight time-clustering of consecutive segments was essentially unchanged (15 vs 17 sub-2 ms pairs), meaning a frame-draining client likely sees similar per-frame *content* either way. The restore therefore stands on Sugar parity + design intent; the delivery mechanism is a measured moderate contributor, not the claimed fix, and loop-rate over live hours remains the deciding evidence.
- Every HermesProxy fork shipped Nagle-batched since 2022-11, so this also explains why "always NODELAY" reasoning never matched observed behavior anywhere downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBuGkUyzoWWPTTxE6q7LXt
