### PR TITLE
JimsPlus: add ApiCompat modern-API shims (adapted from HermesCompat)

### DIFF
--- a/Addons/JimsPlus/ApiCompat.lua
+++ b/Addons/JimsPlus/ApiCompat.lua
@@ -1,0 +1,145 @@
+-- JimsPlus ApiCompat
+-- Fills in modern client APIs that are missing on the 1.14.2 Classic Era client, so
+-- newer addons and WeakAuras packs stop erroring with "attempt to call/index a nil
+-- value". Every shim only installs when the API is actually missing; nothing the
+-- client already provides is ever overridden or wrapped.
+--
+-- Adapted from HermesCompat by techgeekpr (written as a fix for valrios).
+-- https://github.com/techgeekpr/HermesCompat
+-- MIT License, Copyright (c) 2026 techgeekpr.
+--
+-- Deliberately NOT carried over from HermesCompat:
+--   * The GetBattlefieldScore faction wrap. It papers over a proxy bug (jimsproxy
+--     issue #505, cache-miss rows fabricated as Human/Warrior/Horde); the proxy is
+--     the only layer with the data to fix it, and JimsPlus never replaces Blizzard
+--     globals as a rule.
+--   * The WeakAuras aurabar SetStatusBarTextureLSM patch. It edits WeakAuras
+--     internals and tracks one ported WA build; users who need it can run
+--     HermesCompat alongside JimsPlus (every shim on both sides is guarded, so
+--     whichever loads first wins and the other no-ops).
+--
+-- Toggled by Options > "Modern addon API shims" (JimsPlusDB.apiCompat, default on,
+-- /reload to apply). Shims install at our ADDON_LOADED, i.e. before any addon that
+-- loads after JimsPlus and before PLAYER_LOGIN. Addons that loaded before us and
+-- feature-detect at their own load time are out of reach either way; in practice
+-- these APIs are called at runtime (events), where late definitions cover them.
+
+local ADDON_NAME, namespace = ...
+
+local function InstallShims()
+    -- 1) C_Spell.IsSpellInRange: modern range API some WeakAuras call. Map to the
+    --    classic global IsSpellInRange, which takes a spell NAME, so convert numeric
+    --    spell ids via GetSpellInfo. Classic returns 1/0/nil, modern a boolean;
+    --    nil (invalid/unknown spell) passes through as nil like the modern API.
+    if C_Spell and not C_Spell.IsSpellInRange and IsSpellInRange then
+        function C_Spell.IsSpellInRange(spell, unit)
+            local name = spell
+            if type(spell) == "number" then
+                name = GetSpellInfo(spell)
+            end
+            if not name then return nil end
+            local r = IsSpellInRange(name, unit)
+            if r == nil then return nil end
+            return r == 1 or r == true
+        end
+    end
+
+    -- 2) UIPanelScrollFrame_OnLoad: FrameXML helper this client no longer defines,
+    --    still referenced from some addons' XML scroll templates (e.g. NovaWorldBuffs).
+    --    Minimal reimplementation of the old FrameXML behavior: wire up the scrollbar
+    --    references and zero the range so the template starts inert instead of erroring.
+    if not UIPanelScrollFrame_OnLoad then
+        function UIPanelScrollFrame_OnLoad(self)
+            local name = self.GetName and self:GetName()
+            local scrollbar = self.ScrollBar or (name and _G[name .. "ScrollBar"])
+            if scrollbar then
+                self.ScrollBar = scrollbar
+                local sbname = scrollbar.GetName and scrollbar:GetName()
+                scrollbar.ScrollUpButton = scrollbar.ScrollUpButton or (sbname and _G[sbname .. "ScrollUpButton"])
+                scrollbar.ScrollDownButton = scrollbar.ScrollDownButton or (sbname and _G[sbname .. "ScrollDownButton"])
+                scrollbar:SetMinMaxValues(0, 0)
+                scrollbar:SetValue(0)
+            end
+            self.offset = 0
+        end
+    end
+
+    -- 3) C_Container: modern container namespace (reached era in 1.14.4; this client
+    --    is 1.14.2, so it is absent and no Blizzard code can be reading it). Blizzard
+    --    kept the classic globals' names when moving them into the namespace, so any
+    --    unknown member auto-maps to the like-named global via __index (cached with
+    --    rawset on first use; misses stay uncached so late-defined globals are found).
+    --    The two calls whose return shape changed from multiple values to a table get
+    --    explicit conversion wrappers.
+    if not C_Container then
+        local function itemInfo(bag, slot)
+            local icon, count, locked, quality, readable, lootable, link, filtered,
+                  noValue, itemID, isBound = GetContainerItemInfo(bag, slot)
+            if icon == nil and link == nil and itemID == nil then return nil end
+            return {
+                iconFileID = icon, stackCount = count, isLocked = locked, quality = quality,
+                isReadable = readable, hasLoot = lootable, hyperlink = link, isFiltered = filtered,
+                hasNoValue = noValue, itemID = itemID, isBound = isBound,
+            }
+        end
+        local function questInfo(bag, slot)
+            local g = _G.GetContainerItemQuestInfo
+            if g then
+                local isQuestItem, questID, isActive = g(bag, slot)
+                return { isQuestItem = isQuestItem, questID = questID, isActive = isActive }
+            end
+            return { isQuestItem = false } -- no classic equivalent; treat as non-quest
+        end
+        local special = {
+            GetContainerItemInfo = GetContainerItemInfo and itemInfo or nil,
+            GetContainerItemQuestInfo = questInfo,
+        }
+        C_Container = setmetatable({}, {
+            __index = function(t, key)
+                local fn = special[key]
+                if fn == nil then fn = _G[key] end -- same-named classic global
+                if fn ~= nil then rawset(t, key, fn) end
+                return fn
+            end,
+        })
+    end
+
+    -- 4) Vehicle API: added in Wrath, so "no vehicle" is simply the correct answer on
+    --    a vanilla server. Each is defined only when missing; on a client where these
+    --    do not exist, no secure Blizzard code path can be reading them, so
+    --    addon-defined stubs cannot taint anything.
+    local function retFalse() return false end
+    local function retNil() return nil end
+    local function retZero() return 0 end
+    local function noop() end
+
+    UnitHasVehicleUI            = UnitHasVehicleUI            or retFalse
+    UnitHasVehiclePlayerFrameUI = UnitHasVehiclePlayerFrameUI or retFalse
+    UnitInVehicle               = UnitInVehicle               or retFalse
+    UnitControllingVehicle      = UnitControllingVehicle      or retFalse
+    UnitInVehicleControlSeat    = UnitInVehicleControlSeat    or retFalse
+    UnitTargetsVehicleInRaidUI  = UnitTargetsVehicleInRaidUI  or retFalse
+    CanExitVehicle              = CanExitVehicle              or retFalse
+    CanSwitchVehicleSeats       = CanSwitchVehicleSeats       or retFalse
+    UnitVehicleSkin             = UnitVehicleSkin             or retNil
+    UnitVehicleSeatCount        = UnitVehicleSeatCount        or retZero
+    HasVehicleActionBar         = HasVehicleActionBar         or retFalse
+    HasOverrideActionBar        = HasOverrideActionBar        or retFalse
+    HasTempShapeshiftActionBar  = HasTempShapeshiftActionBar  or retFalse
+    GetVehicleBarIndex          = GetVehicleBarIndex          or retNil
+    GetOverrideBarIndex         = GetOverrideBarIndex         or retNil
+    GetTempShapeshiftBarIndex   = GetTempShapeshiftBarIndex   or retNil
+    VehicleExit                 = VehicleExit                 or noop
+    UnitSwitchToVehicleSeat     = UnitSwitchToVehicleSeat     or noop
+end
+
+local f = CreateFrame("Frame")
+f:RegisterEvent("ADDON_LOADED")
+f:SetScript("OnEvent", function(self, _, addon)
+    if addon ~= ADDON_NAME then return end
+    self:UnregisterEvent("ADDON_LOADED")
+    -- Core.lua registered its ADDON_LOADED handler first (earlier file in the .toc),
+    -- so namespace.db is populated by the time this runs.
+    if namespace.db and namespace.db.apiCompat == false then return end
+    InstallShims()
+end)

