### PR TITLE
Stash pre-create enchant time pushes; inject remaining time into the item create (fixes 0s-flashing temp enchant after relogin)

### DIFF
--- a/HermesProxy.Tests/World/ItemEnchantDurationStashTests.cs
+++ b/HermesProxy.Tests/World/ItemEnchantDurationStashTests.cs
@@ -1,0 +1,194 @@
+using HermesProxy;
+using HermesProxy.World;
+using HermesProxy.World.Client;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (temp-enchant-0s-after-relogin): at login vanilla cores send
+// SMSG_ITEM_ENCHANT_TIME_UPDATE — the only carrier of a temp enchant's remaining
+// time — BEFORE the item's create block (2026-08-14 logs: both logins pre-create,
+// one pre-login-verify). The 1.14 client discards updates for guids it has not
+// constructed, and the create's enchantment duration field is zero, so the buff
+// renders as a permanently flashing "0s". The handler stashes the push in
+// GameSessionData and the item-create translation consumes it into the create
+// block's duration field, decayed by the time it spent stashed.
+public class ItemEnchantDurationStashTests
+{
+    private static WowGuid128 Item(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Item, counter);
+
+    private const uint TempSlot = 1;             // vanilla TEMP_ENCHANTMENT_SLOT — sharpening stones, oils
+    private const uint StoneSeconds = 1800;      // 30 min sharpening stone
+
+    // --- stash + consume ---
+
+    [Fact]
+    public void ConsumePendingItemEnchantDurations_JustStored_ReturnsFullMs()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(83718230); // the MH weapon low from jimsproxy-20260814-090718.jsonl
+
+        state.StorePendingItemEnchantDuration(guid, TempSlot, StoneSeconds, nowTick: 100_000);
+        var consumed = state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_000);
+
+        Assert.NotNull(consumed);
+        var entry = Assert.Single(consumed);
+        Assert.Equal(TempSlot, entry.LegacySlot);
+        Assert.Equal(StoneSeconds * 1000, entry.DurationMs);
+    }
+
+    // The observed login gap (push at .213, create at .216) is milliseconds, but a
+    // bank-parked enchanted item's create only arrives at bank-open — the stashed
+    // value must decay by the time it spent waiting, not replay at full.
+    [Fact]
+    public void ConsumePendingItemEnchantDurations_TimePassedSinceStore_DecaysRemaining()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(1);
+
+        state.StorePendingItemEnchantDuration(guid, TempSlot, StoneSeconds, nowTick: 100_000);
+        var consumed = state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_000 + 25_000);
+
+        var entry = Assert.Single(consumed!);
+        Assert.Equal(StoneSeconds * 1000 - 25_000, entry.DurationMs);
+    }
+
+    // Consume-once: the create that eats the stash must leave nothing behind for a
+    // later create to inject stale time from.
+    [Fact]
+    public void ConsumePendingItemEnchantDurations_SecondCall_ReturnsNull()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(1);
+
+        state.StorePendingItemEnchantDuration(guid, TempSlot, StoneSeconds, nowTick: 100_000);
+        state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_000);
+
+        Assert.Null(state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_001));
+    }
+
+    [Fact]
+    public void ConsumePendingItemEnchantDurations_DifferentGuid_ReturnsNull()
+    {
+        var state = GameSessionData.CreateForTesting();
+
+        state.StorePendingItemEnchantDuration(Item(1), TempSlot, StoneSeconds, nowTick: 100_000);
+
+        Assert.Null(state.ConsumePendingItemEnchantDurations(Item(2), nowTick: 100_000));
+    }
+
+    // A push that fully expired while stashed must not resurrect as a 0/negative
+    // duration — dropping it reproduces the server's own removal that is coming.
+    [Fact]
+    public void ConsumePendingItemEnchantDurations_ExpiredWhileStashed_DropsEntry()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(1);
+
+        state.StorePendingItemEnchantDuration(guid, TempSlot, durationSeconds: 10, nowTick: 100_000);
+        var consumed = state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_000 + 10_000);
+
+        Assert.True(consumed == null || consumed.Count == 0);
+    }
+
+    // TickCount skew safety (same rule as HasFreshAuraDurationPush): a receipt tick
+    // "in the future" must not decay the push, only time genuinely elapsed.
+    [Fact]
+    public void ConsumePendingItemEnchantDurations_ClockWentBackwards_NoDecay()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(1);
+
+        state.StorePendingItemEnchantDuration(guid, TempSlot, StoneSeconds, nowTick: 100_000);
+        var consumed = state.ConsumePendingItemEnchantDurations(guid, nowTick: 99_000);
+
+        var entry = Assert.Single(consumed!);
+        Assert.Equal(StoneSeconds * 1000, entry.DurationMs);
+    }
+
+    // A refreshed push (re-applied stone before the create — same slot) replaces the
+    // older value instead of duplicating the slot.
+    [Fact]
+    public void StorePendingItemEnchantDuration_SameSlotTwice_LatestWins()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(1);
+
+        state.StorePendingItemEnchantDuration(guid, TempSlot, durationSeconds: 300, nowTick: 100_000);
+        state.StorePendingItemEnchantDuration(guid, TempSlot, StoneSeconds, nowTick: 101_000);
+        var consumed = state.ConsumePendingItemEnchantDurations(guid, nowTick: 101_000);
+
+        var entry = Assert.Single(consumed!);
+        Assert.Equal(StoneSeconds * 1000, entry.DurationMs);
+    }
+
+    // Both weapons stoned: two slots on... two guids, but also two slots on one guid
+    // (Perm + Temp both timed is impossible for Perm, but the stash must not conflate
+    // distinct slots regardless).
+    [Fact]
+    public void ConsumePendingItemEnchantDurations_TwoSlotsOneItem_ReturnsBoth()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(1);
+
+        state.StorePendingItemEnchantDuration(guid, 0, durationSeconds: 600, nowTick: 100_000);
+        state.StorePendingItemEnchantDuration(guid, TempSlot, StoneSeconds, nowTick: 100_000);
+        var consumed = state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_000);
+
+        Assert.Equal(2, consumed!.Count);
+    }
+
+    // Zero-duration pushes are removal signals, not countdowns — never stashed.
+    [Fact]
+    public void StorePendingItemEnchantDuration_ZeroSeconds_NotStashed()
+    {
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(1);
+
+        state.StorePendingItemEnchantDuration(guid, TempSlot, durationSeconds: 0, nowTick: 100_000);
+
+        Assert.Null(state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_000));
+    }
+
+    // --- injection gate ---
+
+    // Inject only where the create shows a live enchant whose duration the server
+    // left empty (vanilla's login shape). A real duration in the field wins.
+    [Theory]
+    [InlineData(2504, null, true)]   // enchant ID, no duration field → the bug shape, inject
+    [InlineData(2504, 0u, true)]     // explicit zero duration → inject
+    [InlineData(2504, 1_800_000u, false)] // server provided a real duration → keep it
+    [InlineData(0, null, false)]     // no enchant in the slot → nothing to time
+    public void ShouldInjectEnchantDuration_GateShapes(int enchantId, uint? duration, bool expected)
+    {
+        var enchantment = new ItemEnchantment { ID = enchantId, Duration = duration };
+
+        Assert.Equal(expected, GameSessionData.ShouldInjectEnchantDuration(enchantment));
+    }
+
+    [Fact]
+    public void ShouldInjectEnchantDuration_NullEntry_False()
+    {
+        Assert.False(GameSessionData.ShouldInjectEnchantDuration(null));
+    }
+
+    // --- slot translation (vanilla server pinned by TestEnvironmentInitializer) ---
+
+    // Perm/Temp share indices across versions; vanilla's Prop block (3..6) sits at
+    // 8..11 in the modern layout. The old passthrough only ever worked because timed
+    // enchants live in Temp=1.
+    [Theory]
+    [InlineData(0u, 0u)]   // Perm
+    [InlineData(1u, 1u)]   // Temp
+    [InlineData(3u, 8u)]   // Prop0
+    [InlineData(4u, 9u)]   // Prop1
+    [InlineData(5u, 10u)]  // Prop2
+    [InlineData(6u, 11u)]  // Prop3
+    public void TranslateEnchantmentSlotToModern_VanillaSlots_MapToClassicLayout(uint legacy, uint modern)
+    {
+        Assert.Equal(modern, WorldClient.TranslateEnchantmentSlotToModern(legacy));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -850,6 +850,14 @@ public sealed class GameSessionData
     // occupant", which the swap-wipe guard in the UpdateHandler aura loop cannot tell
     // apart by spell ID alone.
     public Dictionary<WowGuid128, Dictionary<byte, int>> UnitAuraDurationPushTime = [];
+    // JimsProxy (temp-enchant-0s-after-relogin): remaining-time pushes from
+    // SMSG_ITEM_ENCHANT_TIME_UPDATE, keyed item guid → (legacy enchantment slot →
+    // seconds + receipt tick). At login vanilla cores send the push BEFORE the item's
+    // create block (the only carrier of remaining time — the create's duration field is
+    // zero), and the modern client discards updates for guids it has not constructed.
+    // The push is stashed here and consumed into the item's create block when it is
+    // translated. Not carried across sessions: each login gets fresh pushes.
+    public Dictionary<WowGuid128, Dictionary<uint, (uint Seconds, int Tick)>> PendingItemEnchantDurations = [];
     public Dictionary<WowGuid128, Dictionary<byte, WowGuid128>> UnitAuraCaster = [];
     // Wall-clock aura expiry per (unit, spell). Unlike the per-slot caches above this
     // survives unit destroys AND relogs (carried over in CreateNewGameSessionData), so a
@@ -1569,6 +1577,40 @@ public sealed class GameSessionData
             UnitAuraDurationUpdateTime.TryGetValue(guid, out var timeDict) &&
             timeDict.TryGetValue(slot, out var time))
             left -= Environment.TickCount - time;
