### PR TITLE
Forward the quest-log-full error (SMSG_QUEST_LOG_FULL)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,3 +113,11 @@ Guard ordering in HandleCastSpell:
 - **Diagnostics:** `rtt.sample` events log each measurement. `gcd.begin` events now emit `fire_offset_ms` (adaptive) and `smoothed_rtt_ms` for post-session analysis.
 
 **Verification:** After 2+ minutes of play, `gcd.begin` events should show `fire_offset_ms > 0`. Arcane Explosion GCD intervals should decrease from ~1700ms to ~1600ms. Zero or near-zero `NOT_READY` failures expected.
+
+## 2026-07-30 — Forward the "quest log is full" error (SMSG_QUEST_LOG_FULL)
+
+**Issue:** Accepting a quest with a full log silently did nothing — vanilla answers with SMSG_QUEST_LOG_FULL (0x195, empty body) and the proxy dropped it (11 corpus sessions in DROPPED-S2C-AUDIT.md, #433; also personally observed — the error simply never appears through the proxy).
+
+**Change:** Forward as modern `QuestLogFull` (0x2A87, empty body, TC-master-sourced) — `QuestPackets.cs` class + `QuestHandler.HandleQuestLogFull`. First s2c translation extracted from the #433 batch under the one-fix-one-PR process.
+
+**Verification:** empty-body layout test; field gate (audit question U4): fill the quest log on PTR, accept one more — the red "Your quest log is full." error must appear. If the 1.14 client turns out to only render this via SMSG_DISPLAY_GAME_ERROR, this slice gets reworked before merge rather than shipping a silent no-op.

--- a/HermesProxy.Tests/World/QuestLogFullTranslationTests.cs
+++ b/HermesProxy.Tests/World/QuestLogFullTranslationTests.cs
@@ -1,0 +1,22 @@
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// SMSG_QUEST_LOG_FULL translation slice (from the #433 dropped-s2c audit):
+/// vanilla and TC-master shapes are both empty-body, so the packet must write
+/// exactly zero bytes — any accidental payload would desync the modern stream.
+/// </summary>
+public class QuestLogFullTranslationTests
+{
+    [Fact]
+    public void QuestLogFull_Layout_EmptyBody()
+    {
+        var packet = new QuestLogFull();
+
+        byte[] buffer = new byte[1];
+        Assert.Equal(0, packet.WriteToSpan(buffer));
+        Assert.Equal(0, packet.MaxSize);
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QuestHandler.cs
@@ -405,6 +405,19 @@ public partial class WorldClient
         SendPacketToClient(quest);
     }
 
+    // JimsProxy: vanilla sends SMSG_QUEST_LOG_FULL (empty body) when the
+    // player accepts a quest with a full log. Forward it so the modern client
+    // shows the "Your quest log is full." error instead of Accept silently
+    // doing nothing (hit in 11 corpus sessions, DROPPED-S2C-AUDIT.md in #433).
+    // Open question U4 from that audit: whether the 1.14 client renders the
+    // red error from this opcode or only via SMSG_DISPLAY_GAME_ERROR —
+    // send-and-see is the field test gating this slice's merge.
+    [PacketHandler(Opcode.SMSG_QUEST_LOG_FULL)]
+    void HandleQuestLogFull(WorldPacket packet)
+    {
+        SendPacketToClient(new QuestLogFull());
+    }
+
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_COMPLETE)]
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_FAILED)]
     [PacketHandler(Opcode.SMSG_QUEST_UPDATE_FAILED_TIMER)]

--- a/HermesProxy/World/Server/Packets/QuestPackets.cs
+++ b/HermesProxy/World/Server/Packets/QuestPackets.cs
@@ -684,6 +684,21 @@ public class QuestGiverCompleteQuest : ClientPacket
     public bool FromScript; // 0 - standart complete quest mode with npc, 1 - auto-complete mode
 }
 
+// JimsProxy: "Your quest log is full." error notification. Empty body on both
+// sides (vanilla SMSG_QUEST_LOG_FULL and TC master QuestLogFull, size 0);
+// without the forward, accepting a quest with a full log silently does
+// nothing on the modern client.
+class QuestLogFull : ServerPacket, ISpanWritable
+{
+    public QuestLogFull() : base(Opcode.SMSG_QUEST_LOG_FULL, ConnectionType.Instance) { }
+
+    public override void Write() { }
+
+    public int MaxSize => 0;
+
+    public int WriteToSpan(Span<byte> buffer) => 0;
+}
+
 class QuestGiverQuestFailed : ServerPacket, ISpanWritable
 {
     public QuestGiverQuestFailed() : base(Opcode.SMSG_QUEST_GIVER_QUEST_FAILED) { }


### PR DESCRIPTION
Second slice extracted from the #433 dropped-s2c audit batch under the one-fix-one-PR process.

## What
Vanilla answers a quest accept on a full log with `SMSG_QUEST_LOG_FULL` (0x195, **empty body**); the proxy dropped it, so clicking Accept with a full log **silently does nothing** on the modern client. 11 distinct corpus sessions hit it (DROPPED-S2C-AUDIT.md), and the maintainer has personally observed the missing error in play. Forward it as modern `QuestLogFull` (0x2A87, empty body, sourced from TC master `QuestPackets.h`). One packet class + one handler; zero state.

## Merge gate — the audit's open question U4
Nobody has verified the 1.14 client renders the red *"Your quest log is full."* from this opcode (vs only via `SMSG_DISPLAY_GAME_ERROR`). **Field test before merge:** on PTR, fill the quest log to cap, accept one more —
- current beta: Accept does nothing, silently (the known symptom)
- this build: the red error text must appear
- if it does not: the translation is wrong-target; rework to `SMSG_DISPLAY_GAME_ERROR` here before merging rather than shipping a silent no-op

## Testing
- `dotnet test`: 760/760 (adds `QuestLogFull_Layout_EmptyBody` — the empty-body invariant; any accidental payload would desync the modern stream).
- Field: U4 send-and-see above, pending.

Note for the review agent: shares only the CHANGES.md tail with sibling slice PR #447 — trivial conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjDvGggC6c6RXCnxGJZXXR