### PR TITLE
Fishing: drop the previous bobber's stale channel zero-update on recast

### DIFF
--- a/HermesProxy.Tests/World/ChannelStaleZeroUpdateTests.cs
+++ b/HermesProxy.Tests/World/ChannelStaleZeroUpdateTests.cs
@@ -1,51 +1,141 @@
-using System;
 using HermesProxy;
 using HermesProxy.World;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
 using Xunit;
+using Disposition = HermesProxy.GameSessionData.LocalChannelZeroUpdateDisposition;
 
 namespace HermesProxy.Tests.World;
 
-// JimsProxy (fishing recast wedge 2026-09-01): state tests for the stale channel
-// zero-update guard in GameSessionData. Recasting fishing while the previous bobber
-// still exists server-side (its teardown lags the channel close by ~2s) makes
-// mangos-family servers tear the old bobber down on the tick AFTER the new channel
-// starts; the teardown's trailing MSG_CHANNEL_UPDATE(0) lands ~100ms behind the new
-// MSG_CHANNEL_START and would end the channel just opened on the modern client. The
-// guard arms only when a fishing channel starts moments after the previous fishing
-// channel closed, drops at most one zero-update, only within the post-start window,
-// and stands down on any client-side channel-breaking action.
+// JimsProxy (fishing recast wedge 2026-09-01): state tests for the held channel
+// zero-update guard in GameSessionData. A fishing bobber outlives its channel by ~2s,
+// and a mangos-family bobber timeout finishes whatever channel the player has at that
+// moment — so a recast inside that window has its NEW channel ended by the server
+// ~100ms after it opened while the new bobber lives on. The guard keeps the client's
+// channel open so the bobber can be waited out: it arms only when the previous bobber
+// is still in the object cache at the new CHANNEL_START, holds the zero-update, and
+// drops it only when that bobber's destroy (or SMSG_FISH_NOT_HOOKED) lands in the same
+// read pass; a socket drain releases anything still held as genuine.
 public class ChannelStaleZeroUpdateTests
 {
+    static ChannelStaleZeroUpdateTests()
+    {
+        // ServerPacket construction resolves opcodes through ModernVersion, whose
+        // static ctor needs a real build — same guard every packet-constructing
+        // test class uses so the class also runs green in isolation.
+        if (global::Framework.Settings.ClientBuild == HermesProxy.Enums.ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = HermesProxy.Enums.ClientVersionBuild.V1_14_2_42597;
+    }
+
     private const uint FishingArtisan = 18248;
     private const uint MindFlay = 15407;
     private const uint ChannelDurationMs = 30000;
-    private const long T0 = 1_000_000;
+    private static readonly WowGuid128 OldBobber = new(0x1F00_0000_0000_0001, 0x0000_0000_0000_0001);
+    private static readonly WowGuid128 NewBobber = new(0x1F00_0000_0000_0002, 0x0000_0000_0000_0002);
+    private static readonly WowGuid128 SomeMob = new(0xF130_0000_0000_0003, 0x0000_0000_0000_0003);
 
     private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
 
-    /// <summary>First channel runs its full course and closes; player recasts inside
-    /// the bobber-teardown lag. Returns the recast's start tick.</summary>
-    private static long RecastIntoTeardownWindow(GameSessionData session, uint spellId = FishingArtisan)
+    private static SpellChannelUpdate ZeroUpdate() => new() { TimeRemaining = 0 };
+
+    /// <summary>The server created a bobber for us (UPDATE_OBJECT create block).</summary>
+    private static void BobberCreated(GameSessionData session, WowGuid128 guid)
     {
-        session.OnLocalChannelStartAtTick(spellId, ChannelDurationMs, T0);
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + ChannelDurationMs)); // natural end forwards
-        long recastTick = T0 + ChannelDurationMs + 1500; // old bobber still exists ~2s more
-        session.OnLocalChannelStartAtTick(spellId, ChannelDurationMs, recastTick);
-        return recastTick;
+        session.ObjectCacheLegacy[guid] = [];
+        session.LocalFishingBobberGuid = guid;
+    }
+
+    /// <summary>SMSG_DESTROY_OBJECT for a guid, as HandleDestroyObject drives the guard.</summary>
+    private static bool Destroyed(GameSessionData session, WowGuid128 guid)
+    {
+        session.ObjectCacheLegacy.Remove(guid);
+        return session.OnFishingBobberTeardownAnchor(guid);
+    }
+
+    /// <summary>The captured wedge's setup: first cast's bobber still alive when the
+    /// recast's CHANNEL_START arrives (the new bobber's create trails it).</summary>
+    private static GameSessionData RecastWithOldBobberAlive(uint spellId = FishingArtisan)
+    {
+        var session = NewSession();
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        BobberCreated(session, OldBobber);
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate())); // natural end
+        session.OnLocalChannelStart(spellId, ChannelDurationMs);
+        BobberCreated(session, NewBobber);
+        return session;
     }
 
     [Fact]
-    public void RecastAfterRecentClose_DropsStaleTail_OnceOnly()
+    public void Wedge_ZeroUpdateHeld_DroppedByOldBobberDestroy_ChannelStaysOpen()
     {
-        var session = NewSession();
-        long recastTick = RecastIntoTeardownWindow(session);
+        var session = RecastWithOldBobberAlive();
 
-        // The captured wedge: teardown tail lands ~100ms behind the new CHANNEL_START.
-        Assert.True(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+        // Captured batch order: UPDATE_OBJECT(old) → CHANNEL_UPDATE(0) → FISH_NOT_HOOKED → DESTROY(old).
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.True(Destroyed(session, OldBobber));
+        Assert.Null(session.HeldLocalChannelZeroUpdate);
         // The channel we protected stays open (also keeps the #244 emote guard honest).
         Assert.Equal(FishingArtisan, session.LocalChannelSpellId);
-        // One-shot: only one stale tail is ever owed — a second zero-update is genuine.
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 200));
+        Assert.Null(session.TakeHeldLocalChannelZeroUpdateAtDrain());
+        // Disarmed: the next zero-update (this channel's real end) is genuine.
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.Equal(0u, session.LocalChannelSpellId);
+    }
+
+    [Fact]
+    public void Wedge_FishNotHookedAlsoAnchorsTheDrop()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.True(session.OnFishingBobberTeardownAnchor());
+        Assert.False(Destroyed(session, OldBobber)); // nothing left to drop
+        Assert.Equal(FishingArtisan, session.LocalChannelSpellId);
+    }
+
+    [Fact]
+    public void OldBobberDestroyBeforeZeroUpdate_SamePass_Drops()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.False(Destroyed(session, OldBobber)); // nothing held yet: remembered for this pass
+        Assert.Equal(Disposition.Dropped, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.Equal(FishingArtisan, session.LocalChannelSpellId);
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate())); // one-shot
+    }
+
+    [Fact]
+    public void OldBobberDestroyThenDrain_Disarms()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.False(Destroyed(session, OldBobber));
+        Assert.Null(session.TakeHeldLocalChannelZeroUpdateAtDrain()); // pass ended, nothing owed any more
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.Equal(0u, session.LocalChannelSpellId);
+    }
+
+    [Fact]
+    public void HeldWithoutAnchor_ReleasedAtDrain_AsGenuineEnd()
+    {
+        var session = RecastWithOldBobberAlive();
+        var update = ZeroUpdate();
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(update));
+        Assert.False(Destroyed(session, SomeMob)); // some other object's destroy is not an anchor
+        Assert.Same(update, session.TakeHeldLocalChannelZeroUpdateAtDrain());
+        Assert.Equal(0u, session.LocalChannelSpellId);
+        Assert.Equal(default, session.StaleZeroUpdateBobberGuid);
+    }
+
+    [Fact]
+    public void OldBobberAlreadyDestroyed_DoesNotArm()
+    {
+        var session = NewSession();
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        BobberCreated(session, OldBobber);
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.False(Destroyed(session, OldBobber)); // teardown finished before the recast
+
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        Assert.Equal(default, session.StaleZeroUpdateBobberGuid);
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
         Assert.Equal(0u, session.LocalChannelSpellId);
     }
 
