### PR TITLE
Hold a dup press's CAST_FAILED until its started cast's terminal event (#394 frame-collision strand)

### DIFF
--- a/HermesProxy.Tests/World/DupFailureFrameHoldTests.cs
+++ b/HermesProxy.Tests/World/DupFailureFrameHoldTests.cs
@@ -1,0 +1,218 @@
+using System;
+using HermesProxy;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (dup-failure frame hold, the #394 collision strand): a dup press's CAST_FAILED
+// delivered while its same-spell STARTED cast is in flight can share a client frame with that
+// cast's SPELL_GO (the legacy server batches the dup rejection into the tick that completes
+// the cast — 2/2 specimens in the 2026-08-14 Stonetavern JSONL at Δ0-1ms). The client's
+// kit-cancel sweep runs by (unit, visualID), not CastID, so the same-frame FAILED can tear the
+// live kit ahead of the GO's end-event close and orphan the loop sound. The fix holds the
+// fully-built dup failure and releases it after the started cast's terminal event forwards
+// (SugarProxy's AddFailedPacket/GetFailedPacket shape — hold by data dependency, no clocks),
+// with a stale sweep tied to the pending-cast lifecycle so a silently-evicted anchor can't
+// strand the dup's button-release. These tests cover the store: the hold predicate
+// (HasStartedPendingCastForSpell), FIFO hold/release, and stale detection.
+public class DupFailureFrameHoldTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static ClientCastRequest MakeCast(uint spellId, bool started = false, uint legacySpellId = 0)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            LegacySpellId = legacySpellId,
+            Timestamp = Environment.TickCount,
+            HasStarted = started,
+        };
+    }
+
+    private static GameSessionData.HeldDupFailure MakeHeld(
+        uint spellId,
+        uint reason = (uint)HermesProxy.World.Enums.SpellCastResultVanilla.SpellInProgress)
+    {
+        var held = new GameSessionData.HeldDupFailure
+        {
+            SpellId = spellId,
+            ReasonId = reason,
+            HeldAtMs = Environment.TickCount64,
+        };
+        held.Packets.Add(new CastFailed { SpellID = spellId, Reason = reason });
+        return held;
+    }
+
+    // ---- HasStartedPendingCastForSpell (the hold predicate) ----
+
+    [Fact]
+    public void HasStarted_EmptyQueue_ReturnsFalse()
+    {
+        Assert.False(NewSession().HasStartedPendingCastForSpell(2053));
+    }
+
+    [Fact]
+    public void HasStarted_OnlyUnstartedSameSpell_ReturnsFalse()
+    {
+        // A dup with no started twin (skip-START instant, or the cast already terminated):
+        // nothing to collide with — the failure must deliver immediately, not hold.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(2053));
+
+        Assert.False(session.HasStartedPendingCastForSpell(2053));
+    }
+
+    [Fact]
+    public void HasStarted_StartedSameSpell_ReturnsTrue()
+    {
+        // The specimen shape: Lesser Heal (2053) started (bar filling), dup press bounced.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(2053, started: true));
+
+        Assert.True(session.HasStartedPendingCastForSpell(2053));
+    }
+
+    [Fact]
+    public void HasStarted_MatchesByLegacySpellId()
+    {
+        // SoM-renumbered item cast: the legacy server replies with the old id.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(363880, started: true, legacySpellId: 17626));
+
+        Assert.True(session.HasStartedPendingCastForSpell(17626));
+        Assert.True(session.HasStartedPendingCastForSpell(363880));
+    }
+
+    // ---- Hold / release bookkeeping ----
+
+    [Fact]
+    public void TakeHeld_ReturnsInHoldOrder_ThenNull()
+    {
+        // Two dup bounces during one cast (spam) must replay in the order the server
+        // rejected them — Sugar appends to a slice and drains it FIFO; so do we.
+        var session = NewSession();
+        var first = MakeHeld(2053);
+        var second = MakeHeld(2053);
+        session.HoldDupFailure(first);
+        session.HoldDupFailure(second);
+        Assert.Equal(2, session.HeldDupFailureCount);
+
+        var taken = session.TakeHeldDupFailures(2053);
+
+        Assert.NotNull(taken);
+        Assert.Equal(2, taken!.Count);
+        Assert.Same(first, taken[0]);
+        Assert.Same(second, taken[1]);
+        Assert.Equal(0, session.HeldDupFailureCount);
+        Assert.Null(session.TakeHeldDupFailures(2053)); // drained — a second GO releases nothing
+    }
+
+    [Fact]
+    public void TakeHeld_OtherSpell_ReturnsNullAndLeavesEntry()
+    {
+        // A different spell's GO must not release another spell's held dup.
+        var session = NewSession();
+        session.HoldDupFailure(MakeHeld(2053));
+
+        Assert.Null(session.TakeHeldDupFailures(592));
+        Assert.Equal(1, session.HeldDupFailureCount);
+    }
+
+    // ---- Stale sweep (anchor lifecycle) ----
+
+    [Fact]
+    public void TakeStale_AnchorStillStarted_ReturnsNull()
+    {
+        // The started cast is still in flight — the hold must stand until its terminal.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(2053, started: true));
+        session.HoldDupFailure(MakeHeld(2053));
+
+        Assert.Null(session.TakeStaleHeldDupFailures());
+        Assert.Equal(1, session.HeldDupFailureCount);
+    }
+
+    [Fact]
+    public void TakeStale_AnchorGone_ReturnsHeld()
+    {
+        // The anchor left the queue through an eviction path (no GO, no real CAST_FAILED):
+        // the held dup must come back for delivery — an unanswered press strands the
+        // client's action button lit.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(2053, started: true));
+        var held = MakeHeld(2053);
+        session.HoldDupFailure(held);
+
+        session.TryDequeuePendingNormalCast(2053, out _); // the anchor leaves (any path)
+        var stale = session.TakeStaleHeldDupFailures();
+
+        Assert.NotNull(stale);
+        Assert.Same(held, Assert.Single(stale!));
+        Assert.Equal(0, session.HeldDupFailureCount);
+    }
+
+    [Fact]
+    public void TakeStale_MixedSpells_ReturnsOnlyOrphaned()
+    {
+        // Spell 2053's anchor died; spell 592's is still casting — only 2053's dup releases.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(592, started: true));
+        var orphaned = MakeHeld(2053);
+        session.HoldDupFailure(orphaned);
+        session.HoldDupFailure(MakeHeld(592));
+
+        var stale = session.TakeStaleHeldDupFailures();
+
+        Assert.NotNull(stale);
+        Assert.Same(orphaned, Assert.Single(stale!));
+        Assert.Equal(1, session.HeldDupFailureCount);
+        Assert.NotNull(session.TakeHeldDupFailures(592));
+    }
+
+    [Fact]
+    public void TakeStale_UnstartedEntryDoesNotAnchor()
+    {
+        // Only a STARTED same-spell cast anchors a hold. A lone unstarted entry (a fresh
+        // press racing in after the anchor terminated) must not keep the old dup captive.
+        var session = NewSession();
+        session.PendingNormalCasts.Enqueue(MakeCast(2053));
+        session.HoldDupFailure(MakeHeld(2053));
+
+        var stale = session.TakeStaleHeldDupFailures();
+
+        Assert.NotNull(stale);
+        Assert.Single(stale!);
+    }
+
+    // ---- The specimen, end-to-end at store level ----
+
+    [Fact]
+    public void StonetavernSpecimen_HoldThenReleaseOnGoDequeue()
+    {
+        // 2026-08-14, both specimens: press A starts Lesser Heal (2053); dup press B bounces
+        // (SpellInProgress) ~70-125ms before cast-end; the rejection and A's GO arrive in one
+        // batch. Wiring contract: the CAST_FAILED handler dequeues B (preferStarted:false),
+        // sees A still started (hold predicate true) → holds; the GO handler dequeues A and
+        // takes the held batch AFTER forwarding the GO.
+        var session = NewSession();
+        var castA = MakeCast(2053, started: true);
+        var dupB = MakeCast(2053);
+        session.PendingNormalCasts.Enqueue(castA);
+        session.PendingNormalCasts.Enqueue(dupB);
+
+        // CAST_FAILED(dup B): consume the unstarted dup, spare the started cast (H7).
+        Assert.True(session.TryDequeuePendingNormalCast(2053, out var consumed, preferStarted: false));
+        Assert.Same(dupB, consumed);
+        Assert.True(session.HasStartedPendingCastForSpell(2053)); // hold predicate
+        session.HoldDupFailure(MakeHeld(2053));
+
+        // SPELL_GO(cast A): dequeue the started cast, then release the held dup after it.
+        Assert.True(session.TryDequeuePendingNormalCast(2053, out var completed));
+        Assert.Same(castA, completed);
+        var released = session.TakeHeldDupFailures(2053);
+        Assert.NotNull(released);
+        Assert.Single(released!);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -3038,6 +3038,14 @@ public sealed class GameSessionData
         int otherCount = ClearObservedCastIds();
         PetAutoCastActiveCastIds.Clear();
         ClearForwardedStartCastIds();
+        // JimsProxy (dup-failure frame hold): drop held dup failures with the session state —
+        // their anchors were just cleared, and the client resets its own cast/button state
+        // across a reconnect or load screen. Delivering them into the new session would ship
+        // stale-CastID packets and pollute the held_ms field-gate metric.
+        lock (_heldDupFailuresLock)
+        {
+            _heldDupFailures.Clear();
+        }
         // Single-slot trackers for melee + auto-repeat (Auto Shot, Shoot Wand)
         // — same lifecycle as PendingNormalCasts; if a tracker was set when
         // the DC fired, it never gets cleared by the SPELL_GO/CAST_FAILED

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -765,7 +765,13 @@ public sealed class GameSessionData
         }
     }
 
