### PR TITLE
Render strafe-cancelled cast bar as "Interrupted" (presentation parity)

### DIFF
--- a/HermesProxy.Tests/World/StrafeCancelSynthTests.cs
+++ b/HermesProxy.Tests/World/StrafeCancelSynthTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using HermesProxy;
 using HermesProxy.World;
+using HermesProxy.World.Client;
+using HermesProxy.World.Enums;
 using HermesProxy.World.Server;
 using Xunit;
 
@@ -186,5 +188,51 @@ public class StrafeCancelSynthTests
         {
             GameData.MovementInterruptibleSpells = prev;
         }
+    }
+
+    // ---- interrupted-presentation parity (strafe cancel-gap follow-up) ----
+    //
+    // The forward/back/jump client-sent cancel makes the 1.14 client render the red
+    // "Interrupted" locally; the strafe cancel the proxy synthesizes does not, so the
+    // trailing SMSG_SPELL_FAILURE must be FORWARDED with the interrupt reason (not
+    // suppressed like the client-predicted case) to match that presentation. The
+    // suppress-vs-forward decision is the pure ResolveMovementCancelInterruptReason.
+
+    [Fact]
+    public void ResolveMovementCancelInterruptReason_StrafeSynthCancelled_ReturnsInterrupted()
+    {
+        var cast = MakeCast(10181, castTimeMs: 3000, hasStarted: true);
+        cast.MovementCancelled = true;
+        cast.StrafeSynthCancelled = true; // proxy synthesized the cancel — client never rendered it
+
+        var reason = WorldClient.ResolveMovementCancelInterruptReason(cast);
+
+        Assert.Equal(SpellCastResultClassic.Interrupted, reason);
+    }
+
+    [Fact]
+    public void ResolveMovementCancelInterruptReason_ClientPredictedCancel_ReturnsNullSuppress()
+    {
+        // forward/back/jump: MovementCancelled but NOT strafe-synth. The client
+        // already flashed "Interrupted" from its own cancel, so the broadcast stays
+        // suppressed (null) — forwarding would double up / mis-render.
+        var cast = MakeCast(10181, castTimeMs: 3000, hasStarted: true);
+        cast.MovementCancelled = true;
+        cast.StrafeSynthCancelled = false;
+
+        Assert.Null(WorldClient.ResolveMovementCancelInterruptReason(cast));
+    }
+
+    [Fact]
+    public void ResolveMovementCancelInterruptReason_KillSwitchOffLeavesFlagUnset_Suppresses()
+    {
+        // Structural inertness: with StrafeCancelPreempt off the synth never runs,
+        // so StrafeSynthCancelled is never set and the decision collapses to today's
+        // suppression regardless of the movement-cancel mark.
+        var cast = MakeCast(10181, castTimeMs: 3000, hasStarted: true);
+        cast.MovementCancelled = true;
+        // StrafeSynthCancelled deliberately left at its default (false)
+
+        Assert.Null(WorldClient.ResolveMovementCancelInterruptReason(cast));
     }
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -3644,6 +3644,18 @@ public class ClientCastRequest
     // client gets its CMSG_CANCEL_CAST ack without a popup.
     public bool MovementCancelled;
 
+    // JimsProxy (strafe cancel-gap presentation parity): set true (alongside
+    // MovementCancelled) ONLY for casts the strafe branch synthesized a
+    // CMSG_CANCEL_CAST for — i.e. the ones the 1.14 client did NOT cancel itself.
+    // The client renders the red "Interrupted" locally when IT initiates the
+    // cancel (forward/back/jump), but it never sends nor predicts a cancel on
+    // strafe, so a strafe-synth-cancelled cast's trailing SMSG_SPELL_FAILURE must
+    // be FORWARDED with the interrupt reason (not suppressed like the
+    // client-predicted case) to reproduce that "Interrupted" render. Only ever set
+    // when Settings.StrafeCancelPreempt is on (the synth's sole trigger), so it is
+    // structurally inert when the kill switch is off.
+    public bool StrafeSynthCancelled;
+
     // DIAGNOSTIC (stuck-spell investigation): TickCount64 when MovementCancelled
     // was set. Used by cast.movement_resolved debug events to measure how long
     // between proxy-side mark and actual server resolution (CAST_FAILED /

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1116,6 +1116,22 @@ public partial class WorldClient
         });
     }
 