+    }
+    public void StorePendingItemEnchantDuration(WowGuid128 itemGuid, uint legacySlot, uint durationSeconds, int nowTick)
+    {
+        if (durationSeconds == 0)
+            return;
+
+        ref var slots = ref CollectionsMarshal.GetValueRefOrAddDefault(PendingItemEnchantDurations, itemGuid, out _);
+        slots ??= [];
+        slots[legacySlot] = (durationSeconds, nowTick);
+    }
+    public List<(uint LegacySlot, uint DurationMs)>? ConsumePendingItemEnchantDurations(WowGuid128 itemGuid, int nowTick)
+    {
+        if (!PendingItemEnchantDurations.Remove(itemGuid, out var slots) || slots.Count == 0)
+            return null;
+
+        List<(uint LegacySlot, uint DurationMs)> result = new(slots.Count);
+        foreach (var (slot, push) in slots)
+        {
+            // TickCount skew safety — a receipt tick "in the future" decays nothing.
+            int elapsed = unchecked(nowTick - push.Tick);
+            if (elapsed < 0)
+                elapsed = 0;
+
+            long remainingMs = (long)push.Seconds * 1000 - elapsed;
+            if (remainingMs > 0)
+                result.Add((slot, (uint)remainingMs));
+        }
+        return result.Count > 0 ? result : null;
+    }
+    // Inject only where the create shows a live enchant whose duration field the
+    // server left empty (vanilla's login shape); a server-provided duration wins.
+    public static bool ShouldInjectEnchantDuration(HermesProxy.World.Objects.ItemEnchantment? enchantment)
+    {
+        return enchantment is { ID: > 0 } && (enchantment.Duration == null || enchantment.Duration == 0);
     }
     public void StoreAuraCaster(WowGuid128 target, byte slot, WowGuid128 caster)
     {

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -419,14 +419,66 @@ public partial class WorldClient
         sell.Reason = packet.ReadUInt8();
         SendPacketToClient(sell);
     }
