### PR TITLE
Fire the feared-sitting stand at SPELL_GO, not SPELL_START

### DIFF
--- a/HermesProxy.Tests/World/FearStandSynthTests.cs
+++ b/HermesProxy.Tests/World/FearStandSynthTests.cs
@@ -60,44 +60,70 @@ public class FearStandSynthTests
         Assert.Equal(0x00C00000u, FearStandSynth.FearConfuseUnitFlagsMask);
     }
 
-    // --- trigger 1: pre-stand at incoming fear cast ---
+    // --- trigger 1: fear-lands stand at SPELL_GO ---
+    //
+    // The decision method takes isSelfInHitTargets as a bool; the caller (HandleSpellGo)
+    // computes it from the GO's HIT target list (never the miss list). SelfInHitList mirrors
+    // that caller-side gate so hit-vs-miss / self-vs-other is exercised end to end, not just
+    // asserted as a bare bool.
+    private static bool SelfInHitList(WowGuid128 self, params WowGuid128[] hitTargets) =>
+        !self.IsEmpty() && hitTargets.Contains(self);
 
     [Fact]
-    public void PreStand_Fires_WhenSeatedSelfTargetedByFearCast()
+    public void FearGo_Fires_WhenSeatedSelfInHitList()
     {
-        Assert.True(FearStandSynth.ShouldPreStandOnIncomingFear(true, WarlockFearR3, Self, Self, Seated));
+        bool selfHit = SelfInHitList(Self, Self); // GO hit list = [Self]
+        Assert.True(selfHit);
+        Assert.True(FearStandSynth.ShouldStandOnFearGoHit(true, WarlockFearR3, selfHit, Seated));
     }
 
     [Fact]
-    public void PreStand_Ignores_WhenAlreadyStanding()
+    public void FearGo_Ignores_WhenSelfOnlyInMissList_Resist()
     {
-        Assert.False(FearStandSynth.ShouldPreStandOnIncomingFear(true, WarlockFearR3, Self, Self, Standing));
+        // Resisted/immune fear: the player is in the MISS list, so the HIT list carries no
+        // self — the caller-side gate returns false and we must not break the drink.
+        bool selfHit = SelfInHitList(Self /* hit list has no targets */);
+        Assert.False(selfHit);
+        Assert.False(FearStandSynth.ShouldStandOnFearGoHit(true, WarlockFearR3, selfHit, Seated));
     }
 
     [Fact]
-    public void PreStand_Ignores_WhenTargetIsAnotherUnit()
+    public void FearGo_Ignores_WhenOnlyOtherPlayerInHitList()
     {
-        Assert.False(FearStandSynth.ShouldPreStandOnIncomingFear(true, WarlockFearR3, Other, Self, Seated));
+        // Fear landed on someone else; local player is seated but not a hit target.
+        bool selfHit = SelfInHitList(Self, Other);
+        Assert.False(selfHit);
+        Assert.False(FearStandSynth.ShouldStandOnFearGoHit(true, WarlockFearR3, selfHit, Seated));
     }
 
     [Fact]
-    public void PreStand_Ignores_NonFearSpell()
+    public void FearGo_Ignores_WhenAlreadyStanding()
     {
-        Assert.False(FearStandSynth.ShouldPreStandOnIncomingFear(true, 116, Self, Self, Seated));
+        bool selfHit = SelfInHitList(Self, Self);
+        Assert.False(FearStandSynth.ShouldStandOnFearGoHit(true, WarlockFearR3, selfHit, Standing));
     }
 
     [Fact]
-    public void PreStand_Ignores_WhenLeverOff()
+    public void FearGo_Ignores_NonFearSpell()
     {
-        Assert.False(FearStandSynth.ShouldPreStandOnIncomingFear(false, WarlockFearR3, Self, Self, Seated));
+        bool selfHit = SelfInHitList(Self, Self);
+        Assert.False(FearStandSynth.ShouldStandOnFearGoHit(true, 116, selfHit, Seated));
     }
 
     [Fact]
