### PR TITLE
Fix map exploration wiping on every new discovery

### DIFF
--- a/HermesProxy.Tests/World/ExploredZonesTranslationTests.cs
+++ b/HermesProxy.Tests/World/ExploredZonesTranslationTests.cs
@@ -1,0 +1,135 @@
+using System.Collections;
+using System.Collections.Generic;
+using HermesProxy.World.Client;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (map exploration reset 2026-09-01): two legacy uint32 explored-zone fields pack
+// into one modern ulong element, and the modern builder always writes the WHOLE element. A
+// mid-session discovery dirties exactly ONE legacy field, so the untouched half must be
+// composed from the cumulative updates dict (the session's merged field cache) — composing
+// it from the outgoing update zeroed 32 zones' worth of exploration on every new discovery.
+public class ExploredZonesTranslationTests
+{
+    private const int BaseField = 200; // arbitrary legacy field index; the helper takes it as a parameter
+    private const int FieldCount = 64; // vanilla: 64 uint32 fields -> 32 modern ulong elements
+
+    private static BitArray EmptyMask() => new BitArray(BaseField + FieldCount);
+
+    private static ulong?[] NewModernArray() => new ulong?[240];
+
+    [Fact]
+    public void PartialUpdate_EvenField_PreservesCachedOddHalf()
+    {
+        // The reported bug: discovering a new area sends ONE legacy field; the cached
+        // paired field (from the login create) must survive into the composed ulong.
+        var mask = EmptyMask();
+        mask[BaseField + 0] = true;
+        var updates = new Dictionary<int, UpdateField>
+        {
+            [BaseField + 0] = new UpdateField(0x00000001u), // newly discovered bit
+            [BaseField + 1] = new UpdateField(0xDEADBEEFu), // cached since create
+        };
+        var modern = NewModernArray();
+
+        WorldClient.TranslateExploredZones(BaseField, FieldCount, mask, updates, modern);
+
+        Assert.Equal(0xDEADBEEF00000001UL, modern[0]);
+    }
+
+    [Fact]
+    public void PartialUpdate_OddField_PreservesCachedEvenHalf()
+    {
+        var mask = EmptyMask();
+        mask[BaseField + 1] = true;
+        var updates = new Dictionary<int, UpdateField>
+        {
+            [BaseField + 0] = new UpdateField(0xCAFEF00Du), // cached since create
+            [BaseField + 1] = new UpdateField(0x80000000u), // newly discovered bit
+        };
+        var modern = NewModernArray();
+
+        WorldClient.TranslateExploredZones(BaseField, FieldCount, mask, updates, modern);
+
+        Assert.Equal(0x80000000CAFEF00DUL, modern[0]);
+    }
+
+    [Fact]
+    public void FullPairUpdate_ComposesBothHalves()
+    {
+        // Create-block shape: both fields of a pair arrive masked together.
+        var mask = EmptyMask();
+        mask[BaseField + 2] = true;
+        mask[BaseField + 3] = true;
+        var updates = new Dictionary<int, UpdateField>
+        {
+            [BaseField + 2] = new UpdateField(0x11111111u),
+            [BaseField + 3] = new UpdateField(0x22222222u),
+        };
+        var modern = NewModernArray();
+
+        WorldClient.TranslateExploredZones(BaseField, FieldCount, mask, updates, modern);
+
+        Assert.Equal(0x2222222211111111UL, modern[1]);
+    }
+
+    [Fact]
+    public void UnmaskedPairs_StayNull_SoBuilderDoesNotSendThem()
+    {
+        // Elements the server didn't touch must remain null — a non-null element makes the
+        // modern builder write it, which would spam full explored-zone state every update.
+        var mask = EmptyMask();
+        mask[BaseField + 0] = true;
+        var updates = new Dictionary<int, UpdateField>
+        {
+            [BaseField + 0] = new UpdateField(1u),
+            [BaseField + 4] = new UpdateField(0xFFFFFFFFu), // cached but not masked this packet
+        };
+        var modern = NewModernArray();
+
+        WorldClient.TranslateExploredZones(BaseField, FieldCount, mask, updates, modern);
+
+        Assert.NotNull(modern[0]);
+        for (int i = 1; i < modern.Length; i++)
+            Assert.Null(modern[i]);
+    }
+
+    [Fact]
+    public void MissingPairedField_ComposesAsUnexplored()
+    {
+        // A field never seen (zero at create, so never sent) is genuinely unexplored.
+        var mask = EmptyMask();
+        mask[BaseField + 6] = true;
+        var updates = new Dictionary<int, UpdateField>
+        {
+            [BaseField + 6] = new UpdateField(0x00000008u),
+        };
+        var modern = NewModernArray();
+
+        WorldClient.TranslateExploredZones(BaseField, FieldCount, mask, updates, modern);
+
+        Assert.Equal(0x0000000000000008UL, modern[3]);
+    }
+
+    [Fact]
+    public void MultiplePairsInOneUpdate_AllComposedIndependently()
+    {
+        var mask = EmptyMask();
+        mask[BaseField + 0] = true;  // partial, even
+        mask[BaseField + 9] = true;  // partial, odd
+        var updates = new Dictionary<int, UpdateField>
+        {
+            [BaseField + 0] = new UpdateField(0x000000FFu),
+            [BaseField + 1] = new UpdateField(0xAAAAAAAAu), // cached
+            [BaseField + 8] = new UpdateField(0x55555555u), // cached
+            [BaseField + 9] = new UpdateField(0xFF000000u),
+        };
+        var modern = NewModernArray();
+
+        WorldClient.TranslateExploredZones(BaseField, FieldCount, mask, updates, modern);
+
+        Assert.Equal(0xAAAAAAAA000000FFUL, modern[0]);
+        Assert.Equal(0xFF00000055555555UL, modern[4]);
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1989,6 +1989,27 @@ public partial class WorldClient
         return flags;
     }
 
+    // JimsProxy (map exploration reset 2026-09-01): compose modern 64-bit explored-zone
+    // elements from the legacy 32-bit field pair. The modern builder always writes the WHOLE
+    // ulong element, and a mid-session discovery dirties exactly ONE legacy field — so the
+    // paired half must come from the cumulative `updates` dict (the values path merges into
+    // the session's cached fields in place), never from the outgoing update being staged.
+    // Composing against the outgoing update zeroed the paired 32 zones on every new
+    // discovery, wiping chunks of the explored map until relog (#331's revert, still
+    // reachable through partial updates).
+    internal static void TranslateExploredZones(int legacyBaseField, int legacyFieldCount, BitArray updateMaskArray, Dictionary<int, UpdateField> updates, ulong?[] modernExploredZones)
+    {
+        for (int i = 0; i < legacyFieldCount; i += 2)
+        {
+            if (updateMaskArray[legacyBaseField + i] || updateMaskArray[legacyBaseField + i + 1])
+            {
+                uint low = updates.TryGetValue(legacyBaseField + i, out var lowField) ? lowField.UInt32Value : 0;
+                uint high = updates.TryGetValue(legacyBaseField + i + 1, out var highField) ? highField.UInt32Value : 0;
+                modernExploredZones[i / 2] = ((ulong)high << 32) | low;
+            }
+        }
+    }
+
     public void StoreObjectUpdate(WowGuid128 guid, ObjectType objectType, BitArray updateMaskArray, Dictionary<int, UpdateField> updates, AuraUpdate auraUpdate, PowerUpdate? powerUpdate, bool isCreate, ObjectUpdate updateData, BitArray actuallyChangedValuesMaskArray)
     {
         StoreObjectUpdateInternal(guid, objectType, updateMaskArray, updates, auraUpdate, powerUpdate, isCreate, updateData);
@@ -4362,24 +4383,9 @@ WowGuid128 charmedBy = GetGuidValue(updates, UnitField.UNIT_FIELD_CHARMEDBY).To1
             int PLAYER_EXPLORED_ZONES_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_EXPLORED_ZONES_1);
             if (PLAYER_EXPLORED_ZONES_1 >= 0)
             {
+                // JimsProxy (map exploration reset 2026-09-01): see TranslateExploredZones.
                 int maxZones = LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180) ? 128 : 64;
-                for (int i = 0; i < maxZones; i++)
-                {
-                    if (updateMaskArray[PLAYER_EXPLORED_ZONES_1 + i])
-                    {
-                        // Two legacy uint32 zone fields pack into one modern ulong: even i → low 32,
-                        // odd i → high 32. On a partial UPDATE_FIELDS we must replace only the
-                        // targeted half and PRESERVE the other half — otherwise the paired field's
-                        // explored bits get clobbered, causing previously-explored areas to revert
-                        // to unexplored on the world map (WowLegacyCore/HermesProxy#331).
-                        ulong existing = updateData.ActivePlayerData.ExploredZones[i / 2] ?? 0UL;
-                        uint newValue = updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value;
-                        if ((i & 1) != 0)
-                            updateData.ActivePlayerData.ExploredZones[i / 2] = (existing & 0xFFFFFFFFUL) | ((ulong)newValue << 32);
-                        else
-                            updateData.ActivePlayerData.ExploredZones[i / 2] = (existing & 0xFFFFFFFF00000000UL) | (ulong)newValue;
-                    }
-                }
+                TranslateExploredZones(PLAYER_EXPLORED_ZONES_1, maxZones, updateMaskArray, updates, updateData.ActivePlayerData.ExploredZones);
             }
             int PLAYER_FIELD_COINAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_COINAGE);
             if (PLAYER_FIELD_COINAGE >= 0 && updateMaskArray[PLAYER_FIELD_COINAGE])


