### PR TITLE
Don't let an in-flight off-GCD cast park every on-GCD spell (#442)

### DIFF
--- a/HermesProxy.Tests/World/ForwardedPendingCastGateTests.cs
+++ b/HermesProxy.Tests/World/ForwardedPendingCastGateTests.cs
@@ -1,0 +1,124 @@
+using HermesProxy;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (#442): HasForwardedPendingCast() gates the ForceHoldCast park at
+// Server/SpellHandler.cs:619, which silently swallows EVERY on-GCD press (no SpellPrepare,
+// DontReport on the displaced one) for as long as it returns true. It is not keyed by spell,
+// arms no timer, and off-GCD entries — every item-use cast since #345 — are exempt from the
+// ClearNonStartedNormalCasts sweep and never receive a WatchdogDeadlineMs. So a leaked
+// off-GCD entry used to mean: all casting dead until relog. Observed live on Ragnaros
+// (Mana Ruby + Robe of the Archmage, then 96s of spell.held_pending).
+//
+// These pin the fix: off-GCD/item entries no longer satisfy the gate, while real on-GCD
+// forwarded casts still do — including when a leaked off-GCD entry sits alongside one.
+public class ForwardedPendingCastGateTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static ClientCastRequest OnGcdCast(uint spellId, bool started = false) => new()
+    {
+        SpellId = spellId,
+        HasStarted = started,
+        IsOffGcd = false,
+    };
+
+    private static ClientCastRequest OffGcdCast(uint spellId, bool started = false) => new()
+    {
+        SpellId = spellId,
+        HasStarted = started,
+        IsOffGcd = true,
+    };
+
+    private static ClientCastRequest ItemUseCast(uint spellId, bool started = false) => new()
+    {
+        SpellId = spellId,
+        HasStarted = started,
+        IsOffGcd = true,                  // HandleUseItem tags item-use casts off-GCD (#345)
+        ItemGUID = new WowGuid128(1, 2),  // non-empty => item-use cast
+    };
+
+    [Fact]
+    public void EmptyQueue_NoForwardedCast()
+    {
+        var s = NewSession();
+        Assert.False(s.HasForwardedPendingCast());
+    }
+
+    [Fact]
+    public void ForwardedUnstartedOnGcdCast_IsCounted()
+    {
+        // The behaviour the gate exists for: a normal cast is in flight to the legacy server
+        // and hasn't been confirmed yet, so the next press is parked to preserve ordering.
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(OnGcdCast(133)); // Fireball, forwarded-unstarted
+
+        Assert.True(s.HasForwardedPendingCast());
+    }
+
+    [Fact]
+    public void StartedOnGcdCast_IsNotCounted()
+    {
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(OnGcdCast(133, started: true));
+
+        Assert.False(s.HasForwardedPendingCast());
+    }
+
+    [Fact]
+    public void ForwardedUnstartedOffGcdCast_IsNotCounted()
+    {
+        // #442: an off-GCD cast coexists with a normal cast server-side, so it must not park
+        // on-GCD presses. Before the fix this returned true and jammed casting until relog.
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(OffGcdCast(11305)); // Sprint, forwarded-unstarted
+
+        Assert.False(s.HasForwardedPendingCast());
+    }
+
+    [Fact]
+    public void ForwardedUnstartedItemUseCast_IsNotCounted()
+    {
+        // The reported case: Mana Ruby / Robe of the Archmage leak into the queue and
+        // previously parked every subsequent spell.
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(ItemUseCast(10058)); // Mana Ruby
+
+        Assert.False(s.HasForwardedPendingCast());
+    }
+
+    [Fact]
+    public void LeakedItemUseCasts_DoNotJamOnGcdCasting()
+    {
+        // Exact shape of the Ragnaros log: two item-use entries left forwarded-unstarted.
+        // The gate must be clear so the next Frostbolt press forwards instead of parking.
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(ItemUseCast(10058)); // Mana Ruby
+        s.PendingNormalCasts.Enqueue(ItemUseCast(18385)); // Robe of the Archmage
+
+        Assert.False(s.HasForwardedPendingCast());
+    }
+
+    [Fact]
+    public void LeakedOffGcdCast_DoesNotMaskARealForwardedOnGcdCast()
+    {
+        // The exemption must not blind the gate: a genuine in-flight on-GCD cast alongside a
+        // leaked item entry still parks the next press.
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(ItemUseCast(10058));  // leaked, ignored
+        s.PendingNormalCasts.Enqueue(OnGcdCast(133));      // real forwarded cast
+
+        Assert.True(s.HasForwardedPendingCast());
+    }
+
+    [Fact]
+    public void StartedOffGcdCast_IsNotCounted()
+    {
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(OffGcdCast(11305, started: true));
+
+        Assert.False(s.HasForwardedPendingCast());
+    }
+}

--- a/HermesProxy.Tests/World/ForwardedPendingCastGateTests.cs
+++ b/HermesProxy.Tests/World/ForwardedPendingCastGateTests.cs
@@ -121,4 +121,21 @@ public class ForwardedPendingCastGateTests
 
         Assert.False(s.HasForwardedPendingCast());
     }
