### PR TITLE
Re-emit pre-create enchant time pushes after the item create (temp-enchant 0s, round 2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,40 @@ A fork of [WowLegacyCore/HermesProxy](https://github.com/WowLegacyCore/HermesPro
 
 ---
 
+## 2026-08-28 — Re-emit pre-create enchant time pushes after the item create (temp-enchant 0s, round 2)
+
+**Issue:** the sharpening-stone "flashing 0s" buff recurred on 5.2.1-beta.1
+(`jimsproxy-20260828-104459.jsonl`) despite the 2026-08-14 stash-and-inject fix (#473). Decoding
+the modern .pkt (`modern_42597_1787939107.pkt`) disproved #473's mechanism: the client's
+weapon-buff countdown is driven **only** by `SMSG_ITEM_ENCHANT_TIME_UPDATE` — the create block's
+enchantment duration field is a stale save-time snapshot that no client generation reads for the
+timer (the bad login's create carried 1,440,292 ms ≈ 24 min in the field and the client still
+rendered flashing 0s). #473's inject never fired in any field log; every "working" login worked
+because Kronos happens to send the push 1–5× per login and one usually lands after the creates.
+The 10:45 login got exactly one push, pre-create — the stash swallowed it and the client never
+received any enchant timer. This matches server canon: cmangos-classic, vmangos, and TrinityCore
+master all send enchant durations from `SendInitialPacketsAfterAddToMap` with the comment
+"must be after add to map" — the post-create requirement is client-imposed and predates 1.14.
+
+**Change:** `World/Client/PacketHandlers/UpdateHandler.cs` — the item-create consume site no
+longer writes the create's duration field; it arms a re-emit
+(`GameSessionData.ArmEnchantTimeReemit`), and `HandleUpdateObject` flushes armed re-emits as
+modern `ItemEnchantTimeUpdate` packets (whole seconds, matching canon `leftduration / 1000`)
+right after the update packet carrying the create — replicating the servers' own ordering at the
+proxy layer. `GlobalSessionData.cs` — `PendingEnchantTimeReemits` + arm/take (grab-and-clear;
+sub-second remainders dropped: 0 is both the broken display value and the client's removal
+signal). Removed the now-dead `ShouldInjectEnchantDuration` gate. The pre-create stash, decay
+tracking, and the forward path for post-create pushes are unchanged. Diags (DebugOutput-gated):
+`enchant.duration.reemitted_post_create` joins `enchant.duration.stashed_precreate`.
+
+**Verification:** red-first — 6 new arm/take tests failed on throwing stubs, green after
+implementation; suite 962/962. Field gate: relogin with an active stone on a login where Kronos's
+only push lands pre-create → expect `stashed_precreate` + `reemitted_post_create` and a real
+countdown (per-login coin flip on Kronos's send pattern, may need several relogs; any login
+showing stash events without a wrong display is a pass for that login).
+
+---
+
 ## 2026-08-22 — Repair the Release workflow (Windows-only) so releases carry assets
 
 **Issue:** `.github/workflows/Release.yml` already builds and attaches packaged binaries plus

--- a/HermesProxy.Tests/World/ItemEnchantDurationStashTests.cs
+++ b/HermesProxy.Tests/World/ItemEnchantDurationStashTests.cs
@@ -7,14 +7,16 @@ using Xunit;
 
 namespace HermesProxy.Tests.World;
 
-// JimsProxy (temp-enchant-0s-after-relogin): at login vanilla cores send
+// JimsProxy (temp-enchant-0s-after-relogin): Kronos can send
 // SMSG_ITEM_ENCHANT_TIME_UPDATE — the only carrier of a temp enchant's remaining
-// time — BEFORE the item's create block (2026-08-14 logs: both logins pre-create,
-// one pre-login-verify). The 1.14 client discards updates for guids it has not
-// constructed, and the create's enchantment duration field is zero, so the buff
-// renders as a permanently flashing "0s". The handler stashes the push in
-// GameSessionData and the item-create translation consumes it into the create
-// block's duration field, decayed by the time it spent stashed.
+// time that the client's weapon-buff countdown reads — BEFORE the item's create
+// block (2026-08-14 and 2026-08-28 logs). The client discards the push for a guid
+// it has not constructed, and the create's enchantment duration field is a stale
+// save-time snapshot no client generation uses for the timer, so the buff renders
+// as a permanently flashing "0s". The handler stashes the pre-create push in
+// GameSessionData (decay-tracked); the item-create translation arms a re-emit,
+// which HandleUpdateObject sends AFTER the create's packet has gone out — the
+// proxy-layer equivalent of the servers' "must be after add to map" ordering.
 public class ItemEnchantDurationStashTests
 {
     private static WowGuid128 Item(ulong counter) =>
@@ -153,26 +155,94 @@ public class ItemEnchantDurationStashTests
         Assert.Null(state.ConsumePendingItemEnchantDurations(guid, nowTick: 100_000));
     }
 
-    // --- injection gate ---
+    // --- post-create re-emit ---
 
-    // Inject only where the create shows a live enchant whose duration the server
-    // left empty (vanilla's login shape). A real duration in the field wins.
-    [Theory]
-    [InlineData(2504, null, true)]   // enchant ID, no duration field → the bug shape, inject
-    [InlineData(2504, 0u, true)]     // explicit zero duration → inject
-    [InlineData(2504, 1_800_000u, false)] // server provided a real duration → keep it
-    [InlineData(0, null, false)]     // no enchant in the slot → nothing to time
-    public void ShouldInjectEnchantDuration_GateShapes(int enchantId, uint? duration, bool expected)
+    // 2026-08-28 model correction (.pkt-proven): the client's weapon-buff timer is
+    // driven ONLY by SMSG_ITEM_ENCHANT_TIME_UPDATE — the create block's enchantment
+    // duration field is a stale save-time snapshot that no client generation reads
+    // for the countdown (every mangos-lineage core ships the stale field AND sends
+    // the packet from SendInitialPacketsAfterAddToMap: "must be after add to map").
+    // So the consume site arms a re-emit, and HandleUpdateObject flushes it to the
+    // client AFTER the update packet carrying the item's create has gone out —
+    // replicating canon server ordering at the proxy layer.
+
+    [Fact]
+    public void ArmEnchantTimeReemit_ThenTake_ReturnsSecondsFromMs()
     {
-        var enchantment = new ItemEnchantment { ID = enchantId, Duration = duration };
+        var state = GameSessionData.CreateForTesting();
+        var guid = Item(61878924); // the MH weapon low from jimsproxy-20260828-104459.jsonl
 
-        Assert.Equal(expected, GameSessionData.ShouldInjectEnchantDuration(enchantment));
+        state.ArmEnchantTimeReemit(guid, TempSlot, durationMs: 1_304_000);
+        var reemits = state.TakeEnchantTimeReemits();
+
+        Assert.NotNull(reemits);
+        var entry = Assert.Single(reemits);
+        Assert.Equal(guid, entry.ItemGuid);
+        Assert.Equal(TempSlot, entry.ModernSlot);
+        Assert.Equal(1304u, entry.DurationSeconds);
+    }
+
+    // Canon wire unit is whole seconds (leftduration / 1000) — truncate, don't round.
+    [Fact]
+    public void ArmEnchantTimeReemit_SubSecondRemainder_TruncatesToWholeSeconds()
+    {
+        var state = GameSessionData.CreateForTesting();
+
+        state.ArmEnchantTimeReemit(Item(1), TempSlot, durationMs: 1_999);
+        var reemits = state.TakeEnchantTimeReemits();
+
+        Assert.Equal(1u, Assert.Single(reemits!).DurationSeconds);
+    }
+
+    // A sub-second remainder would truncate to 0 — the exact broken display value,
+    // and 0 doubles as the client's removal signal. Never emit it; the enchant is
+    // about to expire server-side anyway.
+    [Fact]
+    public void ArmEnchantTimeReemit_UnderOneSecond_NotArmed()
+    {
+        var state = GameSessionData.CreateForTesting();
+
+        state.ArmEnchantTimeReemit(Item(1), TempSlot, durationMs: 999);
+
+        Assert.Null(state.TakeEnchantTimeReemits());
+    }
+
+    // Take is grab-and-clear: the flush at the end of one HandleUpdateObject must
+    // not replay into the next update packet.
+    [Fact]
+    public void TakeEnchantTimeReemits_SecondTake_ReturnsNull()
+    {
+        var state = GameSessionData.CreateForTesting();
+
+        state.ArmEnchantTimeReemit(Item(1), TempSlot, durationMs: 60_000);
+        state.TakeEnchantTimeReemits();
+
+        Assert.Null(state.TakeEnchantTimeReemits());
     }
 
     [Fact]
-    public void ShouldInjectEnchantDuration_NullEntry_False()
+    public void TakeEnchantTimeReemits_NothingArmed_ReturnsNull()
     {
-        Assert.False(GameSessionData.ShouldInjectEnchantDuration(null));
+        var state = GameSessionData.CreateForTesting();
+
+        Assert.Null(state.TakeEnchantTimeReemits());
+    }
+
+    // Both weapons stoned in one login update: both arms survive to the flush.
+    [Fact]
+    public void ArmEnchantTimeReemit_MultipleItems_AllReturnedInOrder()
+    {
+        var state = GameSessionData.CreateForTesting();
+
+        state.ArmEnchantTimeReemit(Item(1), TempSlot, durationMs: 600_000);
+        state.ArmEnchantTimeReemit(Item(2), TempSlot, durationMs: 300_000);
+        var reemits = state.TakeEnchantTimeReemits();
+
+        Assert.Equal(2, reemits!.Count);
+        Assert.Equal(Item(1), reemits[0].ItemGuid);
+        Assert.Equal(600u, reemits[0].DurationSeconds);
+        Assert.Equal(Item(2), reemits[1].ItemGuid);
+        Assert.Equal(300u, reemits[1].DurationSeconds);
     }
 
     // --- slot translation (vanilla server pinned by TestEnvironmentInitializer) ---

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1140,12 +1140,20 @@ public sealed class GameSessionData
     public Dictionary<WowGuid128, Dictionary<byte, int>> UnitAuraDurationPushTime = [];
     // JimsProxy (temp-enchant-0s-after-relogin): remaining-time pushes from
     // SMSG_ITEM_ENCHANT_TIME_UPDATE, keyed item guid → (legacy enchantment slot →
-    // seconds + receipt tick). At login vanilla cores send the push BEFORE the item's
-    // create block (the only carrier of remaining time — the create's duration field is
-    // zero), and the modern client discards updates for guids it has not constructed.
-    // The push is stashed here and consumed into the item's create block when it is
-    // translated. Not carried across sessions: each login gets fresh pushes.
+    // seconds + receipt tick). Kronos can send the push BEFORE the item's create
+    // block (the only carrier the client's weapon-buff timer reads — the create's
+    // duration field is a stale save-time snapshot no client uses for the countdown),
+    // and the client discards it for guids it has not constructed ("must be after
+    // add to map" in every mangos-lineage core). The push is stashed here when it
+    // arrives pre-create and re-emitted (PendingEnchantTimeReemits) once the item's
+    // create has been forwarded. Not carried across sessions: each login gets fresh
+    // pushes.
     public Dictionary<WowGuid128, Dictionary<uint, (uint Seconds, int Tick)>> PendingItemEnchantDurations = [];
+    // Re-emits armed while an item create block is being translated (stash consumed),
+    // flushed by HandleUpdateObject AFTER the update packet carrying the create has
+    // been sent to the client — the proxy-layer equivalent of the servers' own
+    // SendEnchantmentDurations-after-add-to-map ordering.
+    public List<(WowGuid128 ItemGuid, uint ModernSlot, uint DurationSeconds)>? PendingEnchantTimeReemits;
     public Dictionary<WowGuid128, Dictionary<byte, WowGuid128>> UnitAuraCaster = [];
     // Wall-clock aura expiry per (unit, spell). Unlike the per-slot caches above this
     // survives unit destroys AND relogs (carried over in CreateNewGameSessionData), so a
@@ -1894,11 +1902,23 @@ public sealed class GameSessionData
         }
         return result.Count > 0 ? result : null;
     }
-    // Inject only where the create shows a live enchant whose duration field the
-    // server left empty (vanilla's login shape); a server-provided duration wins.
-    public static bool ShouldInjectEnchantDuration(HermesProxy.World.Objects.ItemEnchantment? enchantment)
+    // Sub-second remainders are dropped: they truncate to 0, which is both the
+    // broken display value and the client's removal signal — and the server's own
+    // expiry is due within the second anyway.
+    public void ArmEnchantTimeReemit(WowGuid128 itemGuid, uint modernSlot, uint durationMs)
     {
-        return enchantment is { ID: > 0 } && (enchantment.Duration == null || enchantment.Duration == 0);
+        uint durationSeconds = durationMs / 1000;
+        if (durationSeconds == 0)
+            return;
+
+        PendingEnchantTimeReemits ??= [];
+        PendingEnchantTimeReemits.Add((itemGuid, modernSlot, durationSeconds));
+    }
+    public List<(WowGuid128 ItemGuid, uint ModernSlot, uint DurationSeconds)>? TakeEnchantTimeReemits()
+    {
+        var reemits = PendingEnchantTimeReemits;
+        PendingEnchantTimeReemits = null;
+        return reemits;
     }
     public void StoreAuraCaster(WowGuid128 target, byte slot, WowGuid128 caster)
     {

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -457,14 +457,17 @@ public partial class WorldClient
         enchant.DurationLeft = packet.ReadUInt32();
         enchant.OwnerGuid = packet.ReadGuid().To128(GetSession().GameState);
 
-        // (temp-enchant-0s-after-relogin): at login vanilla cores push this BEFORE the
-        // item's create block — it is the only carrier of the enchant's remaining time
-        // (the create's duration field is zero) and the modern client discards updates
-        // for guids it has not constructed, leaving the buff flashing a permanent "0s".
-        // Stash pre-create pushes only; the item-create translation consumes them into
-        // the create's duration field. Forward when the item already exists client-side —
-        // the forward path never needs the stash, and storing there would leave a
-        // never-consumed entry per enchanted item until logout.
+        // (temp-enchant-0s-after-relogin): Kronos can push this BEFORE the item's
+        // create block — it is the only carrier of the enchant's remaining time the
+        // client's weapon-buff timer reads (the create's duration field is a stale
+        // save-time snapshot no client generation uses for the countdown), and the
+        // client discards it for guids it has not constructed, leaving the buff
+        // flashing a permanent "0s". Stash pre-create pushes only; the item-create
+        // translation re-emits them to the client after the create is forwarded
+        // ("must be after add to map", per every mangos-lineage core). Forward when
+        // the item already exists client-side — the forward path never needs the
+        // stash, and storing there would leave a never-consumed entry per enchanted
+        // item until logout.
         if (GetSession().GameState.GetCachedObjectFieldsLegacy(enchant.ItemGuid) == null)
         {
             GetSession().GameState.StorePendingItemEnchantDuration(enchant.ItemGuid, legacySlot, enchant.DurationLeft, Environment.TickCount);

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -652,6 +652,33 @@ public partial class WorldClient
         foreach (var auraUpdate in auraUpdates)
             SendPacketToClient(auraUpdate);
 
+        // (temp-enchant-0s-after-relogin): deliver enchant timers whose server push
+        // beat the item's create — the client dropped (or would have dropped) the
+        // original, so re-emit now that the create is out. Seconds on the wire,
+        // matching SendItemEnchantTimeUpdate in every mangos-lineage core.
+        var enchantReemits = GetSession().GameState.TakeEnchantTimeReemits();
+        if (enchantReemits != null)
+        {
+            foreach (var (itemGuid, modernSlot, durationSeconds) in enchantReemits)
+            {
+                ItemEnchantTimeUpdate enchant = new ItemEnchantTimeUpdate();
+                enchant.ItemGuid = itemGuid;
+                enchant.DurationLeft = durationSeconds;
+                enchant.Slot = modernSlot;
+                enchant.OwnerGuid = GetSession().GameState.CurrentPlayerGuid;
+                SendPacketToClient(enchant);
+                if (Settings.DebugOutput)
+                {
+                    Log.Event("enchant.duration.reemitted_post_create", new
+                    {
+                        item_guid = itemGuid.ToString(),
+                        modern_slot = modernSlot,
+                        duration_seconds = durationSeconds,
+                    });
+                }
+            }
+        }
+
         // JimsProxy (camp stun lock, step 2): this update carried the login's first
         // self create block (marked in DetectStuckLogoutStunAtSelfCreate) — release
         // any control ops held from before it, in arrival order, now that the create
@@ -2627,37 +2654,23 @@ public partial class WorldClient
                     updateData.ItemData.Enchantment[Enums.Classic.EnchantmentSlot.Prop4] = ReadEnchantData(Enums.WotLK.EnchantmentSlot.Prop4);
                 }
 
-                // (temp-enchant-0s-after-relogin): consume stashed pre-create
-                // SMSG_ITEM_ENCHANT_TIME_UPDATE pushes into this create. At login the
-                // push beats the item's create block and the modern client discards it
-                // for an unbuilt guid — the enchant then renders with the create's zero
-                // duration field as a permanently flashing "0s" buff. The handler
-                // stashed the push (decay-tracked); write it into the create's duration
-                // field so the countdown starts at the real remaining time.
+                // (temp-enchant-0s-after-relogin): a stashed pre-create
+                // SMSG_ITEM_ENCHANT_TIME_UPDATE means this item's enchant timer never
+                // reached the client — it discards the push for an unbuilt guid, and
+                // that push is the ONLY carrier the weapon-buff countdown reads (the
+                // create's duration field is a stale save-time snapshot no client
+                // generation uses for the timer; .pkt-proven 2026-08-28: a create
+                // carrying 24min in the field still rendered flashing "0s"). Arm a
+                // re-emit here; HandleUpdateObject flushes it AFTER this create's
+                // packet is sent — the same "must be after add to map" ordering every
+                // mangos-lineage core enforces server-side.
                 if (isCreate)
                 {
                     var pendingEnchants = GetSession().GameState.ConsumePendingItemEnchantDurations(guid, Environment.TickCount);
                     if (pendingEnchants != null)
                     {
                         foreach (var (legacySlot, durationMs) in pendingEnchants)
-                        {
-                            int modernSlot = (int)TranslateEnchantmentSlotToModern(legacySlot);
-                            if (modernSlot >= updateData.ItemData.Enchantment.Length)
-                                continue;
-                            var enchantment = updateData.ItemData.Enchantment[modernSlot];
-                            if (enchantment == null || !GameSessionData.ShouldInjectEnchantDuration(enchantment))
-                                continue;
-                            enchantment.Duration = durationMs;
-                            if (Framework.Settings.DebugOutput)
-                            {
-                                Log.Event("enchant.duration.injected_at_create", new
-                                {
-                                    item_guid = guid.ToString(),
-                                    legacy_slot = legacySlot,
-                                    duration_ms = durationMs,
-                                });
-                            }
-                        }
+                            GetSession().GameState.ArmEnchantTimeReemit(guid, TranslateEnchantmentSlotToModern(legacySlot), durationMs);
                     }
                 }
 


### PR DESCRIPTION
Fixes the 2026-08-28 recurrence of #472. Supersedes the inject half of #473 (its stash, decay tracking, and forward-path slot mapping remain).

## Problem

The #472 symptom came back on 5.2.1-beta.1: relogin with an active sharpening stone, weapon buff stuck at a **permanently flashing "0s"** (`jimsproxy-20260828-104459.jsonl`). The #473 fix was in the build and its stash half ran (`enchant.duration.stashed_precreate`, 1304s) — but `injected_at_create` never fired, and a log sweep showed it has **never fired in any session on record**. Every "working" login since 08-14 worked by luck, not by #473.

## Root cause — #473's mechanism disproven at the wire

Decoding the modern `.pkt` for the bad login (`modern_42597_1787939107.pkt`) produced a natural experiment #472's original analysis never had:

- The weapon's create block we sent the client carried Temp enchant 1643 with a **nonzero** duration field — 1,440,292 ms (~24 min, a stale save-time snapshot from Kronos's DB, ~2 min before the relogin). `ShouldInjectEnchantDuration` refused by design ("server-provided duration wins") — silently — and the stash was dropped.
- Kronos sent `SMSG_ITEM_ENCHANT_TIME_UPDATE` **exactly once** that login, pre-create. The stash path swallowed it, so the client received **no enchant-time packet at all** (whole-session `.pkt` scan: zero 0x274C sent).
- The client displayed flashing 0s anyway — despite 24 minutes sitting in the field.

Conclusion: **the client's weapon-buff countdown reads only `SMSG_ITEM_ENCHANT_TIME_UPDATE`; the create's enchantment duration field is not a timer source for any client generation.** This is server canon, not a 1.14 quirk: cmangos-classic, vmangos, and TrinityCore master all ship the stale save-time value in the field (`Item::LoadFromDB` → `ITEM_FIELD_ENCHANTMENT`) and all send enchant durations from `SendInitialPacketsAfterAddToMap` with the same ancient comment — `// must be after add to map`. The comment lives in the *1.12* cores: the post-create delivery requirement was discovered on the 1.12 client twenty years ago. Reference servers never hit the bug because they send once, always post-create; Kronos sprays the push 1–5× per login at variable times, and the bug bites on the rare login where every copy (here: the only copy) lands pre-create.

#472's original "the field is zero at login" observation was one Kronos shape, not the rule, and "live re-apply proves the field path works" was confounded — the apply-time push forwarded alongside it is what drove that display.

## Fix

Replicate the servers' own ordering at the proxy layer: **deliver the withheld packet after the item exists client-side.**

1. The item-create consume site (`UpdateHandler`, item-fields section) no longer writes the create's duration field. It arms a re-emit via `GameSessionData.ArmEnchantTimeReemit(guid, modernSlot, decayedMs)`.
2. `HandleUpdateObject` flushes armed re-emits (`TakeEnchantTimeReemits`, grab-and-clear) **after** `SendPacketToClient(updateObject)` — alongside the existing post-create-send hooks (`PreCreateOpHold` release, Chronoboon repaint) — as modern `ItemEnchantTimeUpdate` packets: whole seconds (canon `leftduration / 1000`), owner = current player.
3. Sub-second remainders are dropped: they truncate to 0, which is both the broken display value and the client's removal signal, and the server's own expiry lands within the second.
4. `ShouldInjectEnchantDuration` is removed as dead code. The stale server field passes through untouched — exactly what canon servers ship to their own clients.

Unchanged: the pre-create stash and its decay/skew safety, zero-duration filtering, latest-push-wins refresh, the known-object forward gate, and the version-mapped slot index on the forward path. Still no timers anywhere — deterministic packet-pairing (push ↔ its item's create ↔ the flush of that create's packet).

## Diagnostics

`enchant.duration.reemitted_post_create` (DebugOutput-gated) joins the existing `stashed_precreate`. The never-observed `injected_at_create` is gone with the inject.

## Testing

- **Red-first**: 6 new arm/take tests failed on throwing stubs (NotImplementedException), green on the implementation. Coverage: ms→s conversion, truncation, sub-second drop, grab-and-clear, empty take, multi-item ordering.
- Inject-gate tests removed with the gate; stash/decay/slot-translation tests untouched and green.
- Full suite: **962/962**.

## Field verification (done, 2026-08-28)

Deployed build, 6-hour session (`jimsproxy-20260828-130537.jsonl` + `.pkt`): the fix fired at two logins — two pre-create pushes stashed at each, one re-emit each (1643s / 1638s, slot 1), `.pkt`-confirmed delivered to the client post-create, countdown correct all session. Accounting balances: 8 pushes in = 4 stashed (→ 2 re-emits) + 4 forwarded (2 post-create at login, 2 mid-session refreshes). Caveat noted for honesty: both exercised logins also received a post-create Kronos copy, so the single-push shape that bit on 08-28 hasn't recurred yet — but the re-emit is byte-shaped identically to the forwarded packets that have always produced correct timers.

## Risk

- The re-emit sends a packet the legacy server genuinely sent and the client provably ignored — same values, corrected ordering. Where Kronos also lands a post-create copy, the client just gets the same seconds twice.
- Dropping the field-inject changes nothing observable: it never fired in any recorded session, and the field it wrote is not read for the timer.
- Bank-parked enchanted items keep their late-create handling: the stash decays while waiting, and the re-emit pairs to the bank-open create's own packet flush.