-    // JimsProxy (fifo-terminator-symmetry): per-spell STARTED twin of the check above.
+    // JimsProxy (fifo-terminator-symmetry + dup-failure frame hold): per-spell STARTED twin
+    // of the check above — "is a same-spell cast currently between its forwarded SPELL_START
+    // and its terminal event?" For the frame hold that in-flight window is the hold predicate:
+    // a dup press's CAST_FAILED delivered during it can share a client frame with the cast's
+    // SPELL_GO, and the client's kit-cancel sweep runs by (unit, visualID) — not CastID — so
+    // the correctly-CastID'd dup failure can still tear the live cast's visual kit in the same
+    // frame its GO is closing it (the #394 looping-sound collision, 2026-08-14 Stonetavern JSONL).
     public bool HasStartedPendingCastForSpell(uint spellId)
     {
         lock (PendingCastsLock)
@@ -779,6 +785,96 @@ public sealed class GameSessionData
             return false;
         }
     }
+
+    // JimsProxy (dup-failure frame hold): a dup press's failure delivery, held while its
+    // same-spell started cast is still in flight. Either a list of fully-built client packets
+    // (SpellPrepare + CastFailed, the unsuppressed path) or the pending request to ack via
+    // SendCastRequestFailed(DontReport) (the SuppressSpellCastErrors path). Released after the
+    // started cast's terminal event forwards — SugarProxy's AddFailedPacket/GetFailedPacket
+    // shape (hold by data dependency, never a clock), with a strictly wider release set: the
+    // stale sweep ties held entries to the pending-cast lifecycle, so a silently-evicted cast
+    // can't strand its dup's button-release past the next cast event.
+    public sealed class HeldDupFailure
+    {
+        public uint SpellId;
+        public List<ServerPacket> Packets = new();
+        public ClientCastRequest? SuppressAck;
+        public uint ReasonId;
+        public long HeldAtMs;
+    }
+
+    // Lock order: _heldDupFailuresLock may be taken BEFORE PendingCastsLock (the stale sweep
+    // checks anchors under it) — never call the held-dup methods while holding PendingCastsLock.
+    private readonly Dictionary<uint, List<HeldDupFailure>> _heldDupFailures = new();
+    private readonly object _heldDupFailuresLock = new();
+
+    public void HoldDupFailure(HeldDupFailure held)
+    {
+        lock (_heldDupFailuresLock)
+        {
+            if (!_heldDupFailures.TryGetValue(held.SpellId, out var list))
+            {
+                list = new List<HeldDupFailure>();
+                _heldDupFailures[held.SpellId] = list;
+            }
+            list.Add(held);
+        }
+    }
+
+    public int HeldDupFailureCount
+    {
+        get { lock (_heldDupFailuresLock) { int n = 0; foreach (var l in _heldDupFailures.Values) n += l.Count; return n; } }
+    }
+
+    /// <summary>
+    /// Remove and return every held dup failure for this spell, in hold (FIFO) order —
+    /// null when none (keeps the per-GO hot path allocation-free). Called right after the
+    /// started cast's terminal event (SPELL_GO or its real CAST_FAILED) forwards, so the
+    /// release lands in the flush AFTER the terminal — Sugar's replay position, empirically
+    /// safe in its field record.
+    /// </summary>
+    public List<HeldDupFailure>? TakeHeldDupFailures(uint spellId)
+    {
+        lock (_heldDupFailuresLock)
+        {
+            if (_heldDupFailures.Count != 0 && _heldDupFailures.Remove(spellId, out var list))
+                return list;
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Remove and return held dup failures whose anchor died: no started same-spell cast
+    /// remains pending (evicted by the watchdog, parse-failure drain, destroy eviction, or a
+    /// world transfer clear). The caller must still DELIVER these — a never-released dup
+    /// failure strands the client's action button lit (the press is never answered).
+    /// Self-healing: run on every local cast event, like RunWatchdogEviction.
+    /// </summary>
+    public List<HeldDupFailure>? TakeStaleHeldDupFailures()
+    {
+        List<HeldDupFailure>? stale = null;
+        lock (_heldDupFailuresLock)
+        {
+            if (_heldDupFailures.Count == 0)
+                return null;
+            List<uint>? deadKeys = null;
+            foreach (var key in _heldDupFailures.Keys)
+            {
+                if (!HasStartedPendingCastForSpell(key))
+                    (deadKeys ??= new List<uint>()).Add(key);
+            }
+            if (deadKeys != null)
+            {
+                foreach (var key in deadKeys)
+                {
+                    if (_heldDupFailures.Remove(key, out var list))
+                        (stale ??= new List<HeldDupFailure>()).AddRange(list);
+                }
+            }
+        }
+        return stale;
+    }
+
 
     // JimsProxy: proxy→server RTT measurement for adaptive GCD fire offset.
     private readonly object _rttLock = new();

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -2188,11 +2188,6 @@ public partial class WorldClient
         if (GetSession().GameState.CurrentMapId == null)
             return;
 
-        // JimsProxy (dup-failure frame hold): self-healing release for orphaned holds —
-        // same cadence as HandleCastFailed's sweep, so a spell the player only ever
-        // completes (GOs, no failures) still can't strand another spell's held dup.
-        ReleaseStaleHeldDupFailures();
-
         SpellGo spell = new SpellGo();
         try
         {
@@ -2741,6 +2736,17 @@ public partial class WorldClient
             if (heldOnGo != null)
                 DeliverHeldDupFailures(heldOnGo, "go");
         }
+
+        // JimsProxy (dup-failure frame hold): the stale sweep for THIS handler runs here, after
+        // the forward — NOT at the top like the failure handlers' sweeps. A top-of-handler
+        // sweep can front-run a same-spell GO in this very invocation: a held dup whose
+        // STARTED anchor was destroy-evicted while the server still completes the cast (the
+        // #493 mining-race geometry, started variant) would release its FAILED first and put
+        // FAILED-then-GO in one flush with the kit live — the exact contradiction this fix
+        // exists to prevent. Post-forward, every release lands after the GO in all geometries.
+        // The failure handlers keep their top-of-handler sweeps: they only ever emit
+        // failure-class packets, and a FAILED+FAILED frame contradicts nothing.
+        ReleaseStaleHeldDupFailures();
 
         // JimsProxy threat translation: route Hunter / Pet / class abilities
         // through the threat tracker so SMSG_THREAT_UPDATE reflects the cast.

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -28,6 +28,50 @@ public partial class WorldClient
     // in a clean client frame past the coalesced START+GO burst. A couple of frames at 60fps.
     private const int SpellSuccessRefireDeferMs = 8;
 
+    // JimsProxy (dup-failure frame hold): deliver a batch of held dup failures, in hold order.
+    // Runs on the WorldClient receive thread at a release site — always AFTER the started
+    // cast's terminal event forwarded (or when the anchor entry is gone), never between a
+    // START and its GO.
+    private void DeliverHeldDupFailures(List<GameSessionData.HeldDupFailure> held, string release)
+    {
+        foreach (var item in held)
+        {
+            if (item.SuppressAck != null)
+            {
+                // Stale releases can land in a transfer window where the client-facing
+                // socket is already gone — the client is resetting its own state then,
+                // so dropping the ack is correct, and an NRE here would DC the session.
+                GetSession().InstanceSocket?.SendCastRequestFailed(item.SuppressAck, false, SpellCastResultClassic.DontReport);
+            }
+            else
+                foreach (var pkt in item.Packets)
+                    SendPacketToClient(pkt);
+            if (Framework.Settings.DebugOutput)
+                Log.Event("cast.fail.dup_flushed", new
+                {
+                    spell_id = item.SpellId,
+                    reason_id = item.ReasonId,
+                    held_ms = Environment.TickCount64 - item.HeldAtMs,
+                    release,
+                });
+        }
+    }
+
+    // JimsProxy (dup-failure frame hold): self-healing release for held dup failures whose
+    // started anchor cast left PendingNormalCasts through a path other than its GO / real
+    // CAST_FAILED (watchdog eviction, parse-failure drain, destroy eviction, world-transfer
+    // clear). They must still be DELIVERED — an unanswered dup press strands the client's
+    // action button lit. Run on every local cast event, mirroring RunWatchdogEviction.
+    private void ReleaseStaleHeldDupFailures()
+    {
+        var gameState = GetSession().GameState;
+        if (gameState.HeldDupFailureCount == 0)
+            return;
+        var stale = gameState.TakeStaleHeldDupFailures();
+        if (stale != null)
+            DeliverHeldDupFailures(stale, "stale");
+    }
+
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_SEND_KNOWN_SPELLS)]
     void HandleSendKnownSpells(WorldPacket packet)