+    /// <summary>
+    /// JimsProxy (strafe cancel-gap presentation parity): the client-bound SpellFailure
+    /// reason for a movement-cancelled cast's trailing failure, or null to keep today's
+    /// suppression. Forward/back/jump cancels are predicted client-side — the 1.14 client
+    /// already flashed the red "Interrupted" on its own cast bar, so the broadcast stays
+    /// suppressed (null). Strafe cancels are synthesized by the proxy (the client never
+    /// sends nor predicts one), so return the interrupt reason to forward SMSG_SPELL_FAILURE
+    /// and reproduce that same "Interrupted" render instead of a silent fizzle. Pure /
+    /// deterministic — decided solely by the tracked cast's StrafeSynthCancelled flag, which
+    /// is only ever set when the StrafeCancelPreempt synth fired.
+    /// </summary>
+    internal static SpellCastResultClassic? ResolveMovementCancelInterruptReason(ClientCastRequest cast)
+    {
+        return cast.StrafeSynthCancelled ? SpellCastResultClassic.Interrupted : null;
+    }
+
     // JimsProxy: SMSG_SPELL_FAILURE handler. Block 2 gameplay testing on Kronos
     // surfaced this as packet.untranslated 7x in a 10-min priest leveling session
     // (Smite/Heal failing for OOM, OOR, LoS). Without this, the modern client
@@ -1222,6 +1238,12 @@ public partial class WorldClient
         // reason and renders the correct popup.
         bool overrideReasonForLocalBroadcast = false;
         bool skipBroadcastFailure = false;
+        // JimsProxy (strafe cancel-gap presentation parity): when set, the broadcast
+        // SpellFailure is forwarded with THIS classic reason instead of being
+        // suppressed — used for strafe-synth-cancelled casts so the client renders
+        // the red "Interrupted" it never predicted locally. Null leaves the existing
+        // suppress / reason-override behavior untouched.
+        byte? forcedBroadcastReason = null;
         // JimsProxy (transient-no-dismiss-started): under LowLatencyMode, defer a STARTED local
         // cast's bar-dismiss AND visual-cancel to the caller-aware trailing CAST_FAILED (which
         // knows the real reason — spare a dup-rejection, dismiss a real failure). Set in the
@@ -1283,8 +1305,23 @@ public partial class WorldClient
             // prediction. Suppress the broadcast SpellFailure entirely —
             // emitting it would surface a misleading "You are in combat" popup
             // (Spell::SendInterrupted hardcodes the wire reason to 0).
+            //
+            // JimsProxy (strafe cancel-gap presentation parity): EXCEPT when the
+            // proxy synthesized the cancel itself (strafe). The 1.14 client never
+            // sends nor predicts a cancel on strafe, so it never rendered the red
+            // "Interrupted" — suppressing here would leave a silent fizzle. Forward
+            // the interrupt instead (SMSG_SPELL_FAILURE for the local caster is read
+            // as "in-flight cast interrupted"), keyed purely on the tracked cast, so
+            // the bar matches the forward/back/jump presentation. Inert when the
+            // strafe synth (StrafeCancelPreempt) never fired.
             if (pendingNormal.MovementCancelled)
-                skipBroadcastFailure = true;
+            {
+                var strafeInterruptReason = ResolveMovementCancelInterruptReason(pendingNormal);
+                if (strafeInterruptReason.HasValue)
+                    forcedBroadcastReason = (byte)strafeInterruptReason.Value;
+                else
+                    skipBroadcastFailure = true;
+            }
             // Instant cast that wasn't a ranged auto-attack: SPELL_START was
             // never forwarded, so there's no cast bar to dismiss. Skip the misleading
             // broadcast SpellFailure entirely. The trailing SMSG_CAST_FAILED via
@@ -1366,7 +1403,8 @@ public partial class WorldClient
                 });
         }
 
