### PR TITLE
JimsPlus: fix the 2H weapon vanishing from the back after combat with a bow

### DIFF
--- a/Addons/JimsPlus/BowSheatheFix.lua
+++ b/Addons/JimsPlus/BowSheatheFix.lua
@@ -1,0 +1,86 @@
+local ADDON_NAME, namespace = ...
+
+-- JimsProxy (bow sheathe fix): 1.14 client bug — with a bow equipped, the client's own
+-- DELAYED post-combat auto-sheathe drops the 2H mainhand (and the quiver) from the back
+-- until a manual unsheathe (guns and crossbows are unaffected). Field-observed: an EARLY
+-- sheathe renders correctly every time (looting right after combat forces one and always
+-- fixes it), while late repair nudges are unreliable. So this module mimics looting:
+-- shortly after combat ends with bow + 2H and weapons still drawn, sheathe proactively —
+-- the buggy auto-sheathe then never fires on a drawn weapon. If combat ends with weapons
+-- already away (a possibly-bugged mid-fight sheathe), do an immediate draw+re-sheathe
+-- nudge instead — timing matters, so it fires right at combat end.
+
+local SHEATHED = 1 -- GetSheathState(): 1 = weapons away, 2 = melee drawn, 3 = ranged drawn
+local PROACTIVE_DELAY = 5.0 -- seconds after combat before we sheathe ourselves
+local TICK = 0.25 -- watch granularity: a client auto-sheathe inside the window is repaired within one tick
+
+local watcher
+
+local function Enabled()
+    local db = namespace.db or JimsPlusDB or {}
+    return db.bowSheatheFix ~= false
+end
+
+local function HasBowAnd2H()
+    local ranged = GetInventoryItemID("player", 18)
+    if not ranged then return false end
+    local classID, subclassID = select(6, GetItemInfoInstant(ranged))
+    if classID ~= 2 or subclassID ~= 2 then return false end -- bows only
+    local main = GetInventoryItemID("player", 16)
+    if not main then return false end
+    local equipLoc = select(4, GetItemInfoInstant(main))
+    return equipLoc == "INVTYPE_2HWEAPON" -- covers 2H axes/swords/maces, polearms, staves
+end
+
+local function StopWatch()
+    if watcher then
+        watcher:Cancel()
+        watcher = nil
+    end
+end
+
+-- Draw + re-sheathe repair for a sheathe the client already performed (possibly bugged).
+-- Must run promptly after that sheathe — late nudges fail (field-observed).
+local function RepairNudge()
+    ToggleSheath()
+    C_Timer.After(0.3, function()
+        if not InCombatLockdown() and GetSheathState() ~= SHEATHED then
+            ToggleSheath()
+        end
+    end)
+end
+
+local function OnCombatEnd()
+    if not Enabled() then return end
+    if not GetSheathState or not ToggleSheath then return end
+    if not HasBowAnd2H() then return end
+
+    if GetSheathState() == SHEATHED then
+        -- Weapons already away: the bugged sheathe may have happened mid-fight.
+        RepairNudge()
+        return
+    end
+
+    -- Weapons still drawn: watch for up to PROACTIVE_DELAY. If the client's own (buggy)
+    -- auto-sheathe fires inside the window, repair it within one tick — right away, per
+    -- the field rule. If nothing happened by the deadline, sheathe deliberately ourselves
+    -- (the same early sheathe looting forces, which always renders correctly).
+    StopWatch()
+    local elapsed = 0
+    watcher = C_Timer.NewTicker(TICK, function()
+        elapsed = elapsed + TICK
+        if InCombatLockdown() then StopWatch() return end -- back in combat, next regen handles it
+        if not Enabled() or not HasBowAnd2H() then StopWatch() return end
+        if GetSheathState() == SHEATHED then
+            StopWatch()
+            RepairNudge()
+        elseif elapsed >= PROACTIVE_DELAY then
+            StopWatch()
+            ToggleSheath()
+        end
+    end)
+end
+
+local f = CreateFrame("Frame")
+f:RegisterEvent("PLAYER_REGEN_ENABLED")
+f:SetScript("OnEvent", OnCombatEnd)

--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -13,6 +13,7 @@ TaxiFix.lua
 TooltipFix.lua
 ZoneSync.lua
 MoonkinSound.lua
+BowSheatheFix.lua
 AuctionsPaginationFix.lua
 MailNameFix.lua
 NameDashFix.lua