@@ -53,79 +143,54 @@ public class ChannelStaleZeroUpdateTests
     public void FirstCastOfSession_GenuineEarlyInterrupt_Forwards()
     {
         var session = NewSession();
-        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        BobberCreated(session, OldBobber);
 
-        // No previous fishing channel ⇒ no bobber can be owed a teardown ⇒ a zero-update
-        // 100ms in (mob damage, movement interrupt) is genuine and must end the channel.
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + 100));
+        // No previous bobber ⇒ nothing owed ⇒ a zero-update 100ms in (mob damage) is genuine.
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
         Assert.Equal(0u, session.LocalChannelSpellId);
-    }
-
-    [Fact]
-    public void RecastLongAfterClose_DoesNotArm()
-    {
-        var session = NewSession();
-        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + ChannelDurationMs));
-
-        // Recast after the old bobber is provably gone — nothing stale can arrive.
-        long recastTick = T0 + ChannelDurationMs + GameSessionData.FishingBobberTeardownLagMs;
-        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, recastTick);
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
     }
 
     [Fact]
     public void ReplacedWhileStillOpen_ArmsGuard()
     {
+        // Recast mid-channel with no zero-update seen in between: the old bobber is alive,
+        // its teardown will finish the new channel, and that zero-update is droppable.
         var session = NewSession();
-        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
-
-        // Recast mid-channel with no zero-update seen in between: the replaced channel
-        // counts as closed now, so its late teardown tail is still owed and droppable.
-        long recastTick = T0 + 15000;
-        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, recastTick);
-        Assert.True(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        BobberCreated(session, OldBobber);
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        Assert.Equal(OldBobber, session.StaleZeroUpdateBobberGuid);
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.True(Destroyed(session, OldBobber));
     }
 
     [Fact]
-    public void BreakActionAfterStart_DisarmsGuard()
+    public void BreakActionAfterStart_ForwardsImmediately()
     {
-        var session = NewSession();
-        long recastTick = RecastIntoTeardownWindow(session);
+        var session = RecastWithOldBobberAlive();
 
-        // Player clicked a GO / cancelled right after recasting — the zero-update that
-        // follows is the genuine result of that action and must reach the client.
+        // Player moved / cast / clicked a GO right after recasting — the zero-update that
+        // follows is the genuine result of that action and must reach the client now.
         session.RecordLocalChannelBreakAction();
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
         Assert.Equal(0u, session.LocalChannelSpellId);
+        Assert.Equal(default, session.StaleZeroUpdateBobberGuid);
     }
 
     [Fact]
-    public void BreakActionFromPreviousCast_ClearedByStart_StillDrops()
+    public void BreakActionFromPreviousCast_ClearedByStart_StillHolds()
     {
         var session = NewSession();
-        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        BobberCreated(session, OldBobber);
         session.RecordLocalChannelBreakAction(); // e.g. clicked the old bobber early
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + 5000));
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
 
         // The new CHANNEL_START resets the break flag — an earlier cast's action must
         // not disarm the guard for the channel that follows it.
-        long recastTick = T0 + 6500;
-        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, recastTick);
-        Assert.True(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
-    }
-
-    [Fact]
-    public void ZeroUpdatePastWindow_Forwards()
-    {
-        var session = NewSession();
-        long recastTick = RecastIntoTeardownWindow(session);
-
-        // Stale tails land within one server update batch of the START; anything at or
-        // past the window bound (e.g. the real end of this channel) is genuine.
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(
-            recastTick + GameSessionData.StaleChannelZeroUpdateWindowMs));
-        Assert.Equal(0u, session.LocalChannelSpellId);
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
     }
 
     [Fact]
@@ -133,9 +198,29 @@ public class ChannelStaleZeroUpdateTests
     {
         // A genuine early interrupt of a combat channel (damage pushback at <1.5s into
         // Mind Flay) must reach the client, or the cast bar wedges the other way.
+        var session = RecastWithOldBobberAlive(MindFlay);
+        Assert.Equal(default, session.StaleZeroUpdateBobberGuid);
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+    }
+
+    [Fact]
+    public void NewStart_SupersedesAnythingHeld()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        Assert.Null(session.HeldLocalChannelZeroUpdate);
+        Assert.Null(session.TakeHeldLocalChannelZeroUpdateAtDrain());
+    }
+
+    [Fact]
+    public void DestroyOfNewestBobber_ForgetsIt()
+    {
         var session = NewSession();
-        long recastTick = RecastIntoTeardownWindow(session, MindFlay);
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        BobberCreated(session, OldBobber);
+        Assert.False(Destroyed(session, OldBobber));
+        Assert.Equal(default, session.LocalFishingBobberGuid);
     }
 
     [Fact]
@@ -143,9 +228,9 @@ public class ChannelStaleZeroUpdateTests
     {
         // Pre-existing #244 behavior: a CHANNEL_START with no duration means no channel.
         var session = NewSession();
-        session.OnLocalChannelStartAtTick(FishingArtisan, 0, T0);
+        session.OnLocalChannelStart(FishingArtisan, 0);
         Assert.Equal(0u, session.LocalChannelSpellId);
-        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + 100));
+        Assert.Equal(Disposition.Forward, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
     }
 
     [Theory]

--- a/HermesProxy.Tests/World/ChannelStaleZeroUpdateTests.cs
+++ b/HermesProxy.Tests/World/ChannelStaleZeroUpdateTests.cs
@@ -224,6 +224,55 @@ public class ChannelStaleZeroUpdateTests
     }
 
     [Fact]
