### PR TITLE
Extend RefireSpellGo: frame-clearing defer, observed casters, local cast-time, off-GCD excluded

### DIFF
--- a/HermesProxy.Tests/World/RefireOffGcdGuardTests.cs
+++ b/HermesProxy.Tests/World/RefireOffGcdGuardTests.cs
@@ -1,0 +1,54 @@
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// RefireSpellGo off-GCD guard: the duplicate SPELL_GO must never be sent for off-GCD spells.
+/// Cooldown-on-event spells (Feign Death, Stealth, Vanish, Presence of Mind...) grey their button on
+/// GO and only release it on SMSG_COOLDOWN_EVENT; when the aura breaks in the cast's own server tick
+/// that event lands before the duplicate GO, which re-arms the grey for good (field-caught on Feign
+/// Death). These tests pin the data assumption the guard rests on: every player cooldown-on-event
+/// spell is in SpellOffGcd1.csv, and every known loop target the refire exists for is NOT.
+/// </summary>
+public class RefireOffGcdGuardTests
+{
+    static RefireOffGcdGuardTests()
+    {
+        GameData.LoadOffGcdSpells();
+    }
+
+    [Theory]
+    [InlineData(5384u)]  // Feign Death — the field-caught case
+    [InlineData(1784u)]  // Stealth
+    [InlineData(1787u)]  // Stealth (max rank)
+    [InlineData(5215u)]  // Prowl
+    [InlineData(9913u)]  // Prowl (max rank)
+    [InlineData(20580u)] // Shadowmeld
+    [InlineData(12043u)] // Presence of Mind
+    [InlineData(16188u)] // Nature's Swiftness (druid)
+    [InlineData(17116u)] // Nature's Swiftness (shaman)
+    [InlineData(14751u)] // Inner Focus
+    [InlineData(14177u)] // Cold Blood
+    [InlineData(20216u)] // Divine Favor
+    [InlineData(18288u)] // Amplify Curse
+    [InlineData(11129u)] // Combustion
+    [InlineData(16166u)] // Elemental Mastery
+    [InlineData(8788u)]  // Lightning Shield (rank 1)
+    public void CooldownOnEventSpells_AreOffGcd_SoRefireSkipsThem(uint spellId)
+    {
+        Assert.True(GameData.IsOffGcd(spellId), $"spell {spellId} must be off-GCD so RefireSpellGo skips it");
+    }
+
+    [Theory]
+    [InlineData(13877u)] // Blade Flurry
+    [InlineData(7386u)]  // Sunder Armor
+    [InlineData(6673u)]  // Battle Shout
+    [InlineData(19750u)] // Flash of Light — the live-caught loop
+    [InlineData(686u)]   // Shadow Bolt
+    [InlineData(13819u)] // Summon Warhorse — the WSG mount loop
+    public void KnownLoopTargets_StayOnGcd_SoRefireStillCoversThem(uint spellId)
+    {
+        Assert.False(GameData.IsOffGcd(spellId), $"spell {spellId} is a refire target and must stay on-GCD");
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -184,8 +184,10 @@ public static class Settings
     // frame; the 1.14 client can drop the coalesced SPELL_GO, so the cast never closes — a stuck
     // cast pose + looping cast sound + lit action button that persists until logout (survives
     // /reload). When set, on a local instant's first SPELL_GO re-fire a stripped duplicate SPELL_GO
-    // (~8ms later, in a clean frame, visual suppressed, no targets/log) so the client processes it
+    // (RefireSpellGoDeferMs later, in a clean frame, visual suppressed, no targets/log) so the client processes it
     // and closes the cast. No-op on clean casts. Independent of LowLatencyMode. Default OFF — opt-in.
+    // Also covers OBSERVED casters (other players / NPCs, incl. cast-time spells like Flash of Light) on any
+    // SPELL_GO that paired with a seen SPELL_START — most stuck precast sounds are observed, not local.
     public static bool RefireSpellGo;
     // JimsProxy (post-kill upstream stop): the ghost-swing preempt pushes the modern client an
     // early SMSG_ATTACK_STOP when its melee victim dies, but that is CLIENT-only — the client,
@@ -198,6 +200,11 @@ public static class Settings
     // the server's echo is consumed instead of forwarded. Kill switch: set false to restore the
     // client-only preempt. Default on.
     public static bool PreemptAttackStopUpstream = true;
+    // JimsProxy (RefireSpellGo defer): ms the stripped duplicate GO lands after the original. Must exceed ONE
+    // client frame so it processes in a clean frame, separate from the coalesced START+GO — else it's useless.
+    // 50ms clears down to ~20fps (crowds, where the bug is worst); the duplicate is inert so a late land is
+    // UX-free. Frame-clearing via a conservative fixed margin, not per-frame FPS estimation. Tune to your FPS floor.
+    public static int RefireSpellGoDeferMs;
     // JimsProxy (#379 form-exit): the 1.14 client auto-shifts out of a form to cast
     // (CMSG_CANCEL_AURA + CMSG_CAST_SPELL ~1ms apart), but the 1.12 server emits the cast's
     // SMSG_SPELL_START ~20ms BEFORE the form-removal SMSG_UPDATE_OBJECT. The cast's visual kit
@@ -300,6 +307,7 @@ public static class Settings
         IdentityPinnedCastIds = config.GetBoolean("IdentityPinnedCastIds", false);
         RefireSpellGo = config.GetBoolean("RefireSpellGo", false);
         PreemptAttackStopUpstream = config.GetBoolean("PreemptAttackStopUpstream", true);
+        RefireSpellGoDeferMs = config.GetInt("RefireSpellGoDeferMs", 50);
         var rttPrefireStr = config.GetString("RttPrefire", "off");
         RttPrefire = rttPrefireStr.Equals("timer", StringComparison.OrdinalIgnoreCase) ? RttPrefireMode.Timer
             : rttPrefireStr.Equals("knocker", StringComparison.OrdinalIgnoreCase) ? RttPrefireMode.Knocker

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -25,9 +25,10 @@ public partial class WorldClient
     private const int AutoRepeatRetryMinDelayMs = 500;
     private const int AutoRepeatRetryMaxDelayMs = 3500;
 
-    // JimsProxy (Spell Success Kit Reset): defer (ms) before re-firing the cast-finish, so it lands
-    // in a clean client frame past the coalesced START+GO burst. A couple of frames at 60fps.
-    private const int SpellSuccessRefireDeferMs = 8;
+    // JimsProxy (Spell Success Kit Reset): the duplicate-GO defer now lives in Settings.RefireSpellGoDeferMs (frame-clearing, was a fixed 8ms = under one frame = same-frame as the original, defeating the point).
+
+    // JimsProxy (observed-refire): HandleSpellStartOrGo sets this when an observed caster's SPELL_GO paired with a seen START; HandleSpellGo reads it once to schedule the clean-frame refire (single-threaded WC thread).
+    private bool _observedGoStartPaired;
 
     // JimsProxy (dup-failure frame hold): deliver a batch of held dup failures, in hold order.
     // Runs on the WorldClient receive thread at a release site — always AFTER the started
@@ -2487,12 +2488,15 @@ public partial class WorldClient
             // looping cast sound + lit action button, persisting until logout (survives /reload). Seen on
             // Blade Flurry, Sunder, Battle Shout, holy casts. (Natural trigger appears to be the client
             // coalescing the GO with the same-frame START, but that's inferred — we reproduce it with the
-            // injector, not yet captured in the wild.) We re-fire the cast-finish ~8ms later as a
+            // injector, not yet captured in the wild.) We re-fire the cast-finish a frame-clearing delay later (RefireSpellGoDeferMs) as a
             // DUPLICATE SPELL_GO in a CLEAN frame (visual suppressed, no targets/log): the client
             // processes the clean-frame copy and closes the cast. No effect/CLEU replay, cancels nothing,
-            // no-op on clean casts. Original GO forwards first (below). Local-player instants only.
+            // no-op on clean casts. Original GO forwards first (below).
             // Caveat: needs the server to send the first GO — a server-missing GO wouldn't trigger this.
-            if (Settings.RefireSpellGo && pendingCast.StartedCastTimeMs == 0)
+            // JimsProxy (observed-refire / Option 1b): now covers local CAST-TIME spells too, not just instants — a spammed heal (Flash of Light, the live-caught culprit) coalesces GO(N) with the next cast's START(N+1), the same end-event drop. Channels excluded (refiring their GO would restart the channel visual); auto-repeat + charge-stun sub-effects never reach here (no PendingNormalCast entry).
+            // JimsProxy (crafting-regression): NEVER refire off-GCD spells (any cast time). Off-GCD is the client's double-send / re-issue-on-GO class — crafting (3275/3276) auto-repeats on GO so a duplicate GO desyncs the craft-all queue (stops early), and the same re-issue risk applies to off-GCD instants (untested — the refire was never field-active before). Every known loop target (FoL, Shadow Bolt, holy/combat casts) is on-GCD.
+            if (Settings.RefireSpellGo && !GameData.IsChanneledSpell(gcdLookupId) &&
+                !GameData.IsOffGcd(gcdLookupId))
             {
                 var rfCasterGuid = spell.Cast.CasterGUID;
                 var rfCasterUnit = spell.Cast.CasterUnit;
@@ -2503,7 +2507,7 @@ public partial class WorldClient
                 uint rfCastFlagsEx = spell.Cast.CastFlagsEx;
                 _ = Task.Run(async () =>
                 {
-                    await Task.Delay(SpellSuccessRefireDeferMs);
+                    await Task.Delay(Settings.RefireSpellGoDeferMs);
                     try
                     {
                         var refire = new SpellGo();
@@ -2521,7 +2525,7 @@ public partial class WorldClient
                             Log.Event("cast.success_refire", new
                             {
                                 spell_id = rfSpellId,
-                                defer_ms = SpellSuccessRefireDeferMs,
+                                defer_ms = Settings.RefireSpellGoDeferMs,
                             });
                     }
                     catch
@@ -2694,6 +2698,49 @@ public partial class WorldClient
             // Bind the sweep's cancel callback lazily to this live WorldClient (mirrors OnGcdHeldCastFire); also gates the quiescence timer on in NoteObservedAutoRepeatActivity.
             GetSession().GameState.OnObservedAutoRepeatExpire ??= SendObservedAutoRepeatCancel;
             GetSession().GameState.NoteObservedAutoRepeatActivity(spell.Cast.CasterUnit, shotTarget);
+        }
+
+        // JimsProxy (observed-refire): extend RefireSpellGo to OBSERVED casters — the stuck precast sound is mostly other players/NPCs (live-caught on Flash of Light, a cast-time heal), which our local-only, instants-only refire never covered. Gate on the seen START↔GO pair (loop precondition, set in HandleSpellStartOrGo) so it fires only for a real observed cast; exclude auto-repeat (its GO is handled above and a duplicate would double the shot visual). Re-fire the GO a frame-clearing delay later (RefireSpellGoDeferMs) as a clean-frame duplicate (visual suppressed, empty targets/log) so a coalesced START+GO whose kit end-event dropped still closes. No-op on cleanly-closed casts; opt-in via RefireSpellGo (default off).
+        if (Settings.RefireSpellGo && _observedGoStartPaired &&
+            !GameData.AutoRepeatSpells.Contains((uint)spell.Cast.SpellID) &&
+            !GameData.IsOffGcd((uint)spell.Cast.SpellID))
+        {
+            var rfCasterGuid = spell.Cast.CasterGUID;
+            var rfCasterUnit = spell.Cast.CasterUnit;
+            var rfCastId = spell.Cast.CastID;
+            var rfOriginalCastId = spell.Cast.OriginalCastID;
+            int rfSpellId = spell.Cast.SpellID;
+            uint rfCastFlags = spell.Cast.CastFlags;
+            uint rfCastFlagsEx = spell.Cast.CastFlagsEx;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(Settings.RefireSpellGoDeferMs);
+                try
+                {
+                    var refire = new SpellGo();
+                    refire.Cast.CasterGUID = rfCasterGuid;
+                    refire.Cast.CasterUnit = rfCasterUnit;
+                    refire.Cast.CastID = rfCastId;
+                    refire.Cast.OriginalCastID = rfOriginalCastId;
+                    refire.Cast.SpellID = rfSpellId;
+                    refire.Cast.SpellXSpellVisualID = 0; // suppress visual so nothing replays
+                    refire.Cast.CastFlags = rfCastFlags;
+                    refire.Cast.CastFlagsEx = rfCastFlagsEx;
+                    // targets + LogData left empty: a pure cast-finish, no effect/CLEU replay
+                    SendPacketToClient(refire);
+                    if (Framework.Settings.DebugOutput)
+                        Log.Event("cast.observed_success_refire", new
+                        {
+                            spell_id = rfSpellId,
+                            caster_low = rfCasterUnit.GetCounter(),
+                            defer_ms = Settings.RefireSpellGoDeferMs,
+                        });
+                }
+                catch
+                {
+                    // session/socket may have torn down during the defer — best-effort
+                }
+            });
         }
 
         // JimsProxy (#379 form-exit): this GO completes the instant cast whose START was stashed
@@ -2874,6 +2921,7 @@ public partial class WorldClient
     SpellCastData HandleSpellStartOrGo(WorldPacket packet, bool isSpellGo)
     {
         SpellCastData dbdata = new SpellCastData();
+        _observedGoStartPaired = false; // set below only for an observed GO that pairs with a seen START
 
         dbdata.CasterGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         dbdata.CasterUnit = packet.ReadPackedGuid().To128(GetSession().GameState);
@@ -2906,6 +2954,8 @@ public partial class WorldClient
                 // Pairs with the NEWEST tracked entry — only the live cast can complete;
                 // an older entry is a superseded predecessor this GO purges (#484).
                 dbdata.CastID = existingCastId;
+                // JimsProxy (observed-refire): a seen START↔GO pair on an observed caster is the stuck-precast-sound precondition; flag it so HandleSpellGo can re-fire the GO in a clean frame.
+                _observedGoStartPaired = true;
             }
             // JimsProxy (#485 killed-then-fired): a terminator already consumed the tracked
             // entry but the cast completed anyway (Kronos broadcasts SPELL_FAILED_OTHER for


### PR DESCRIPTION
# What

Extends the opt-in `RefireSpellGo` mechanism (default OFF, unchanged) — the clean-frame duplicate-GO re-fire that closes the 1.14 client's coalesced-START+GO cast loop (stuck cast pose + looping cast sound + lit action button, survives `/reload`). Four changes, one bundle because they were soaked together:

1. **Frame-clearing defer — new `RefireSpellGoDeferMs`, default 50ms.** The old hardcoded 8ms in `SpellHandler` is *under* one 60fps frame (16.7ms), so the duplicate GO could land in the same client frame as the original — the exact frame it was supposed to clear. 50ms clears down to ~20fps crowds (where the bug is worst); the duplicate is inert, so a late land costs nothing.

2. **Observed-caster coverage.** Most stuck precast sounds are *other* players/NPCs — live-caught on an observed Flash of Light. A new `_observedGoStartPaired` flag is set in `HandleSpellStartOrGo` when an observed GO pairs with its seen START via `OtherCasterActiveCastIds` (the loop precondition); `HandleSpellGo` then schedules the same stripped duplicate GO (visual suppressed, empty targets/LogData). Auto-repeat excluded (its GO already has dedicated handling and a duplicate would double the shot visual).

3. **Local cast-time coverage.** The local gate changes from `pendingCast.StartedCastTimeMs == 0` (instants only) to `!GameData.IsChanneledSpell` — a spammed heal coalesces GO(N) with the *next* cast's START(N+1), the same end-event drop; the instants-only gate excluded the exact spell we caught looping live (Flash of Light). Channels stay excluded: re-firing a channel's GO restarts the channel visual.

4. **Off-GCD exclusion (both paths, `GameData.IsOffGcd`).** Field-caught regression during testing: off-GCD spells re-issue on GO, so a duplicate GO desyncs craft-all queues — heavy/runecloth bandages (3275/3276) stopped mid-queue. Every known loop target is on-GCD, so nothing is lost.

# Field validation

Six-day soak on Kronos (2026-08-13 → 08-19), Spell Queue mode (worst case for this bug), `RefireSpellGo=true`, DebugOutput on, including a full raid night on the 19th:

- **Zero looping cast sounds/poses across the whole soak** — first time the loop class has ever been beaten proxy-side (`RefireSpellGo` was inactive for every previously captured loop).
- Local refire fired 16/16 on spammed Flash of Light; observed refire 4/4, each paired exactly to one observed START (NPC and player casters). Zero parse failures, zero errors — the duplicate GOs perturb nothing.
- Crafting clean after the off-GCD exclusion (`cast.dropped.duplicate reason=off_gcd_double_send` gone).

Diagnostics: `cast.success_refire` / `cast.observed_success_refire` (DebugOutput-gated).

Default OFF, so zero behavior change for anyone who doesn't opt in. Build clean, suite 935/935 on beta.

# Interaction with #486

`_observedGoStartPaired` is set on the same pairing branch `fix/observed-castid-pairing` rewrites (`TryRemove` → `TryPairObservedGoCastId`). Merge either order — the resolution is one line: set the flag where the GO pairing succeeds. Happy to rebase this on top of #486 if you'd rather take that first.

# Not included

The observed-cast **eviction** (no-terminator class — deadline + supersede synthesis) is deliberately left out: it's soaking separately and hasn't produced a classified `evicted` fire yet, and its supersede edge would collide with #486's queue rework. It comes as its own PR once the soak proves it (per the two-fronts plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Field evidence update (2026-09-04): the off-GCD exclusion is a bug fix to the shipped refire

A hunter on Kronos (~80 ms ping, beta 2026-08-23, `RefireSpellGo` on) hit **Feign Death stuck greyed for the rest of the session**, only with the option on. Log `jimsproxy-20260902-234809.jsonl`, three FD casts:

| Cast | Duplicate GO landed | COOLDOWN_EVENT landed | Result |
|---|---|---|---|
| 1 | GO +8 ms | GO +245 ms | fine |
| 2 | GO +21 ms | GO +55 ms | fine |
| 3 | GO +14 ms | same batch as GO (pressed mid-jump, aura broke in the cast's own server tick) | **stuck greyed** |

Feign Death is cooldown-on-event: the client greys the button on SPELL_GO and releases it only on SMSG_COOLDOWN_EVENT. When that event arrives before the duplicate GO, the duplicate re-arms the grey with nothing left to release it. Any defer loses this race. Beta's refire has no gate for it; the `GameData.IsOffGcd` exclusion in this PR is exactly the fix. Every player-castable cooldown-on-event spell in the 1.14 data (Feign Death, Stealth, Prowl, Vanish, Shadowmeld, Presence of Mind, Nature's Swiftness, Inner Focus, Cold Blood, Divine Favor, Amplify Curse, Combustion, Elemental Mastery, Lightning Shield) is off-GCD; every known loop target (Flash of Light, Shadow Bolt, Sunder, Battle Shout, Blade Flurry, Summon Warhorse) is on-GCD and keeps its coverage.

New commit `f1e53093` adds `HermesProxy.Tests/World/RefireOffGcdGuardTests.cs` (22 cases) pinning both halves of that data assumption. No code change. Suite 957/957. Test-rebased onto current beta: clean, no conflict with #486.