### PR TITLE
Correct the shipped config defaults for standalone (non-launcher) use

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,35 @@ A fork of [WowLegacyCore/HermesProxy](https://github.com/WowLegacyCore/HermesPro
 
 ---
 
+## 2026-08-20 — Correct the shipped config defaults for standalone (non-launcher) use
+
+**Issue:** `HermesProxy/HermesProxy.config` is what anyone building from source or running the
+proxy without the launcher actually gets, and it had drifted from the client this fork targets.
+`ClientBuild` shipped as `40618` (1.14.0) while development, testing, and the launcher's own
+client check all pin 1.14.2 build `42597` (`repair.rs:145`, `EXPECTED_CLIENT_VERSION`) — and a
+`ClientBuild` that does not match the running client fails login outright. `PacketsLog` shipped
+as `true`, so every standalone session wrote a full packet capture to disk unprompted and
+indefinitely; the launcher already forced this off, so only standalone users paid for it.
+Separately, `ThreatEngine` and `ServerType` were the only two keys in the file with no
+`Option/Description/Default` comment block, leaving a standalone user no way to learn what they
+do — `ServerType` in particular silently selects the fork-specific item-data overlays loaded at
+startup.
+
+**Change:** `HermesProxy/HermesProxy.config` — `ClientBuild` `40618` → `42597`; `PacketsLog`
+`true` → `false`; added full comment blocks for `ThreatEngine` and `ServerType`, documenting
+`ServerType` values as `Kronos` (default) and `Generic`, with `Generic` stated as scaffolding for
+future server support rather than a tested configuration. `ServerAddress` (`127.0.0.1`),
+`ServerBuild` (`auto`) and `ClientSeed` deliberately unchanged — the first two are correct
+generic defaults, and `ClientSeed` is the static-seed fallback users should never edit.
+Data-only; no code change. The launcher writes its own config from a template (`setup.rs`) and
+is unaffected.
+
+**Verification:** XML parses clean, BOM preserved, file remains pure ASCII. Field gate pending:
+a standalone run using only the documented manual steps (take the shipped config, set
+`ServerAddress`, start the proxy, log in) against Kronos.
+
+---
+
 ## 2026-08-20 — Unlock the shop's epic Reins of the Nightsaber (12303)
 
 **Issue:** an undead player could not use the shop-bought **Reins of the Nightsaber (12303)**.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,9 +36,12 @@ generic defaults, and `ClientSeed` is the static-seed fallback users should neve
 Data-only; no code change. The launcher writes its own config from a template (`setup.rs`) and
 is unaffected.
 
-**Verification:** XML parses clean, BOM preserved, file remains pure ASCII. Field gate pending:
-a standalone run using only the documented manual steps (take the shipped config, set
-`ServerAddress`, start the proxy, log in) against Kronos.
+**Verification:** XML parses clean, BOM preserved, file remains pure ASCII. **Field gate passed
+2026-08-20** — a standalone run against Kronos using only the documented manual steps (take the
+shipped config, edit `ServerAddress` and nothing else, start `JimsProxy.exe`, log in) reached
+in-game with no errors, with no launcher involved at any step. That clears the change under
+test: `ClientBuild=42597` is correct against the real 1.14.2 client and produces no version
+mismatch. Test composition: 5.2.0-beta.4 exe (`f842db7d`) + `CSV/` + this config.
 
 ---
 

--- a/HermesProxy/HermesProxy.config
+++ b/HermesProxy/HermesProxy.config
@@ -3,14 +3,15 @@
   <appSettings>
     <!--
             Option:      ClientBuild
-            Description: The version of the client you will play with.
-            Default:     "40618" (1.14.0)
+            Description: The version of the client you will play with. This must match
+                         your game client exactly, or login will fail.
+            Default:     "42597" (1.14.2) - the build JimsProxy is developed against
+            Others:      "40618" (1.14.0)
                          "41794" (1.14.1)
-                         "42597" (1.14.2)
                          "40892" (2.5.2)
                          "42328" (2.5.3)
     -->
-    <add key="ClientBuild" value="40618" />
+    <add key="ClientBuild" value="42597" />
     <!--
             Option:      ClientSeed
             Description: The auth seed of the client you will play with.
@@ -89,10 +90,13 @@
     <add key="DebugOutput" value="false" />
     <!--
             Option:      PacketsLog
-            Description: Save each session's packets to a single file in PacketsLog directory.
-            Default:     "true"
+            Description: Save each session's packets to a single file in the PacketsLog
+                         directory. Off by default: the captures are large and one is
+                         written per session. Turn it on only when capturing for a bug
+                         report, then turn it back off.
+            Default:     "false"
     -->
-    <add key="PacketsLog" value="true" />
+    <add key="PacketsLog" value="false" />
     <!--
             Option:      StructuredLog
             Description: (JimsProxy) Write structured JSONL diagnostic events to Logs/jimsproxy-*.jsonl.
@@ -118,7 +122,27 @@
             Range:       0-50 (clamped)
     -->
     <add key="SpellCastEarlyFireOffsetMs" value="0" />
+    <!--
+            Option:      ThreatEngine
+            Description: (JimsProxy) Synthesize threat values for threat-meter addons.
+                         Vanilla 1.12 servers never send threat over the wire, so the
+                         proxy estimates it from combat events. Automatically inactive
+                         inside battlegrounds.
+            Default:     "false"
+    -->
     <add key="ThreatEngine" value="false" />
+    <!--
+            Option:      ServerType
+            Description: (JimsProxy) Which vanilla 1.12 server fork you are connecting
+                         to. Forks differ in the wire format of a few CMSGs, and this
+                         also selects the fork-specific item-data overlays the proxy
+                         loads at startup.
+                         "Generic" is scaffolding for future server support - it is not
+                         a tested configuration today. Leave this on "Kronos" unless you
+                         are developing against another fork.
+            Default:     "Kronos"
+            Values:      "Kronos" | "Generic"
+    -->
     <add key="ServerType" value="Kronos" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
## What

Fix three drifted defaults in the tracked `HermesProxy/HermesProxy.config`, and document the two keys that had no documentation.

| Key | Before | After |
|---|---|---|
| `ClientBuild` | `40618` (1.14.0) | `42597` (1.14.2) |
| `PacketsLog` | `true` | `false` |
| `ThreatEngine` | *(no comment block)* | documented |
| `ServerType` | *(no comment block)* | documented, incl. `Kronos` \| `Generic` |

## Why

This file is what anyone **building from source or running the proxy without the launcher** actually gets. The launcher writes its own config from a template (`setup.rs`) and never reads this one, so the drift was invisible to every launcher user and hit only standalone users.

- **`ClientBuild 40618`** — development, testing, and the launcher's own client check all pin 1.14.2 build `42597` (`repair.rs:145`, `EXPECTED_CLIENT_VERSION`). A `ClientBuild` that doesn't match the running client fails login outright, so the shipped default was a guaranteed failure for the 1.14.2 client this fork targets. The comment block also listed 40618 first as "Default", which is where the value came from.
- **`PacketsLog true`** — every standalone session wrote a full packet capture to disk, unprompted and indefinitely. The launcher already forces this off; only standalone users were paying for it.
- **`ThreatEngine` / `ServerType`** — the only two keys in the file with no `Option/Description/Default` block. `ServerType` matters most: it silently selects the fork-specific item-data overlays loaded at startup (`GameData.cs:3170`), so a user who never learns it exists can't reason about their item data.

## How

Data-only. No code change — this file is read at startup by `ConfigurationManager`.

Deliberately **unchanged**: `ServerAddress` (`127.0.0.1`) and `ServerBuild` (`auto`) are correct generic defaults; the Kronos address belongs in the docs as a worked example, not baked into a file every fork-builder inherits. `ClientSeed` is the static-seed fallback (`RealmManager.cs:62`) and users should never edit it — real per-build seeds load automatically from `CSV/BuildAuthSeeds.csv`.

Per-fork wording on `ServerType`: `Generic` is described as scaffolding for future server support and explicitly **not** a tested configuration today, rather than presented as a supported option.

## Verification

- XML parses clean (`[xml]` load), BOM preserved, file remains **pure ASCII** (0 non-ASCII bytes — an em-dash was introduced during editing and removed).
- Values confirmed post-edit: `ClientBuild=42597`, `PacketsLog=false`, `ThreatEngine=false`, `ServerType=Kronos`.

**Field gate — not yet run.** A standalone run following only the documented manual steps (take the shipped config, set `ServerAddress`, start the proxy, log in) against Kronos. Test folder is staged; this PR should not be treated as field-verified until that passes.

## Context

First piece of a larger effort to make non-launcher use of the proxy actually work and be documented — README rewrite, `docs/` reference, and a setup page follow. Also supersedes the motivation behind #458 (refreshing the stale in-repo `build-single/` distribution), which is proposed for retirement in favour of a release asset.