+    public void AfterDrop_ClientChannelIsOrphaned_EndedByNewBobberDestroy()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.True(Destroyed(session, OldBobber));
+
+        // The server has no channel any more; the client's is ours to end, and only the
+        // new bobber's destroy (catch looted, fish escaped, timed out) ends it.
+        Assert.Equal(NewBobber, session.OrphanedClientChannelBobberGuid);
+        Assert.False(session.TakeOrphanedClientChannelEnd(SomeMob));
+        Assert.Equal(FishingArtisan, session.LocalChannelSpellId);
+        Assert.True(session.TakeOrphanedClientChannelEnd(NewBobber));
+        Assert.Equal(0u, session.LocalChannelSpellId);
+        Assert.False(session.TakeOrphanedClientChannelEnd(NewBobber)); // one-shot
+    }
+
+    [Fact]
+    public void AfterDropViaEarlyAnchor_ClientChannelIsOrphaned()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.False(Destroyed(session, OldBobber));
+        Assert.Equal(Disposition.Dropped, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.Equal(NewBobber, session.OrphanedClientChannelBobberGuid);
+    }
+
+    [Fact]
+    public void OrphanedChannel_ClearedByNewStartOrGenuineEnd()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.True(Destroyed(session, OldBobber));
+
+        // A recast while orphaned: the new START owns the client channel again.
+        session.OnLocalChannelStart(FishingArtisan, ChannelDurationMs);
+        Assert.Equal(default, session.OrphanedClientChannelBobberGuid);
+        Assert.Equal(NewBobber, session.StaleZeroUpdateBobberGuid); // and the orphan bobber, still alive, is the next teardown owed
+    }
+
+    [Fact]
+    public void ReleasedAtDrain_NothingOrphaned()
+    {
+        var session = RecastWithOldBobberAlive();
+        Assert.Equal(Disposition.Held, session.ClassifyLocalChannelZeroUpdate(ZeroUpdate()));
+        Assert.NotNull(session.TakeHeldLocalChannelZeroUpdateAtDrain());
+        Assert.Equal(default, session.OrphanedClientChannelBobberGuid);
+        Assert.False(session.TakeOrphanedClientChannelEnd(NewBobber));
+    }
+
+    [Fact]
     public void ZeroDurationStart_ClosesChannelWindow()
     {
         // Pre-existing #244 behavior: a CHANNEL_START with no duration means no channel.

--- a/HermesProxy.Tests/World/ChannelStaleZeroUpdateTests.cs
+++ b/HermesProxy.Tests/World/ChannelStaleZeroUpdateTests.cs
@@ -1,0 +1,163 @@
+using System;
+using HermesProxy;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (fishing recast wedge 2026-09-01): state tests for the stale channel
+// zero-update guard in GameSessionData. Recasting fishing while the previous bobber
+// still exists server-side (its teardown lags the channel close by ~2s) makes
+// mangos-family servers tear the old bobber down on the tick AFTER the new channel
+// starts; the teardown's trailing MSG_CHANNEL_UPDATE(0) lands ~100ms behind the new
+// MSG_CHANNEL_START and would end the channel just opened on the modern client. The
+// guard arms only when a fishing channel starts moments after the previous fishing
+// channel closed, drops at most one zero-update, only within the post-start window,
+// and stands down on any client-side channel-breaking action.
+public class ChannelStaleZeroUpdateTests
+{
+    private const uint FishingArtisan = 18248;
+    private const uint MindFlay = 15407;
+    private const uint ChannelDurationMs = 30000;
+    private const long T0 = 1_000_000;
+
+    private static GameSessionData NewSession() => GameSessionData.CreateForTesting();
+
+    /// <summary>First channel runs its full course and closes; player recasts inside
+    /// the bobber-teardown lag. Returns the recast's start tick.</summary>
+    private static long RecastIntoTeardownWindow(GameSessionData session, uint spellId = FishingArtisan)
+    {
+        session.OnLocalChannelStartAtTick(spellId, ChannelDurationMs, T0);
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + ChannelDurationMs)); // natural end forwards
+        long recastTick = T0 + ChannelDurationMs + 1500; // old bobber still exists ~2s more
+        session.OnLocalChannelStartAtTick(spellId, ChannelDurationMs, recastTick);
+        return recastTick;
+    }
+
+    [Fact]
+    public void RecastAfterRecentClose_DropsStaleTail_OnceOnly()
+    {
+        var session = NewSession();
+        long recastTick = RecastIntoTeardownWindow(session);
+
+        // The captured wedge: teardown tail lands ~100ms behind the new CHANNEL_START.
+        Assert.True(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+        // The channel we protected stays open (also keeps the #244 emote guard honest).
+        Assert.Equal(FishingArtisan, session.LocalChannelSpellId);
+        // One-shot: only one stale tail is ever owed — a second zero-update is genuine.
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 200));
+        Assert.Equal(0u, session.LocalChannelSpellId);
+    }
+
+    [Fact]
+    public void FirstCastOfSession_GenuineEarlyInterrupt_Forwards()
+    {
+        var session = NewSession();
+        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
+
+        // No previous fishing channel ⇒ no bobber can be owed a teardown ⇒ a zero-update
+        // 100ms in (mob damage, movement interrupt) is genuine and must end the channel.
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + 100));
+        Assert.Equal(0u, session.LocalChannelSpellId);
+    }
+
+    [Fact]
+    public void RecastLongAfterClose_DoesNotArm()
+    {
+        var session = NewSession();
+        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + ChannelDurationMs));
+
+        // Recast after the old bobber is provably gone — nothing stale can arrive.
+        long recastTick = T0 + ChannelDurationMs + GameSessionData.FishingBobberTeardownLagMs;
+        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, recastTick);
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+    }
+
+    [Fact]
+    public void ReplacedWhileStillOpen_ArmsGuard()
+    {
+        var session = NewSession();
+        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
+
+        // Recast mid-channel with no zero-update seen in between: the replaced channel
+        // counts as closed now, so its late teardown tail is still owed and droppable.
+        long recastTick = T0 + 15000;
+        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, recastTick);
+        Assert.True(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+    }
+
+    [Fact]
+    public void BreakActionAfterStart_DisarmsGuard()
+    {
+        var session = NewSession();
+        long recastTick = RecastIntoTeardownWindow(session);
+
+        // Player clicked a GO / cancelled right after recasting — the zero-update that
+        // follows is the genuine result of that action and must reach the client.
+        session.RecordLocalChannelBreakAction();
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+        Assert.Equal(0u, session.LocalChannelSpellId);
+    }
+
+    [Fact]
+    public void BreakActionFromPreviousCast_ClearedByStart_StillDrops()
+    {
+        var session = NewSession();
+        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, T0);
+        session.RecordLocalChannelBreakAction(); // e.g. clicked the old bobber early
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + 5000));
+
+        // The new CHANNEL_START resets the break flag — an earlier cast's action must
+        // not disarm the guard for the channel that follows it.
+        long recastTick = T0 + 6500;
+        session.OnLocalChannelStartAtTick(FishingArtisan, ChannelDurationMs, recastTick);
+        Assert.True(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+    }
+
+    [Fact]
+    public void ZeroUpdatePastWindow_Forwards()
+    {
+        var session = NewSession();
+        long recastTick = RecastIntoTeardownWindow(session);
+
+        // Stale tails land within one server update batch of the START; anything at or
+        // past the window bound (e.g. the real end of this channel) is genuine.
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(
+            recastTick + GameSessionData.StaleChannelZeroUpdateWindowMs));
+        Assert.Equal(0u, session.LocalChannelSpellId);
+    }
+
+    [Fact]
+    public void NonFishingChannel_NeverArms()
+    {
+        // A genuine early interrupt of a combat channel (damage pushback at <1.5s into
+        // Mind Flay) must reach the client, or the cast bar wedges the other way.
+        var session = NewSession();
+        long recastTick = RecastIntoTeardownWindow(session, MindFlay);
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(recastTick + 100));
+    }
+
+    [Fact]
+    public void ZeroDurationStart_ClosesChannelWindow()
+    {
+        // Pre-existing #244 behavior: a CHANNEL_START with no duration means no channel.
+        var session = NewSession();
+        session.OnLocalChannelStartAtTick(FishingArtisan, 0, T0);
+        Assert.Equal(0u, session.LocalChannelSpellId);
+        Assert.False(session.ConsumeLocalChannelZeroUpdateAtTick(T0 + 100));
+    }
+
+    [Theory]
+    [InlineData(7620u, true)]   // Fishing (Apprentice)
+    [InlineData(7731u, true)]   // Fishing (Journeyman)
+    [InlineData(7732u, true)]   // Fishing (Expert)
+    [InlineData(18248u, true)]  // Fishing (Artisan)
+    [InlineData(33095u, true)]  // Fishing (Master) — TBC 2.4.3 backends are accepted
+    [InlineData(15407u, false)] // Mind Flay
+    [InlineData(0u, false)]     // not channeling
+    public void IsFishingChannelSpell_CoversAllRanks(uint spellId, bool expected)
+    {
+        Assert.Equal(expected, GameData.IsFishingChannelSpell(spellId));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -170,12 +170,13 @@ public sealed class GameSessionData
     // permanently.
     public uint LocalChannelSpellId; // 0 means not channeling
     public long LocalChannelEndTickMs;
-    // JimsProxy (fishing recast wedge 2026-09-01): stale channel zero-update guard
-    // state — see OnLocalChannelStart / ConsumeLocalChannelZeroUpdate below.
-    public long LocalChannelStartTickMs;
+    // JimsProxy (fishing recast wedge 2026-09-01): packet-anchored guard state for the
+    // previous bobber's channel zero-update — see OnLocalChannelStart below.
+    public WowGuid128 LocalFishingBobberGuid;     // newest bobber the server created for us
+    public WowGuid128 StaleZeroUpdateBobberGuid;  // armed while set: the bobber whose teardown is still owed
     public bool LocalChannelBreakActionSeen;
-    public long LastFishingChannelCloseTickMs;
-    public bool StaleChannelZeroUpdateArmed;
+    public bool StaleBobberTeardownSeenThisPass;
+    public SpellChannelUpdate? HeldLocalChannelZeroUpdate;
 
     /// <summary>True while the local player's channel window (tracked from
     /// MSG_CHANNEL_START/UPDATE) is open, with a small grace margin. Used to
@@ -189,72 +190,122 @@ public sealed class GameSessionData
 
     /// <summary>
     /// JimsProxy (fishing recast wedge 2026-09-01): MSG_CHANNEL_START bookkeeping for the
-    /// local player. Arms the stale zero-update guard iff this is a fishing channel opened
-    /// moments after the previous fishing channel closed — the only situation in which the
-    /// previous bobber can still exist server-side (its teardown lags the channel close by
-    /// ~2s). Mangos-family servers then tear the old bobber down on the tick AFTER the new
-    /// channel starts, and its trailing MSG_CHANNEL_UPDATE(0) — vanilla carries no spell id
-    /// — would end the channel just opened on the modern client: the char stops fishing
-    /// while the new bobber floats out its full lifetime, and every recast from then on
-    /// repeats the race. Scoped to fishing because eating a genuine early interrupt of a
-    /// combat channel would wedge the cast bar the other way.
+    /// local player. A fishing bobber outlives its channel by a couple of seconds, and on
+    /// mangos-family cores the bobber's timeout finishes whatever channel the player has
+    /// at that moment (Unit::FinishSpell sends a channel update with no time remaining
+    /// for CURRENT_CHANNELED_SPELL without checking that the bobber belongs to it). So a
+    /// recast inside that window has its NEW channel ended by the server ~100ms after it
+    /// opened, while the new bobber lives on and stays lootable. Vanilla's channel update
+    /// carries no spell id, so the modern client faithfully ends the channel it just
+    /// opened: the char stands idle, the bobber floats out its full life, and every recast
+    /// from then on repeats the race. The guard keeps the client's channel open so the
+    /// bobber can be waited out. It arms only when the previous bobber is still in the
+    /// object cache at the new CHANNEL_START, and it acts only on the zero-update that
+    /// shares a read pass with that bobber's SMSG_DESTROY_OBJECT / SMSG_FISH_NOT_HOOKED.
+    /// Scoped to fishing because eating a genuine early interrupt of a combat channel
+    /// would wedge the cast bar the other way.
     /// </summary>
     public void OnLocalChannelStart(uint spellId, uint durationMs)
-        => OnLocalChannelStartAtTick(spellId, durationMs, Environment.TickCount64);
-
-    // Test seam (ChannelStaleZeroUpdateTests): drive the guard with chosen timestamps.
-    internal void OnLocalChannelStartAtTick(uint spellId, uint durationMs, long tickMs)
     {
-        // A fishing channel replaced while we still believed it open also counts as closed.
-        if (GameData.IsFishingChannelSpell(LocalChannelSpellId))
-            LastFishingChannelCloseTickMs = tickMs;
         LocalChannelSpellId = durationMs > 0 ? spellId : 0;
-        LocalChannelEndTickMs = tickMs + durationMs;
-        LocalChannelStartTickMs = tickMs;
+        LocalChannelEndTickMs = Environment.TickCount64 + durationMs;
         LocalChannelBreakActionSeen = false;
-        StaleChannelZeroUpdateArmed =
-            GameData.IsFishingChannelSpell(LocalChannelSpellId) &&
-            tickMs - LastFishingChannelCloseTickMs < FishingBobberTeardownLagMs;
+        StaleBobberTeardownSeenThisPass = false;
+        HeldLocalChannelZeroUpdate = null; // a new START supersedes anything still held
+        StaleZeroUpdateBobberGuid = default;
+        if (!GameData.IsFishingChannelSpell(LocalChannelSpellId) || LocalFishingBobberGuid == default)
+            return;
+        // The new bobber's create block trails this START in the same batch, so the newest
+        // bobber we know of is still the previous cast's — armed iff it is not destroyed yet.
+        bool previousBobberAlive;
+        lock (ObjectCacheLock)
+            previousBobberAlive = ObjectCacheLegacy.ContainsKey(LocalFishingBobberGuid);
+        if (previousBobberAlive)
+            StaleZeroUpdateBobberGuid = LocalFishingBobberGuid;
     }
+
+    public enum LocalChannelZeroUpdateDisposition { Forward, Held, Dropped }
 
     /// <summary>
     /// JimsProxy (fishing recast wedge 2026-09-01): decision for a MSG_CHANNEL_UPDATE with
-    /// no time remaining for the local player. True = drop it as the previous bobber's
-    /// stale teardown tail (one-shot, and only within StaleChannelZeroUpdateWindowMs of the
-    /// channel opening with no client-side break action since). False = genuine end: the
-    /// #244 emote-guard window is closed here and the caller forwards the packet.
+    /// no time remaining for the local player. Forward = genuine end (the #244 emote-guard
+    /// window is closed here). Held = the previous bobber's teardown may follow in this
+    /// read pass: the caller parks the packet until that bobber's destroy drops it or the
+    /// socket drains and releases it. Dropped = the teardown already passed this pass.
     /// </summary>
-    public bool ConsumeLocalChannelZeroUpdate()
-        => ConsumeLocalChannelZeroUpdateAtTick(Environment.TickCount64);
-
-    internal bool ConsumeLocalChannelZeroUpdateAtTick(long tickMs)
+    public LocalChannelZeroUpdateDisposition ClassifyLocalChannelZeroUpdate(SpellChannelUpdate update)
     {
-        if (StaleChannelZeroUpdateArmed &&
-            !LocalChannelBreakActionSeen &&
-            tickMs - LocalChannelStartTickMs < StaleChannelZeroUpdateWindowMs)
+        if (StaleZeroUpdateBobberGuid == default || LocalChannelBreakActionSeen)
         {
-            StaleChannelZeroUpdateArmed = false; // one-shot: a second zero-update is genuine
-            return true;
+            // JimsProxy (#244 emote channel guard): the server ends a channel by sending an
+            // update with no time remaining — close our window early.
+            LocalChannelSpellId = 0;
+            StaleZeroUpdateBobberGuid = default;
+            return LocalChannelZeroUpdateDisposition.Forward;
         }
-        if (GameData.IsFishingChannelSpell(LocalChannelSpellId))
-            LastFishingChannelCloseTickMs = tickMs;
-        // JimsProxy (#244 emote channel guard): the server ends a channel by sending an
-        // update with no time remaining — close our window early.
+        if (StaleBobberTeardownSeenThisPass)
+        {
+            StaleBobberTeardownSeenThisPass = false;
+            StaleZeroUpdateBobberGuid = default;
+            return LocalChannelZeroUpdateDisposition.Dropped;
+        }
+        HeldLocalChannelZeroUpdate = update;
+        return LocalChannelZeroUpdateDisposition.Held;
+    }
+
+    /// <summary>
+    /// JimsProxy (fishing recast wedge 2026-09-01): SMSG_DESTROY_OBJECT for the armed
+    /// bobber, or SMSG_FISH_NOT_HOOKED (guid-less; only a bobber's teardown or a bobber
+    /// click sends it, and a click is a break action). True = a held zero-update was
+    /// dropped. With nothing held, the anchor is remembered for the rest of this read pass.
+    /// </summary>
+    public bool OnFishingBobberTeardownAnchor(WowGuid128 destroyedGuid = default)
+    {
+        if (destroyedGuid != default && destroyedGuid == LocalFishingBobberGuid)
+            LocalFishingBobberGuid = default;
+        if (StaleZeroUpdateBobberGuid == default)
+            return false;
+        if (destroyedGuid != default && destroyedGuid != StaleZeroUpdateBobberGuid)
+            return false;
+        if (HeldLocalChannelZeroUpdate == null)
+        {
+            StaleBobberTeardownSeenThisPass = true;
+            return false;
+        }
+        HeldLocalChannelZeroUpdate = null;
+        StaleZeroUpdateBobberGuid = default;
+        return true;
+    }
+
+    /// <summary>
+    /// JimsProxy (fishing recast wedge 2026-09-01): the legacy socket has no more buffered
+    /// packets, so the read pass is over. Returns a held zero-update for forwarding (no
+    /// anchor came with it, so it was genuine) and closes the channel window; an anchor
+    /// seen without a zero-update disarms the guard — nothing is owed any more.
+    /// </summary>
+    public SpellChannelUpdate? TakeHeldLocalChannelZeroUpdateAtDrain()
+    {
+        if (StaleBobberTeardownSeenThisPass)
+        {
+            StaleBobberTeardownSeenThisPass = false;
+            StaleZeroUpdateBobberGuid = default;
+        }
+        var held = HeldLocalChannelZeroUpdate;
+        if (held == null)
+            return null;
+        HeldLocalChannelZeroUpdate = null;
+        StaleZeroUpdateBobberGuid = default;
         LocalChannelSpellId = 0;
-        return false;
+        return held;
     }
 
     /// <summary>
     /// JimsProxy (fishing recast wedge 2026-09-01): the client did something that can
-    /// legitimately end its channel early (cancel cast/channel, GO use) — any zero-update
-    /// after this is genuine, so the guard stands down until the next channel start.
+    /// legitimately end its channel early (cancel cast/channel, GO use, another cast) —
+    /// any zero-update after this is genuine, so the guard stands down until the next
+    /// channel start.
     /// </summary>
     public void RecordLocalChannelBreakAction() => LocalChannelBreakActionSeen = true;
-
-    // Stale tails land ~100ms behind the new CHANNEL_START (same server update batch); a
-    // genuine bobber click can never come this early. Teardown lag observed at ~2s.
-    public const long StaleChannelZeroUpdateWindowMs = 1500;
-    public const long FishingBobberTeardownLagMs = 5000;
     public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -170,6 +170,12 @@ public sealed class GameSessionData
     // permanently.
     public uint LocalChannelSpellId; // 0 means not channeling
     public long LocalChannelEndTickMs;
+    // JimsProxy (fishing recast wedge 2026-09-01): stale channel zero-update guard
+    // state — see OnLocalChannelStart / ConsumeLocalChannelZeroUpdate below.
+    public long LocalChannelStartTickMs;
+    public bool LocalChannelBreakActionSeen;
+    public long LastFishingChannelCloseTickMs;
+    public bool StaleChannelZeroUpdateArmed;
 
     /// <summary>True while the local player's channel window (tracked from
     /// MSG_CHANNEL_START/UPDATE) is open, with a small grace margin. Used to
@@ -180,6 +186,75 @@ public sealed class GameSessionData
         return LocalChannelSpellId != 0 &&
                Environment.TickCount64 < LocalChannelEndTickMs + 2000;
     }
