### PR TITLE
Give every forwarded-START FIFO enqueue a consuming terminator, matched or not

### DIFF
--- a/HermesProxy.Tests/World/ForwardedStartFifoSymmetryTests.cs
+++ b/HermesProxy.Tests/World/ForwardedStartFifoSymmetryTests.cs
@@ -1,0 +1,101 @@
+using System;
+using HermesProxy;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (fifo-terminator-symmetry): the forwarded-START CastID FIFO must obey
+// "every enqueue has exactly one consuming terminator, matched or not". An orphan
+// START (pending entry evicted before the START arrived) enqueues like any other,
+// but its terminator used to take the unmatched paths, which never consumed the
+// entry — leaving the FIFO off-by-one for every later same-spell cast for the rest
+// of the session (the mining cast-bar-overrun wedge, jimsproxy-20260820-191703).
+// These tests pin the session-level state the new unmatched-terminator paths key on.
+public class ForwardedStartFifoSymmetryTests
+{
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    private static WowGuid128 CastId(ulong low) => new WowGuid128(0x1234, low);
+
+    private static ClientCastRequest MakeCast(uint spellId, bool hasStarted = false, uint legacySpellId = 0)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = spellId,
+            LegacySpellId = legacySpellId,
+            Timestamp = Environment.TickCount,
+            HasStarted = hasStarted,
+        };
+    }
+
+    [Fact]
+    public void HasStartedPendingCastForSpell_TrueOnlyForStartedSameSpell()
+    {
+        var session = NewSession();
+        session.EnqueuePendingNormalCast(MakeCast(10248, hasStarted: false));
+
+        Assert.False(session.HasStartedPendingCastForSpell(10248));
+
+        session.EnqueuePendingNormalCast(MakeCast(10248, hasStarted: true));
+
+        Assert.True(session.HasStartedPendingCastForSpell(10248));
+        Assert.False(session.HasStartedPendingCastForSpell(2053));
+    }
+
+    [Fact]
+    public void HasStartedPendingCastForSpell_MatchesLegacySpellId()
+    {
+        var session = NewSession();
+        session.EnqueuePendingNormalCast(MakeCast(25007, hasStarted: true, legacySpellId: 24997));
+
+        Assert.True(session.HasStartedPendingCastForSpell(24997));
+        Assert.True(session.HasStartedPendingCastForSpell(25007));
+    }
+
+    // The GO-side guard's exact precondition set: an orphan's forwarded-START entry in the
+    // FIFO, a fresh unstarted press pending, no started pending cast. The guard must resolve
+    // the GO from the FIFO and leave the press's pending entry untouched for its own
+    // terminator — dequeuing it here is the entry-steal that re-arms the wedge.
+    [Fact]
+    public void OrphanGoScenario_FifoResolvesWithoutStealingUnstartedPress()
+    {
+        var session = NewSession();
+        var orphanCastId = CastId(20733);   // orphan START forwarded after its pending entry died
+        session.EnqueueForwardedStartCastId(10248, orphanCastId);
+        var freshPress = MakeCast(10248, hasStarted: false);
+        session.EnqueuePendingNormalCast(freshPress);
+
+        Assert.True(session.HasNonStartedPendingCastForSpell(10248));
+        Assert.False(session.HasStartedPendingCastForSpell(10248));
+
+        Assert.True(session.TryPopForwardedStartCastId(10248, out var recovered));
+        Assert.Equal(orphanCastId, recovered);
+
+        // The press is still queued for its own START/GO/failure to consume.
+        Assert.True(session.HasNonStartedPendingCastForSpell(10248));
+        Assert.False(session.TryPopForwardedStartCastId(10248, out _));
+    }
+
+    // Terminator symmetry for the wedge specimen itself: the orphan's failure pops its FIFO
+    // entry, so the next cast's START↔terminator pairing starts from an aligned head.
+    [Fact]
+    public void OrphanFailure_PopRestoresFifoAlignmentForNextCast()
+    {
+        var session = NewSession();
+        var orphanCastId = CastId(20733);
+        session.EnqueueForwardedStartCastId(10248, orphanCastId);
+
+        // Unmatched CAST_FAILED path: pop consumes the orphan entry.
+        Assert.True(session.TryPopForwardedStartCastId(10248, out var popped));
+        Assert.Equal(orphanCastId, popped);
+
+        // Next mining cast enqueues and pops ITS OWN CastID — no off-by-one.
+        var nextCastId = CastId(20734);
+        session.EnqueueForwardedStartCastId(10248, nextCastId);
+        Assert.True(session.TryPeekForwardedStartCastId(10248, out var peeked));
+        Assert.Equal(nextCastId, peeked);
+        Assert.True(session.TryPopForwardedStartCastId(10248, out var next));
+        Assert.Equal(nextCastId, next);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -765,6 +765,21 @@ public sealed class GameSessionData
         }
     }
 
