### PR TITLE
Keep Baron Geddon's Inferno pulse visual at full radius

### DIFF
--- a/HermesProxy/CSV/Hotfix/SpellXSpellVisual1.csv
+++ b/HermesProxy/CSV/Hotfix/SpellXSpellVisual1.csv
@@ -2,3 +2,4 @@ Id,DifficultyId,SpellVisualId,Probability,Flags,Priority,SpellIconFileId,ActiveI
 316112,0,7434,1,0,1,0,0,0,0,0,0,32950
 316810,0,107,1,0,1,0,0,0,0,0,0,33389
 316812,0,107,1,0,1,0,0,0,0,0,0,33392
+340001,0,781,1,0,1,0,0,0,0,0,0,19698


### PR DESCRIPTION
## Problem

Baron Geddon's Inferno shows the correct large-radius fire nova only on the initial burst. Every subsequent 1-second pulse renders a visibly smaller nova, so players can't judge the real run-out distance.

## Cause

The initial burst is the aura application (spell 19695), which the client renders with SpellVisual 781 — the big, correct graphic. Each pulse is a separate triggered spell (19698) whose SPELL_GO carries SpellVisual 5728, which the 1.14 client renders diminished.

This isn't a data drift: vanilla 1.12 spell data maps the exact same visuals (19695 → 781, 19698 → 5728). The 1.14 client simply renders visual 5728 smaller than the 1.12 client did.

## Fix

One row added to `CSV/Hotfix/SpellXSpellVisual1.csv` mapping spell 19698 to SpellVisual 781 (record ID 340001, above the client table's max of 339844, matching the existing synthetic hotfix rows). The existing `LoadSpellXSpellVisualHotfixes` machinery pushes the DB2 hotfix to the client and redirects the proxy's visual lookup, so every pulse now fires the same full-radius nova as the initial burst. No code changes.

## Testing

Confirmed live on Kronos in Molten Core: all Inferno pulses now render the full-size nova for the whole 8-second duration, no added sound or animation issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