+    // (temp-enchant-0s-after-relogin): legacy Prop slots sit at different indices than
+    // the modern layout (vanilla 3.., TBC 6.., WotLK 7.. → modern 8..); every slot
+    // below the Prop block (Perm/Temp/Sock/Bonus/Prismatic) shares its index. Timed
+    // enchants live in Temp=1, so the old raw passthrough happened to work for them.
+    internal static uint TranslateEnchantmentSlotToModern(uint legacySlot)
+    {
+        int firstProp, max;
+        if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+        {
+            firstProp = Enums.Vanilla.EnchantmentSlot.Prop0;
+            max = Enums.Vanilla.EnchantmentSlot.Max;
+        }
+        else if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V3_0_2_9056))
+        {
+            firstProp = Enums.TBC.EnchantmentSlot.Prop0;
+            max = Enums.TBC.EnchantmentSlot.Max;
+        }
+        else
+        {
+            firstProp = Enums.WotLK.EnchantmentSlot.Prop0;
+            max = Enums.WotLK.EnchantmentSlot.Max;
+        }
+
+        if (legacySlot >= firstProp && legacySlot < max)
+            return (uint)(Enums.Classic.EnchantmentSlot.Prop0 + ((int)legacySlot - firstProp));
+        return legacySlot;
+    }
+
     [PacketHandler(Opcode.SMSG_ITEM_ENCHANT_TIME_UPDATE)]
     void HandleItemEnchantTimeUpdate(WorldPacket packet)
     {
         ItemEnchantTimeUpdate enchant = new ItemEnchantTimeUpdate();
         enchant.ItemGuid = packet.ReadGuid().To128(GetSession().GameState);
-        enchant.Slot = packet.ReadUInt32();
+        uint legacySlot = packet.ReadUInt32();
+        enchant.Slot = TranslateEnchantmentSlotToModern(legacySlot);
         enchant.DurationLeft = packet.ReadUInt32();
         enchant.OwnerGuid = packet.ReadGuid().To128(GetSession().GameState);
+
+        // (temp-enchant-0s-after-relogin): at login vanilla cores push this BEFORE the
+        // item's create block — it is the only carrier of the enchant's remaining time
+        // (the create's duration field is zero) and the modern client discards updates
+        // for guids it has not constructed, leaving the buff flashing a permanent "0s".
+        // Stash every live push; the item-create translation consumes it into the
+        // create's duration field. Forward only when the item already exists client-side.
+        GetSession().GameState.StorePendingItemEnchantDuration(enchant.ItemGuid, legacySlot, enchant.DurationLeft, Environment.TickCount);
+
+        if (GetSession().GameState.GetCachedObjectFieldsLegacy(enchant.ItemGuid) == null)
+        {
+            if (Framework.Settings.DebugOutput)
+            {
+                Log.Event("enchant.duration.stashed_precreate", new
+                {
+                    item_guid = enchant.ItemGuid.ToString(),
+                    legacy_slot = legacySlot,
+                    duration_seconds = enchant.DurationLeft,
+                });
+            }
+            return;
+        }
+
         SendPacketToClient(enchant);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -461,12 +461,13 @@ public partial class WorldClient
         // item's create block — it is the only carrier of the enchant's remaining time
         // (the create's duration field is zero) and the modern client discards updates
         // for guids it has not constructed, leaving the buff flashing a permanent "0s".
-        // Stash every live push; the item-create translation consumes it into the
-        // create's duration field. Forward only when the item already exists client-side.
-        GetSession().GameState.StorePendingItemEnchantDuration(enchant.ItemGuid, legacySlot, enchant.DurationLeft, Environment.TickCount);
-
+        // Stash pre-create pushes only; the item-create translation consumes them into
+        // the create's duration field. Forward when the item already exists client-side —
+        // the forward path never needs the stash, and storing there would leave a
+        // never-consumed entry per enchanted item until logout.
         if (GetSession().GameState.GetCachedObjectFieldsLegacy(enchant.ItemGuid) == null)
         {
+            GetSession().GameState.StorePendingItemEnchantDuration(enchant.ItemGuid, legacySlot, enchant.DurationLeft, Environment.TickCount);
             if (Framework.Settings.DebugOutput)
             {
                 Log.Event("enchant.duration.stashed_precreate", new

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2570,6 +2570,40 @@ public partial class WorldClient
                     updateData.ItemData.Enchantment[Enums.Classic.EnchantmentSlot.Prop4] = ReadEnchantData(Enums.WotLK.EnchantmentSlot.Prop4);
                 }
 
+                // (temp-enchant-0s-after-relogin): consume stashed pre-create
+                // SMSG_ITEM_ENCHANT_TIME_UPDATE pushes into this create. At login the
+                // push beats the item's create block and the modern client discards it
+                // for an unbuilt guid — the enchant then renders with the create's zero
+                // duration field as a permanently flashing "0s" buff. The handler
+                // stashed the push (decay-tracked); write it into the create's duration
+                // field so the countdown starts at the real remaining time.
+                if (isCreate)
+                {
+                    var pendingEnchants = GetSession().GameState.ConsumePendingItemEnchantDurations(guid, Environment.TickCount);
+                    if (pendingEnchants != null)
+                    {
+                        foreach (var (legacySlot, durationMs) in pendingEnchants)
+                        {
+                            int modernSlot = (int)TranslateEnchantmentSlotToModern(legacySlot);
+                            if (modernSlot >= updateData.ItemData.Enchantment.Length)
+                                continue;
+                            var enchantment = updateData.ItemData.Enchantment[modernSlot];
+                            if (enchantment == null || !GameSessionData.ShouldInjectEnchantDuration(enchantment))
+                                continue;
+                            enchantment.Duration = durationMs;
+                            if (Framework.Settings.DebugOutput)
+                            {
+                                Log.Event("enchant.duration.injected_at_create", new
+                                {
+                                    item_guid = guid.ToString(),
+                                    legacy_slot = legacySlot,
+                                    duration_ms = durationMs,
+                                });
+                            }
+                        }
+                    }
+                }
+
                 uint?[] gems = new uint?[ItemConst.MaxGemSockets];
                 for (int i = 0; i < ItemConst.MaxGemSockets; i++)
                 {


### PR DESCRIPTION
Fixes #472.

## Problem

After a relogin with an active temp weapon enchant (sharpening stone, oil), the buff can render as a **permanently flashing "0s"** that never expires. Surfaced 2026-08-14 when a Kronos outage forced a mass mid-buff relogin. Display-only: the enchant stays live server-side (re-applying prompts "replace sharpening with sharpening" and cures the display).

## Root cause

At login vanilla cores send `SMSG_ITEM_ENCHANT_TIME_UPDATE` — the **only carrier of the enchant's remaining time** — *before* the item's create block (log evidence in #472; at the 08:57 login the pushes even beat login-verify). The proxy forwarded it verbatim, but the 1.14.2 client discards GUID-addressed updates for objects it has not constructed. The item then arrives with a zero enchantment-duration field → enchant icon with 0 remaining, flashing forever. Whether the bug bites is a per-login timing coin flip: a push that happens to land *after* the creates works (observed at the 08:57 login), which is why this stayed unreported until a mass DC.

## Fix

Mirror the in-tree precedent for the identical aura race (`SMSG_UPDATE_AURA_DURATION` → store-then-inject, the #454 res-sickness machinery):

1. **Stash** (`GameSessionData.StorePendingItemEnchantDuration`): the handler stores every live push keyed (item guid, legacy slot) with a receipt tick. Zero-duration pushes (removal signals) are never stashed.
2. **Gate the forward**: the packet is sent to the client only when the item already exists client-side (`GetCachedObjectFieldsLegacy(itemGuid) != null` — the same known-object gate the aura handler uses; item creates populate that cache before their translated create is flushed, and legacy packets process sequentially, so the gate is race-free).
3. **Inject at create** (`ConsumePendingItemEnchantDurations` in the UpdateHandler item-fields section): on an item **create** block, stashed pushes are written into the create's enchantment duration field (seconds→ms), **decayed by the time spent stashed** — a bank-parked enchanted item whose create only arrives at bank-open gets its true remaining time, not a stale full replay. Consume-once; a server-provided nonzero field duration always wins (`ShouldInjectEnchantDuration`).

Also fixed in passing: the forwarded packet's slot index is now version-mapped (vanilla `Prop0=3` → modern `Prop0=8`, etc.). The old raw passthrough only ever worked because timed enchants live in `Temp=1`, which shares its index across layouts.

Lifecycle: the stash lives on `GameSessionData` and is not carried over in `CreateNewGameSessionData` — each login gets fresh pushes. No timers anywhere; deterministic packet-pairing only (push ↔ its item's create).

### Considered and rejected

- **Delay queue** (`SendPacketToClient(pkt, flushOpcode)`, the #410 proficiency mechanism): its login-verify flush point is too early (the item create lands after verify), and flushing on "first update-object" is positional rather than paired to the item — a bank-parked item would still 0s. The stash pairs the push to the item's own create.
- **Extending `PreCreateOpHold`**: arms at login-verify, but the 08:57 log shows pushes arriving *before* verify — outside its window.

## Diagnostics

Two new structured events, both `DebugOutput`-gated: `enchant.duration.stashed_precreate` (handler withheld a pre-create push) and `enchant.duration.injected_at_create` (create consumed the stash). Zero JSONL traffic in production bundles.

## Testing

- **Red-first**: all 20 new tests (`ItemEnchantDurationStashTests`) run against a stubbed surface first — 20/20 red — then 20/20 green on the implementation.
- Coverage: full-ms consume, decay-while-stashed, consume-once, guid isolation, expired-in-stash dropped, TickCount-skew safety (no decay on backwards clock), latest-push-wins refresh, two-slots-one-item, zero-duration never stashed, injection gate shapes (ID+no-duration → inject; real duration wins; empty slot skipped), vanilla slot mapping (0→0, 1→1, 3..6→8..11).
- Full suite: **874/874** (854 existing + 20 new).
- Handler/UpdateHandler wiring is not unit-testable in this repo (no WorldClient harness); verified by build + the field plan below.

## Field verification plan

Relogin with an active sharpening stone on the fix build (DebugOutput on): expect `enchant.duration.stashed_precreate` at login followed by `enchant.duration.injected_at_create`, and the buff counting down from the true remaining time instead of flashing 0s. The race is a per-login coin flip, so a few relogs may be needed to catch the pre-create ordering.

## Risk

- Pre-create pushes were previously **discarded by the client anyway** — withholding them changes nothing the client ever saw; the injection only writes a field that was previously always zero in the bug shape, and only when the create shows a live enchant with no server-provided duration.
- Mid-session pushes (item known) forward exactly as before, now with a correctly mapped slot index (identity mapping for every slot the vanilla server actually sends timed updates for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTuyexbeTBDZwN4YJSeCpF
