### PR TITLE
Chronoboon: refresh the tooltip alias at every login from the server's own template push

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -886,6 +886,28 @@ public sealed class GameSessionData
     // HandleShowBank can repaint their cooldown without scanning the global (all-players) alias map. WC only.
     public HashSet<WowGuid128> ChronoboonItemGuids = new();
 
+    // JimsProxy (Kronos Chronoboon): boon GUIDs whose login-time tooltip refresh already ran this login,
+    // so re-creates of the same item (same real entry) can't re-trigger an infinite refresh loop. WC only.
+    public HashSet<WowGuid128> ChronoboonLoginRefreshFired = new();
+
+    // JimsProxy (Kronos Chronoboon): the per-player boon template Kronos PUSHES unsolicited during login
+    // (a solicited entry query answers with the BASE template — 2026-07-30 log — so this push is the only
+    // correct login-time source). Latest push wins; per-login. WC only.
+    public ItemTemplate? ChronoboonLoginPushTemplate = null;
+
+    // JimsProxy (Kronos Chronoboon): boon GUIDs created before the login push arrived, awaiting refresh
+    // when it does (ordering fallback — observed order is push first, creates after). WC only.
+    public HashSet<WowGuid128> ChronoboonLoginBoonGuids = new();
+
+    // JimsProxy (Kronos Chronoboon): SEND_KNOWN_SPELLS item cooldowns keyed by ITEM entry — store and
+    // restore are different spells, so a spell-keyed lookup misses when the boon's current on-use isn't
+    // the spell that's cooling down. WC only.
+    public Dictionary<uint, (uint SpellId, long EndMs)> LoginItemCooldownByItemEntry = new();
+
+    // JimsProxy (Kronos Chronoboon): boon GUID whose remaining-cooldown repaint must go out AFTER the
+    // current update packet (carrying its aliased create) is forwarded. WC only.
+    public WowGuid128? ChronoboonRepaintPendingGuid = null;
+
     // Mobs we've seen send Flying spline or FixedZ movement flags. Vanilla servers
     // don't populate UNIT_FIELD_HOVERHEIGHT consistently (Twinstar e.g. leaves it at 0),
     // so we need a server-agnostic hover signal. Once a guid lands here, all subsequent

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -736,6 +736,12 @@ public partial class WorldClient
         if (item.Name[0]?.Contains("Chronoboon Displacer") == true)
         {
             item.ItemGroupSoundsId = 24;
+
+            // JimsProxy (Kronos Chronoboon): remember the latest boon template seen this login. Kronos
+            // pushes the per-player rebuilt template UNSOLICITED during login processing — the only
+            // login-time source with the current stored-buff state (a solicited entry query returns the
+            // base template). StoreObjectUpdateInternal mints the login alias from this.
+            GetSession().GameState.ChronoboonLoginPushTemplate = item;
         }
 
         // JimsProxy (Kronos Chronoboon): this answers the proxy-issued re-query fired from
@@ -800,8 +806,86 @@ public partial class WorldClient
             return;
         }
 
+        // JimsProxy (Kronos Chronoboon): the login push arrived AFTER the boon's item create (ordering
+        // fallback — observed order is push first). Refresh the parked GUIDs now via the validated
+        // use-path flow: mint from this template, destroy+recreate, repaint the remaining sweep.
+        if (item.Name[0]?.Contains("Chronoboon Displacer") == true &&
+            GetSession().GameState.ChronoboonLoginBoonGuids.Count != 0)
+        {
+            foreach (var boonGuid in GetSession().GameState.ChronoboonLoginBoonGuids)
+            {
+                if (!GetSession().GameState.ChronoboonLoginRefreshFired.Add(boonGuid))
+                    continue;
+                bool reminted = ChronoboonAliasNeedsRefresh(boonGuid, item);
+                if (reminted)
+                {
+                    MintChronoboonAlias(boonGuid, item);
+                    RecreateItemObjectForClient(boonGuid);
+                    SendChronoboonRemainingCooldown(boonGuid);
+                }
+                Log.Event("item.chronoboon.login_refresh_after_push", new
+                {
+                    guid = boonGuid.ToString(),
+                    name = item.Name[0],
+                    reminted = reminted,
+                });
+            }
+            GetSession().GameState.ChronoboonLoginBoonGuids.Clear();
+        }
+
         SendItemUpdatesIfNeeded(item);
         GameData.StoreItemTemplate((uint)entry.Key, item);
