### PR TITLE
Logout-stun gate: benign login debuffs must not veto the cure (#431 follow-up)

### DIFF
--- a/HermesProxy.Tests/World/StuckLogoutStunGateTests.cs
+++ b/HermesProxy.Tests/World/StuckLogoutStunGateTests.cs
@@ -5,20 +5,28 @@ using Xunit;
 namespace HermesProxy.Tests.World;
 
 // JimsProxy (stuck-logout-stun): gate for the artificial-logout-stun login fix. The detector
-// may only trip when the local player's create block carries UNIT_FLAG_STUNNED with ZERO
-// debuff auras — every genuine vanilla stun is a MOD_STUN debuff occupying a debuff slot in
-// the same create block, so a real stun must never open the gate (it would let the synthesized
-// CMSG_LOGOUT_CANCEL free a legitimately stunned player).
+// may only trip when the local player's create block carries UNIT_FLAG_STUNNED with no debuff
+// beyond the known-benign login set (Resurrection Sickness, Deserter) — every genuine vanilla
+// stun is a MOD_STUN debuff occupying a debuff slot in the same create block, and a stun's
+// debuff is never on the allow-list, so a real stun must never open the gate (it would let the
+// synthesized CMSG_LOGOUT_CANCEL free a legitimately stunned player).
 public class StuckLogoutStunGateTests
 {
     const uint Stunned = (uint)UnitFlagsVanilla.Stunned;
     const uint InCombat = (uint)UnitFlagsVanilla.InCombat;
     const uint PlayerControlled = (uint)UnitFlagsVanilla.PlayerControlled;
 
+    const uint ResurrectionSickness = 15007;
+    const uint Deserter = 26013;
+    const uint KidneyShot = 408;   // a real MOD_STUN debuff — stands in for any unrecognized debuff
+    const uint Dazed = 1604;       // non-stun but NOT on the allow-list — must stay conservative
+
+    static readonly uint[] NoDebuffs = new uint[0];
+
     [Fact]
     public void IsArtificialLogoutStun_StunnedFlagNoDebuffs_Trips()
     {
-        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned, debuffAuraCount: 0));
+        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned, NoDebuffs));
     }
 
     // The 2026-07-17 incident wire state: stunned + in-combat on a player, zero debuffs
@@ -26,30 +34,64 @@ public class StuckLogoutStunGateTests
     [Fact]
     public void IsArtificialLogoutStun_IncidentFlagCombination_Trips()
     {
-        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned | InCombat | PlayerControlled, debuffAuraCount: 0));
+        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned | InCombat | PlayerControlled, NoDebuffs));
+    }
+
+    // #431 follow-up: the artificial stun coinciding with a benign login debuff was a false
+    // negative under the old debuffAuraCount==0 gate — the player stayed half-rooted all
+    // session. Res Sickness / Deserter must not veto the cure.
+    [Fact]
+    public void IsArtificialLogoutStun_StunnedWithResurrectionSickness_Trips()
+    {
+        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned, new[] { ResurrectionSickness }));
+    }
+
+    [Fact]
+    public void IsArtificialLogoutStun_StunnedWithDeserter_Trips()
+    {
+        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned, new[] { Deserter }));
+    }
+
+    [Fact]
+    public void IsArtificialLogoutStun_StunnedWithBothBenignDebuffs_Trips()
+    {
+        Assert.True(WorldClient.IsArtificialLogoutStun(Stunned, new[] { ResurrectionSickness, Deserter }));
     }
 
     // Re-attach mid genuine stun: the stun's own debuff (e.g. Kidney Shot, War Stomp) is in
-    // the create block — gate must stay closed.
+    // the create block — gate must stay closed, even when a benign debuff is also present.
     [Fact]
-    public void IsArtificialLogoutStun_StunnedWithDebuffPresent_DoesNotTrip()
+    public void IsArtificialLogoutStun_StunnedWithRealStunDebuff_DoesNotTrip()
     {
-        Assert.False(WorldClient.IsArtificialLogoutStun(Stunned | InCombat, debuffAuraCount: 1));
+        Assert.False(WorldClient.IsArtificialLogoutStun(Stunned | InCombat, new[] { KidneyShot }));
+        Assert.False(WorldClient.IsArtificialLogoutStun(Stunned, new[] { ResurrectionSickness, KidneyShot }));
+    }
+
+    // Non-stun debuffs OFF the allow-list (Dazed 1604 was live mid-session in the incident)
+    // close the gate too: a false negative is safe — no cure that login — while a false
+    // positive is not. Only ids explicitly verified benign may trip the gate.
+    [Fact]
+    public void IsArtificialLogoutStun_StunnedWithUnrecognizedDebuff_DoesNotTrip()
+    {
+        Assert.False(WorldClient.IsArtificialLogoutStun(Stunned, new[] { Dazed }));
     }
 
     [Fact]
     public void IsArtificialLogoutStun_NoStunnedFlag_DoesNotTrip()
     {
-        Assert.False(WorldClient.IsArtificialLogoutStun(InCombat | PlayerControlled, debuffAuraCount: 0));
-        Assert.False(WorldClient.IsArtificialLogoutStun(0, debuffAuraCount: 0));
+        Assert.False(WorldClient.IsArtificialLogoutStun(InCombat | PlayerControlled, NoDebuffs));
+        Assert.False(WorldClient.IsArtificialLogoutStun(0, NoDebuffs));
+        Assert.False(WorldClient.IsArtificialLogoutStun(0, new[] { ResurrectionSickness }));
     }
 