@@ -334,6 +378,9 @@ public partial class WorldClient
         // get its own trailing CAST_FAILED — happens occasionally on Kronos
         // for cast-time + target-dies. Self-healing on every cast event.
         GetSession().RunWatchdogEviction();
+        // JimsProxy (dup-failure frame hold): after the watchdog may have evicted a started
+        // cast, deliver any held dup failures whose anchor died — same self-healing cadence.
+        ReleaseStaleHeldDupFailures();
 
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
             packet.ReadUInt8(); // cast count
@@ -486,7 +533,32 @@ public partial class WorldClient
             // with no popup / error sound. Mirrors the item-use-orphan eviction ack above.
             // preferStarted:false (H7, from #372): consume the UNSTARTED dup, leave the started cast for its GO.
             if (GetSession().GameState.TryDequeuePendingNormalCast(spellId, out var suppressedCast, preferStarted: false) && suppressedCast != null)
-                GetSession().InstanceSocket.SendCastRequestFailed(suppressedCast, false, SpellCastResultClassic.DontReport);
+            {
+                // JimsProxy (dup-failure frame hold): if this dup's started twin is still in
+                // flight, even the DontReport ack rides the hold — whether a DontReport
+                // CastFailed skips the client's (unit, visualID) kit-cancel sweep is unproven,
+                // and the ack loses nothing by arriving one terminal later.
+                if (!suppressedCast.HasStarted &&
+                    GetSession().GameState.HasStartedPendingCastForSpell(spellId))
+                {
+                    GetSession().GameState.HoldDupFailure(new GameSessionData.HeldDupFailure
+                    {
+                        SpellId = suppressedCast.SpellId,
+                        SuppressAck = suppressedCast,
+                        ReasonId = reason,
+                        HeldAtMs = Environment.TickCount64,
+                    });
+                    if (Framework.Settings.DebugOutput)
+                        Log.Event("cast.fail.dup_held", new
+                        {
+                            spell_id = suppressedCast.SpellId,
+                            reason_id = reason,
+                            path = "suppress_ack",
+                        });
+                }
+                else
+                    GetSession().InstanceSocket.SendCastRequestFailed(suppressedCast, false, SpellCastResultClassic.DontReport);
+            }
             Log.Event("cast.error_suppressed", new
             {
                 spell_id = spellId,
@@ -499,7 +571,13 @@ public partial class WorldClient
         // caster directly, so any pending resurrection cast tracked for
         // us is now cancelled — emit HC-1.0 stop so 1.12-native listeners
         // clear the rez indicator on their unit frames.
-        GetSession().HealCommBridge.OnLocalPlayerSpellStop(spellId);
+        // JimsProxy (dup-failure frame hold rider): transient reasons (NotReady /
+        // SpellInProgress) are dup-press rejections, never an interrupt of the cast in
+        // progress (the #397 axiom: the server never starts a cast and then rejects it with a
+        // pre-cast reason) — firing the stop for them falsely cleared the rez indicator while
+        // the real cast was still casting. Real failures keep firing exactly as before.
+        if (!isTransientReason)
+            GetSession().HealCommBridge.OnLocalPlayerSpellStop(spellId);
 
         // Check special casts first - try next melee, then auto repeat
         ClientCastRequest? specialCast = null;
@@ -594,12 +672,32 @@ public partial class WorldClient
                         client_cast_id = pendingCast.ClientGUID.ToString(),
                     });
             }
