### PR TITLE
Never dedup a SPELL_FAILED_OTHER that terminates a live tracked cast

### DIFF
--- a/HermesProxy.Tests/World/SpellFailedOtherDedupTests.cs
+++ b/HermesProxy.Tests/World/SpellFailedOtherDedupTests.cs
@@ -1,0 +1,145 @@
+using System;
+using HermesProxy;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (observed-pose strand, 2026-08-14): the SMSG_SPELL_FAILED_OTHER retry-storm
+// dedup must never swallow the terminator of a live tracked cast instance. Field capture:
+// a party member spam-recasting Skinning (10768) had the cancel of one in-flight cast
+// classified as a storm duplicate (411ms after the previous routed failure); the next
+// SPELL_START overwrote the tracked CastID and the cast-hold kit ("crafting hands" pose)
+// stayed frozen on the 1.14.2 client until the unit despawned. These drive
+// GameSessionData.ShouldDedupSpellFailedOther directly — no clock, fully synchronous.
+public class SpellFailedOtherDedupTests
+{
+    static SpellFailedOtherDedupTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+
+    private const uint Skinning = 10768;
+    private const uint Firebolt = 3110;
+    private const long Window = 500;
+
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+    private static WowGuid128 Caster(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 12345, counter);
+    private static WowGuid128 SomeCastId(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, 99999, counter);
+
+    [Fact]
+    public void FirstFailure_NoHistory_Forwards()
+    {
+        var session = NewSession();
+        Assert.False(session.ShouldDedupSpellFailedOther(Caster(1), Skinning, 1000, Window, out var msSince));
+        Assert.Equal(-1, msSince);
+    }
+
+    [Fact]
+    public void RepeatWithinWindow_NoLiveInstance_Skips()
+    {
+        // The storm the dedup exists for (imp Firebolt retry spam): repeat failures with
+        // no intervening SPELL_START must still be dropped.
+        var session = NewSession();
+        var pet = Caster(1);
+        session.RecentlyForwardedSpellFailedOther[(pet, Firebolt)] = 1000;
+
+        Assert.True(session.ShouldDedupSpellFailedOther(pet, Firebolt, 1400, Window, out var msSince));
+        Assert.Equal(400, msSince);
+    }
+
+    [Fact]
+    public void RepeatOutsideWindow_Forwards()
+    {
+        var session = NewSession();
+        var pet = Caster(1);
+        session.RecentlyForwardedSpellFailedOther[(pet, Firebolt)] = 1000;
+
+        Assert.False(session.ShouldDedupSpellFailedOther(pet, Firebolt, 1500, Window, out var msSince));
+        Assert.Equal(-1, msSince);
+    }
+
+    [Fact]
+    public void RepeatWithinWindow_LiveOtherCasterInstance_Forwards()
+    {
+        // The strand: a SPELL_START minted a fresh CastID after the last routed failure.
+        // This failure is that instance's only terminator — never a duplicate.
+        var session = NewSession();
+        var member = Caster(73772);
+        session.RecentlyForwardedSpellFailedOther[(member, Skinning)] = 1000;
+        session.OtherCasterActiveCastIds[(member, Skinning)] = SomeCastId(5);
+
+        Assert.False(session.ShouldDedupSpellFailedOther(member, Skinning, 1411, Window, out var msSince));
+        Assert.Equal(411, msSince); // within the window: callers log the bypass
+    }
+
+    [Fact]
+    public void RepeatWithinWindow_LivePetAutoCastInstance_Forwards()
+    {
+        var session = NewSession();
+        var pet = Caster(1);
+        session.RecentlyForwardedSpellFailedOther[(pet, Firebolt)] = 1000;
+        session.PetAutoCastActiveCastIds[(pet, Firebolt)] = SomeCastId(6);
+
+        Assert.False(session.ShouldDedupSpellFailedOther(pet, Firebolt, 1400, Window, out var msSince));
+        Assert.Equal(400, msSince);
+    }
+
+    [Fact]
+    public void RepeatWithinWindow_LiveInstanceForDifferentSpell_StillSkips()
+    {
+        // The bypass keys on exactly (caster, spell) — an unrelated in-flight cast by the
+        // same unit must not defeat the storm dedup for this spell.
+        var session = NewSession();
+        var member = Caster(73772);
+        session.RecentlyForwardedSpellFailedOther[(member, Firebolt)] = 1000;
+        session.OtherCasterActiveCastIds[(member, Skinning)] = SomeCastId(7);
+
+        Assert.True(session.ShouldDedupSpellFailedOther(member, Firebolt, 1400, Window, out _));
+    }
+
+    [Fact]
+    public void RapidRecastSequence_MatchesFieldCapture()
+    {
+        // The 2026-08-14 sequence for (member 73772, Skinning 10768), collapsed:
+        //   t=1000 FAILED routed  -> handler removes the tracked instance, records t
+        //   t=1150 SPELL_START    -> handler mints + tracks a fresh CastID
+        //   t=1411 FAILED         -> old logic skipped this (411ms < 500ms) = strand;
+        //                            must now forward because the instance is live.
+        var session = NewSession();
+        var member = Caster(73772);
+
+        session.OtherCasterActiveCastIds[(member, Skinning)] = SomeCastId(4);
+        Assert.False(session.ShouldDedupSpellFailedOther(member, Skinning, 1000, Window, out _));
+        session.OtherCasterActiveCastIds.TryRemove((member, Skinning), out _);
+        session.RecentlyForwardedSpellFailedOther[(member, Skinning)] = 1000;
+
+        session.OtherCasterActiveCastIds[(member, Skinning)] = SomeCastId(5);
+
+        Assert.False(session.ShouldDedupSpellFailedOther(member, Skinning, 1411, Window, out var msSince));
+        Assert.Equal(411, msSince);
+    }
+
+    [Fact]
+    public void StormAfterRoutedTerminator_Skips()
+    {
+        // After a routed failure consumed the live instance, follow-up storm repeats
+        // within the window (no new SPELL_START) are still deduped.
+        var session = NewSession();
+        var pet = Caster(1);
+
+        session.PetAutoCastActiveCastIds[(pet, Firebolt)] = SomeCastId(8);
+        Assert.False(session.ShouldDedupSpellFailedOther(pet, Firebolt, 1000, Window, out _));
+        session.PetAutoCastActiveCastIds.TryRemove((pet, Firebolt), out _);
+        session.RecentlyForwardedSpellFailedOther[(pet, Firebolt)] = 1000;
+
+        Assert.True(session.ShouldDedupSpellFailedOther(pet, Firebolt, 1100, Window, out var msSince));
+        Assert.Equal(100, msSince);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -783,6 +783,33 @@ public sealed class GameSessionData
     // overridden with ServerGUID downstream → the auto-cast map entry is a harmless
     // orphan in that case.
     public ConcurrentDictionary<(WowGuid128 caster, uint spellId), WowGuid128> PetAutoCastActiveCastIds = new();
+
+    // JimsProxy (observed-pose strand, 2026-08-14): decide whether an incoming
+    // SMSG_SPELL_FAILED_OTHER may be dropped by the retry-storm dedup. A failure whose
+    // (caster, spell) has a live tracked cast instance (OtherCasterActiveCastIds /
+    // PetAutoCastActiveCastIds) is that instance's ONLY terminator — the next
+    // SPELL_START overwrites the tracked entry, so a skipped cancel permanently
+    // strands the cast-hold kit on the 1.14.2 client (observed player frozen in the
+    // skinning "crafting hands" pose until despawn; same for mob casting poses).
+    // The storm the dedup was built for (repeat failures with NO intervening
+    // SPELL_START) still dedups: the first routed failure removes the tracked entry,
+    // so storm repeats find no live instance.
+    // Returns true = skip this failure. msSinceLastForwarded: -1 when outside the
+    // window / first failure; >= 0 when within the window (callers log the
+    // live-cast bypass case). Callers record forwarded failures in
+    // RecentlyForwardedSpellFailedOther.
+    public bool ShouldDedupSpellFailedOther(WowGuid128 caster, uint spellId, long nowMs, long dedupWindowMs, out long msSinceLastForwarded)
+    {
+        msSinceLastForwarded = -1;
+        var key = (caster, spellId);
+        if (!RecentlyForwardedSpellFailedOther.TryGetValue(key, out var lastMs) || nowMs - lastMs >= dedupWindowMs)
+            return false;
+        msSinceLastForwarded = nowMs - lastMs;
+        if (OtherCasterActiveCastIds.ContainsKey(key) || PetAutoCastActiveCastIds.ContainsKey(key))
+            return false; // live cast instance: this failure is its terminator, never a duplicate
+        return true;
+    }
+
     // JimsProxy (cast-go-castid-recovery): per-spell FIFO of the client-facing CastIDs
     // forwarded to the modern client at the LOCAL PLAYER's SMSG_SPELL_START, keyed by spellId.
     // HandleSpellGo recalls the oldest when no PendingNormalCast / melee / auto-repeat entry

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -922,12 +922,15 @@ public partial class WorldClient
         // SMSG_SPELL_FAILED_OTHER 5+/sec while a target is out of range / dying;
         // forwarding each one chains CancelSpellVisuals into a stuck cast sound on
         // the 1.14.2 client. The first failure carries all the state the client
-        // needs; subsequent same-(caster, spell) failures within 500ms add nothing.
+        // needs; subsequent same-(caster, spell) failures within 500ms add nothing —
+        // UNLESS the failure terminates a live tracked cast instance
+        // (GameSessionData.ShouldDedupSpellFailedOther): that one is the instance's
+        // only terminator and must always be forwarded, or the cast-hold kit strands
+        // on the 1.14.2 client (2026-08-14 observed-skinning capture).
         const long DedupWindowMs = 500;
         long nowMs = Time.GetMSTime();
         var dedupKey = (casterUnit, spellId);
-        if (GetSession().GameState.RecentlyForwardedSpellFailedOther.TryGetValue(dedupKey, out var lastMs) &&
-            nowMs - lastMs < DedupWindowMs)
+        if (GetSession().GameState.ShouldDedupSpellFailedOther(casterUnit, spellId, nowMs, DedupWindowMs, out long msSinceLastForwarded))
         {
             // JimsProxy (warlock-pet-gcd-on-failure): the visual/SpellFailure storm is deduped, but a double-clicked pet-bar press is a distinct failed cast whose predicted GCD sweep must still be released. Gated to unqueued presses (CMSG_PET_ACTION, deterministic seed CastID).
             bool dedupReleasePetGcd = GetSession().GameState.CurrentPetGuid == casterUnit && !HasQueuedPetCast(spellId);
@@ -938,11 +941,19 @@ public partial class WorldClient
                 spellId,
                 reason,
                 casterCounter = casterUnit.GetCounter(),
-                ms_since_last = nowMs - lastMs,
+                ms_since_last = msSinceLastForwarded,
                 sentPetCastFailed = dedupReleasePetGcd,
             });
             return;
         }