-        byte broadcastReason = overrideReasonForLocalBroadcast ? (byte)SpellCastResultClassic.DontReport : reason;
+        byte broadcastReason = forcedBroadcastReason
+            ?? (overrideReasonForLocalBroadcast ? (byte)SpellCastResultClassic.DontReport : reason);
         if (!skipBroadcastFailure)
         {
             SpellFailure spell = new SpellFailure();

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -114,6 +114,13 @@ public partial class WorldSocket
                     uint cancelSpellId = ResolveStrafeCancelSpellId(cast);
                     if (cancelSpellId == 0)
                         continue;
+                    // Presentation parity: the 1.14 client never predicted this
+                    // interrupt (it doesn't self-cancel on strafe), so flag the cast
+                    // for HandleSpellFailure to FORWARD the interrupt broadcast rather
+                    // than suppress it — otherwise the cast bar silently fizzles
+                    // instead of showing the red "Interrupted" the client-sent cancels
+                    // (forward/back/jump) render locally.
+                    cast.StrafeSynthCancelled = true;
                     WorldPacket cancel = new WorldPacket(Opcode.CMSG_CANCEL_CAST);
                     if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                         cancel.WriteUInt8(0);


### PR DESCRIPTION
## Symptom

Follow-up to #478 (strafe cancel synth). Field test tonight: the synthesized strafe cancel is fast (~190ms) and works, **but the cast-bar presentation diverged**:

- **Forward / back / jump** (client-initiated cancel): cast bar flashes the red **"Interrupted"**.
- **Strafe** (our synthesized cancel): the bar just **fizzles / disappears** — no "Interrupted".

## Mechanism

Both movement paths mark the in-flight cast `MovementCancelled`, and the client-bound `HandleSpellFailure` **suppresses** the broadcast `SMSG_SPELL_FAILURE` for movement-cancelled casts (`SpellHandler.cs`, the `if (pendingNormal.MovementCancelled) skipBroadcastFailure = true;` branch). The premise: *the 1.14 client already predicted the interrupt locally and rendered "Interrupted" itself.*

That premise holds for forward/back/jump — the client sends its own `CMSG_CANCEL_CAST` and flashes "Interrupted" locally, independent of the server round-trip. It does **not** hold for strafe: the 1.14 client sends and predicts **nothing** (the whole reason #478 exists). With the broadcast suppressed, the client receives only the trailing `CastFailed(DontReport)` → the bar silently vanishes.

`SMSG_SPELL_FAILURE` for the local caster is read by the 1.14 client as *"in-flight cast interrupted"* (documented in this handler) — i.e. it renders "Interrupted". For forward/back that packet is redundant (client already did it), so suppression is correct. For strafe it is exactly what's missing.

## Fix

Deterministic, packet-pairing keyed on the tracked cast — **no timers**, timing untouched:

1. `ClientCastRequest.StrafeSynthCancelled` — set **only** for casts the strafe branch synthesized a cancel for (`MovementHandler.cs`, right where the `CMSG_CANCEL_CAST` is emitted, i.e. only when `cancelSpellId != 0`).
2. `HandleSpellFailure`: for a movement-cancelled cast, `ResolveMovementCancelInterruptReason` decides suppress-vs-forward — strafe-synth casts **forward** `SMSG_SPELL_FAILURE` with `SpellCastResultClassic.Interrupted`; client-predicted (forward/back/jump) casts keep today's suppression.

The trailing `CastFailed(DontReport)` in `HandleCastFailed` is unchanged; it silently acks/clears button state after the interrupt renders (mirrors the existing started-cast failure sequence: SpellFailure then CastFailed).

**Only the client-bound presentation of the already-cancelled cast changes.** The server-bound synth, its spell-gating, and the ~190ms timing are not touched.

### Kill-switch

Structurally inert when `StrafeCancelPreempt` is off: the flag is only ever set inside the synth (which only runs when the setting is on), so `ResolveMovementCancelInterruptReason` collapses to today's suppression.

## Tests

`HermesProxy.Tests/World/StrafeCancelSynthTests.cs` — pure suppress-vs-forward decision:
- strafe-synth → `Interrupted`
- client-predicted cancel → `null` (suppress)
- kill-switch-off (flag unset) → `null` (suppress)

Red-first verified: reverting the method body to suppress-always fails the `Interrupted` case (`Expected: Interrupted / Actual: null`). **Full suite: 934 passed, 0 failed.**

## Field gate

In-game verification is load-bearing and required before merge: confirm the strafe-cancelled cast bar now shows the red **"Interrupted"** (matching forward/back/jump), with **no** spurious error popup and **no** GCD/button regression, and that the ~190ms cancel timing is unchanged. The exact reason value (`Interrupted` = 61) driving the render is the one open uncertainty — if it produces a stray popup rather than a clean bar flash, a quieter reason is the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPoXhjHomE1JS8eFSGQk2h