-            else if (!pendingCast.HasStarted)
+            // JimsProxy (dup-failure frame hold, the #394 collision strand): a dup press's
+            // failure resolved while its same-spell STARTED cast is still in flight. Delivering
+            // it now can land it in the same client frame as that cast's SPELL_GO (Stonetavern
+            // batches the dup rejection into the tick that completes the cast — 2/2 specimens in
+            // the 2026-08-14 reporter JSONL, both at Δ0-1ms from the GO). The failure's CastID is
+            // correct (the dup's), but the client's kit-cancel sweep runs by (unit, visualID) —
+            // a same-frame FAILED+GO can tear the live kit ahead of its end-event close and
+            // orphan the loop sound. Build everything exactly as before, but HOLD the delivery;
+            // released after the started cast's terminal event forwards (GO / real CAST_FAILED /
+            // eviction sweep) — SugarProxy's AddFailedPacket shape, keyed on data dependency,
+            // never a clock. MovementCancelled acks are exempt: the client is blocked on them
+            // (its own cancel awaits the confirm — the #161 bar-linger), and they never carry a
+            // live same-spell started twin anyway.
+            bool holdAsDup = !pendingCast.HasStarted && !movementSuppressed &&
+                GetSession().GameState.HasStartedPendingCastForSpell(spellId);
+
+            SpellPrepare? dupPrepare = null;
+            if (!movementSuppressed && !pendingCast.HasStarted)
             {
                 SpellPrepare prepare2 = new SpellPrepare();
                 prepare2.ClientCastID = pendingCast.ClientGUID;
                 prepare2.ServerCastID = pendingCast.ServerGUID;
-                SendPacketToClient(prepare2);
+                if (holdAsDup)
+                    dupPrepare = prepare2;
+                else
+                    SendPacketToClient(prepare2);
             }
 
             CastFailed failed = new();