+    // JimsProxy (fifo-terminator-symmetry): per-spell STARTED twin of the check above.
+    public bool HasStartedPendingCastForSpell(uint spellId)
+    {
+        lock (PendingCastsLock)
+        {
+            foreach (var item in PendingNormalCasts)
+            {
+                if (item.HasStarted &&
+                    (item.SpellId == spellId || (item.LegacySpellId != 0 && item.LegacySpellId == spellId)))
+                    return true;
+            }
+            return false;
+        }
+    }
+
     // JimsProxy: proxy→server RTT measurement for adaptive GCD fire offset.
     private readonly object _rttLock = new();
     private long _lastPingSendTickMs;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -654,6 +654,28 @@ public partial class WorldClient
                 }
             }
         }
+        // JimsProxy (fifo-terminator-symmetry): no pending entry at all — if the FIFO holds a
+        // forwarded START CastID, this failure is that orphan cast's terminator (its pending
+        // entry was evicted before the START arrived). POP the entry and forward the failure on
+        // the popped CastID so the client closes the bar it actually opened and the FIFO head
+        // stays aligned for later same-spell casts (the mining cast-bar-overrun wedge).
+        else if (GetSession().GameState.TryPopForwardedStartCastId(spellId, out var orphanFailCastId))
+        {
+            CastFailed orphanFailed = new();
+            orphanFailed.SpellID = spellId;
+            orphanFailed.SpellXSpellVisualID = GameData.GetSpellVisual(spellId);
+            orphanFailed.Reason = LegacyVersion.ConvertSpellCastResult(reason);
+            orphanFailed.CastID = orphanFailCastId;
+            orphanFailed.FailedArg1 = arg1;
+            orphanFailed.FailedArg2 = arg2;
+            SendPacketToClient(orphanFailed);
+            Log.Event("cast.orphan_start_failure_resolved", new
+            {
+                spell_id = spellId,
+                reason_id = reason,
+                cast_id = orphanFailCastId.ToString(),
+            });
+        }
     }
 
     [PacketHandler(Opcode.SMSG_PET_CAST_FAILED, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]
@@ -1224,6 +1246,8 @@ public partial class WorldClient
         bool dequeued = false;
         bool wasStarted = false;
         bool foundActiveCastId = false;
+        // JimsProxy (fifo-terminator-symmetry): forwarded failure CastID pinned from the FIFO front.
+        bool orphanFifoPinned = false;
 
         // JimsProxy: Twinstar's Spell::SendInterrupted hardcodes the wire reason
         // byte to vanilla 0 (= classic AffectingCombat=1 after translation). For
@@ -1384,6 +1408,15 @@ public partial class WorldClient
                 castId = petCastId;
                 foundActiveCastId = true;
             }
+            // JimsProxy (fifo-terminator-symmetry): local-player failure with no pending entry —
+            // PEEK the FIFO (the trailing CAST_FAILED pops) so the forwarded failure carries the
+            // orphan START's CastID the client is actually tracking, not a re-minted seed.
+            else if (casterIsLocalPlayer &&
+                     GetSession().GameState.TryPeekForwardedStartCastId(spellId, out var orphanStartCastId))
+            {
+                castId = orphanStartCastId;
+                orphanFifoPinned = true;
+            }
             else
                 castId = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId!, spellId, spellId + casterUnit.GetCounter());
             spellVisual = GameData.GetSpellVisual(spellId);
@@ -1400,6 +1433,7 @@ public partial class WorldClient
                     spell_id = spellId,
                     reason,
                     pending_queue_depth = GetSession().GameState.PendingNormalCasts.Count,
+                    fifo_pinned = orphanFifoPinned,
                 });
         }
 
@@ -2122,8 +2156,24 @@ public partial class WorldClient
             GetSession().HealCommBridge.OnLocalPlayerSpellCompleted((uint)spell.Cast.SpellID);
         }
 
-        // Dequeue completed cast (queue-based, FIFO order)
+        // JimsProxy (fifo-terminator-symmetry): a FIFO entry with NO started pending cast but a
+        // fresh UNSTARTED press queued means this GO completes the orphan START (one in-flight
+        // started cast per player), not the press — stamp it from the FIFO and leave the press
+        // pending for its own terminator instead of letting the dequeue below steal its entry.
         if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