-    public void PreStand_Ignores_NullOrEmptyGuids()
+    public void FearGo_Ignores_WhenLeverOff()
     {
-        Assert.False(FearStandSynth.ShouldPreStandOnIncomingFear(true, WarlockFearR3, null, Self, Seated));
-        Assert.False(FearStandSynth.ShouldPreStandOnIncomingFear(true, WarlockFearR3, Self, null, Seated));
-        Assert.False(FearStandSynth.ShouldPreStandOnIncomingFear(true, WarlockFearR3, WowGuid128.Empty, WowGuid128.Empty, Seated));
+        bool selfHit = SelfInHitList(Self, Self);
+        Assert.False(FearStandSynth.ShouldStandOnFearGoHit(false, WarlockFearR3, selfHit, Seated));
+    }
+
+    [Fact]
+    public void FearGo_Ignores_WhenSelfGuidEmpty()
+    {
+        // Pre-login / unresolved local-player guid must never be counted as a hit target.
+        bool selfHit = SelfInHitList(WowGuid128.Empty, WowGuid128.Empty);
+        Assert.False(selfHit);
+        Assert.False(FearStandSynth.ShouldStandOnFearGoHit(true, WarlockFearR3, selfHit, Seated));
     }
 
     // --- trigger 2: CC-onset fallback ---

--- a/HermesProxy/World/Client/FearStandSynth.cs
+++ b/HermesProxy/World/Client/FearStandSynth.cs
@@ -18,13 +18,19 @@ namespace HermesProxy.World.Client;
 /// gets the player out of the chair.
 ///
 /// Two triggers, both synthesizing a legacy CMSG_STAND_STATE_CHANGE(STAND):
-///  1. Incoming-cast pre-stand: a fear-aura cast with a cast time STARTS against
-///     the seated local player. The synth reaches the server while the player
-///     still has control, so it is honored unconditionally; the fear then lands
-///     on a standing player. Covers warlock Fear — the reported PvP case.
+///  1. Fear-lands stand: a fear-aura cast GOES (SMSG_SPELL_GO) with the seated local
+///     player in its HIT target list — i.e. the fear actually lands. Fired at the GO,
+///     not the START: a cast that is interrupted / whose caster dies / that fails at
+///     completion never GOes, so it no longer breaks the player's drink for nothing
+///     (the field-reported START-timing defect). A resisted/immune fear lists the
+///     player in the MISS list, not the hit list, so it never stands them. The stand
+///     races the aura application inside Kronos's ~400ms batching window; win → the
+///     fear lands on a standing player and fear-break items pass NOT_STANDING on both
+///     sides; lose → it degrades to a harmless mid-fear stand attempt (the same packet
+///     trigger 2 sends). Covers warlock Fear — the reported PvP case.
 ///  2. CC-onset fallback: the local player's UNIT_FIELD_FLAGS gain Fleeing or
 ///     Confused while seated (instant fears — Psychic Scream, many mob fears —
-///     never produce a victim-side SPELL_START). Whether the lineage server
+///     never produce a victim-side SPELL_GO). Whether the lineage server
 ///     honors a stand-state change mid-fear is untested (asked in #479); if
 ///     ignored, the synth is one harmless packet.
 /// </summary>
@@ -50,14 +56,17 @@ public static class FearStandSynth
         28315, 28412, 29111, 29124, 29168, 29419, 29685, 30001, 30002, 31365,
     }.ToFrozenSet();
 
-    // Trigger 1 gate: fear-aura cast STARTING against the seated local player.
-    internal static bool ShouldPreStandOnIncomingFear(bool leverOn, uint spellId, WowGuid128? targetUnit, WowGuid128? localPlayer, uint localStandState)
+    // Trigger 1 gate: a fear-aura cast GOES (SMSG_SPELL_GO) with the seated local player
+    // in its HIT target list — the fear actually lands. The caller computes
+    // isSelfInHitTargets from the GO's HIT list (never the MISS list), so a resisted or
+    // immune fear (self in the miss list) leaves it false and never stands the player.
+    // spellId is the RAW legacy spell id off the GO: a fear is always cast by ANOTHER unit
+    // on us, so the SoM remap (local-caster only) never touches it.
+    internal static bool ShouldStandOnFearGoHit(bool leverOn, uint spellId, bool isSelfInHitTargets, uint localStandState)
     {
         if (!leverOn || localStandState == 0)
             return false;
-        if (targetUnit is not WowGuid128 target || localPlayer is not WowGuid128 self)
-            return false;
-        if (self.IsEmpty() || target != self)
+        if (!isSelfInHitTargets)
             return false;
         return FearAuraSpellIds.Contains(spellId);
     }

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1628,17 +1628,12 @@ public partial class WorldClient
         bool casterIsLocalPlayer = GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit;
         bool casterIsLocalPet    = GetSession().GameState.CurrentPetGuid    == spell.Cast.CasterUnit;
 