+    }
+
+    // JimsProxy (Kronos Chronoboon): true when no alias is presented for this GUID yet, or the presented
+    // alias's template no longer matches the server's current Name/Description (the dynamic tooltip bits).
+    private bool ChronoboonAliasNeedsRefresh(WowGuid128 guid, ItemTemplate current)
+    {
+        if (!GameData.ItemEntryAlias.TryGetValue(guid, out var aliasEntry))
+            return true;
+        var aliasTemplate = GameData.GetItemTemplate(aliasEntry);
+        return aliasTemplate == null ||
+               aliasTemplate.Name[0] != current.Name[0] ||
+               aliasTemplate.Description != current.Description;
+    }
+
+    // JimsProxy (Kronos Chronoboon): repaint the on-use sweep with the TRUE remaining captured at login —
+    // a full re-assert would restart the 40min sweep on every relog. Prefer the item-entry-keyed capture
+    // (store/restore are different spells, so the current template's on-use may not be the spell cooling
+    // down); no SpellCooldownPkt — the client already holds the spell cooldown from SEND_KNOWN_SPELLS.
+    private void SendChronoboonRemainingCooldown(WowGuid128 guid)
+    {
+        uint spellId = 0;
+        long endMs = 0;
+        if (GetSession().GameState.LoginItemCooldownByItemEntry.TryGetValue(GameData.KronosChronoboonEntry, out var byItem))
+        {
+            spellId = byItem.SpellId;
+            endMs = byItem.EndMs;
+        }
+        else if (GameData.ItemEntryAlias.TryGetValue(guid, out var aliasEntry) &&
+                 GameData.GetItemTemplate(aliasEntry) is { } aliasTemplate &&
+                 aliasTemplate.TriggeredSpellIds[0] > 0 &&
+                 GetSession().GameState.ChronoboonOnUseCooldownEndMs.TryGetValue((uint)aliasTemplate.TriggeredSpellIds[0], out var endBySpell))
+        {
+            spellId = (uint)aliasTemplate.TriggeredSpellIds[0];
+            endMs = endBySpell;
+        }
+
+        long remaining = endMs - Environment.TickCount64;
+        if (spellId == 0 || remaining <= 0)
+            return;
+
+        ItemCooldown itemCooldownPkt = new();
+        itemCooldownPkt.ItemGuid = guid;
+        itemCooldownPkt.SpellID = spellId;
+        itemCooldownPkt.Cooldown = (uint)remaining;
+        SendPacketToClient(itemCooldownPkt);
+        Log.Event("item.chronoboon.login_cooldown_repaint", new
+        {
+            guid = guid.ToString(),
+            spell_id = spellId,
+            remaining_ms = remaining,
+        });
     }
 
     void SendItemUpdatesIfNeeded(ItemTemplate item)

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -109,7 +109,13 @@ public partial class WorldClient
                 // a banked boon's sweep — the client gets the spell cooldown now but won't bind it to a bank
                 // item that only becomes visible when the bank opens. Keyed by on-use spell; endTick = now+left.
                 if (history.ItemID != 0 && history.RecoveryTime > 0)
+                {
                     GetSession().GameState.ChronoboonOnUseCooldownEndMs[history.SpellID] = Environment.TickCount64 + history.RecoveryTime;
+                    // JimsProxy (Kronos Chronoboon): also keyed by item entry — the boon's store and restore are
+                    // DIFFERENT spells, so a lookup via the current template's on-use spell misses the cooldown
+                    // left by the other state's use. Item-entry key finds it regardless.
+                    GetSession().GameState.LoginItemCooldownByItemEntry[history.ItemID] = (history.SpellID, Environment.TickCount64 + history.RecoveryTime);
+                }
             }
             SendPacketToClient(histories, Opcode.SMSG_SEND_UNLEARN_SPELLS);
         }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -636,6 +636,14 @@ public partial class WorldClient
         FlushPendingMcRuneResyncs();
         SuppressMcCirclesOnDousedRunes();
 