--- a/Addons/JimsPlus/Core.lua
+++ b/Addons/JimsPlus/Core.lua
@@ -36,5 +36,6 @@ f:SetScript("OnEvent", function(_, _, addon)
     if JimsPlusDB.taxiFix == nil then JimsPlusDB.taxiFix = true end
     if JimsPlusDB.bagSortOrder == nil then JimsPlusDB.bagSortOrder = false end
     if JimsPlusDB.performanceMode == nil then JimsPlusDB.performanceMode = false end
+    if JimsPlusDB.apiCompat == nil then JimsPlusDB.apiCompat = true end
     namespace.db = JimsPlusDB
 end)

--- a/Addons/JimsPlus/JimsPlus.toc
+++ b/Addons/JimsPlus/JimsPlus.toc
@@ -3,7 +3,7 @@
 ## Notes: Bundled client-side fixes for JimsProxy / Classic WoW 1.14 Launcher
 ## SavedVariables: JimsPlusDB, JimsPlusCastbarsDB
 ## SavedVariablesPerCharacter: JimsPlusCastbarsCharDB
-## Author: JimsProxy Team (CastBars based on ClassicCastbars by Wardz)
+## Author: JimsProxy Team (CastBars based on ClassicCastbars by Wardz; ApiCompat based on HermesCompat by techgeekpr)
 ## Version: 1.2.2
 
 Core.lua