+
+    /// <summary>
+    /// JimsProxy (fishing recast wedge 2026-09-01): MSG_CHANNEL_START bookkeeping for the
+    /// local player. Arms the stale zero-update guard iff this is a fishing channel opened
+    /// moments after the previous fishing channel closed — the only situation in which the
+    /// previous bobber can still exist server-side (its teardown lags the channel close by
+    /// ~2s). Mangos-family servers then tear the old bobber down on the tick AFTER the new
+    /// channel starts, and its trailing MSG_CHANNEL_UPDATE(0) — vanilla carries no spell id
+    /// — would end the channel just opened on the modern client: the char stops fishing
+    /// while the new bobber floats out its full lifetime, and every recast from then on
+    /// repeats the race. Scoped to fishing because eating a genuine early interrupt of a
+    /// combat channel would wedge the cast bar the other way.
+    /// </summary>
+    public void OnLocalChannelStart(uint spellId, uint durationMs)
+        => OnLocalChannelStartAtTick(spellId, durationMs, Environment.TickCount64);
+
+    // Test seam (ChannelStaleZeroUpdateTests): drive the guard with chosen timestamps.
+    internal void OnLocalChannelStartAtTick(uint spellId, uint durationMs, long tickMs)
+    {
+        // A fishing channel replaced while we still believed it open also counts as closed.
+        if (GameData.IsFishingChannelSpell(LocalChannelSpellId))
+            LastFishingChannelCloseTickMs = tickMs;
+        LocalChannelSpellId = durationMs > 0 ? spellId : 0;
+        LocalChannelEndTickMs = tickMs + durationMs;
+        LocalChannelStartTickMs = tickMs;
+        LocalChannelBreakActionSeen = false;
+        StaleChannelZeroUpdateArmed =
+            GameData.IsFishingChannelSpell(LocalChannelSpellId) &&
+            tickMs - LastFishingChannelCloseTickMs < FishingBobberTeardownLagMs;
+    }
+
+    /// <summary>
+    /// JimsProxy (fishing recast wedge 2026-09-01): decision for a MSG_CHANNEL_UPDATE with
+    /// no time remaining for the local player. True = drop it as the previous bobber's
+    /// stale teardown tail (one-shot, and only within StaleChannelZeroUpdateWindowMs of the
+    /// channel opening with no client-side break action since). False = genuine end: the
+    /// #244 emote-guard window is closed here and the caller forwards the packet.
+    /// </summary>
+    public bool ConsumeLocalChannelZeroUpdate()
+        => ConsumeLocalChannelZeroUpdateAtTick(Environment.TickCount64);
+
+    internal bool ConsumeLocalChannelZeroUpdateAtTick(long tickMs)
+    {
+        if (StaleChannelZeroUpdateArmed &&
+            !LocalChannelBreakActionSeen &&
+            tickMs - LocalChannelStartTickMs < StaleChannelZeroUpdateWindowMs)
+        {
+            StaleChannelZeroUpdateArmed = false; // one-shot: a second zero-update is genuine
+            return true;
+        }
+        if (GameData.IsFishingChannelSpell(LocalChannelSpellId))
+            LastFishingChannelCloseTickMs = tickMs;
+        // JimsProxy (#244 emote channel guard): the server ends a channel by sending an
+        // update with no time remaining — close our window early.
+        LocalChannelSpellId = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// JimsProxy (fishing recast wedge 2026-09-01): the client did something that can
+    /// legitimately end its channel early (cancel cast/channel, GO use) — any zero-update
+    /// after this is genuine, so the guard stands down until the next channel start.
+    /// </summary>
+    public void RecordLocalChannelBreakAction() => LocalChannelBreakActionSeen = true;
+
+    // Stale tails land ~100ms behind the new CHANNEL_START (same server update batch); a
+    // genuine bobber click can never come this early. Teardown lag observed at ~2s.
+    public const long StaleChannelZeroUpdateWindowMs = 1500;
+    public const long FishingBobberTeardownLagMs = 5000;
     public string? TaxiAttemptId;
     public bool IsWaitingForNewWorld;
     public bool IsWaitingForWorldPortAck;

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -177,6 +177,7 @@ public sealed class GameSessionData
     public bool LocalChannelBreakActionSeen;
     public bool StaleBobberTeardownSeenThisPass;
     public SpellChannelUpdate? HeldLocalChannelZeroUpdate;
+    public WowGuid128 OrphanedClientChannelBobberGuid; // set after a drop: the client's channel outlives the server's; the proxy ends it when this bobber goes
 
     /// <summary>True while the local player's channel window (tracked from
     /// MSG_CHANNEL_START/UPDATE) is open, with a small grace margin. Used to
@@ -213,6 +214,7 @@ public sealed class GameSessionData
         StaleBobberTeardownSeenThisPass = false;
         HeldLocalChannelZeroUpdate = null; // a new START supersedes anything still held
         StaleZeroUpdateBobberGuid = default;
+        OrphanedClientChannelBobberGuid = default;
         if (!GameData.IsFishingChannelSpell(LocalChannelSpellId) || LocalFishingBobberGuid == default)
             return;
         // The new bobber's create block trails this START in the same batch, so the newest
@@ -241,12 +243,14 @@ public sealed class GameSessionData
             // update with no time remaining — close our window early.
             LocalChannelSpellId = 0;
             StaleZeroUpdateBobberGuid = default;
+            OrphanedClientChannelBobberGuid = default;
             return LocalChannelZeroUpdateDisposition.Forward;
         }
         if (StaleBobberTeardownSeenThisPass)
         {
             StaleBobberTeardownSeenThisPass = false;
             StaleZeroUpdateBobberGuid = default;
+            OrphanedClientChannelBobberGuid = LocalFishingBobberGuid;
             return LocalChannelZeroUpdateDisposition.Dropped;
         }
         HeldLocalChannelZeroUpdate = update;
