### PR TITLE
README: fix two remaining factual errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [CHANGES.md](CHANGES.md) for the full changelog.
 
 ## Configuration
 
-The proxy reads `HermesProxy.config` (XML format) from the working directory. The JimsProxy Launcher manages this automatically.
+The proxy reads `HermesProxy.config` (XML format) from the folder containing the executable — it switches its working directory there at startup, so it does not matter where you launch it from. The JimsProxy Launcher manages this automatically.
 
 For advanced use, CLI arguments override config values:
 
@@ -77,9 +77,9 @@ Output: `build/JimsProxy.exe` + `build/CSV/` + `build/HermesProxy.config`
 
 To test locally, copy the build output to your game's `Hermes/` directory:
 
-```bash
-cp build/JimsProxy.exe <game_dir>/Hermes/JimsProxy.exe
-cp -r build/CSV/* <game_dir>/Hermes/CSV/
+```
+copy build\JimsProxy.exe <game_dir>\Hermes\JimsProxy.exe
+xcopy /E /Y build\CSV <game_dir>\Hermes\CSV\
 ```
 
 .NET 6 will not work — the target framework is `net10.0` (set centrally in `Directory.Packages.props`).


### PR DESCRIPTION
Follow-up to #499 — same class of defect, **no new content**. Two lines changed.

## 1. The config-location claim was wrong

```diff
-The proxy reads `HermesProxy.config` (XML format) from the working directory.
+The proxy reads `HermesProxy.config` (XML format) from the folder containing the
+executable — it switches its working directory there at startup, so it does not
+matter where you launch it from.
```

`Server.cs:77-84` re-homes `Environment.CurrentDirectory` to `AppContext.BaseDirectory` **before** the config is parsed at `Server.cs:86`:

```csharp
if (Environment.CurrentDirectory != Path.GetDirectoryName(AppContext.BaseDirectory))
{
    Log.Print(LogType.Storage, "Switching working directory");
    Environment.CurrentDirectory = Path.GetDirectoryName(AppContext.BaseDirectory)!;
}
```

So `HermesProxy.config`, `CSV/`, `Logs/` and `AccountData/` always resolve **beside the executable**, whatever directory you launch from. "Working directory" is precisely backwards for the reader most likely to depend on that sentence — someone running the proxy by hand from somewhere else.

## 2. Bash commands on a Windows-only product

```diff
-```bash
-cp build/JimsProxy.exe <game_dir>/Hermes/JimsProxy.exe
-cp -r build/CSV/* <game_dir>/Hermes/CSV/
+```
+copy build\JimsProxy.exe <game_dir>\Hermes\JimsProxy.exe
+xcopy /E /Y build\CSV <game_dir>\Hermes\CSV\
```

Exactly the defect #499 fixed for the publish command, one section further down. Also dropped the `bash` fence, which was the thing advertising it as pasteable.

## Scope

Deliberately **nothing else**. The `Hermes/` directory referenced here is a launcher convention the README never defines, and `--metrics` is missing from the CLI list — both are *missing information* rather than errors, so they wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jMDMjkwau6a35jGViz5SL