### PR DESCRIPTION
## Problem
Explored areas keep vanishing from players' world maps mid-session. Each newly discovered subzone darkens a chunk of previously explored map; relogging restores everything until the next discovery.

## Cause
Two legacy 32-bit `PLAYER_EXPLORED_ZONES` fields pack into one modern 64-bit `ExploredZones` element, and the modern update builder always writes the whole element. A mid-session discovery dirties exactly **one** legacy field, but the pair-merge in `StoreObjectUpdate` composed the untouched half from the outgoing update being staged — which is empty on a values update — so the paired half was written as zero, un-exploring those 32 zone bits on the client. The earlier #331 fix only covered the create path, where both halves of a pair arrive masked together.

## Fix
New `WorldClient.TranslateExploredZones` composes each 64-bit element from **both** 32-bit halves out of the cumulative field dict — the values path merges every update into the session's cached legacy fields in place, so it always holds the latest value of both halves. A field the server never sent is genuinely unexplored (zero at create is omitted from the mask), and untouched pairs stay null so the builder doesn't resend full exploration state on every update.

## Testing
- Reproduction shape confirmed from a live capture: each discovery arrives as `SMSG_EXPLORATION_EXPERIENCE` plus a values `SMSG_UPDATE_OBJECT` masking a single explored-zones field.
- Verified in-game: three mid-session discoveries, previously explored map stayed intact, and exploration held across a relog.
- 6 unit tests in `ExploredZonesTranslationTests`; the partial-update-preserves-cached-half cases fail against the old code. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TriGAZmcC8DEGE2FhUZ4cX