@@ -274,6 +278,22 @@ public sealed class GameSessionData
         }
         HeldLocalChannelZeroUpdate = null;
         StaleZeroUpdateBobberGuid = default;
+        OrphanedClientChannelBobberGuid = LocalFishingBobberGuid;
+        return true;
+    }
+
+    /// <summary>
+    /// JimsProxy (fishing recast wedge 2026-09-01): after a drop the server has no channel
+    /// but the client still does, so nothing on the wire will ever end it. The new bobber's
+    /// SMSG_DESTROY_OBJECT (catch looted, fish escaped, or timed out) is where the server
+    /// would have ended a channel of its own — true = the caller ends the client's now.
+    /// </summary>
+    public bool TakeOrphanedClientChannelEnd(WowGuid128 destroyedGuid)
+    {
+        if (OrphanedClientChannelBobberGuid == default || destroyedGuid != OrphanedClientChannelBobberGuid)
+            return false;
+        OrphanedClientChannelBobberGuid = default;
+        LocalChannelSpellId = 0;
         return true;
     }
 
@@ -295,6 +315,7 @@ public sealed class GameSessionData
             return null;
         HeldLocalChannelZeroUpdate = null;
         StaleZeroUpdateBobberGuid = default;
+        OrphanedClientChannelBobberGuid = default;
         LocalChannelSpellId = 0;
         return held;
     }