-        // JimsProxy (feared-while-sitting, issue #479): a fear-aura cast with a cast time
-        // is STARTING against the seated local player. Stand them up now, while they still
-        // have control server-side — guaranteed honored — so the fear lands on a standing
-        // player and fear-break items pass NOT_STANDING on both sides. Instant fears never
-        // produce a victim-side SPELL_START; those fall to the CC-onset fallback in
-        // UpdateHandler (SynthStandOnFearCcOnset).
-        if (FearStandSynth.ShouldPreStandOnIncomingFear(Framework.Settings.SynthStandOnFear,
-                (uint)spell.Cast.SpellID, spell.Cast.Target.Unit,
-                GetSession().GameState.CurrentPlayerGuid,
-                GetSession().GameState.GetLocalPlayerStandState()))
-            SendSynthStandUp("incoming_fear_cast", (uint)spell.Cast.SpellID);
+        // JimsProxy (feared-while-sitting, issue #479): the fear-lands stand-up moved from
+        // here (SPELL_START) to the SPELL_GO path in HandleSpellGo — see that trigger and
+        // FearStandSynth.ShouldStandOnFearGoHit. Standing at START breaks the drink of a
+        // seated player even when the fear cast is then interrupted / the caster dies / it
+        // fails at completion (no GO ever arrives); standing at GO-with-self-in-hit fires
+        // only when the fear actually lands.
 
         // Mark pending cast as started (queue-based, FIFO order)
         if (casterIsLocalPlayer &&
@@ -1975,6 +1970,34 @@ public partial class WorldClient
             LogSpellStartGoParseFailure(packet, e, isSpellGo: true);
             DrainOrphanedStartedNormalCastsOnParseFailure(isSpellGo: true);
             return;
+        }
+
+        // JimsProxy (feared-while-sitting, issue #479): a fear-aura cast has GONE with the
+        // seated local player in its HIT list — the fear actually LANDS. Synthesize a legacy
+        // CMSG_STAND_STATE_CHANGE(STAND) now, at the GO, not at the START. Standing at START
+        // was field-rejected: a started fear that is interrupted / whose caster dies / that
+        // fails at completion never GOes, so standing at START broke the player's drink for
+        // nothing. Gated on the HIT list only — a resisted/immune fear lists the player in
+        // the MISS list and must NOT stand them. This runs for casts by OTHER units targeting
+        // us (a fear is never self-cast): CasterUnit != local player, so the SoM remap in the
+        // dequeue block below never touches SpellID — the raw legacy id read here is correct,
+        // and this insertion is independent of that local-caster remap. Timing: the stand
+        // races the aura application inside Kronos's ~400ms batching window; win → the fear
+        // lands on a standing player and fear-break items pass NOT_STANDING both sides; lose →
+        // it degrades to a harmless mid-fear stand attempt, the same packet the CC-onset
+        // fallback (trigger 2, UpdateHandler) would send. Instant fears carry no victim-side
+        // GO and fall to that fallback. The (cheap) hit-list scan is gated behind the FrozenSet
+        // spell-id lookup so the common non-fear SPELL_GO path stays scan-free.
+        if (Framework.Settings.SynthStandOnFear &&
+            FearStandSynth.FearAuraSpellIds.Contains((uint)spell.Cast.SpellID))
+        {
+            var fearVictimGuid = GetSession().GameState.CurrentPlayerGuid;
+            bool selfInFearHitTargets = !fearVictimGuid.IsEmpty() &&
+                                        spell.Cast.HitTargets.Contains(fearVictimGuid);
+            if (FearStandSynth.ShouldStandOnFearGoHit(Framework.Settings.SynthStandOnFear,
+                    (uint)spell.Cast.SpellID, selfInFearHitTargets,
+                    GetSession().GameState.GetLocalPlayerStandState()))
+                SendSynthStandUp("fear_go_hit", (uint)spell.Cast.SpellID);
         }
 
         // JimsProxy (#383): a Summoning Portal (GameObject) casting a participant's