-    // Non-stun debuffs (Dazed 1604 was live mid-session in the incident) close the gate too:
-    // a false negative is safe — no cure that login — while a false positive is not.
+    // The allow-list is deliberately tiny and explicit — growing it is a reviewed decision,
+    // not a data-load side effect.
     [Fact]
-    public void IsArtificialLogoutStun_StunnedWithHarmlessDebuff_DoesNotTrip()
+    public void BenignLoginDebuffAllowList_IsExactlyTheVerifiedSet()
     {
-        Assert.False(WorldClient.IsArtificialLogoutStun(Stunned, debuffAuraCount: 2));
+        Assert.Equal(2, WorldClient.BenignLoginDebuffSpellIds.Count);
+        Assert.True(WorldClient.BenignLoginDebuffSpellIds.Contains(ResurrectionSickness));
+        Assert.True(WorldClient.BenignLoginDebuffSpellIds.Contains(Deserter));
     }
 
     // Locks the vanilla slot layout the detector's buff/debuff partition assumes:

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1,4 +1,4 @@
-﻿//#define DEBUG_UPDATES
+//#define DEBUG_UPDATES
 
 using Framework;
 using Framework.GameMath;
@@ -2178,11 +2178,13 @@ public partial class WorldClient
     // the lingering object out of the world — clears it.
     //
     // Detection is one-shot per world login, on the FIRST create block for the local player,
-    // and only when the stunned flag arrives with ZERO debuff auras: every genuine vanilla stun
-    // is a MOD_STUN debuff occupying one of slots 32-47 of the same create block, so an aura-less
-    // stunned flag at login has exactly one producer — the logout machinery. A genuine stun at
-    // re-attach (debuff present) leaves the gate closed: a false negative is safe (no cure this
-    // login), a false positive is structurally impossible.
+    // and only when the stunned flag arrives with no debuff beyond the known-benign login set
+    // (Resurrection Sickness, Deserter): every genuine vanilla stun is a MOD_STUN debuff
+    // occupying one of slots 32-47 of the same create block, so a stunned flag whose only
+    // debuffs are certainly-not-stuns has exactly one producer — the logout machinery. A
+    // genuine stun at re-attach (its debuff is not on the allow-list) leaves the gate closed:
+    // a false negative is safe (no cure this login), a false positive is structurally
+    // impossible.
     //
     // Three layers, the last two individually toggleable:
     //   tripwire — login.self_create_state always logs the raw wire state, gate hit or not
@@ -2235,7 +2237,7 @@ public partial class WorldClient
                 (i < VanillaFirstDebuffSlot ? buffSpellIds : debuffSpellIds).Add(slot.UInt32Value);
         }
 
