### PR TITLE
Cure the post-Charge stuck-strafe latch (orphaned pending-strafe flag) with a force ROOT+UNROOT pulse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,44 @@ A fork of [WowLegacyCore/HermesProxy](https://github.com/WowLegacyCore/HermesPro
 
 ---
 
+## 2026-08-29 — Cure the post-Charge stuck-strafe latch (orphaned pending-strafe flag)
+
+**Issue:** after a Charge the character sometimes came out of the spline stuck strafing —
+transmitted in every movement packet, so server-visible — until a strafe key was pressed;
+forward, backward and turn keys could not clear it. Wire-proven mechanism (.pkt movement-flag
+decode over 4 sessions / 83 charges): the 1.14.2 client queues a strafe key pressed mid-air
+during a forward-held jump as `PendingStrafeLeft/Right` instead of applying it; when the Charge
+spline hijacks the fall, the key release mid-spline is swallowed without clearing the pend, and
+the spline-exit landing applies the stale pend as a real strafe flag with no key behind it. A
+pending strafe start in the `CMSG_MOVE_CHANGE_TRANSPORT` the client emits at charge GO appeared
+on exactly the latching charges (3/3 field latches + 2/2 deliberate reproductions).
+
+**Change:** `World/Client/ChargePendLatchCure.cs` (new, pure decision logic): arm predicate
+(pending strafe starts only), fire predicate (armed pend's real bit set with the pend bit gone,
+i.e. the orphan observed), 3 s arm TTL, synth counters 0xFFFFFF03/04 inside the established
+`IsSynthCounter` swallow range. `Server/PacketHandlers/MovementHandler.cs`: arm inside the
+existing CHANGE_TRANSPORT drop (`pend_latch_armed` added to that always-on event for wild
+frequency); fire at the top of `HandlePlayerMove` on the first client packet showing the pend
+applied — a synthetic SMSG_MOVE_ROOT + SMSG_MOVE_UNROOT pulse to the client (corpus-proven: a
+force-root wipes all client movement flags and makes the client emit the matching stop opcodes,
+which forward and correct the server's view too; a force-unroot rebuilds flags from physical
+key state, so a genuinely held key resumes same-frame — safe in both worlds); dedicated ack
+branch in `HandleMoveForceAck2` swallows both acks. `Client/PacketHandlers/MovementHandler.cs`:
+a real self force-root between arm and fire disarms. Kronos's charge-bracketing spline
+root/unroot addresses the charge TARGET, never the charging player, so no server anchor exists
+and the cure fires on the orphan's own appearance. Config kill switch `ChargePendLatchCure`
+(default true) gates the pulse only. Diagnostics `charge.pend_latch.cure_sent` /
+`charge.pend_latch.cure_acked` are DebugOutput-gated (review 2026-09-05).
+
+**Verification:** 24 unit tests (`ChargePendLatchCureTests`) pin the arm/fire predicates
+against the verbatim wire shapes of every specimen plus the counter-range invariants (cure acks
+can never reach the legacy server); suite 985/985. Field-verified 2026-08-29, 5 recipe attempts:
+2 armed → 2 cures → 0 latches, both ROOT acks returned `client_flags=Root` only (the orphaned
+strafe wiped), same-frame ROOT→UNROOT applied in order, cure within ~100 ms of touchdown, no
+false-positive fires anywhere in the session.
+
+---
+
 ## 2026-08-28 — Re-emit pre-create enchant time pushes after the item create (temp-enchant 0s, round 2)
 
 **Issue:** the sharpening-stone "flashing 0s" buff recurred on 5.2.1-beta.1

--- a/HermesProxy.Tests/World/ChargePendLatchCureTests.cs
+++ b/HermesProxy.Tests/World/ChargePendLatchCureTests.cs
@@ -1,0 +1,178 @@
+using HermesProxy.World.Client;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// JimsProxy (charge strafe-latch cure): the arm predicate, TTL gate, and synth
+/// counter classification. See <see cref="ChargePendLatchCure"/> for the wire
+/// evidence behind each rule.
+/// </summary>
+public class ChargePendLatchCureTests
+{
+    // The wire-proven orphan signature (3/3 field latches + 2/2 deliberate repros):
+    // a pending strafe start in the charge-GO CHANGE_TRANSPORT flags.
+    [Theory]
+    [InlineData((uint)MovementFlagModern.PendingStrafeRight)]
+    [InlineData((uint)MovementFlagModern.PendingStrafeLeft)]
+    [InlineData((uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeRight))] // the exact 08-28 C30 shape
+    public void ShouldArm_PendingStrafeStart_True(uint flags)
+    {
+        Assert.True(ChargePendLatchCure.ShouldArm(flags));
+    }
+
+    // Real (key-backed) strafe flags resolve from physical key state at spline
+    // exit (tonight's C1–C4 controls) — never arm on them.
+    [Theory]
+    [InlineData((uint)MovementFlagModern.StrafeLeft)]
+    [InlineData((uint)MovementFlagModern.StrafeRight)]
+    [InlineData((uint)(MovementFlagModern.Forward | MovementFlagModern.StrafeRight | MovementFlagModern.Falling))] // session-2 C5: mid-air press, direct apply
+    public void ShouldArm_RealStrafeFlags_False(uint flags)
+    {
+        Assert.False(ChargePendLatchCure.ShouldArm(flags));
+    }
+
+    // Pending STOPS resolve safely at spline exit (07-11 C1: PendStrafeStop+PendFwd
+    // both wiped clean), and PendingForward did not orphan in its one specimen —
+    // out of scope until evidence says otherwise.
+    [Theory]
+    [InlineData((uint)MovementFlagModern.PendingStrafeStop)]
+    [InlineData((uint)MovementFlagModern.PendingStop)]
+    [InlineData((uint)(MovementFlagModern.StrafeLeft | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeStop | MovementFlagModern.PendingForward))] // the exact 07-11 C1 shape
+    [InlineData(0u)]
+    public void ShouldArm_NonArmingFlags_False(uint flags)
+    {
+        Assert.False(ChargePendLatchCure.ShouldArm(flags));
+    }
+
+    // Arm→fire spans the charge spline (≤ ~0.95s observed) plus the server's
+    // unroot lag (~0.6s); a stale arm (e.g. a pend-carrying real transport
+    // boarding, where no spline-unroot ever follows) must expire.
+    [Fact]
+    public void IsArmed_WithinTtl_True()
+    {
+        Assert.True(ChargePendLatchCure.IsArmed(armedAtMs: 1000, nowMs: 1000 + ChargePendLatchCure.ArmTtlMs));
+    }
+
+    [Fact]
+    public void IsArmed_Expired_False()
+    {
+        Assert.False(ChargePendLatchCure.IsArmed(armedAtMs: 1000, nowMs: 1001 + ChargePendLatchCure.ArmTtlMs));
+    }
+
+    [Fact]
+    public void IsArmed_Disarmed_False()
+    {
+        Assert.False(ChargePendLatchCure.IsArmed(armedAtMs: 0, nowMs: 5000));
+    }
+
+    // Fire on the orphan's first appearance: armed pend's real bit set, pend bit
+    // gone. Shapes below are verbatim from the 08-29 falsification captures.
+    [Fact]
+    public void ShouldFire_PendApplied_True()
+    {
+        uint armed = (uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeRight);
+        // charge 1: SPLINE_DONE/MOVE_STOP [StrafeR|Falling]
+        Assert.True(ChargePendLatchCure.ShouldFire(armed, (uint)(MovementFlagModern.StrafeRight | MovementFlagModern.Falling)));
+        // charge 1: FALL_LAND [StrafeR]
+        Assert.True(ChargePendLatchCure.ShouldFire(armed, (uint)MovementFlagModern.StrafeRight));
+    }
+
+    [Fact]
+    public void ShouldFire_PendAppliedLeft_True()
+    {
+        // charge 2: armed [Fwd|Falling|PendStop|PendStrafeL], FALL_LAND [StrafeL]
+        uint armed = (uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStop | MovementFlagModern.PendingStrafeLeft);
+        Assert.True(ChargePendLatchCure.ShouldFire(armed, (uint)MovementFlagModern.StrafeLeft));
+    }
+
+    // The arming packet itself and mid-spline packets still carry the pend
+    // unapplied (real bit absent or pend bit still set) — no fire.
+    [Fact]
+    public void ShouldFire_PendStillQueued_False()
+    {
+        uint armed = (uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeRight);
+        Assert.False(ChargePendLatchCure.ShouldFire(armed, armed)); // the arming CHANGE_TRANSPORT
+        // charge 2's SPLINE_DONE [Falling|PendStrafeL]: pend not yet applied
+        uint armedL = (uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeLeft);
+        Assert.False(ChargePendLatchCure.ShouldFire(armedL, (uint)(MovementFlagModern.Falling | MovementFlagModern.PendingStrafeLeft)));
+    }
+
+    // Defensive (never wire-observed): real bit AND the armed pend bit set in the
+    // same packet must NOT fire — a pend still queued could re-apply after the
+    // pulse and re-latch; wait for a packet where the pend is consumed.
+    [Fact]
+    public void ShouldFire_RealBitWithPendStillPresent_False()
+    {
+        uint armed = (uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeRight);
+        Assert.False(ChargePendLatchCure.ShouldFire(armed,
+            (uint)(MovementFlagModern.StrafeRight | MovementFlagModern.PendingStrafeRight)));
+    }
+
+    // The OTHER side's strafe appearing is the player's own fresh input, not the
+    // armed pend applying — no fire.
+    [Fact]
+    public void ShouldFire_OppositeSideStrafe_False()
+    {
+        uint armed = (uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeLeft);
+        Assert.False(ChargePendLatchCure.ShouldFire(armed, (uint)MovementFlagModern.StrafeRight));
+    }
+
+    // Flags with no strafe content at all (the common post-exit packets when the
+    // pend was resolved) — no fire; the TTL expires the arm.
+    [Fact]
+    public void ShouldFire_NoStrafeContent_False()
+    {
+        uint armed = (uint)(MovementFlagModern.Forward | MovementFlagModern.Falling | MovementFlagModern.PendingStrafeRight);
+        Assert.False(ChargePendLatchCure.ShouldFire(armed, (uint)MovementFlagModern.Falling));
+        Assert.False(ChargePendLatchCure.ShouldFire(armed, 0));
+    }
+
+    [Fact]
+    public void ExpectedRealStrafeMask_MapsPendsToRealBits()
+    {
+        Assert.Equal((uint)MovementFlagModern.StrafeLeft,
+            ChargePendLatchCure.ExpectedRealStrafeMask((uint)MovementFlagModern.PendingStrafeLeft));
+        Assert.Equal((uint)MovementFlagModern.StrafeRight,
+            ChargePendLatchCure.ExpectedRealStrafeMask((uint)(MovementFlagModern.Forward | MovementFlagModern.PendingStrafeRight)));
+        Assert.Equal(0u, ChargePendLatchCure.ExpectedRealStrafeMask((uint)MovementFlagModern.StrafeRight));
+    }
+
+    [Fact]
+    public void IsCureCounter_OwnCounters_True()
+    {
+        Assert.True(ChargePendLatchCure.IsCureCounter(ChargePendLatchCure.SynthCounterRoot));
+        Assert.True(ChargePendLatchCure.IsCureCounter(ChargePendLatchCure.SynthCounterUnroot));
+    }
+
+    // Never claim the carried-root cure's counter (or the legacy server's constant
+    // 0) — the dedicated ack breadcrumb must not shadow either.
+    [Fact]
+    public void IsCureCounter_ForeignCounters_False()
+    {
+        Assert.False(ChargePendLatchCure.IsCureCounter(WorldEntryCeremonyTracker.SynthCounterUnroot));
+        Assert.False(ChargePendLatchCure.IsCureCounter(0));
+        Assert.False(ChargePendLatchCure.IsCureCounter(0xFFFFFFFF));
+    }
+
+    // Cross-invariant: the cure counters must sit inside the synth range so the
+    // existing generic swallow in HandleMoveForceAck2 remains a safety net — a
+    // cure ack must NEVER reach the legacy server (kick-counter exposure) even if
+    // the dedicated branch is ever reordered or removed.
+    [Fact]
+    public void CureCounters_AreInsideSynthSwallowRange()
+    {
+        Assert.True(WorldEntryCeremonyTracker.IsSynthCounter(ChargePendLatchCure.SynthCounterRoot));
+        Assert.True(WorldEntryCeremonyTracker.IsSynthCounter(ChargePendLatchCure.SynthCounterUnroot));
+    }
+
+    // And they must not collide with the carried-root cure's counter, whose ack
+    // path logs a different event.
+    [Fact]
+    public void CureCounters_DistinctFromCarriedRootCure()
+    {
+        Assert.NotEqual(WorldEntryCeremonyTracker.SynthCounterUnroot, ChargePendLatchCure.SynthCounterRoot);
+        Assert.NotEqual(WorldEntryCeremonyTracker.SynthCounterUnroot, ChargePendLatchCure.SynthCounterUnroot);
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -97,6 +97,14 @@ public static class Settings
     // active regardless (instrument, not cure). See World/Client/WorldEntryCeremony.cs.
     // Default-init true so paths that bypass LoadAndVerifyFrom (tests) get the fix.
     public static bool WorldEntryCarriedRootCure = true;
+    // JimsProxy (charge strafe-latch cure 2026-08-28): synthesize a force ROOT+UNROOT pulse to
+    // the client when a Charge spline exit applies an orphaned pending-strafe flag (the player
+    // comes out of the charge stuck strafing until a strafe key is touched). Key = kill switch
+    // for the cure pulse only; the arm signature still stamps `pend_latch_armed` on the
+    // change_transport.dropped event so wild frequency stays measurable with the cure off.
+    // See World/Client/ChargePendLatchCure.cs. Default-init true so paths that bypass
+    // LoadAndVerifyFrom (tests) get the fix.
+    public static bool ChargePendLatchCure = true;
     // JimsProxy (#382 MC-cap BG FPS drop): strip UNIT_FLAG_PET_IN_COMBAT (0x800) from a
     // PLAYER for exactly the duration of a player-on-player charm (Gnomish MC Cap 13181,
     // priest MC 605). Vanilla cores set that flag on the charmed unit itself; modern
@@ -281,6 +289,7 @@ public static class Settings
         LoginEvictionMerge = config.GetBoolean("LoginEvictionMerge", true);
         LoginPreCreateOpHold = config.GetBoolean("LoginPreCreateOpHold", true);
         WorldEntryCarriedRootCure = config.GetBoolean("WorldEntryCarriedRootCure", true);
+        ChargePendLatchCure = config.GetBoolean("ChargePendLatchCure", true);
         Charm382StripPetInCombat = config.GetBoolean("Charm382StripPetInCombat", true);
         SynthStandOnFear = config.GetBoolean("SynthStandOnFear", true);
         AuthHandshakeTimeoutMs = Math.Clamp(config.GetInt("AuthHandshakeTimeoutMs", 15000), 1000, 60000);

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -359,6 +359,18 @@ public sealed class GameSessionData
     public bool WorldEntryPendingCarriedRootCheck;   // set at NEW_WORLD; consumed at the player's first destination update
     public bool WorldEntryCarriedRootCureArmed;      // dispatcher → end-of-UPDATE_OBJECT synth handoff (stuck-stun pattern)
     public bool WorldEntryCureAfterTeleportAck;      // same-map teleport variant: armed at the self MoveTeleport, fired at its CMSG_MOVE_TELEPORT_ACK
+    // JimsProxy (charge strafe-latch cure 2026-08-28, re-anchored 2026-08-29):
+    // one-shot armed when the charge-GO CHANGE_TRANSPORT carries a pending strafe
+    // start (the wire-proven orphan signature — see ChargePendLatchCure), fired as
+    // a synthetic force ROOT+UNROOT pulse on the first client movement packet
+    // showing the pend APPLIED (real strafe bit set, pend bit gone) — both sites
+    // live in HandlePlayerMove, same thread. 0 = disarmed; TTL-guarded so an arm
+    // whose pend never applies (client resolved it) expires silently. Disarmed by
+    // any real self force-root: the root itself wipes the client's movement flags
+    // (the natural cure), and pulsing an unroot under a live server root would
+    // free the player early.
+    public long ChargePendLatchArmedAtMs;
+    public uint ChargePendLatchArmedFlags;           // the arming packet's modern movement flags, for the cure breadcrumb
     // JimsProxy (zep-stuck-no-move 2026-05-14): set to a sentinel MoveCounter when
     // HandleNewWorld emits a synthesized SMSG_MOVE_TELEPORT to clear the modern
     // client's stale MOVEMENTFLAG_ONTRANSPORT after a cross-continent transport

--- a/HermesProxy/World/Client/ChargePendLatchCure.cs
+++ b/HermesProxy/World/Client/ChargePendLatchCure.cs
@@ -1,0 +1,106 @@
+using HermesProxy.World.Enums;
+
+namespace HermesProxy.World.Client;
+
+/// <summary>
+/// JimsProxy (charge strafe-latch cure, 2026-08-28): pure decision logic for the
+/// pending-strafe orphan cure, extracted for unit tests (WorldEntryCeremonyTracker
+/// precedent).
+///
+/// The 1.14.2 client queues a strafe key pressed mid-air during a locked-trajectory
+/// (forward-held) jump as PendingStrafeLeft/Right instead of applying it. When a
+/// Charge spline hijacks the fall, the key's release mid-spline is swallowed
+/// without clearing the pend, and the spline-exit landing APPLIES the stale pend as
+/// a real strafe flag with no key behind it. The character then strafes on its own
+/// (transmitted in every movementinfo) until the player touches a strafe-axis key,
+/// because non-strafe inputs only toggle their own flag bits. Wire-proven on 3/3
+/// field latches + 2/2 deliberate repros (2026-08-28 .pkt flag decode); the arming
+/// signature (Pend flag in the CHANGE_TRANSPORT the client emits at charge GO)
+/// appeared on exactly the latching charges across 4 sessions / 83 charges.
+///
+/// Cure: a synthetic force ROOT+UNROOT pulse to the client, fired the moment the
+/// orphan is OBSERVED — the first post-arm client movement packet whose flags show
+/// the armed pend's REAL strafe bit set with the pend bit gone (the apply). The
+/// apply lands at the client's SPLINE_DONE or at the FALL_LAND up to ~250ms later
+/// (both shapes wire-observed 2026-08-29); every subsequent movement packet also
+/// carries the applied flag, so the detector catches within one packet either way.
+/// Corpus-proven client behavior (~40 natural self force-root episodes, 2026-08-28
+/// rootscan): a force-root wipes ALL client movement flags and makes the client
+/// emit the matching stop opcodes (which forward to the server normally,
+/// correcting its view too); a force-unroot makes the client rebuild flags from
+/// PHYSICAL key state, re-emitting starts for genuinely held keys in the same
+/// millisecond. The pulse is therefore safe in both worlds: orphaned flag wiped,
+/// genuinely held key resumes instantly.
+///
+/// v1 fire anchor was WRONG (2026-08-29 field falsification): it waited for the
+/// player's post-charge SPLINE_UNROOT, but the charge-bracketing spline
+/// root/unroot Kronos sends is addressed to the charge TARGET, never the charging
+/// player (mover GUIDs decoded = the victim mobs). No self anchor packet exists —
+/// and consequently there is also no moved-while-server-rooted exposure to time
+/// around: the server never roots the charging player at all.
+/// </summary>
+public static class ChargePendLatchCure
+{
+    /// <summary>
+    /// The proven orphan-makers: pending strafe STARTS. Pending stops
+    /// (PendStop/PendStrafeStop) resolve safely at spline exit (07-11 C1 wire
+    /// evidence), and PendingForward did not orphan in the one specimen carrying
+    /// it; scope stays on the strafe pends until evidence says otherwise.
+    /// </summary>
+    public const uint PendingStartStrafeMask =
+        (uint)(MovementFlagModern.PendingStrafeLeft | MovementFlagModern.PendingStrafeRight);
+
+    /// <summary>
+    /// Covers arm-to-fire across the longest observed charge spline (~0.95s) plus
+    /// the server's unroot lag (~0.6s) with slack; expires stale arms (e.g. a real
+    /// transport boarding that carried a pend flag, where no spline-unroot follows).
+    /// </summary>
+    public const long ArmTtlMs = 3000;
+
+    /// <summary>
+    /// Synth MoveCounters inside the WorldEntryCeremonyTracker.IsSynthCounter range
+    /// so the existing ack-swallow path covers them (the legacy server never sent
+    /// these ops; a spurious force-ack can feed Kronos's malformed-input kick
+    /// counters). 0xFFFFFF02 is taken by the carried-root cure unroot.
+    /// </summary>
+    public const uint SynthCounterRoot = 0xFFFFFF03;
+    public const uint SynthCounterUnroot = 0xFFFFFF04;
+
+    /// <summary>
+    /// Arm on the charge-GO CHANGE_TRANSPORT (the packet we already intercept and
+    /// drop) when the client's reported flags carry a pending strafe start.
+    /// </summary>
+    public static bool ShouldArm(uint modernMovementFlags)
+        => (modernMovementFlags & PendingStartStrafeMask) != 0;
+
+    public static bool IsArmed(long armedAtMs, long nowMs)
+        => armedAtMs != 0 && nowMs - armedAtMs <= ArmTtlMs;
+
+    /// <summary>
+    /// The real strafe bit(s) the armed pend will turn into when the spline-exit
+    /// landing applies it: PendingStrafeLeft -> StrafeLeft, PendingStrafeRight ->
+    /// StrafeRight.
+    /// </summary>
+    public static uint ExpectedRealStrafeMask(uint armedFlags)
+    {
+        uint mask = 0;
+        if ((armedFlags & (uint)MovementFlagModern.PendingStrafeLeft) != 0)
+            mask |= (uint)MovementFlagModern.StrafeLeft;
+        if ((armedFlags & (uint)MovementFlagModern.PendingStrafeRight) != 0)
+            mask |= (uint)MovementFlagModern.StrafeRight;
+        return mask;
+    }
+
+    /// <summary>
+    /// True when a post-arm movement packet shows the orphan in existence: the
+    /// armed pend's real strafe bit is now set AND the pend bit itself is gone
+    /// (applied, no longer queued). Mid-spline packets still carrying the pend
+    /// don't fire; neither does the arming packet itself (real bit absent).
+    /// </summary>
+    public static bool ShouldFire(uint armedFlags, uint currentFlags)
+        => (currentFlags & ExpectedRealStrafeMask(armedFlags)) != 0
+           && (currentFlags & armedFlags & PendingStartStrafeMask) == 0;
+
+    public static bool IsCureCounter(uint moveCounter)
+        => moveCounter == SynthCounterRoot || moveCounter == SynthCounterUnroot;
+}

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -1049,7 +1049,15 @@ public partial class WorldClient
         if (ceremony.Active && selfUnroot)
             System.Threading.Interlocked.Increment(ref ceremony.UnrootsForwarded);
         if (selfRoot)
+        {
             GetSession().GameState.ClientBelievesRooted = true;
+            // JimsProxy (charge strafe-latch cure 2026-08-28): a real self force-root
+            // between arm and fire disarms the cure — the root itself wipes the
+            // client's movement flags (the orphan is already gone, corpus-proven),
+            // and pulsing an unroot under a live server root would free the player
+            // early.
+            GetSession().GameState.ChargePendLatchArmedAtMs = 0;
+        }
         else if (selfUnroot)
             GetSession().GameState.ClientBelievesRooted = false;
 

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -78,8 +78,9 @@ public partial class WorldSocket
             {
                 GetSession().GameState.ChargePendLatchArmedAtMs = 0;
             }
-            else if (World.Client.ChargePendLatchCure.ShouldFire(
-                GetSession().GameState.ChargePendLatchArmedFlags, movement.MoveInfo.Flags))
+            else if (Framework.Settings.ChargePendLatchCure &&
+                     World.Client.ChargePendLatchCure.ShouldFire(
+                         GetSession().GameState.ChargePendLatchArmedFlags, movement.MoveInfo.Flags))
             {
                 GetSession().GameState.ChargePendLatchArmedAtMs = 0;
                 MoveSetFlag cureRoot = new MoveSetFlag(Opcode.SMSG_MOVE_ROOT);
@@ -90,13 +91,16 @@ public partial class WorldSocket
                 cureUnroot.MoverGUID = GetSession().GameState.CurrentPlayerGuid;
                 cureUnroot.MoveCounter = World.Client.ChargePendLatchCure.SynthCounterUnroot;
                 SendPacket(cureUnroot);
-                Framework.Logging.Log.Event("charge.pend_latch.cure_sent", new
-                {
-                    armed_flags = GetSession().GameState.ChargePendLatchArmedFlags,
-                    observed_flags = movement.MoveInfo.Flags,
-                    trigger_opcode = movement.GetUniversalOpcode().ToString(),
-                    armed_age_ms = nowMs - pendLatchArmedAt,
-                });
+                // DebugOutput-gated per the diagnostics rubric: this is the fix working,
+                // not an unexpected-edge signature (review 2026-09-05).
+                if (Framework.Settings.DebugOutput)
+                    Framework.Logging.Log.Event("charge.pend_latch.cure_sent", new
+                    {
+                        armed_flags = GetSession().GameState.ChargePendLatchArmedFlags,
+                        observed_flags = movement.MoveInfo.Flags,
+                        trigger_opcode = movement.GetUniversalOpcode().ToString(),
+                        armed_age_ms = nowMs - pendLatchArmedAt,
+                    });
             }
         }
 
@@ -456,15 +460,17 @@ public partial class WorldSocket
         // ROOT+UNROOT pulse. Swallowed for the same reason as the carried-root cure
         // ack below (the legacy server never sent these ops); the flags the client
         // reports in each ack are the field proof of the cure working — the root ack
-        // should show the orphaned strafe already wiped.
+        // should show the orphaned strafe already wiped. DebugOutput-gated per the
+        // diagnostics rubric (fix-working breadcrumb; review 2026-09-05).
         if (World.Client.ChargePendLatchCure.IsCureCounter(movementAck.Ack.MoveCounter))
         {
-            Log.Event("charge.pend_latch.cure_acked", new
-            {
-                opcode = universalOpcode.ToString(),
-                move_counter = movementAck.Ack.MoveCounter,
-                client_flags = movementAck.Ack.MoveInfo.Flags,
-            });
+            if (Framework.Settings.DebugOutput)
+                Log.Event("charge.pend_latch.cure_acked", new
+                {
+                    opcode = universalOpcode.ToString(),
+                    move_counter = movementAck.Ack.MoveCounter,
+                    client_flags = movementAck.Ack.MoveInfo.Flags,
+                });
             return;
         }
 

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -59,6 +59,47 @@ public partial class WorldSocket
         // Stamped before the CHANGE_TRANSPORT drop below so boarding via that opcode counts.
         GetSession().GameState.DiagLastObservedPlayerTransportGuid = movement.MoveInfo.TransportGuid;
 
+        // JimsProxy (charge strafe-latch cure 2026-08-28, re-anchored 2026-08-29):
+        // fire the cure the moment the orphan is observed — the armed pend's real
+        // strafe bit set with the pend bit gone in the client's own reported flags
+        // (lands at SPLINE_DONE's same-ms MOVE_STOP or the FALL_LAND up to ~250ms
+        // later; both shapes wire-observed). v1 anchored on the player's
+        // post-charge SPLINE_UNROOT, which does not exist — Kronos spline-roots
+        // the charge TARGET, never the charging player. The synth ROOT wipes the
+        // client's movement flags and makes it emit the matching stop opcodes
+        // (correcting Kronos's view too); the synth UNROOT rebuilds from physical
+        // key state, so a genuinely-held strafe resumes same-frame. Both acks are
+        // swallowed by counter in HandleMoveForceAck2.
+        long pendLatchArmedAt = GetSession().GameState.ChargePendLatchArmedAtMs;
+        if (pendLatchArmedAt != 0)
+        {
+            long nowMs = Environment.TickCount64;
+            if (!World.Client.ChargePendLatchCure.IsArmed(pendLatchArmedAt, nowMs))
+            {
+                GetSession().GameState.ChargePendLatchArmedAtMs = 0;
+            }
+            else if (World.Client.ChargePendLatchCure.ShouldFire(
+                GetSession().GameState.ChargePendLatchArmedFlags, movement.MoveInfo.Flags))
+            {
+                GetSession().GameState.ChargePendLatchArmedAtMs = 0;
+                MoveSetFlag cureRoot = new MoveSetFlag(Opcode.SMSG_MOVE_ROOT);
+                cureRoot.MoverGUID = GetSession().GameState.CurrentPlayerGuid;
+                cureRoot.MoveCounter = World.Client.ChargePendLatchCure.SynthCounterRoot;
+                SendPacket(cureRoot);
+                MoveSetFlag cureUnroot = new MoveSetFlag(Opcode.SMSG_MOVE_UNROOT);
+                cureUnroot.MoverGUID = GetSession().GameState.CurrentPlayerGuid;
+                cureUnroot.MoveCounter = World.Client.ChargePendLatchCure.SynthCounterUnroot;
+                SendPacket(cureUnroot);
+                Framework.Logging.Log.Event("charge.pend_latch.cure_sent", new
+                {
+                    armed_flags = GetSession().GameState.ChargePendLatchArmedFlags,
+                    observed_flags = movement.MoveInfo.Flags,
+                    trigger_opcode = movement.GetUniversalOpcode().ToString(),
+                    armed_age_ms = nowMs - pendLatchArmedAt,
+                });
+            }
+        }
+
         bool isMoveStart = IsMovementStartOpcode(movement.GetUniversalOpcode());
 
         // JimsProxy (PR #161 follow-up — movement preemption): mark any in-flight
@@ -165,10 +206,26 @@ public partial class WorldSocket
         // transport state rides in every ordinary movement packet; 1.12 has no such opcode.
         if (movement.GetUniversalOpcode() == Opcode.CMSG_MOVE_CHANGE_TRANSPORT)
         {
+            // JimsProxy (charge strafe-latch cure 2026-08-28): the client emits this
+            // packet at every charge GO (spline≈pseudo-transport). A pending strafe
+            // start in its flags is the wire-proven orphan signature — the mid-air
+            // press whose release the spline will swallow and whose pend the spline
+            // exit will apply as a keyless real strafe flag (stuck-strafing-after-
+            // Charge, 3/3 field latches + 2/2 deliberate repros). Arm the one-shot
+            // cure; it fires at the top of this handler on the first packet showing
+            // the pend applied, and is harmless if the key is actually still held
+            // (force-unroot rebuilds from physical key state).
+            bool pendStrafeArmed = World.Client.ChargePendLatchCure.ShouldArm(movement.MoveInfo.Flags);
+            if (pendStrafeArmed)
+            {
+                GetSession().GameState.ChargePendLatchArmedAtMs = Environment.TickCount64;
+                GetSession().GameState.ChargePendLatchArmedFlags = movement.MoveInfo.Flags;
+            }
             Framework.Logging.Log.Event("movement.change_transport.dropped", new
             {
                 server_build = Framework.Settings.ServerBuild.ToString(),
                 on_transport = !movement.MoveInfo.TransportGuid.IsEmpty(),
+                pend_latch_armed = pendStrafeArmed,
             });
             return;
         }
@@ -394,6 +451,22 @@ public partial class WorldSocket
     void HandleMoveForceAck2(MovementAckMessage movementAck)
     {
         var universalOpcode = movementAck.GetUniversalOpcode();
+
+        // JimsProxy (charge strafe-latch cure 2026-08-28): the ack legs of the synth
+        // ROOT+UNROOT pulse. Swallowed for the same reason as the carried-root cure
+        // ack below (the legacy server never sent these ops); the flags the client
+        // reports in each ack are the field proof of the cure working — the root ack
+        // should show the orphaned strafe already wiped.
+        if (World.Client.ChargePendLatchCure.IsCureCounter(movementAck.Ack.MoveCounter))
+        {
+            Log.Event("charge.pend_latch.cure_acked", new
+            {
+                opcode = universalOpcode.ToString(),
+                move_counter = movementAck.Ack.MoveCounter,
+                client_flags = movementAck.Ack.MoveInfo.Flags,
+            });
+            return;
+        }
 
         // JimsProxy (carried-root cure): the ack for the proxy-synthesized cure
         // unroot carries a sentinel counter. The legacy server never sent that op,


### PR DESCRIPTION
No linked issue — reported and investigated live (2026-07-11 first sighting, 2026-08-28/29 full investigation). Warrior, Kronos.

## What

After a Charge, the character sometimes comes out of the spline **stuck strafing** — visibly and server-visibly (it's transmitted) — until the player presses a strafe key. Forward, backward, and turn keys cannot clear it; on a "last charge of the fight" it runs for many seconds. This PR detects the exact wire signature that causes it and cures it with a synthetic force ROOT+UNROOT pulse to the client.

## Why — the mechanism, wire-proven

The 1.14.2 client queues a strafe key pressed mid-air during a locked-trajectory (forward-held) jump as `PendingStrafeLeft/Right` (0x20000/0x40000) instead of applying it — "start strafing when I land." When a Charge spline hijacks the fall:

1. the key **release** mid-spline is swallowed without clearing the pend, and
2. the spline-exit landing **applies** the stale pend as a real strafe flag **with no key behind it**.

The orphaned flag then rides every outgoing movementinfo; only a strafe-axis key event rewrites the strafe bits. Non-strafe inputs toggle their own bits only (field-confirmed: three backward press/release cycles and a turn press all left the flag standing).

Evidence base (.pkt movement-flag decode across 4 sessions / 83 charges): the arming signature — a pending strafe start in the `CMSG_MOVE_CHANGE_TRANSPORT` the client emits at every charge GO — appeared on **exactly** the latching charges: 3/3 field latches (2026-07-11 and 2026-08-28) plus 2/2 deliberate reproductions once the recipe was derived (forward-held jump → strafe pressed mid-air → Charge before landing → release during flight). Grounded strafes, standing-jump strafes, and pending *stops* all resolve cleanly and never arm.

## How

- `World/Client/ChargePendLatchCure.cs` (new) — pure decision logic (WorldEntryCeremonyTracker pattern): arm predicate (pending strafe starts only), fire predicate (armed pend's **real** bit set with the pend bit gone — the orphan observed), 3s arm TTL, synth counters 0xFFFFFF03/04 inside the established `IsSynthCounter` swallow range.
- `Server/PacketHandlers/MovementHandler.cs` — **arm** inside the existing CHANGE_TRANSPORT drop (adds `pend_latch_armed` to its event, giving per-charge wild-frequency data); **fire** at the top of `HandlePlayerMove` on the first packet showing the pend applied: synth `SMSG_MOVE_ROOT` + `SMSG_MOVE_UNROOT` to the client. Dedicated ack branch in `HandleMoveForceAck2` logs `charge.pend_latch.cure_acked` (DebugOutput-gated) with the client's reported flags and swallows the acks (the legacy server never sent these ops). Arm and fire share one thread.
- `World/Client/PacketHandlers/MovementHandler.cs` — a real self force-root between arm and fire disarms: the root itself wipes the client's flags (the natural cure), and pulsing an unroot under a live server root would free the player early.
- `GlobalSessionData.cs` — the one-shot state (armed-at + armed-flags).
- **Review changes (2026-09-05):** config kill switch `ChargePendLatchCure` (default on) gates the pulse only, so `pend_latch_armed` keeps reporting the condition's wild frequency with the cure off; `charge.pend_latch.cure_sent` / `charge.pend_latch.cure_acked` are DebugOutput-gated per the diagnostics rubric; CHANGES.md entry added. No behavior change with the defaults.

Why ROOT+UNROOT: corpus-proven client behavior from ~40 natural self force-root episodes — a force-root **wipes all movement flags and makes the client emit the matching stop opcodes** (which forward to Kronos normally, correcting the server's view of the phantom strafe too); a force-unroot **rebuilds flags from physical key state**, re-emitting starts for genuinely held keys in the same millisecond. Safe in both worlds: orphaned flag wiped, genuinely held key resumes instantly. Rejected alternative: `SMSG_MOVE_UPDATE` to self (1 occurrence in an 84-minute session vs 16k for other movers; no evidence the client applies it to its own mover).

One design note: the spline root/unroot pair Kronos sends around every charge addresses the charge **target**, never the charging player (decoded from capture GUIDs) — the player is never server-rooted during a charge, so the cure fires on the orphan's own appearance in the client's reported flags rather than on any server packet.

## Testing

- 24 unit tests pinning the arm/fire predicates against the verbatim wire shapes of every specimen (latching, self-clearing, arming-packet, opposite-side, pend-still-queued) plus counter-range cross-invariants (cure acks can never reach the legacy server even if the dedicated branch is removed). Full suite 985 green. Mutation-checked (mask swap → 7 red; fire-guard drop → pinned by a dedicated case).
- **Field-verified 2026-08-29** (5 recipe attempts): 2 armed → 2 cures → 0 latches; 3 unarmed → normal. Both ROOT acks returned `client_flags=Root` only — packet-level proof the orphaned strafe was wiped — and the back-to-back same-frame ROOT→UNROOT pulse was applied in order by the client. Cure lands within ~100ms of touchdown; no false-positive fires in any session.