+        // JimsProxy (Kronos Chronoboon): repaint the remaining on-use sweep AFTER the aliased create is
+        // forwarded — the fresh alias replaced the item the client bound its login cooldown to.
+        if (GetSession().GameState.ChronoboonRepaintPendingGuid is { } chronoRepaintGuid)
+        {
+            GetSession().GameState.ChronoboonRepaintPendingGuid = null;
+            SendChronoboonRemainingCooldown(chronoRepaintGuid);
+        }
+
         // JimsProxy (stuck-logout-stun): fire the cure only after the whole update packet is
         // processed and forwarded. Armed exclusively by DetectStuckLogoutStunAtSelfCreate;
         // one shot per login.
@@ -2199,10 +2207,43 @@ public partial class WorldClient
         {
             updateData.ObjectData.EntryID = updates[OBJECT_FIELD_ENTRY].Int32Value;
 
-            // JimsProxy (Kronos Chronoboon): proactive login-alias removed 2026-06-22 (it regressed the
-            // bag sound). The login bag sound is now delivered statically by the Kronos Item overlay
-            // (CSV/Hotfix/Item1.kronos.csv, ItemGroupSoundsId 24) — a fresh hotfix id the cached client
-            // re-fetches at login via SMSG_AVAILABLE_HOTFIXES, so no login alias is needed for the sound.
+            // JimsProxy (Kronos Chronoboon): login-time tooltip refresh. The boon's state can change where the
+            // proxy can't see it (native 1.12 client session), leaving the 1.14 client rendering a stale cached
+            // template on the next proxied login. Kronos PUSHES the boon's per-player rebuilt template
+            // unsolicited during login — a solicited entry query answers with the BASE template (2026-07-30
+            // log: push=858B supercharged vs query reply=479B base), so the push is the ONLY correct source.
+            // Mint the alias from it BEFORE the substitution below so this very create carries the fresh id —
+            // no destroy+recreate, no extra traffic. Skipped when the existing alias already shows the pushed
+            // state. If the push hasn't arrived yet, park the GUID for HandleItemQueryResponse (ordering
+            // fallback). Once per GUID per login.
+            if (isCreate && objectType == ObjectType.Item &&
+                Framework.Settings.ServerType == Framework.ServerFork.Kronos &&
+                updates[OBJECT_FIELD_ENTRY].Int32Value == (int)GameData.KronosChronoboonEntry &&
+                !GetSession().GameState.ChronoboonLoginRefreshFired.Contains(guid))
+            {
+                var pushedTemplate = GetSession().GameState.ChronoboonLoginPushTemplate;
+                if (pushedTemplate != null)
+                {
+                    GetSession().GameState.ChronoboonLoginRefreshFired.Add(guid);
+                    bool reminted = ChronoboonAliasNeedsRefresh(guid, pushedTemplate);
+                    if (reminted)
+                    {
+                        MintChronoboonAlias(guid, pushedTemplate);
+                        GetSession().GameState.ChronoboonRepaintPendingGuid = guid;
+                    }
+                    Log.Event("item.chronoboon.login_refresh_at_create", new
+                    {
+                        guid = guid.ToString(),
+                        name = pushedTemplate.Name[0],
+                        reminted = reminted,
+                    });
+                }
+                else
+                {
+                    GetSession().GameState.ChronoboonLoginBoonGuids.Add(guid);
+                    Log.Event("item.chronoboon.login_refresh_waiting_push", new { guid = guid.ToString() });
+                }
+            }
 
             // JimsProxy (Kronos Chronoboon alias): present a throwaway alias entry to the client
             // for items whose tooltip is dynamic server-side, so it re-fetches the template (the

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -2481,6 +2481,9 @@ public static partial class GameData
     }
     public static bool IsItemEntryAlias(uint id) => id >= ItemEntryAliasBegin && id < ItemEntryAliasEnd;
 