-        bool artificial = IsArtificialLogoutStun(rawFlags, debuffSpellIds.Count);
+        bool artificial = IsArtificialLogoutStun(rawFlags, debuffSpellIds);
 
         Log.Event("login.self_create_state", new
         {
@@ -2291,11 +2293,36 @@ public partial class WorldClient
     internal const int VanillaAuraSlotCount = 48;
     internal const int VanillaFirstDebuffSlot = 32;
 
-    // Pure gate: the stunned flag with no debuff present cannot be a real stun — every vanilla
-    // MOD_STUN aura occupies a debuff slot in the same create block.
-    internal static bool IsArtificialLogoutStun(uint rawUnitFlags, int debuffAuraCount)
+    // JimsProxy (#431 follow-up, 2026-08-15): vanilla debuffs that (a) persist across a login /
+    // re-attach and (b) are certainly not stuns. Their presence must not veto the
+    // artificial-logout-stun cure — the original debuffAuraCount==0 gate false-negatived
+    // whenever the artificial stun coincided with e.g. Resurrection Sickness, leaving the
+    // player half-rooted all session. Kept as an explicit allow-list, NOT a MOD_STUN
+    // classification: SpellAuraEffects is a curated stat subset with zero stun rows, so a real
+    // stun can never be positively identified from proxy data. Any debuff NOT on this list
+    // keeps the gate closed — a genuine stun (whose MOD_STUN debuff we would not recognize)
+    // still can never open it. Extend only with ids verified to carry no stun effect.
+    internal static readonly FrozenSet<uint> BenignLoginDebuffSpellIds = new uint[]
     {
-        return (rawUnitFlags & (uint)UnitFlagsVanilla.Stunned) != 0 && debuffAuraCount == 0;
+        15007, // Resurrection Sickness
+        26013, // Deserter
+    }.ToFrozenSet();
+
+    // Pure gate: the artificial logout stun is the stunned flag whose every present debuff is a
+    // known-benign login debuff (empty set = the original 2026-07-17 incident shape). A real
+    // stun's MOD_STUN debuff is not on the allow-list, so it keeps the gate closed — a false
+    // positive stays structurally impossible; this only removes the false negative when the
+    // artificial stun coincides with a benign login debuff.
+    internal static bool IsArtificialLogoutStun(uint rawUnitFlags, IReadOnlyList<uint> debuffSpellIds)
+    {
+        if ((rawUnitFlags & (uint)UnitFlagsVanilla.Stunned) == 0)
+            return false;
+        foreach (var id in debuffSpellIds)
+        {
+            if (!BenignLoginDebuffSpellIds.Contains(id))
+                return false;
+        }
+        return true;
     }
 
     private bool ShouldClearMountDisplayOnDeadNonPlayerUnit(WowGuid128 guid, ObjectType objectType, ObjectUpdate updateData, Dictionary<int, UpdateField> updates, int mountDisplayField)


### PR DESCRIPTION
## Symptom

A player re-attaching after a cancelled/interrupted logout while carrying an ordinary debuff — most naturally **Resurrection Sickness** (die → release → res → cancel a logout) or **Deserter** — logs in **half-rooted for the whole session**: forward/back/strafe work, but facing input and the spell system are dead until relog. This is the exact #431 symptom, un-cured, because the detector misclassified the login.

## Root cause

`IsArtificialLogoutStun` (`UpdateHandler.cs:2296`) gates on `debuffAuraCount == 0` — it counts **any** debuff, not a stun debuff. The design intent (per its own comment) was "every genuine vanilla stun is a MOD_STUN debuff in the same create block, so aura-less stunned = artificial." The implementation over-approximates that to *any-debuff = real stun*, so the artificial stun + a benign debuff is a **false negative**: no root strip, no `CMSG_LOGOUT_CANCEL` synth, and `StuckStunLoginCheckDone` means no second chance that login.

Found by the 08-14 strand-hunt workflow (thread #8, `LOOPING-CAST-THREAD-REGISTRY.md`); the gate was verified against the live tree before any code was written.

## Why not "classify against the MOD_STUN set"

That was the obvious fix and it is **infeasible**: `SpellAuraEffects1.csv` is a curated ~50-spell stat-computation subset with **zero MOD_STUN rows** (verified — Hammer of Justice, Cheap Shot, Kidney Shot, Bash, Intimidation are all absent; Res Sickness is present but as aura type 79). A real stun can never be positively identified from proxy data.

## Fix

Explicit **benign-debuff allow-list** (Res Sickness 15007, Deserter 26013): the gate trips when the stunned flag arrives and **every** present debuff is on the list. Any unrecognized debuff — including every real stun — still closes the gate.

- **The original invariant is preserved structurally**: a genuine stun can never open the gate, because its MOD_STUN debuff is never on the allow-list. False positives remain impossible; only the false negative is removed.
- Unknown-but-harmless debuffs (e.g. Dazed 1604) also still close the gate — conservative behavior unchanged. Growing the list is a reviewed decision, not a data-load side effect (locked by a test).
- One method, one caller, no new packets, no timers.

## Testing

- `StuckLogoutStunGateTests` extended 6 → 10 (benign single/double, benign+real-stun, unrecognized-debuff, allow-list lock).
- **Red-first proven**: with the old `Count == 0` gate shimmed back in, the 3 new benign-debuff tests **fail** and the 7 conservative-behavior tests pass; with the fix, **10/10**.
- Full suite **858/858**.

## Field verification (tentative until observed)

`login.self_create_state` with `stunned:true`, `artificial_logout_stun:true` and a **non-empty** `debuff_spell_ids` names each rescued login (previously impossible — that combination was the false negative). A misfire would show as a cure on a genuinely stunned login, which the allow-list makes structurally unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeCPsB6vTkDMk6pVFUw2WT