### PR TITLE
Log schema: decoded casterKind on cast/failure events (local-player-flag trap)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1088,6 +1088,12 @@ public partial class WorldClient
             castIdCounter = castId.GetCounter(),
             casterIsPlayer,
             casterIsPet,
+            // JimsProxy (2026-08-16): decoded guid kind (Player/Creature/Pet/...). casterIsPlayer
+            // above means "caster is the LOCAL player" (CurrentPlayerGuid compare) — every OTHER
+            // player logs false, so any caster-kind split keyed on the flag buckets other players
+            // as mobs. Both corpora were mis-swept on exactly that this week. The flag stays for
+            // tooling compatibility; new sweeps must key on casterKind.
+            casterKind = casterUnit.GetHighType().ToString(),
             sentInterruptLog,
             sentCancelVisual,
             sentPetCastFailed,
@@ -1481,6 +1487,9 @@ public partial class WorldClient
             is_ranged_auto_attack = isRangedAutoAttack,
             isCaster = GetSession().GameState.CurrentPlayerGuid == casterUnit,
             isPetCaster = GetSession().GameState.CurrentPetGuid == casterUnit,
+            // JimsProxy (2026-08-16): decoded guid kind — see spell.failed_other.routed. isCaster
+            // above is a LOCAL-player compare, not a kind test.
+            casterKind = casterUnit.GetHighType().ToString(),
             dequeued,
             wasStarted,
             foundActiveCastId,
@@ -2658,8 +2667,12 @@ public partial class WorldClient
             spell_visual_id = dbdata.SpellXSpellVisualID,
             visual_lookup_missing = dbdata.SpellXSpellVisualID == 0,
             caster_guid = dbdata.CasterGUID.ToString(),
+            // JimsProxy (2026-08-16): caster_is_player means "caster is the LOCAL player" (guid
+            // compare against CurrentPlayerGuid) — other players log false. caster_kind is the
+            // decoded guid kind (Player/Creature/Pet/...); observed-caster sweeps must key on it.
             caster_is_player = dbdata.CasterGUID == GetSession().GameState.CurrentPlayerGuid,
             caster_is_pet = dbdata.CasterUnit == GetSession().GameState.CurrentPetGuid,
+            caster_kind = dbdata.CasterUnit.GetHighType().ToString(),
             cast_time = dbdata.CastTime,
             cast_flags = dbdata.CastFlags,
             casterCounter = dbdata.CasterUnit.GetCounter(), //MIRASU - lets us correlate with spell.failed_other.routed


### PR DESCRIPTION
## Problem

`casterIsPlayer` / `caster_is_player` on `spell.cast`, `spell.failed_other.routed` and `spell.failure.routed` are computed as `CurrentPlayerGuid == casterUnit` — they mean **"caster is the LOCAL player"**, not "caster is a player". Every other player logs `false` and lands in the "mob" bucket of any flag-keyed split.

This is not hypothetical: **both corpora in the no-terminator investigation were mis-swept on exactly this field on 2026-08-16.** Decoded properly, our corpus's FAILED_OTHER split is **1,435 player / 1,106 unit / 27 pet** where the flag showed 0 players — and a flag-keyed observed-caster scan silently selects *only local-player casts*, which produced a vacuous "zero observed no-terminator instances" result.

## Fix

Additive `casterKind` / `caster_kind` field (decoded `WowGuid128.GetHighType()`: Player/Creature/Pet/…) on all three events. Existing flags untouched for tooling compatibility; a comment at each site names the trap so future sweeps key on the decoded kind. Also cross-references that `reason` on FAILED_OTHER is a hardcoded 61 (the 14-byte vanilla packet carries no reason byte — F1N-10).

## Testing

Additive logging only, no behavior change. Suite **854/854**.

## Field verification

First post-merge session: `spell.failed_other.routed` events for other players should show `casterKind: "Player"` with `casterIsPlayer: false` — the pair that was previously indistinguishable from a mob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeCPsB6vTkDMk6pVFUw2WT