+        if (msSinceLastForwarded >= 0)
+            Log.Event("spell.failed_other.dedup_bypassed_live_cast", new
+            {
+                spellId,
+                reason,
+                casterCounter = casterUnit.GetCounter(),
+                ms_since_last = msSinceLastForwarded,
+            });
         GetSession().GameState.RecentlyForwardedSpellFailedOther[dedupKey] = nowMs;
 
         WowGuid128 castId;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -946,7 +946,9 @@ public partial class WorldClient
             });
             return;
         }
-        if (msSinceLastForwarded >= 0)
+        // Gated: this is the fix-working breadcrumb, not an unexpected-edge signature
+        // (2026-08-18 review rubric — devs/testers run DebugOutput on).
+        if (msSinceLastForwarded >= 0 && Framework.Settings.DebugOutput)
             Log.Event("spell.failed_other.dedup_bypassed_live_cast", new
             {
                 spellId,


### PR DESCRIPTION
## Symptom

Observed party member frozen in the skinning "crafting hands" cast-hold pose for ~6 minutes (2026-08-14 field capture, live report while it happened). The pose survived a bunch of combat, the member's own later casts, and the observer's `/reload`; it cleared only when the unit despawned out of range. The same mechanism freezes **mob** casting poses (mob Flash Heal / Shadow Bolt / Piercing Shot strands found in older logs).

## Root cause

1. Each forwarded observed `SMSG_SPELL_START` mints a **unique modern CastID** (`OtherCasterActiveCastIds`); the 1.14.2 client tracks cast-visual kits **per CastID**, and a kit with no terminator loops until the unit despawns.
2. Legacy `SMSG_SPELL_FAILED_OTHER` carries **no cast ID** — only (caster, spell).
3. The 500ms (caster, spell) dedup added in `1f58cba2` for the pet auto-cast retry storm treats a genuinely-new cancel as a duplicate whenever it lands <500ms after the previous routed one.
4. Rapid re-casting produces exactly that rhythm (corpse spam-skinning: 6 STARTs in 3s, Kronos sending a well-formed `FAILED_OTHER` after every superseded START). The skipped cancel was the in-flight instance's **only terminator**, and the next START **overwrites** the tracked entry — the orphaned CastID becomes permanently unreachable.

**Wire evidence** (session `jimsproxy-20260814-090718.jsonl`, archived in `Downloads\PROXY-EVIDENCE-ARCHIVE` with the raw `.pkt`): every Skinning cast instance in the session got a GO or a routed cancel **except exactly the two whose cancels were dedup-skipped** (`ms_since_last` 411 / 491) — the two stranded kits, born at the moments the reporter described.

**741-log sweep (259.5 logged hours, May 16 → today):** 410 dedup skips — 402 benign (no live instance; genuine mob failure storms: Shadow Bolt Volley ×71, Backstab ×26, etc.), **8 hit a live cast instance** (4 permanent strands incl. a player Hamstring and a mob Shadow Bolt), and **0 were ever recovered by a later packet**.

**Field validation — eyewitnessed (2026-08-18):** the 9th known live-cast hit, and the first one watched as it happened (session `jimsproxy-20260818-123912.jsonl` + raw `.pkt`, archived in `Downloads\PROXY-EVIDENCE-ARCHIVE\wild-specimen-miluna-20260818\`). An observed priest (caster low 98905) spam-cancel-healing on the EK→Kalimdor boat stranded exactly as this PR describes, in front of the observer: her cast bar kept filling over the holy-hands kit, the bar completed with nothing cast, and the glow persisted ~40s until her mount's display swap replaced it. The proxy logged the eat itself: `t=1787089985299 spell.failed_other.dedup_skipped spellId=2055 casterCounter=98905 ms_since_last=401`. Every link of the root-cause chain is in the capture:

1. `FAILED_OTHER` routed at t=…984899 closes the previous cast (castIdCounter 210453498464 = seq 49 `<<32` | 2055+98905) and stamps the dedup clock.
2. `SPELL_START` at t=…985099 mints and tracks **seq 50** (castId 214748465760) in `OtherCasterActiveCastIds`.
3. Her tap-cancel's `FAILED_OTHER` arrives at t=…985299 — 401ms after the last routed one, inside the window — and is skipped. The skip event carries no castIdCounter (the eat returns before castId resolution); **seq 50 never appears in any event again**.
4. The next START (t=…985900) overwrites the tracked entry; that cast GOes normally. The orphaned kit is unreachable forever after.

The raw `.pkt` proves the eaten packet was that cast's genuine terminator: movement-flag decode pairs every routed `FAILED_OTHER` in the sequence with its cast's locomotion-flag onset within ~50ms (+359/+2062/+407ms), and the stuck cast's Back-flag blip at +203ms pairs with the eaten failure at +200ms — the server cancelled the cast the instant she moved; only the dedup stood between that cancel and the observer's client. The geometry (routed failure → new START +200ms → cancel +401ms) is the exact sequence `RapidRecastSequence_MatchesFieldCapture` drives (+150ms / +411ms), so the fix forwards this one by construction.

The same session also contains the fix's negative control, from the same caster 90 seconds earlier: a 3-failure burst for spell 2791 (routed, then eaten ×2 at 190/400ms) with **no intervening START** — the routed neighbor's castIdCounter is the flat fallback seed (101696 = 2791+98905, sequence 0), i.e. no live instance ever existed — plus creature failure storms (17164, same flat-seed shape). `ShouldDedupSpellFailedOther` keeps eating all of those. One caster, ninety seconds, both sides of the gate, split correctly.

## Fix

`GameSessionData.ShouldDedupSpellFailedOther(...)`: the dedup skips **only when no live tracked cast instance exists** for (caster, spell) (`OtherCasterActiveCastIds` / `PetAutoCastActiveCastIds`). A live instance means the failure is that instance's terminator — always forwarded, regardless of the window.

- **Storm behavior preserved**: the first routed failure removes the tracked entry, so storm repeats (no intervening SPELL_START) find no live instance and still dedup. Red-first proof confirmed the 5 storm/window tests pass on both old and new logic.
- The warlock pet-GCD release carve-out in the skip body is untouched; player-pressed queued pet casts keep their existing behavior.
- New structured event `spell.failed_other.dedup_bypassed_live_cast` marks each rescued cancel — the field-verification signal (~8 occurrences per 259 logged hours by historical data, so no volume risk). Approved pre-PR.

## Testing

- 8 new tests (`SpellFailedOtherDedupTests`) drive the decision method synchronously, including the exact field sequence (routed cancel → new START → cancel at +411ms).
- **Red-first proven**: with the live-instance gate disabled (old behavior), the 3 strand tests fail and the 5 storm tests pass; with the gate, full suite **862/862**.

## Field verification (tentative until observed)

Watch beta logs for `spell.failed_other.dedup_bypassed_live_cast`; each one is a cancel that would previously have stranded a kit. Stuck observed poses from the burst-recast trigger (gatherers, interrupt-chained mobs) should stop. This does **not** address the self instant-cast looping-sound bug (separate mechanism, still open) nor the ~250 no-terminator-on-wire overwrites (mounts/Hearthstone/crafting — upstream gap, follow-up).