### PR DESCRIPTION
## Symptom

Field-tested tonight: the feared-while-sitting synth (#479, PR #480) stands the
seated local player the instant a fear-aura cast **STARTS** against them. It
works — but the owner rejects the timing: *"he stands at the start of the cast,
not at the GO when he actually gets feared. It's meant to be just before the
flee — the actual hit — there are so many ways a start may fail with no go, then
no reason to stand!"* A started fear that gets interrupted, whose caster is
killed, or that fails at completion breaks the player's drink for nothing.

## Mechanism

Trigger 1 moves from `SMSG_SPELL_START` (`HandleSpellStart`) to the
`SMSG_SPELL_GO` path (`HandleSpellGo`), and now fires only when **all** hold:

- (a) the packet is a **GO**,
- (b) the raw legacy spell id is in `FearStandSynth.FearAuraSpellIds` (74-entry table),
- (c) the **local player is in the GO's HIT target list** (parsed into
  `spell.Cast.HitTargets`), never the miss list,
- (d) the local player's cached stand state is seated (`GetLocalPlayerStandState() != 0`),
- (e) `Settings.SynthStandOnFear` is on.

`GO-with-self-in-hit-list` = the fear **actually landed**. Failed/interrupted
casts never GO; resisted/immune fears land the player in the **MISS** list, so
neither breaks the drink anymore.

The raw legacy spell id is read straight off the GO. A fear is always cast by
another unit on us (`CasterUnit != CurrentPlayerGuid`), so the SoM item remap —
which only rewrites local-caster casts inside the dequeue block below — never
touches it. The insertion sits right after the parse, before/independent of that
local-caster remap.

## Race analysis

The synthesized `CMSG_STAND_STATE_CHANGE(STAND)` races the aura application
inside Kronos's ~400ms batching window:

- **Win** → the fear lands on a standing player and fear-break items (PvP
  insignia) pass `NOT_STANDING` on both client and server.
- **Lose** → it degrades to a harmless mid-fear stand attempt — the exact same
  packet trigger 2 (the CC-onset fallback in `UpdateHandler`) already sends.

Instant fears (Psychic Scream, most mob fears) carry no victim-side GO and still
fall to that CC-onset fallback. Trigger 2 and the kill switch are unchanged.

## Tests (red-first)

Decision logic moved to `FearStandSynth.ShouldStandOnFearGoHit(leverOn, spellId,
isSelfInHitTargets, localStandState)`. `FearStandSynthTests` rewritten for GO
semantics:

- self in hit list + seated → **stand**
- self only in MISS list (resist) → no
- other player hit while self seated → no
- hit but already standing → no
- kill switch off → no
- empty self guid (pre-login) → no
- non-fear spell → no

**Red-first proof:** neutering the gate to `leverOn && FearAuraSpellIds.Contains(spellId)`
(dropping the hit-list and stand-state checks) fails exactly the four load-bearing
tests — `WhenSelfOnlyInMissList_Resist`, `WhenOnlyOtherPlayerInHitList`,
`WhenAlreadyStanding`, `WhenSelfGuidEmpty` — while the lever/non-fear tests stay
green. Restored gate → full suite **932 passed, 0 failed**.

## Field gate (re-test)

- Warlock Fear on a seated (drinking) player → player **stands at the GO**, just
  before the flee.
- A fear cast that gets **interrupted** (kick / caster killed / line-of-sight
  fail) → player **stays seated drinking** (no GO, no stand).
- A **resisted** fear → player **stays seated** (self in miss list, not hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPoXhjHomE1JS8eFSGQk2h