--- a/HermesProxy/World/Client/PacketHandlers/GameObjectHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GameObjectHandler.cs
@@ -40,6 +40,9 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_FISH_NOT_HOOKED)]
     void HandleFishNotHooked(WorldPacket packet)
     {
+        // JimsProxy (fishing recast wedge): a bobber timeout sends this right after the
+        // channel zero-update it caused — an anchor for dropping a held one.
+        DropHeldChannelZeroUpdateIfAnchored(default, "fish_not_hooked");
         FishNotHooked fish = new FishNotHooked();
         SendPacketToClient(fish);
     }

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -2,6 +2,7 @@
 using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Collections.Generic;
@@ -3811,7 +3812,7 @@ public partial class WorldClient
                 case GameSessionData.LocalChannelZeroUpdateDisposition.Held:
                     return;
                 case GameSessionData.LocalChannelZeroUpdateDisposition.Dropped:
-                    LogStaleChannelZeroUpdateDropped("teardown_before_update");
+                    OnStaleChannelZeroUpdateDropped("teardown_before_update");
                     return;
             }
         }
@@ -3823,18 +3824,43 @@ public partial class WorldClient
     private void DropHeldChannelZeroUpdateIfAnchored(WowGuid128 destroyedGuid, string anchor)
     {
         if (GetSession().GameState.OnFishingBobberTeardownAnchor(destroyedGuid))
-            LogStaleChannelZeroUpdateDropped(anchor);
+            OnStaleChannelZeroUpdateDropped(anchor);
     }
 
-    private void LogStaleChannelZeroUpdateDropped(string anchor)
+    // The same server tick that sends the zero-update also clears the player's channel
+    // spell and channel object fields, and that values block was already forwarded ahead
+    // of it — without the fields the client drops the fishing pose, refuses the bobber and
+    // refuses a recast. Point them at the new bobber again so the client's channel is whole.
+    private void OnStaleChannelZeroUpdateDropped(string anchor)
     {
-        if (!Settings.DebugOutput)
+        var state = GetSession().GameState;
+        UpdateObject updateObject = new UpdateObject(state);
+        ObjectUpdate update = new ObjectUpdate(state.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
+        update.UnitData.ChannelData = new UnitChannel((int)state.LocalChannelSpellId, (int)GameData.GetSpellVisual(state.LocalChannelSpellId));
+        update.UnitData.ChannelObject = state.OrphanedClientChannelBobberGuid;
+        updateObject.ObjectUpdates.Add(update);
+        SendPacketToClient(updateObject);
+        if (Settings.DebugOutput)
+            Log.Event("spell.channel.stale_zero_update_dropped", new
+            {
+                spell_id = state.LocalChannelSpellId,
+                anchor,
+                bobber = state.OrphanedClientChannelBobberGuid.ToString(),
+            });
+    }
+
+    // The server never ends a channel it no longer has, so the new bobber's destroy is
+    // where the client's kept-alive channel must end instead.
+    private void EndOrphanedClientChannelIfBobber(WowGuid128 destroyedGuid)
+    {
+        var state = GetSession().GameState;
+        uint spellId = state.LocalChannelSpellId;
+        if (!state.TakeOrphanedClientChannelEnd(destroyedGuid))
             return;
-        Log.Event("spell.channel.stale_zero_update_dropped", new
-        {
-            spell_id = GetSession().GameState.LocalChannelSpellId,
-            anchor,
-        });
+        SpellChannelUpdate end = new() { CasterGUID = state.CurrentPlayerGuid, TimeRemaining = 0 };
+        SendPacketToClient(end);
+        if (Settings.DebugOutput)
+            Log.Event("spell.channel.orphan_end_synthesized", new { spell_id = spellId, bobber = destroyedGuid.ToString() });
     }
 
     // JimsProxy (fishing recast wedge): the read pass ended with the zero-update still

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3785,10 +3785,7 @@ public partial class WorldClient
         // JimsProxy (#244 emote channel guard): record our own channel window
         // so text-emote forwards hold off while it is open.
         if (channel.CasterGUID == GetSession().GameState.CurrentPlayerGuid)
-        {
-            GetSession().GameState.LocalChannelSpellId = channel.Duration > 0 ? channel.SpellID : 0;
-            GetSession().GameState.LocalChannelEndTickMs = Environment.TickCount64 + channel.Duration;
-        }
+            GetSession().GameState.OnLocalChannelStart(channel.SpellID, channel.Duration);
         SendPacketToClient(channel);
     }
 
@@ -3801,10 +3798,26 @@ public partial class WorldClient
         else
             channel.CasterGUID = GetSession().GameState.CurrentPlayerGuid;
         channel.TimeRemaining = packet.ReadInt32();
-        // JimsProxy (#244 emote channel guard): the server ends a channel by
-        // sending an update with no time remaining — close our window early.
         if (channel.TimeRemaining <= 0 && channel.CasterGUID == GetSession().GameState.CurrentPlayerGuid)
-            GetSession().GameState.LocalChannelSpellId = 0;
+        {
+            var gameState = GetSession().GameState;
+            // JimsProxy (fishing recast wedge 2026-09-01): a zero-update this early into a
+            // freshly recast fishing channel is the PREVIOUS bobber's teardown tail —
+            // forwarding it would kill the channel we just opened. See
+            // GameSessionData.ConsumeLocalChannelZeroUpdate.
+            if (gameState.ConsumeLocalChannelZeroUpdate())
+            {
+                Log.Event("spell.channel.stale_zero_update_dropped", new
+                {
+                    spell_id = gameState.LocalChannelSpellId,
+                    ms_since_channel_start = Environment.TickCount64 - gameState.LocalChannelStartTickMs,
+                });
+                return;
+            }
+            // JimsProxy (#244 emote channel guard): the server ends a channel by
+            // sending an update with no time remaining — close our window early.
+            gameState.LocalChannelSpellId = 0;
+        }
         SendPacketToClient(channel);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3800,25 +3800,53 @@ public partial class WorldClient
         channel.TimeRemaining = packet.ReadInt32();
         if (channel.TimeRemaining <= 0 && channel.CasterGUID == GetSession().GameState.CurrentPlayerGuid)
         {
-            var gameState = GetSession().GameState;
-            // JimsProxy (fishing recast wedge 2026-09-01): a zero-update this early into a
-            // freshly recast fishing channel is the PREVIOUS bobber's teardown tail —
-            // forwarding it would kill the channel we just opened. See
-            // GameSessionData.ConsumeLocalChannelZeroUpdate.
-            if (gameState.ConsumeLocalChannelZeroUpdate())
+            // JimsProxy (fishing recast wedge 2026-09-01): on a fresh fishing recast the
+            // server ends the NEW channel when the previous bobber times out (its timeout
+            // finishes whatever channel is current). Keep the client's channel open so the
+            // new bobber can be waited out: park this zero-update until the old bobber's
+            // teardown in this read pass drops it, or the socket drains and releases it.
+            // See GameSessionData.ClassifyLocalChannelZeroUpdate.
+            switch (GetSession().GameState.ClassifyLocalChannelZeroUpdate(channel))
             {
-                Log.Event("spell.channel.stale_zero_update_dropped", new
-                {
-                    spell_id = gameState.LocalChannelSpellId,
-                    ms_since_channel_start = Environment.TickCount64 - gameState.LocalChannelStartTickMs,
-                });
-                return;
+                case GameSessionData.LocalChannelZeroUpdateDisposition.Held:
+                    return;
+                case GameSessionData.LocalChannelZeroUpdateDisposition.Dropped:
+                    LogStaleChannelZeroUpdateDropped("teardown_before_update");
+                    return;
             }
-            // JimsProxy (#244 emote channel guard): the server ends a channel by
-            // sending an update with no time remaining — close our window early.
-            gameState.LocalChannelSpellId = 0;
         }
         SendPacketToClient(channel);