--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -164,6 +164,11 @@ y = y - 28
 local cbMoonkinSound = CreateCheckbox(panel, y,
     "Moonkin Form sound  |cFF888888(Druid only)|r",
     "Gives Moonkin Form a distinct transformation sound instead\nof reusing the Bear Form sound.\n\nOnly affects Druid characters.")
+y = y - 28
+
+local cbBowSheathe = CreateCheckbox(panel, y,
+    "Show 2H weapon on back with a bow",
+    "Fixes a 1.14 client bug where a sheathed two-handed weapon\n(and your quiver) disappears from your back after combat while\na bow is equipped (guns and crossbows are unaffected).\n\nYour character puts the bow away a few seconds after combat\nends; if the client sheathes on its own first, the addon instantly\nre-sheathes to restore the models.\n\nTakes effect immediately.")
 y = y - 40
 
 ---------------------------------------------------------------------------
@@ -219,6 +224,7 @@ local function RefreshCheckboxes()
     local db = namespace.db or JimsPlusDB or {}
     cbTooltipFix:SetChecked(db.tooltipFix == true)
     cbMoonkinSound:SetChecked(db.moonkinSound ~= false)
+    cbBowSheathe:SetChecked(db.bowSheatheFix ~= false)
     cbBagSort:SetChecked(db.bagSortOrder ~= false)
 
     local cdb = JimsPlusCastbars and JimsPlusCastbars.db
@@ -260,6 +266,15 @@ cbMoonkinSound:SetScript("OnClick", function(self)
         namespace.db.moonkinSound = enabled
     end
     print("|cFF00FF00[JimsPlus]|r Moonkin Form sound " .. (enabled and "enabled" or "disabled") .. ". Type /reload to apply.")
+end)
+
+-- JimsProxy (bow sheathe fix): purely addon-side (BowSheatheFix.lua re-sheathe nudge), read live from db
+cbBowSheathe:SetScript("OnClick", function(self)
+    local enabled = self:GetChecked() and true or false
+    if namespace.db then
+        namespace.db.bowSheatheFix = enabled
+    end
+    print("|cFF00FF00[JimsPlus]|r Bow 2H-sheathe fix " .. (enabled and "enabled" or "disabled") .. ".")
 end)
 
 cbBagSort:SetScript("OnClick", function(self)


### PR DESCRIPTION
## The bug

1.14 client bug (repros on retail Classic Era — [Blizzard forum report](https://us.forums.blizzard.com/en/wow/t/classic-era-hunter-cannot-see-2-handed-sword-or-axe-when-using-bow-or-after-combat/1565775)): with a **bow** equipped, the client's delayed post-combat auto-sheathe drops the sheathed 2H mainhand — and the quiver — from the character's back until a manual unsheathe. Guns and crossbows are immune.

**Why bows only:** bows are the only ranged weapons with `INVTYPE_RANGED` (15) — every other ranged weapon is `INVTYPE_RANGEDRIGHT` (26) — and only the bow path renders a quiver, whose back-attachment swap is what strands the 2H model.

## The fix (addon-side, `BowSheatheFix.lua`)

Field-established timing rule: an **early** sheathe renders correctly every time (looting right after combat forces one and always avoids the bug); the client's own delayed auto-sheathe is the bugged one, and late draw+re-sheathe repairs are unreliable.

On `PLAYER_REGEN_ENABLED` with a bow (weapon class 2, subclass 2) + 2H mainhand (`INVTYPE_2HWEAPON`) equipped and weapons still drawn:
- a 0.25s ticker watches for up to 5s;
- if the client auto-sheathes inside the window, the addon repairs it within one tick (`ToggleSheath` draw, re-sheathe 0.3s later);
- otherwise it sheathes deliberately at the 5s mark — the same early sheathe looting performs.

If combat ends with weapons already away (possible bugged mid-fight sheathe), the repair fires immediately.

Purely visual and addon-side: keeps the quiver, no proxy or item-data involvement. Options checkbox under Client Fixes (default on), takes effect instantly.

## Rejected alternative

A proxy-side route (hotfixing bows to `InventoryType` 26 so the client takes the immune gun path) was prototyped and field-tested working, but rejected: it costs the quiver visual, and turning it off is sticky in the client's hotfix cache (the client never re-fetches a hotfix id it has already applied). The addon route has neither drawback.

## Testing

Field-tested across multiple play sessions on a hunter with bow + 2H: the 2H stays on the back after every combat exit, quiver intact. The 5s proactive delay was tuned by feel in play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)