### PR TITLE
README: fix three glaring errors (typo, stale test count, unpasteable publish command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JimsProxy
 
-A maintained fork of [HermesProxy](https://github.com/WowLegacyCore/HermesProxy) — a protocol translation proxy that lets WoW Classic 1.14.2 clients connect to vanilla 1.12.1 server. Primary target: [Kronos](https://www.kronos-wow.com/).
+A maintained fork of [HermesProxy](https://github.com/WowLegacyCore/HermesProxy) — a protocol translation proxy that lets WoW Classic 1.14.2 clients connect to vanilla 1.12.1 servers. Primary target: [Kronos](https://www.kronos-wow.com/).
 
 The upstream HermesProxy project was [archived in November 2024](https://github.com/WowLegacyCore/HermesProxy). JimsProxy is rebased onto [Xian55's fork](https://github.com/Xian55/HermesProxy) (April 2026) for 18 months of community fixes, then adds Kronos-specific translation fixes and diagnostic tooling on top.
 
@@ -66,15 +66,11 @@ cd jimsproxy
 # Build
 dotnet build HermesProxy
 
-# Run tests (320 tests)
+# Run tests
 dotnet test
 
 # Publish (self-contained single-file exe + CSV data)
-dotnet publish HermesProxy \
-  --configuration Release \
-  --use-current-runtime \
-  -p:UsePublishBuildSettings=true \
-  -o build/
+dotnet publish HermesProxy --configuration Release --use-current-runtime -p:UsePublishBuildSettings=true -o build/
 ```
 
 Output: `build/JimsProxy.exe` + `build/CSV/` + `build/HermesProxy.config`


### PR DESCRIPTION
Error fixes to the existing README only — no rewrite, no new content.

1. **Typo:** "connect to vanilla 1.12.1 server" → "servers"
2. **Stale claim:** "# Run tests (320 tests)" → "# Run tests" — the count was wrong by a wide margin; removed rather than replaced with a number that rots again
3. **Broken command:** the `dotnet publish` block used bash line-continuations (`\`) that cannot be pasted into PowerShell — collapsed to one line, flags unchanged

Scope (2026-08-23): only glaring errors/typos/mistakes in current documentation ship now; the fuller documentation pass is parked for an unrushed round.