+    }
+
+    // JimsProxy (fishing recast wedge): SMSG_DESTROY_OBJECT / SMSG_FISH_NOT_HOOKED are the
+    // anchors that identify a held zero-update as the previous bobber's teardown.
+    private void DropHeldChannelZeroUpdateIfAnchored(WowGuid128 destroyedGuid, string anchor)
+    {
+        if (GetSession().GameState.OnFishingBobberTeardownAnchor(destroyedGuid))
+            LogStaleChannelZeroUpdateDropped(anchor);
+    }
+
+    private void LogStaleChannelZeroUpdateDropped(string anchor)
+    {
+        if (!Settings.DebugOutput)
+            return;
+        Log.Event("spell.channel.stale_zero_update_dropped", new
+        {
+            spell_id = GetSession().GameState.LocalChannelSpellId,
+            anchor,
+        });
+    }
+
+    // JimsProxy (fishing recast wedge): the read pass ended with the zero-update still
+    // held — no bobber teardown came with it, so it was a genuine end and goes through.
+    internal void ReleaseHeldChannelZeroUpdateAtDrain()
+    {
+        uint spellId = GetSession().GameState.LocalChannelSpellId;
+        var held = GetSession().GameState.TakeHeldLocalChannelZeroUpdateAtDrain();
+        if (held == null)
+            return;
+        Log.Event("spell.channel.zero_update_released_at_drain", new { spell_id = spellId });
+        SendPacketToClient(held);
     }
 
     [PacketHandler(Opcode.SMSG_SPELL_DAMAGE_SHIELD)]

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -239,6 +239,10 @@ public partial class WorldClient
         }
         GetSession().GameState.LastAuraCasterOnTarget.Remove(guid);
 
+        // JimsProxy (fishing recast wedge): the previous bobber's destroy is the anchor
+        // that lets a held channel zero-update be dropped as its teardown.
+        DropHeldChannelZeroUpdateIfAnchored(guid, "destroy_object");
+
         // JimsProxy (PR #161 follow-up — destroy-hook fast path): if any pending
         // cast was aimed at this GUID, evict it now and emit synthetic
         // CastFailed(BadTargets). Faster than waiting up to 2.5s for the
@@ -2064,6 +2068,13 @@ public partial class WorldClient
     {
         DetectStuckLogoutStunAtSelfCreate(guid, updates, isCreate, updateData);
         SynthStandOnFearCcOnset(guid, updates);
+
+        // JimsProxy (fishing recast wedge): remember our newest bobber so a recast's
+        // CHANNEL_START can tell whether the previous one is still alive.
+        if (isCreate && objectType == ObjectType.GameObject &&
+            updateData.GameObjectData.TypeID == GameData.FishingNodeGameObjectType &&
+            updateData.GameObjectData.CreatedBy == GetSession().GameState.CurrentPlayerGuid)
+            GetSession().GameState.LocalFishingBobberGuid = guid;
 
         // JimsProxy: comprehensive pet diagnostics for the Hunter-Pet-Stealth-Stuck
         // investigation. Fires on every UPDATE_OBJECT block targeting a pet GUID

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -240,8 +240,10 @@ public partial class WorldClient
         GetSession().GameState.LastAuraCasterOnTarget.Remove(guid);
 
         // JimsProxy (fishing recast wedge): the previous bobber's destroy is the anchor
-        // that lets a held channel zero-update be dropped as its teardown.
+        // that lets a held channel zero-update be dropped as its teardown, and the new
+        // bobber's destroy is where the kept-alive client channel ends.
         DropHeldChannelZeroUpdateIfAnchored(guid, "destroy_object");
+        EndOrphanedClientChannelIfBobber(guid);
 
         // JimsProxy (PR #161 follow-up — destroy-hook fast path): if any pending
         // cast was aimed at this GUID, evict it now and emit synthetic

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -390,22 +390,37 @@ public partial class WorldClient
         var state = GetSession()?.GameState;
         if (state == null || state.PendingPreemptAttackStopVictim == default)
             return;
-
-        bool drained;
-        try
-        {
-            drained = _clientSocket.Available == 0;
-        }
-        catch
-        {
-            drained = true; // socket torn down — flush rather than leak the armed stop
-        }
-        if (!drained)
+        if (!LegacySocketDrained())
             return;
 
         var victim = state.TakePreemptAttackStopForFlush();
         if (victim != default)
             SendPreemptAttackStop(victim, "drain");
+    }
+
+    // JimsProxy (fishing recast wedge): same drain rule for the held channel zero-update —
+    // the previous bobber's teardown anchors arrive in the same read pass as the stale
+    // zero-update or not at all, so drain is the release point for a genuine one.
+    private void FlushHeldChannelZeroUpdateAtDrain()
+    {
+        var state = GetSession()?.GameState;
+        if (state == null || (state.HeldLocalChannelZeroUpdate == null && !state.StaleBobberTeardownSeenThisPass))
+            return;
+        if (!LegacySocketDrained())
+            return;
+        ReleaseHeldChannelZeroUpdateAtDrain();
+    }
+
+    private bool LegacySocketDrained()
+    {
+        try
+        {
+            return _clientSocket.Available == 0;
+        }
+        catch
+        {
+            return true; // socket torn down — flush rather than leak what is armed
+        }
     }
 
     private async Task ReceiveLoop()
@@ -448,6 +463,7 @@ public partial class WorldClient
                 packet.SetReceiveTime(Environment.TickCount);
                 HandlePacket(packet);
                 FlushPreemptAttackStopAtDrain();
+                FlushHeldChannelZeroUpdateAtDrain();
             }
         }
         catch(Exception e)

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -685,7 +685,7 @@ public static partial class GameData
         15473,  // Shadowform
     }.ToFrozenSet();
 
-    // JimsProxy (fishing recast wedge): the Fishing channel spells. Scopes the stale
+    // JimsProxy (fishing recast wedge): the Fishing channel spells. Scopes the held
     // channel zero-update guard to fishing only — see GameSessionData.OnLocalChannelStart.
     // 33095 included because TBC 2.4.3 backends are accepted by the version checker.
     public static readonly FrozenSet<uint> FishingChannelSpells = new uint[]
@@ -698,6 +698,9 @@ public static partial class GameData
     }.ToFrozenSet();
 
     public static bool IsFishingChannelSpell(uint spellId) => FishingChannelSpells.Contains(spellId);
+
+    // GAMEOBJECT_TYPE_FISHINGNODE — the bobber a fishing channel spawns for its caster.
+    public const sbyte FishingNodeGameObjectType = 17;
 
     /// <summary>
     /// JimsProxy: true if the spell is a CP-scaling enemy-debuff finisher we compute

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -685,6 +685,20 @@ public static partial class GameData
         15473,  // Shadowform
     }.ToFrozenSet();
 
+    // JimsProxy (fishing recast wedge): the Fishing channel spells. Scopes the stale
+    // channel zero-update guard to fishing only — see GameSessionData.OnLocalChannelStart.
+    // 33095 included because TBC 2.4.3 backends are accepted by the version checker.
+    public static readonly FrozenSet<uint> FishingChannelSpells = new uint[]
+    {
+        7620,   // Fishing (Apprentice)
+        7731,   // Fishing (Journeyman)
+        7732,   // Fishing (Expert)
+        18248,  // Fishing (Artisan)
+        33095,  // Fishing (Master, TBC)
+    }.ToFrozenSet();
+
+    public static bool IsFishingChannelSpell(uint spellId) => FishingChannelSpells.Contains(spellId);
+
     /// <summary>
     /// JimsProxy: true if the spell is a CP-scaling enemy-debuff finisher we compute
     /// duration for locally. Used by the CMSG_CAST_SPELL handler to decide whether to