+            GetSession().GameState.HasNonStartedPendingCastForSpell((uint)spell.Cast.SpellID) &&
+            !GetSession().GameState.HasStartedPendingCastForSpell((uint)spell.Cast.SpellID) &&
+            GetSession().GameState.TryPopForwardedStartCastId((uint)spell.Cast.SpellID, out var orphanGoCastId))
+        {
+            spell.Cast.CastID = orphanGoCastId;
+            Log.Event("cast.go.orphan_castid_recovered", new
+            {
+                spell_id = spell.Cast.SpellID,
+                recovered_cast_id = orphanGoCastId.ToString(),
+            });
+        }
+        // Dequeue completed cast (queue-based, FIFO order)
+        else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.TryDequeuePendingNormalCast((uint)spell.Cast.SpellID, out var pendingCast))
         {
             spell.Cast.CastID = pendingCast!.ServerGUID;


### PR DESCRIPTION
## Symptom

Mining (10248, 3.2s cast) bar kept running past the loot window on **every** node, session-wide, until a proxy restart. Wire was byte-clean throughout. Root-caused from `jimsproxy-20260820-191703.jsonl` (handoff: `MIRASU-MINING-CASTBAR-FIFO-WEDGE-20260820.md`, your §6 reply).

## Root cause

An orphan `SPELL_START` — the pending entry died in the `cast.destroy_eviction` race before its START arrived (~150ms) — still enqueues its forwarded CastID via `EnqueueForwardedStartCastId` (by design; the FIFO is the recovery store for exactly these no-pending STARTs). But its terminator took the **unmatched** paths, none of which touch the FIFO: every consumer (`TryPopForwardedStartCastId` in `HandleCastFailed` / `HandleSpellGo`, the watchdog remove-by-value, the parse-failure drain) sits behind a pending-entry match the orphan no longer has. The entry is immortal; every later same-spell cast pops the **previous** cast's CastID; GO arrives mispaired; the 1.14 client never closes the bar. `ClearForwardedStartCastIds` only runs on reconnect/transfer, so it never self-heals in-session — and it manufactures the exact stuck-cast / looping-visual class we're screening for in the A/B week.

## Fix — terminator symmetry on the three unmatched paths

*Every enqueue has exactly one consuming terminator, matched or not*, mirroring what the matched paths already do:

1. **Unmatched local CAST_FAILED** (`HandleCastFailed`, new trailing `else if`): pop the FIFO and forward the failure on the popped CastID — consumes the orphan entry and closes the bar the client actually opened. Safe by construction: transient dup-rejections early-return above (they never own FIFO entries), so only a real failure with zero pending entries reaches the pop. Marker: `cast.orphan_start_failure_resolved`.
2. **Unmatched local SPELL_FAILURE** (`HandleSpellFailure` else-branch): peek the FIFO for the forwarded CastID instead of re-minting the deterministic seed; the trailing CAST_FAILED still pops — same peek/pop pairing as the matched path. The `cast.unmatched_failure_forwarded` screening marker stays alive, now carrying `fifo_pinned`.
3. **GO-side stolen-dequeue guard** (`HandleSpellGo`, before the matched dequeue): a FIFO entry with an **unstarted** press pending and **no started** pending cast means the GO completes the orphan (one in-flight started cast per player; the press's own GO can't precede its START on the ordered stream) — stamp the GO from the FIFO and leave the press's entry for its own terminator, instead of the dequeue stealing it (which both mispairs this GO and re-arms the wedge). Uses a new `HasStartedPendingCastForSpell` twin of the existing non-started check. Marker: `cast.go.orphan_castid_recovered`.

## Correction to my handoff

The "sibling GO-side leak" as I described it was wrong — the unmatched-GO recovery pop already exists (the `cast.go.castid_recovered` else-branch), so the pure no-pending server-initiated START+GO pair was already balanced. The real residual GO edge is the stolen-dequeue case above (orphan completes while a fresh same-spell press sits queued — e.g. re-pressing the node after the eviction race when the cast completes instead of interrupting). Flagging it since you said you'd verify that pairing in review.

## Scope

Independent of #488, the refire question, and your dup-CAST_FAILED frame-hold (different machinery: CastID pairing vs failure delivery — your hold defers sends and never dequeues, so the only interaction is textual adjacency in `HandleCastFailed`).

Build 0 errors; suite **939/939** on the beta base (935 + 4 new in `ForwardedStartFifoSymmetryTests` pinning the orphan-GO precondition set and the pop-realignment sequence from the specimen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQLjJBWwo8CAniARNUkBvm