@@ -616,7 +714,28 @@ public partial class WorldClient
                 failed.CastID = pinnedFailCastId;
             failed.FailedArg1 = arg1;
             failed.FailedArg2 = arg2;
-            SendPacketToClient(failed);
+            if (holdAsDup)
+            {
+                var held = new GameSessionData.HeldDupFailure
+                {
+                    SpellId = pendingCast.SpellId,
+                    ReasonId = reason,
+                    HeldAtMs = Environment.TickCount64,
+                };
+                if (dupPrepare != null)
+                    held.Packets.Add(dupPrepare);
+                held.Packets.Add(failed);
+                GetSession().GameState.HoldDupFailure(held);
+                if (Framework.Settings.DebugOutput)
+                    Log.Event("cast.fail.dup_held", new
+                    {
+                        spell_id = pendingCast.SpellId,
+                        reason_id = reason,
+                        path = "cast_failed",
+                    });
+            }
+            else
+                SendPacketToClient(failed);
 
             // JimsProxy (transient-no-dismiss-started): under LowLatencyMode the SPELL_FAILURE
             // deferred the caster-side visual-cancel to here so the REAL reason drives it. A real
@@ -634,6 +753,17 @@ public partial class WorldClient
                     cancelVisual.SpellVisualID = (int)resolvedVisual;
                     SendPacketToClient(cancelVisual);
                 }