+
+    [Fact]
+    public void LeakedItemUseCast_StillBlocksThatSameItem_KnownResidual()
+    {
+        // Documents the boundary of this fix. Spell casting recovers, but the leaked entry
+        // still satisfies HasInFlightNormalCastForSpell(), which gates HandleUseItem at
+        // Server/SpellHandler.cs:962 — so THAT item stays silently unusable for the rest of
+        // the session (cast.dropped.duplicate, reason "in_flight_same_spell_use_item").
+        // The symptom degrades from "no casting at all" to "one dead item"; the underlying
+        // leak is still the thing to fix. If a later change reaps leaked item entries, this
+        // assertion should flip and the residual note in #442 can be closed out.
+        var s = NewSession();
+        s.PendingNormalCasts.Enqueue(ItemUseCast(10058)); // leaked Mana Ruby
+
+        Assert.False(s.HasForwardedPendingCast());              // spells flow again
+        Assert.True(s.HasInFlightNormalCastForSpell(10058));    // but the gem stays blocked
+    }
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -2132,6 +2132,17 @@ public sealed class GameSessionData
     /// Returns true if any pending normal cast has been forwarded to the legacy server but
     /// hasn't received SMSG_SPELL_START yet. Covers the post-GCD-expiry window where
     /// IsGcdHoldActive() returns false but the server hasn't confirmed the forwarded cast.
+    ///
+    /// JimsProxy (#442): off-GCD entries are NOT counted — since #345 that includes every
+    /// item-use cast. An in-flight off-GCD cast has no ordering claim over an on-GCD spell
+    /// (the legacy server casts both independently, verified on the wire), so gating on one
+    /// buys nothing. It costs a great deal: off-GCD entries are already exempt from the
+    /// ClearNonStartedNormalCasts sweep (:2291) and never get a WatchdogDeadlineMs, so a
+    /// leaked one is unreapable — and because this gate is not keyed by spell, it then parks
+    /// EVERY subsequent on-GCD press in ForceHoldCast (Server/SpellHandler.cs:619), silently
+    /// (no SpellPrepare, DontReport on the displaced press) until relog. Observed in a live
+    /// Ragnaros raid log: a Mana Ruby + Robe of the Archmage pair 499ms apart, then 96
+    /// seconds of spell.held_pending with no cast reaching the server.
     /// </summary>
     public bool HasForwardedPendingCast()
     {
@@ -2139,7 +2150,7 @@ public sealed class GameSessionData
         {
             foreach (var item in PendingNormalCasts)
             {
-                if (!item.HasStarted)
+                if (!item.HasStarted && !item.IsOffGcd)
                     return true;
             }
             return false;


### PR DESCRIPTION
Fixes #442.

## Problem

`HasForwardedPendingCast()` returned true for **any** `!HasStarted` entry in `PendingNormalCasts`, including off-GCD ones — which since #345 means **every item-use cast**.

That gate drives the `ForceHoldCast` park at `Server/SpellHandler.cs:619`. While it holds, every on-GCD `CMSG_CAST_SPELL` is parked instead of forwarded, and the park is deliberately invisible to the client: no `SpellPrepare` for the new hold (`:633`), `CastFailed(DontReport)` for the displaced one. So the player sees the cast animation start, no cast, no error text, no lit button.

Nothing could reap a leaked off-GCD entry:

- `ClearNonStartedNormalCasts` skips `IsOffGcd` entries (`GlobalSessionData.cs:2291`)
- `WatchdogDeadlineMs` is never armed for a forwarded-but-unstarted cast
- the keepalive eviction pump is gated on `IdentityPinnedCastIdsActive` (Low Latency only)

The gate is not keyed by spell, so one leaked item entry killed *all* casting until relog.

## Evidence

From a live Ragnaros raid JSONL (5.1.9-beta.2, Spell Queue mode):

```
12:41:02.660  CAST 10181 go        Frostbolt completes, queue drains clean
12:41:02.858  CAST 10058 start/go  Mana Ruby              (+198 ms)
12:41:03.357  CAST 18385 start/go  Robe of the Archmage   (+499 ms)
12:41:03.378  spell.held_pending   spell_id 10181, displaced 0
12:41:04.539  spell.held_pending   spell_id 10181, displaced 10181
              ... unbroken for 96 s across 10181/10151/10161/10202/122/10187/10216 ...
12:42:39      log ends - proxy restarted
```

Player damage casts per minute across the collapse: **15, 23, 2**, while raid-wide cast volume held at **1100-1682** — the encounter was still in full swing and the player did not die.

## Change

One condition: off-GCD entries no longer satisfy the gate.

```csharp
if (!item.HasStarted && !item.IsOffGcd)
    return true;
```

Off-GCD casts coexist with a normal cast server-side — the legacy server casts them independently, confirmed on the wire across five capture sessions where item and spell casts were accepted concurrently every time. An in-flight off-GCD cast therefore has no ordering claim over an on-GCD spell and must not gate one. This is the same reasoning as the sweep exemption granted in #344/#345, applied to the gate that was left behind.

Deterministic, no timer, consistent with the packet-pairing-not-clocks rule.

## Tests

`HermesProxy.Tests/World/ForwardedPendingCastGateTests.cs` — 8 cases.

Verified red before the fix: `ForwardedUnstartedOffGcdCast_IsNotCounted`, `ForwardedUnstartedItemUseCast_IsNotCounted`, `LeakedItemUseCasts_DoNotJamOnGcdCasting` all fail on the unpatched tree; the 5 regression guards pass both ways.

Full suite: **767/767 passing.**

## Regression risk

The gate exists to preserve ordering while a cast is in flight. Narrowing it to on-GCD casts means an off-GCD press no longer delays a following on-GCD press by up to one round trip — which is the correct vanilla behaviour and what the sweep exemption already assumes. `LeakedOffGcdCast_DoesNotMaskARealForwardedOnGcdCast` pins that a genuine on-GCD cast alongside a leaked item entry still parks, so the exemption can't blind the gate.

Not affected: Low Latency mode (returns at `:454`, never consults this gate), pet casts, next-melee/auto-repeat slots.

## Scope

**This treats the lockout, not the leak.** An item-use entry surviving its own `SPELL_GO` is still unexplained — `DebugOutput` was off in the capture, so the enqueue side wasn't recorded. Tracked separately; the fix here makes that leak survivable rather than session-ending.
