### PR TITLE
BowSheatheFix: gate to hunters only

### DIFF
--- a/Addons/JimsPlus/BowSheatheFix.lua
+++ b/Addons/JimsPlus/BowSheatheFix.lua
@@ -22,6 +22,8 @@ local function Enabled()
 end
 
 local function HasBowAnd2H()
+    local _, class = UnitClass("player")
+    if class ~= "HUNTER" then return false end -- warriors/rogues with a stat-stick bow: the nudge kept drawing it
     local ranged = GetInventoryItemID("player", 18)
     if not ranged then return false end
     local classID, subclassID = select(6, GetItemInfoInstant(ranged))


### PR DESCRIPTION
Follow-up to #476. Field reports since the merge: warriors and rogues who carry a bow purely as a stat-stick (with a 2H mainhand) were having their weapons drawn by the addon after combat — the repair-nudge path in `BowSheatheFix.lua` fired for them too, since the old check only looked at equipment.

The render bug this module works around only matters in practice for hunters, so `HasBowAnd2H` now short-circuits unless the player''s class is HUNTER. Two-line change, addon-only, `/reload` picks it up.

Field-tested locally on a hunter (fix still active) — warriors/rogues no longer get the post-combat draw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RehzqEc6hoG5NboAZmqVAi