@@ -19,6 +19,7 @@ MailNameFix.lua
 NameDashFix.lua
 KeyringClamp.lua
 BagnonSort.lua
+ApiCompat.lua
 castbars/PoolManager.lua
 castbars/AnchorManager.lua
 castbars/Data.lua

--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -1,8 +1,8 @@
 local ADDON_NAME, namespace = ...
 
-local function CreateCheckbox(parent, yOffset, label, tooltip)
+local function CreateCheckbox(parent, yOffset, label, tooltip, xOffset)
     local cb = CreateFrame("CheckButton", nil, parent, "InterfaceOptionsCheckButtonTemplate")
-    cb:SetPoint("TOPLEFT", parent, "TOPLEFT", 16, yOffset)
+    cb:SetPoint("TOPLEFT", parent, "TOPLEFT", xOffset or 16, yOffset)
     cb.Text:SetText(label)
     if tooltip then
         cb.tooltipText = tooltip
@@ -164,6 +164,13 @@ y = y - 28
 local cbMoonkinSound = CreateCheckbox(panel, y,
     "Moonkin Form sound  |cFF888888(Druid only)|r",
     "Gives Moonkin Form a distinct transformation sound instead\nof reusing the Bear Form sound.\n\nOnly affects Druid characters.")
+
+-- Right column, same row (the panel is already near the container's bottom edge,
+-- so new rows go sideways rather than down).
+local cbApiCompat = CreateCheckbox(panel, y,
+    "Modern addon API shims  |cFFFF6600(reload)|r",
+    "Fills in modern APIs that are missing on the 1.14.2 client so newer\naddons and WeakAuras packs stop erroring: C_Container, the\nC_Spell range check, vehicle API stubs, and a scroll-frame helper.\n\nOnly ever adds what is missing; never overrides anything the\nclient already provides.\n\nBased on HermesCompat by techgeekpr (MIT).\n\nChanges take effect after /reload.",
+    330)
 y = y - 28
 
 local cbBowSheathe = CreateCheckbox(panel, y,
@@ -224,6 +231,7 @@ local function RefreshCheckboxes()
     local db = namespace.db or JimsPlusDB or {}
     cbTooltipFix:SetChecked(db.tooltipFix == true)
     cbMoonkinSound:SetChecked(db.moonkinSound ~= false)
+    cbApiCompat:SetChecked(db.apiCompat ~= false)
     cbBowSheathe:SetChecked(db.bowSheatheFix ~= false)
     cbBagSort:SetChecked(db.bagSortOrder ~= false)
 
@@ -266,6 +274,14 @@ cbMoonkinSound:SetScript("OnClick", function(self)
         namespace.db.moonkinSound = enabled
     end
     print("|cFF00FF00[JimsPlus]|r Moonkin Form sound " .. (enabled and "enabled" or "disabled") .. ". Type /reload to apply.")
+end)
+
+cbApiCompat:SetScript("OnClick", function(self)
+    local enabled = self:GetChecked() and true or false
+    if namespace.db then
+        namespace.db.apiCompat = enabled
+    end
+    print("|cFF00FF00[JimsPlus]|r Modern addon API shims " .. (enabled and "enabled" or "disabled") .. ". Type /reload to apply.")
 end)
 
 -- JimsProxy (bow sheathe fix): purely addon-side (BowSheatheFix.lua re-sheathe nudge), read live from db


### PR DESCRIPTION
No linked issue for the feature itself. Extracted, with attribution, from the community addon [HermesCompat](https://github.com/techgeekpr/HermesCompat) by techgeekpr (MIT), written for exactly our client-through-proxy setup. Filed alongside #505, which tracks the proxy bug HermesCompat also works around client-side (that part is deliberately NOT bundled, see below).

## What

New JimsPlus module `ApiCompat.lua`: fills in modern client APIs that are missing on the 1.14.2 Classic Era client, so newer addons and WeakAuras packs stop erroring with "attempt to call/index a nil value". Every shim installs only when the API is actually missing; nothing the client already provides is ever overridden or wrapped.

Shims carried over:

- **`C_Container` namespace**: absent on 1.14.2 (reached era in 1.14.4). Blizzard kept the classic globals' names when namespacing, so unknown members auto-map to the like-named global via `__index`; the two calls whose return shape changed from multiple values to a table (`GetContainerItemInfo`, `GetContainerItemQuestInfo`) get explicit conversion wrappers. This is the big one for modern bag addons and WA packs.
- **`C_Spell.IsSpellInRange`**: maps to the classic name-based `IsSpellInRange`, converting numeric spell ids via `GetSpellInfo`, returning a boolean like the modern API.
- **Vehicle API stubs** (`UnitHasVehicleUI`, `HasVehicleActionBar`, ...): "no vehicle" is simply the correct answer on a vanilla server. Defined only when missing, and on a client where they are missing no secure Blizzard code can be reading them, so addon-defined stubs cannot taint anything.
- **`UIPanelScrollFrame_OnLoad`**: FrameXML helper this client no longer defines, still referenced by some addons' XML scroll templates (e.g. NovaWorldBuffs).

## Deliberately not carried over

- HermesCompat's `GetBattlefieldScore` faction wrap: it papers over our proxy bug (#505), can only half-fix it client-side (the proxy fabricates race for the affected rows), and it replaces a Blizzard global, which JimsPlus never does. The proxy fix supersedes it.
- Its WeakAuras aurabar `SetStatusBarTextureLSM` patch: edits WeakAuras internals and tracks one ported WA build. Users who need it can run HermesCompat alongside JimsPlus; every shim on both sides is guarded, so whichever loads first wins and the other no-ops.

## How

- Shims install at JimsPlus's own ADDON_LOADED (Core.lua's handler registers first and populates the db; installation lands before later-loading addons and before PLAYER_LOGIN), gated on a new `JimsPlusDB.apiCompat` toggle, default on, reload to apply. Addons that loaded before JimsPlus and feature-detect at their own load time are out of reach either way; in practice these APIs are called at runtime, where late definitions cover them.
- Options: "Modern addon API shims" checkbox, credit in the tooltip. Placed as a right column on an existing row because the panel is already at the container's bottom edge; a new full row would risk clipping the Tools section. `CreateCheckbox` gains an optional x offset to support this.
- The .toc author line extends the existing credit pattern (Wardz for CastBars) with techgeekpr for ApiCompat.

## Risk notes

- The one behavioral risk of default-on: the mere existence of `C_Container` flips feature detection (`if C_Container then`) in third-party addons onto their modern code paths. The auto-map covers every same-named global; a member with no classic equivalent returns nil and the addon errors differently than before. The toggle is the kill switch.
- Version stays 1.2.2; the bump belongs to whichever cut ships this.

## Testing

- New module plus all three edited files parse clean under Lua 5.1 (luaparse).
- Not yet field-tested in game. Before this rides a cut it needs an in-game pass: options toggle round-trip, then a modern bag addon or WA pack exercising `C_Container`/`C_Spell` through the shims, plus a sanity check that existing modules (KeyringClamp reads `C_Container` guardedly) still behave.