+            }
+
+            // JimsProxy (dup-failure frame hold): this failure terminated the STARTED cast —
+            // its terminal is on the wire, so release any dup failures held against it, after
+            // it (a FAILED+FAILED frame contradicts nothing; the kit is closing via the real
+            // terminator that just went out).
+            if (pendingCast.HasStarted)
+            {
+                var heldOnTerminator = GetSession().GameState.TakeHeldDupFailures(pendingCast.SpellId);
+                if (heldOnTerminator != null)
+                    DeliverHeldDupFailures(heldOnTerminator, "terminator");
             }
 
             var gameState = GetSession().GameState;
@@ -1194,6 +1324,9 @@ public partial class WorldClient
         // get a trailing CAST_FAILED within the watchdog window. Runs before
         // we set up a new watchdog so leaks can't accumulate across failures.
         GetSession().RunWatchdogEviction();
+        // JimsProxy (dup-failure frame hold): same self-healing cadence as the other
+        // cast-event handlers — the watchdog above may have just evicted a held dup's anchor.
+        ReleaseStaleHeldDupFailures();
 
         WowGuid128 casterUnit;
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
@@ -2055,6 +2188,11 @@ public partial class WorldClient
         if (GetSession().GameState.CurrentMapId == null)
             return;
 
+        // JimsProxy (dup-failure frame hold): self-healing release for orphaned holds —
+        // same cadence as HandleCastFailed's sweep, so a spell the player only ever
+        // completes (GOs, no failures) still can't strand another spell's held dup.
+        ReleaseStaleHeldDupFailures();
+
         SpellGo spell = new SpellGo();
         try
         {
@@ -2589,6 +2727,19 @@ public partial class WorldClient
         else
         {
             SendPacketToClient(spell);
+        }
+
+        // JimsProxy (dup-failure frame hold): the local cast's GO is on the wire — release any
+        // dup failures held against it now, AFTER the GO (Sugar's replay position: the failure
+        // can no longer share the frame that closes the kit ahead of the close). In the
+        // form-exit branch above the GO send is deferred; releasing here puts the failure
+        // BEFORE the deferred START+GO pair, which is the safe order (sweep with nothing live,
+        // then open+close in a later frame).
+        if (spell.Cast.CasterUnit == GetSession().GameState.CurrentPlayerGuid)
+        {
+            var heldOnGo = GetSession().GameState.TakeHeldDupFailures((uint)spell.Cast.SpellID);
+            if (heldOnGo != null)
+                DeliverHeldDupFailures(heldOnGo, "go");
         }
 
         // JimsProxy threat translation: route Hunter / Pet / class abilities


### PR DESCRIPTION
# What

A new proxy-source strand of the #394 looping-cast class, found by per-cast autopsy of the reporter's 2026-08-14 log, and its fix: **a dup press's `CAST_FAILED` is no longer delivered while its same-spell STARTED cast is in flight — it's built exactly as before, held, and released immediately after that cast's terminal event forwards.**

# The strand

Spam a cast-time spell: press A starts the cast; impatient re-press B lands near cast-end. The legacy server batches B's rejection into the same tick that completes A, so the client receives, in one TCP flush — one client frame:

```
+0ms  SPELL_CAST_FAILED (dup B's rejection — CastID correctly B's, H7 pairing intact)
+0ms  SPELL_GO           (cast A completing)
```

The CastIDs are right — but the 1.14 client's kit-cancel sweep runs by **(unit, visualID), not CastID** (Mirasu R19). A same-frame FAILED+GO can tear the live cast's visual kit *ahead of* the GO's end-event-13 close. A torn kit whose close never lands is the orphaned loop sound: `SpellVisualKit` has no duration column, end-event-13 is the only terminator, and the handle sits at `obj+0x16c == 0` — no stop ever requested.

**Field evidence** (AliziaKaline's 08-14 JSONL, Stonetavern, 5.2h, DebugOutput on):
- 2/2 specimens with the exact signature (`cast.fail.spared_started` + same-ms `SPELL_GO`, Δ0–1ms), on spammed Lesser Heal 2053; the second sits **84s before a loop-shaped quiet logout**.
- Reporter named PW:Shield — **Shield and Lesser Heal share SpellVisualKit 270** (both on start-3 → end-event-13, same sound effect, verified in DB2 42597), so the perceived spell is structurally indistinguishable from the causal one. The report and the specimens agree.
- `RefireSpellGo` was **active** (600 refires that session, 167/167 on the named spell) and cannot reach this strand: no duplicate GO can close a sound handle the sweep already orphaned.
- Corpus sweep, delivered-to-client at |Δt|≤3ms: ours 13,055 across 70 sessions — all instant GCD-mash where the kit is never audibly live (the cofactor is a **live loop sound at sweep time**, i.e. cast-time spells); Mirasu's 15 instrumented sessions: **zero** delivered collisions, zero loops, consistent.

# The fix (SugarProxy's confirmed shape)

Re-decoded from the live Sugar binary this session (not the July doc): per-spell bucket; `SMSG_CAST_FAILED` → resolve first (consume queued press, else clear in-flight) → hold **only if the in-flight marker survived**; held list drained inside `SMSG_SPELL_GO` after the GO send *and* on the failure-terminal broadcast. Hold by data dependency, never a clock. Ours mirrors it with a strictly wider release set:

- **Hold**: dup resolved (`preferStarted:false`, unstarted, not MovementCancelled) while `HasStartedPendingCastForSpell` — packets built identically (same CastID pairing, same `SpellPrepare` rules, T1 pin untouched).
- **Release after the started cast's GO** (post-send — Sugar's replay position, empirically safe in its field record), **or its real CAST_FAILED** (FAILED+FAILED contradicts nothing), **or the stale sweep**: run at every cast-event handler top beside `RunWatchdogEviction`, releasing holds whose anchor left `PendingNormalCasts` by any eviction path — an unanswered dup press must still be delivered or the client's button strands lit.
- MovementCancelled acks exempt (the client blocks on them — the #161 bar-linger). `SuppressSpellCastErrors` DontReport acks ride the same hold (whether DontReport skips the kit sweep is unproven — Mirasu RE item, non-blocking).
- **Rider**: transient reasons (NotReady/SpellInProgress) no longer fire `HealCommBridge.OnLocalPlayerSpellStop` — a dup bounce is never an interrupt of the cast in progress (#397 axiom); the rez indicator no longer falsely clears mid-cast.

Worst-case UX cost: a dup press's red error text arrives one terminal later (~70–300ms in practice — the LL in-flight guard already drops early dups proxy-side, so survivors are late re-presses near cast-end).

# Scope

Local player casts only (pets follow if the field asks). Default ON, no config knob — deterministic packet-pairing correction, beta-channel. Diagnostics DebugOutput-gated: `cast.fail.dup_held` / `cast.fail.dup_flushed {release, held_ms}`.

# Testing

- 11 new tests (`DupFailureFrameHoldTests`): hold predicate incl. legacy-id (SoM) matching, FIFO hold/release, drained-once semantics, stale-sweep anchor lifecycle (started anchors hold; evicted/unstarted anchors release), and the Stonetavern specimen's wiring contract end-to-end at store level.
- Full suite **946/946** on the branch; build clean.
- Handler paths aren't unit-testable in this harness (no socket fixtures) — same limitation as every fix in this area.

# Field gate (ship-and-observe — no reporter interviews)

The verdict is Alizia's cohort on the next beta cut: spam-healing sessions that previously reproduced through an active refire. Success signature in their logs: `cast.fail.dup_held` → `dup_flushed release=go` pairs present, `cast.fail.spared_started` no longer co-timestamped with a same-ms `SPELL_GO` — and no loop report. This strand is refire-independent, so the result reads cleanly against Mirasu's refire-off control week.

# Interactions

- **#376/#397 transient guards**: unchanged and still required — they cover transient-with-no-dup (nothing to pair); this covers dup-present.
- **#488/RefireSpellGo**: independent; this strand is the one the refire demonstrably couldn't reach.
- **Mirasu's FIFO-wedge fix (incoming)**: different machinery (CastID pairing vs failure delivery); the hold defers only sends, never dequeues — textual adjacency in `HandleCastFailed` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KDnDLRHcUyAuNgVLNB18w