--- a/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
@@ -73,7 +73,7 @@ public partial class WorldSocket
 
         // JimsProxy (fishing recast wedge): using a GO (e.g. clicking your own
         // bobber early) can legitimately end a channel — record it so the
-        // stale-zero-update guard in HandleSpellChannelUpdate stands down.
+        // held-zero-update guard in HandleSpellChannelUpdate stands down.
         GetSession().GameState.RecordLocalChannelBreakAction();
 
         WorldPacket packet = new WorldPacket(Opcode.CMSG_GAME_OBJ_USE);

--- a/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GameObjectHandler.cs
@@ -71,6 +71,11 @@ public partial class WorldSocket
             }
         }
 
+        // JimsProxy (fishing recast wedge): using a GO (e.g. clicking your own
+        // bobber early) can legitimately end a channel — record it so the
+        // stale-zero-update guard in HandleSpellChannelUpdate stands down.
+        GetSession().GameState.RecordLocalChannelBreakAction();
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_GAME_OBJ_USE);
         packet.WriteGuid(use.Guid.To64());
         SendPacketToServer(packet);

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -141,6 +141,10 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_CAST_SPELL)]
     void HandleCastSpell(CastSpell cast)
     {
+        // JimsProxy (fishing recast wedge): casting anything ends a running channel on the
+        // server, so a zero-update that follows is genuine — stand the guard down.
+        GetSession().GameState.RecordLocalChannelBreakAction();
+
         // JimsProxy (cast-block-unknown-spells): vanilla 1.12 server autobans clients that
         // emit CMSG_CAST_SPELL for spells they don't know. Native 1.12 clients block this
         // locally and never send the packet; modern Classic 1.14 clients send it through to
@@ -1085,7 +1089,7 @@ public partial class WorldSocket
         }
 
         // JimsProxy (fishing recast wedge): a client-initiated cancel makes any
-        // following zero channel-update genuine — don't let the guard eat it.
+        // following zero channel-update genuine — don't let the guard hold it.
         GetSession().GameState.RecordLocalChannelBreakAction();
 
         WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_CAST);

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -1084,6 +1084,10 @@ public partial class WorldSocket
             SendCastFailedWithoutPrepare(heldCastTimeDrop);
         }
 
+        // JimsProxy (fishing recast wedge): a client-initiated cancel makes any
+        // following zero channel-update genuine — don't let the guard eat it.
+        GetSession().GameState.RecordLocalChannelBreakAction();
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_CAST);
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
             packet.WriteUInt8(0);
@@ -1097,6 +1101,8 @@ public partial class WorldSocket
         {
             spell_id = cast.SpellID,
         });
+        // JimsProxy (fishing recast wedge): see HandleCancelCast.
+        GetSession().GameState.RecordLocalChannelBreakAction();
         WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_CHANNELLING);
         packet.WriteInt32(cast.SpellID);
         SendPacketToServer(packet);


### PR DESCRIPTION
## Problem
Recasting fishing right after the cast bar empties desyncs fishing: the character stops the fishing animation while the new bobber floats out its full lifetime (fish even bite it), and every recast after that repeats the failure until the player waits out a whole bobber untouched.

## Cause (from a captured session, mechanism confirmed in cmangos-classic)
A fishing bobber outlives its channel by ~2s. On mangos-family cores the bobber's timeout (`GameObject::Update`, `GAMEOBJECT_TYPE_FISHINGNODE`) calls `Unit::FinishSpell(CURRENT_CHANNELED_SPELL)`, which sends a channel update with no time remaining for **whatever channel the player currently has** and finishes it, without checking that the bobber belongs to that spell. So when the player recasts inside the old bobber's remaining life, the old bobber's timeout ends the **new** channel ~100ms after it opened. The new bobber survives because a game object's lifetime is independent of the spell, and the `GO_READY` loot path has no channel requirement, which is why fish still bite it and the catch still works. Vanilla's `MSG_CHANNEL_UPDATE` carries no spell id, so the modern client faithfully ends the channel it just opened. Since the player naturally recasts the moment the char looks idle, every subsequent cast lands in the same race.

## Fix
The proxy keeps the client's channel open so the bobber can be waited out. `GameSessionData` tracks the local player's newest bobber (own `GAMEOBJECT_TYPE_FISHINGNODE` create block) and anchors the guard on packets, not clocks:

- **Arm** at `MSG_CHANNEL_START` of a fishing spell (`GameData.IsFishingChannelSpell`; ranks 1-4 + TBC Master) iff the previous bobber is still in the object cache. A session's first cast, a recast after the old bobber's destroy, and any non-fishing channel never arm.
- **Hold** the local player's zero-time channel update while armed, unless the client sent a channel-breaking action since the channel opened (`RecordLocalChannelBreakAction` in `HandleCastSpell`, `HandleCancelCast`, `HandleCancelChannelling`, `HandleGameObjUse`), in which case it forwards immediately.
- **Drop** the held update only when that bobber's `SMSG_DESTROY_OBJECT` (or `SMSG_FISH_NOT_HOOKED`) lands in the same read pass; if the anchor arrives first in the pass, the zero-update that follows is dropped directly.
- **Release** at legacy-socket drain (same rule as the #450 preempt attack stop): a zero-update with no anchor in its pass was genuine and goes through, closing the emote-guard channel window as before. An anchor with no zero-update in its pass disarms the guard.

The zero-update is only half of what the server sends when it ends the channel. The same tick also clears the player's `UNIT_CHANNEL_SPELL` and `UNIT_FIELD_CHANNEL_OBJECT`, and that values block is forwarded ahead of the held update. With those fields cleared the client drops the fishing pose, refuses the bobber click and refuses a recast until the bobber expires (this is what the 09-01 v1 test actually left behind: its one live drop was followed by a bite that never got a click). So after a drop the proxy also:

- **Re-asserts the fields** with a values update pointing the channel spell and channel object at the new bobber, so the pose, the bobber click and recasting all work.
- **Ends the client's channel itself** when that bobber's `SMSG_DESTROY_OBJECT` arrives (catch looted, fish escaped, timed out), with a synthesized zero-update, because the server no longer has a channel to end. A recast before that just supersedes it.

Everything else, including the old bobber's `SMSG_FISH_NOT_HOOKED` and despawn, still forwards. `spell.channel.stale_zero_update_dropped` and `spell.channel.orphan_end_synthesized` are behind `Settings.DebugOutput`; the release-at-drain edge logs `spell.channel.zero_update_released_at_drain` unconditionally.

Movement interrupts: the 1.14 client sends `CMSG_CANCEL_CHANNELLING` before the movement packet (70 of 70 episodes across 25 local sessions, one of them fishing), so a movement break always disarms the guard before the server's genuine zero-update arrives.

## Testing
- In-game on Kronos V, 2026-09-06, four sessions: spam recasts and recast-then-move never trip the guard (76 channels, zero guard events); the wedge shape (bite in the last second, delayed click, recast inside the bobber's remaining life) reproduced twice. With packet anchoring alone the drop landed and the wedge still showed (second wire above). With the field re-assert, the character kept fishing, the new bobber was clicked and looted 29 s later, and an immediate recast on top of it worked.
- 25 unit tests in `ChannelStaleZeroUpdateTests`: captured batch order (hold, drop on destroy, channel stays open, one-shot), fish-not-hooked anchor, anchor-before-update, anchor-then-drain disarm, release at drain, old bobber already destroyed, first cast, mid-channel recast, break-action disarm and reset, non-fishing channel, new START superseding a hold, orphaned client channel ended by the new bobber's destroy and cleared by a new START or drain release, rank coverage. Full suite 986/986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QW6ofT2m5aQQmD2ZnpagHj