+    // JimsProxy (Kronos Chronoboon): Kronos's custom Chronoboon Displacer item entry (dynamic server-side tooltip).
+    public const uint KronosChronoboonEntry = 25007;
+
     // JimsProxy (Kronos Chronoboon): item GUID -> current alias entry, applied to the outgoing
     // OBJECT_FIELD_ENTRY in StoreObjectUpdateInternal. STATIC (not per-session GameState) so it SURVIVES
     // a relogin — else the alias map is wiped, the item reverts to base 25007, and the client renders its


### PR DESCRIPTION
## Problem

The Chronoboon Displacer's tooltip (the stored world-buff list, rewritten server-side into the item's Name/Description) went stale on the 1.14 client whenever the boon's state changed where the proxy couldn't observe it — e.g. storing or restoring buffs in a native 1.12 session, then logging in through the proxy. The 1.14 client caches item templates per id and never re-queries, so it kept rendering the old state (worst case: a supercharged boon showing the default empty tooltip) until the next proxied use or a client cache wipe.

## Key server behavior this builds on

Captured in JSONL during diagnosis (2026-07-30):

- **Kronos pushes the boon's per-player rebuilt template unsolicited** (`SMSG_ITEM_QUERY_SINGLE_RESPONSE`) during login processing — before the item creates — and again at each use completion. That push is how native 1.12 clients get fresh boon tooltips.
- **A solicited entry query for the boon returns the BASE template** (observed: 858-byte supercharged push vs 479-byte base reply to the same-entry query, seconds apart). So re-querying at login is not just redundant — it actively clobbers the correct data the push already delivered. A first-cut implementation did exactly that and was reworked into this design.

## Fix

All on the WorldClient thread, Kronos-gated (`ServerType == Kronos`), keyed on the boon entry (`GameData.KronosChronoboonEntry = 25007`):

- `HandleItemQueryResponse` remembers the latest boon-named template as `ChronoboonLoginPushTemplate` (per-login session state).
- `StoreObjectUpdateInternal`, on the boon's item create (once per GUID per login), mints a fresh alias from the pushed template **before** the entry substitution — so the natural create itself carries the never-seen alias id and the client fetches the current state cleanly. No destroy+recreate, no extra server traffic in the normal path.
- A `Name`/`Description` comparison skips the re-mint when the existing alias already shows the pushed state, so unchanged relogs keep their alias (no alias-id churn, no pointless client re-fetch).
- Ordering fallback: if a boon create arrives before any push has been seen, the GUID is parked and the refresh runs (mint + destroy/recreate, the validated use-path flow) when the push lands.
- Cooldown correctness: `SMSG_SEND_KNOWN_SPELLS` item cooldowns are now also captured **keyed by item entry** — the boon's store and restore are different spells, so a spell-keyed lookup can miss the active cooldown. After a login re-mint, the proxy repaints the sweep with the true captured remaining (never a fresh full re-assert), sent after the update packet carrying the aliased create is forwarded.

This is not the previously reverted 2026-06-22 proactive login alias: that predated the `AliasPendingPackets` delivery architecture and rebuilt hotfix records mid-login (regressing the bag sound). This version rides entirely on the shipped, validated delivery paths from #385.

## Validation

Tested in-game on Kronos PTR (2026-07-30): buffs stored via the native 1.12 client now show correctly at 1.14 login on the first try; a stale alias from before the fix was detected and self-healed; restore and re-store through the proxy each re-minted from the server's post-use push; bag clink sound intact; no errors or parse failures in the session JSONL. Diagnostics added: `item.chronoboon.login_refresh_at_create` / `_waiting_push` / `_after_push` / `login_cooldown_repaint`. Builds clean, all 759 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)