### PR TITLE
Lock talent spells at the respec confirm so a lagged press can't reach the server after the wipe

### DIFF
--- a/HermesProxy.Tests/World/RespecCastLockTests.cs
+++ b/HermesProxy.Tests/World/RespecCastLockTests.cs
@@ -1,0 +1,233 @@
+using System.Collections.Generic;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (respec cast lock): truth table for the speculative talent-spell lock armed at
+// CMSG_CONFIRM_RESPEC_WIPE. The cast-block-unknown-spells guard only learns a spell is gone when
+// SMSG_REMOVED_SPELL reaches the proxy; the server wiped it the moment it processed the confirm.
+// A press in that window is the Kronos "Spell not in player book" autoban (Shadowform, 2026-09-06),
+// so the orderings below are ban-critical:
+//
+//   confirm → press Shadowform            → LOCKED: rejected locally (THE ban case).
+//   confirm → REMOVED(Shadowform) → press → released from the lock; the known-set check now
+//                                           blocks it (removal took it out of the mirror).
+//   confirm → burst → fence reply         → whatever the server kept is released — safe to cast.
+//   confirm → silent rejection → fence    → same: nothing was removed, everything releases.
+//   confirm → "no talents" / BUY_FAILED   → explicit rejection releases before the fence.
+//   confirm → nothing, ever               → timeout backstop releases (fence lost).
+public class RespecCastLockTests
+{
+    private const uint Shadowform = 15473;        // priest talent, single rank
+    private const uint MindBlast = 8092;          // priest trainer spell
+    private const uint PermafrostR3 = 12571;      // mage passive talent, rank 3
+    private const uint MortalStrikeR1 = 12294;    // warrior talent
+    private const uint MortalStrikeR3 = 21553;    // trainer-bought rank of that talent
+    private const uint HolyShockR2 = 20929;       // paladin trainer rank of talent 20473
+    private const byte Warrior = 1, Paladin = 2, Priest = 5, Mage = 8;
+
+    static RespecCastLockTests()
+    {
+        GameData.LoadTalentSpellRanks();
+        GameData.LoadSpellRankChain();
+    }
+
+    // The mock skips field initializers (GetUninitializedObject) — hydrate the mirror the lock reads.
+    private static GameSessionData NewState(byte playerClass, params uint[] known)
+    {
+        var state = WowGuidTestHelper.CreateMockGameSessionData();
+        state.CurrentPlayerKnownSpells = new HashSet<uint>(known);
+        state.CurrentPlayerClass = playerClass;
+        return state;
+    }
+
+    private static HashSet<uint> Collect(byte playerClass, params uint[] known)
+    {
+        var into = new HashSet<uint>();
+        GameSessionData.CollectRespecLockSpells(known, playerClass, into);
+        return into;
+    }
+
+    // === Which spells get locked ===
+
+    [Fact]
+    public void Collect_LocksOwnTalent_NotTrainerSpells()
+    {
+        var locked = Collect(Priest, Shadowform, MindBlast);
+        Assert.Equal(new HashSet<uint> { Shadowform }, locked);
+    }
+
+    [Fact]
+    public void Collect_LocksTrainerRankRootedInTalent_WhenTalentRankItselfIsGone()
+    {
+        // Learning R2/R3 superseded R1 out of the known set; the server still unlearns R3 on respec.
+        var locked = Collect(Warrior, MortalStrikeR3);
+        Assert.Equal(new HashSet<uint> { MortalStrikeR3 }, locked);
+        Assert.Equal(new HashSet<uint> { HolyShockR2 }, Collect(Paladin, HolyShockR2));
+    }
+
+    [Fact]
+    public void Collect_LocksPassiveTalentRanks()
+    {
+        Assert.Equal(new HashSet<uint> { PermafrostR3 }, Collect(Mage, PermafrostR3));
+    }
+
+    [Fact]
+    public void Collect_SkipsOtherClassTalents_UnlessClassUnknown()
+    {
+        // A spell that is a talent for another class must not be locked for this one.
+        Assert.Empty(Collect(Priest, MortalStrikeR1, MortalStrikeR3));
+        // Class not yet observed (0): lock every talent-rooted spell — over-blocking beats a ban.
+        Assert.Equal(new HashSet<uint> { MortalStrikeR1, MortalStrikeR3 }, Collect(0, MortalStrikeR1, MortalStrikeR3));
+    }
+
+    [Fact]
+    public void Collect_EmptyKnownSet_LocksNothing()
+    {
+        Assert.Empty(Collect(Priest));
+    }
+
+    // === Lock lifecycle ===
+
+    [Fact]
+    public void Arm_ThenPressBeforeRemoval_IsLocked()
+    {
+        var state = NewState(Priest, Shadowform, MindBlast);
+        Assert.Equal(1, state.ArmRespecCastLock(1000));
+        Assert.True(state.IsRespecCastLockArmed);
+        Assert.True(state.IsRespecCastLocked(Shadowform, 1500, out int expired));
+        Assert.Equal(0, expired);
+        Assert.False(state.IsRespecCastLocked(MindBlast, 1500, out _));
+    }
+
+    [Fact]
+    public void Removal_ReleasesThatSpell_AndDrainsWhenLast()
+    {
+        var state = NewState(Warrior, MortalStrikeR3, MortalStrikeR1);
+        Assert.Equal(2, state.ArmRespecCastLock(0));
+        Assert.True(state.ReleaseRespecLockedSpell(MortalStrikeR3, out int remaining));
+        Assert.Equal(1, remaining);
+        Assert.False(state.IsRespecCastLocked(MortalStrikeR3, 10, out _));
+        Assert.True(state.IsRespecCastLocked(MortalStrikeR1, 10, out _));
+        Assert.True(state.ReleaseRespecLockedSpell(MortalStrikeR1, out remaining));
+        Assert.Equal(0, remaining);
+        Assert.False(state.IsRespecCastLockArmed);
+    }
+
+    [Fact]
+    public void Removal_OfUnlockedSpell_IsIgnored()
+    {
+        var state = NewState(Priest, Shadowform);
+        state.ArmRespecCastLock(0);
+        Assert.False(state.ReleaseRespecLockedSpell(MindBlast, out int remaining));
+        Assert.Equal(1, remaining);
+        Assert.True(state.IsRespecCastLockArmed);
+    }
+
+    [Fact]
+    public void Fence_ReleasesWhateverTheServerKept()
+    {
+        var state = NewState(Warrior, MortalStrikeR3, MortalStrikeR1);
+        state.ArmRespecCastLock(0);
+        state.ReleaseRespecLockedSpell(MortalStrikeR3, out _);
+        Assert.Equal(1, state.ClearRespecCastLock());
+        Assert.False(state.IsRespecCastLockArmed);
+        Assert.False(state.IsRespecCastLocked(MortalStrikeR1, 10, out _));
+    }
+
+    [Fact]
+    public void Timeout_Backstop_ReleasesAllAndReportsCount()
+    {
+        var state = NewState(Priest, Shadowform);
+        state.ArmRespecCastLock(1000);
+        Assert.True(state.IsRespecCastLocked(Shadowform, 1000 + GameSessionData.RespecLockTimeoutMs, out int expired));
+        Assert.Equal(0, expired);
+        Assert.False(state.IsRespecCastLocked(Shadowform, 1001 + GameSessionData.RespecLockTimeoutMs, out expired));
+        Assert.Equal(1, expired);
+        Assert.False(state.IsRespecCastLockArmed);
+    }
+
+    [Fact]
+    public void Rearm_UnionsAndRestartsTimeout()
+    {
+        var state = NewState(Priest, Shadowform);
+        state.ArmRespecCastLock(0);
+        state.ReleaseRespecLockedSpell(Shadowform, out _);
+        // Second confirm while still known (server kept it, or the mirror is stale): locked again.
+        Assert.Equal(1, state.ArmRespecCastLock(50_000));
+        Assert.True(state.IsRespecCastLocked(Shadowform, 50_000 + GameSessionData.RespecLockTimeoutMs, out _));
+    }
+
+    [Fact]
+    public void NeverArmed_IsInert()
+    {
+        var state = NewState(Priest, Shadowform);
+        Assert.False(state.IsRespecCastLockArmed);
+        Assert.False(state.IsRespecCastLocked(Shadowform, 0, out int expired));
+        Assert.Equal(0, expired);
+        Assert.False(state.ReleaseRespecLockedSpell(Shadowform, out int remaining));
+        Assert.Equal(0, remaining);
+        Assert.Equal(0, state.ClearRespecCastLock());
+    }
+
+    [Fact]
+    public void Arm_DoesNotTouchTheKnownSetMirror()
+    {
+        // The lock is a veto layered on the guard; the mirror stays the server's word alone.
+        var state = NewState(Priest, Shadowform, MindBlast);
+        state.ArmRespecCastLock(0);
+        Assert.Contains(Shadowform, state.CurrentPlayerKnownSpells);
+        state.ClearRespecCastLock();
+        Assert.Contains(Shadowform, state.CurrentPlayerKnownSpells);
+    }
+    // === Fence ordinal ===
+
+    [Fact]
+    public void Fence_StaleClientReplyDoesNotStandDown_OwnReplyDoes()
+    {
+        var state = NewState(Priest, Shadowform);
+        state.NoteMailTimeQuerySent(isRespecFence: false);   // client's own query, still in flight
+        state.ArmRespecCastLock(0);
+        state.NoteMailTimeQuerySent(isRespecFence: true);    // the fence, queued behind the confirm
+        Assert.False(state.NoteMailTimeReplyReachesRespecFence());  // reply to the client's query
+        Assert.True(state.IsRespecCastLocked(Shadowform, 10, out _));
+        Assert.True(state.NoteMailTimeReplyReachesRespecFence());   // the fence's own reply
+    }
+
+    [Fact]
+    public void Fence_ReplyWhileNotArmed_IsFalse()
+    {
+        var state = NewState(Priest, Shadowform);
+        state.NoteMailTimeQuerySent(isRespecFence: false);
+        Assert.False(state.NoteMailTimeReplyReachesRespecFence());
+        // Armed but no fence sent (nothing locked → no fence): a reply never matches.
+        state.ArmRespecCastLock(0);
+        state.NoteMailTimeQuerySent(isRespecFence: false);
+        Assert.False(state.NoteMailTimeReplyReachesRespecFence());
+    }
+
+    [Fact]
+    public void Fence_RearmMovesTheFenceForward()
+    {
+        var state = NewState(Priest, Shadowform);
+        state.ArmRespecCastLock(0);
+        state.NoteMailTimeQuerySent(isRespecFence: true);
+        state.ArmRespecCastLock(5);
+        state.NoteMailTimeQuerySent(isRespecFence: true);
+        Assert.False(state.NoteMailTimeReplyReachesRespecFence());  // first fence: second wipe still pending
+        Assert.True(state.NoteMailTimeReplyReachesRespecFence());
+    }
+
+    [Fact]
+    public void Fence_ClearForgetsTheFence_LateReplyCannotStandDownANewLock()
+    {
+        var state = NewState(Priest, Shadowform);
+        state.ArmRespecCastLock(0);
+        state.NoteMailTimeQuerySent(isRespecFence: true);
+        state.ClearRespecCastLock();                          // explicit rejection cleared it
+        state.ArmRespecCastLock(5);                           // re-armed, new fence not yet sent
+        Assert.False(state.NoteMailTimeReplyReachesRespecFence());  // the old fence's reply
+        Assert.True(state.IsRespecCastLocked(Shadowform, 10, out _));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -3643,6 +3643,146 @@ public sealed class GameSessionData
         PendingTrainerBuyRemovedPredecessor = 0u;
         return restored;
     }
+    // JimsProxy (respec cast lock): the cast-block-unknown-spells guard is reactive — it learns a
+    // spell is gone only when the server's SMSG_REMOVED_SPELL reaches the proxy. A talent respec
+    // wipes every talent spell server-side the instant MSG_TALENT_WIPE_CONFIRM is processed, so
+    // between the client's confirm and the removal burst arriving (a full RTT — seconds under a
+    // lag spike) a lingering action-bar press is forwarded for a spell the server no longer has →
+    // Kronos "Spell not in player book" autoban (2026-09-06, Shadowform). Arm at the confirm:
+    // every known spell that is, or descends by rank chain from, one of this class's talent
+    // spells is locked and the guard rejects its casts locally. Each real removal releases its
+    // spell. MSG_QUERY_NEXT_MAIL_TIME queued right behind the confirm is processed in order on
+    // the server, so its reply fences the wipe — success or silent rejection — and clears
+    // whatever the server kept. The timeout is a backstop for a lost fence only.
+    private HashSet<uint>? _respecLockedSpells;
+    private object? _respecLockSync;
+    public long RespecLockArmedTickMs;
+    public const long RespecLockTimeoutMs = 120_000;
+    // The fence is matched by ordinal: the modern client sends its own mail-time queries, and a
+    // reply to one of those landing inside the window must not read as "wipe processed".
+    private long _mailTimeQueriesSent;
+    private long _mailTimeRepliesSeen;
+    private long _respecFenceOrdinal; // 0 = no fence outstanding (ordinals start at 1)
+
+    private object RespecLockSync => System.Threading.LazyInitializer.EnsureInitialized(ref _respecLockSync);
+
+    public bool IsRespecCastLockArmed
+    {
+        get { lock (RespecLockSync) return _respecLockedSpells is { Count: > 0 }; }
+    }
+
+    /// <summary>Locks every known spell rooted in a talent of the local player's class (class 0 =
+    /// not yet seen: every talent-rooted spell). Returns the locked count. Re-arming while armed
+    /// unions the sets and restarts the timeout.</summary>
+    public int ArmRespecCastLock(long nowTickMs)
+    {
+        lock (RespecLockSync)
+        {
+            _respecLockedSpells ??= new HashSet<uint>();
+            CollectRespecLockSpells(CurrentPlayerKnownSpells, CurrentPlayerClass, _respecLockedSpells);
+            RespecLockArmedTickMs = nowTickMs;
+            return _respecLockedSpells.Count;
+        }
+    }
+
+    /// <summary>Walks each known spell's rank chain down to its first rank: a talent of this class
+    /// anywhere on the chain marks the known spell. Catches the talent itself (Shadowform) and the
+    /// trainer-bought higher ranks the server unlearns with it (Mortal Strike R3 whose R1 talent
+    /// was superseded out of the known set long ago).</summary>
+    public static void CollectRespecLockSpells(IEnumerable<uint> knownSpells, byte playerClass, HashSet<uint> into)
+    {
+        uint classMask = playerClass == 0 ? 0u : 1u << (playerClass - 1);
+        foreach (uint known in knownSpells)
+        {
+            uint cur = known;
+            for (int depth = 0; depth < 16; depth++)
+            {
+                if (GameData.TalentSpellClassMask.TryGetValue(cur, out uint talentClasses)
+                    && (classMask == 0 || (talentClasses & classMask) != 0))
+                {
+                    into.Add(known);
+                    break;
+                }
+                if (!GameData.SpellRankPredecessor.TryGetValue(cur, out cur))
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Every MSG_QUERY_NEXT_MAIL_TIME the proxy sends to the server — the client's own and
+    /// the fence — so the fence's reply can be told apart from a stale one by ordinal.</summary>
+    public void NoteMailTimeQuerySent(bool isRespecFence)
+    {
+        lock (RespecLockSync)
+        {
+            _mailTimeQueriesSent++;
+            if (isRespecFence)
+                _respecFenceOrdinal = _mailTimeQueriesSent;
+        }
+    }
+
+    /// <summary>Counts a MSG_QUERY_NEXT_MAIL_TIME reply; true when it is the fence's own reply (or a
+    /// later one) and the lock is still armed — the wipe has been processed either way.</summary>
+    public bool NoteMailTimeReplyReachesRespecFence()
+    {
+        lock (RespecLockSync)
+        {
+            _mailTimeRepliesSeen++;
+            return _respecFenceOrdinal != 0 && _respecLockedSpells is { Count: > 0 } && _mailTimeRepliesSeen >= _respecFenceOrdinal;
+        }
+    }
+
+    /// <summary>Whether a cast must be rejected because the wipe is still pending for this spell.
+    /// Lazily expires the whole lock past RespecLockTimeoutMs; <paramref name="expiredCount"/> is
+    /// how many spells that released (0 when nothing expired).</summary>
+    public bool IsRespecCastLocked(uint spellId, long nowTickMs, out int expiredCount)
+    {
+        expiredCount = 0;
+        lock (RespecLockSync)
+        {
+            if (_respecLockedSpells is not { Count: > 0 })
+                return false;
+            if (nowTickMs - RespecLockArmedTickMs > RespecLockTimeoutMs)
+            {
+                expiredCount = _respecLockedSpells.Count;
+                _respecLockedSpells.Clear();
+                return false;
+            }
+            return _respecLockedSpells.Contains(spellId);
+        }
+    }
+
+    /// <summary>A real removal (SMSG_REMOVED_SPELL) confirms this spell is gone — the known-set
+    /// check covers it from here, so release it. Returns whether it was locked; <paramref
+    /// name="remaining"/> is how many locked spells still await the server.</summary>
+    public bool ReleaseRespecLockedSpell(uint spellId, out int remaining)
+    {
+        lock (RespecLockSync)
+        {
+            remaining = 0;
+            if (_respecLockedSpells == null)
+                return false;
+            bool wasLocked = _respecLockedSpells.Remove(spellId);
+            remaining = _respecLockedSpells.Count;
+            return wasLocked;
+        }
+    }
+
+    /// <summary>The server is done with the wipe (fence reply, explicit rejection, fresh spellbook):
+    /// anything still locked was kept server-side and is safe to cast. Returns the released count.</summary>
+    public int ClearRespecCastLock()
+    {
+        lock (RespecLockSync)
+        {
+            if (_respecLockedSpells == null)
+                return 0;
+            int released = _respecLockedSpells.Count;
+            _respecLockedSpells.Clear();
+            _respecFenceOrdinal = 0;
+            return released;
+        }
+    }
+
     public void StoreCreatureClass(uint entry, Class classId)
     {
         CreatureClasses[entry] = classId;

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -227,6 +227,14 @@ public partial class WorldClient
         fail.Reason = (BuyResult)rawReason;
         SendPacketToClient(fail);
 
+        // JimsProxy (respec cast lock): the respec's insufficient-funds rejection comes through
+        // SMSG_BUY_FAILED — the server removed nothing, stand the lock down.
+        if (GetSession().GameState.IsRespecCastLockArmed)
+        {
+            int released = GetSession().GameState.ClearRespecCastLock();
+            Log.Event("spell.respec_lock.cleared", new { reason = "buy_failed", released_count = released, buy_reason = fail.Reason.ToString() });
+        }
+
         Log.Event("vendor.buy.failed", new
         {
             vendor_guid_low = fail.VendorGUID.GetCounter(),

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -232,7 +232,8 @@ public partial class WorldClient
         if (GetSession().GameState.IsRespecCastLockArmed)
         {
             int released = GetSession().GameState.ClearRespecCastLock();
-            Log.Event("spell.respec_lock.cleared", new { reason = "buy_failed", released_count = released, buy_reason = fail.Reason.ToString() });
+            if (Framework.Settings.DebugOutput)
+                Log.Event("spell.respec_lock.cleared", new { reason = "buy_failed", released_count = released, buy_reason = fail.Reason.ToString() });
         }
 
         Log.Event("vendor.buy.failed", new

--- a/HermesProxy/World/Client/PacketHandlers/MailHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MailHandler.cs
@@ -39,7 +39,8 @@ public partial class WorldClient
         if (GetSession().GameState.NoteMailTimeReplyReachesRespecFence())
         {
             int released = GetSession().GameState.ClearRespecCastLock();
-            Log.Event("spell.respec_lock.cleared", new { reason = "fence_reply", released_count = released });
+            if (Framework.Settings.DebugOutput)
+                Log.Event("spell.respec_lock.cleared", new { reason = "fence_reply", released_count = released });
         }
 
         // Capture raw payload for diagnostics before any reads consume bytes.

--- a/HermesProxy/World/Client/PacketHandlers/MailHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MailHandler.cs
@@ -32,6 +32,16 @@ public partial class WorldClient
     [PacketHandler(Opcode.MSG_QUERY_NEXT_MAIL_TIME)]
     void HandleQueryNextMailTime(WorldPacket packet)
     {
+        // JimsProxy (respec cast lock): the fence queued behind MSG_TALENT_WIPE_CONFIRM replies here.
+        // The server handles both in order, so by now the wipe ran and every removal it sent is
+        // already processed on this thread — whatever is still locked was kept server-side. Matched
+        // by ordinal so a reply to the client's own query from before the confirm can't stand down.
+        if (GetSession().GameState.NoteMailTimeReplyReachesRespecFence())
+        {
+            int released = GetSession().GameState.ClearRespecCastLock();
+            Log.Event("spell.respec_lock.cleared", new { reason = "fence_reply", released_count = released });
+        }
+
         // Capture raw payload for diagnostics before any reads consume bytes.
         uint rawSize = packet.GetSize();
         string rawHex = Convert.ToHexString(packet.GetData(), 0, (int)Math.Min(rawSize, 64));

--- a/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
@@ -365,7 +365,8 @@ public partial class WorldClient
         if (respec.TrainerGUID.IsEmpty() && GetSession().GameState.IsRespecCastLockArmed)
         {
             int released = GetSession().GameState.ClearRespecCastLock();
-            Log.Event("spell.respec_lock.cleared", new { reason = "wipe_confirm_no_talents", released_count = released });
+            if (Framework.Settings.DebugOutput)
+                Log.Event("spell.respec_lock.cleared", new { reason = "wipe_confirm_no_talents", released_count = released });
         }
         SendPacketToClient(respec);
     }

--- a/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
@@ -360,6 +360,13 @@ public partial class WorldClient
         RespecWipeConfirm respec = new();
         respec.TrainerGUID = packet.ReadGuid().To128(GetSession().GameState);
         respec.Cost = packet.ReadUInt32();
+        // JimsProxy (respec cast lock): an empty guid is the server's "you have no talents" reply to
+        // our confirm — nothing was removed, so the lock can stand down before the fence lands.
+        if (respec.TrainerGUID.IsEmpty() && GetSession().GameState.IsRespecCastLockArmed)
+        {
+            int released = GetSession().GameState.ClearRespecCastLock();
+            Log.Event("spell.respec_lock.cleared", new { reason = "wipe_confirm_no_talents", released_count = released });
+        }
         SendPacketToClient(respec);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -88,6 +88,8 @@ public partial class WorldClient
         {
             GetSession().GameState.CurrentPlayerKnownSpells.Clear();
             GetSession().GameState.SynthesizedTalentRanks.Clear();
+            // JimsProxy (respec cast lock): a fresh spellbook is authoritative — nothing pending.
+            GetSession().GameState.ClearRespecCastLock();
         }
         for (ushort i = 0; i < spellCount; i++)
         {
@@ -331,6 +333,7 @@ public partial class WorldClient
             // JimsProxy (cast-block-unknown-spells): drop unlearned spells from the
             // proxy-side known set so the CMSG_CAST_SPELL guard matches the real server state.
             knownSpellsSendUnlearn.Remove(spellId);
+            ReleaseRespecLockedSpell(spellId);
         }
         SendPacketToClient(spells);
         ReconcileTalentRankInjection();
@@ -352,8 +355,19 @@ public partial class WorldClient
         // for unlearned spells — same autoban path Nellag confirmed (server treats CMSG_CAST_SPELL
         // for an unknown spell as cheating and bans).
         GetSession().GameState.CurrentPlayerKnownSpells.Remove(spellId);
+        ReleaseRespecLockedSpell(spellId);
         SendPacketToClient(spells);
         ReconcileTalentRankInjection();
+    }
+
+    // JimsProxy (respec cast lock): the server confirmed this spell is gone, so the known-set check
+    // now covers it — hand it back from the speculative lock. Logs the moment the wipe drains.
+    private void ReleaseRespecLockedSpell(uint spellId)
+    {
+        if (!GetSession().GameState.ReleaseRespecLockedSpell(spellId, out int remaining))
+            return;
+        if (remaining == 0)
+            Log.Event("spell.respec_lock.drained", new { last_spell_id = spellId });
     }
 
     // JimsProxy (stuck-logout-stun): drain and hex-dump whatever the server appended beyond the

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -366,7 +366,7 @@ public partial class WorldClient
     {
         if (!GetSession().GameState.ReleaseRespecLockedSpell(spellId, out int remaining))
             return;
-        if (remaining == 0)
+        if (remaining == 0 && Framework.Settings.DebugOutput)
             Log.Event("spell.respec_lock.drained", new { last_spell_id = spellId });
     }
 

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -63,6 +63,11 @@ public static partial class GameData
     // by the IsInWorld() gate. Without this, players get autobanned for casting a
     // predecessor rank whose silent server-side removal the proxy never saw.
     public static FrozenDictionary<uint, uint> SpellRankPredecessor = FrozenDictionary<uint, uint>.Empty;
+    // JimsProxy (respec cast lock): talent-rank spell id -> Talent.dbc ClassMask, from the same
+    // TalentSpellRanks.csv as TalentRankPredecessors. Lets the respec lock pick out the local
+    // player's OWN talent spells (a spell can be a talent for one class and a trainer spell for
+    // another) without a per-class table.
+    public static FrozenDictionary<uint, uint> TalentSpellClassMask = FrozenDictionary<uint, uint>.Empty;
     public static FrozenDictionary<uint, uint> TransportPeriods = FrozenDictionary<uint, uint>.Empty;
     public static FrozenDictionary<uint, string> AreaNames = FrozenDictionary<uint, string>.Empty;
     public static FrozenDictionary<string, uint> AreaIdsByName = FrozenDictionary<string, uint>.Empty;
@@ -1593,8 +1598,10 @@ public static partial class GameData
         using var reader = Sep.Reader(o => o with { HasHeader = true }).FromFile(path);
         var predecessors = new Dictionary<uint, uint[]>(2048);
         var siblings = new Dictionary<uint, uint[]>(2048);
+        var classMasks = new Dictionary<uint, uint>(2048);
         foreach (var row in reader)
         {
+            uint.TryParse(row[1].Span, out uint classMask);
             var ranks = new System.Collections.Generic.List<uint>(5);
             for (int col = 3; col <= 7; col++)
             {
@@ -1607,6 +1614,7 @@ public static partial class GameData
                 uint thisRank = ranks[i];
                 uint[] preds = i == 0 ? Array.Empty<uint>() : ranks.GetRange(0, i).ToArray();
                 predecessors[thisRank] = preds;
+                classMasks[thisRank] = classMask;
                 var sib = new System.Collections.Generic.List<uint>(ranks.Count - 1);
                 for (int j = 0; j < ranks.Count; j++)
                     if (j != i) sib.Add(ranks[j]);
@@ -1615,6 +1623,7 @@ public static partial class GameData
         }
         TalentRankPredecessors = predecessors.ToFrozenDictionary();
         TalentRankSiblings = siblings.ToFrozenDictionary();
+        TalentSpellClassMask = classMasks.ToFrozenDictionary();
     }
 
     public static void LoadSpellRankChain()

--- a/HermesProxy/World/Server/PacketHandlers/MailHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MailHandler.cs
@@ -16,6 +16,8 @@ public partial class WorldSocket
     void HandleMailGetList(EmptyClientPacket mail)
     {
         WorldPacket packet = new WorldPacket(Opcode.MSG_QUERY_NEXT_MAIL_TIME);
+        // JimsProxy (respec cast lock): counted so the respec fence's reply is matched by ordinal.
+        GetSession().GameState.NoteMailTimeQuerySent(isRespecFence: false);
         SendPacketToServer(packet);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/NPCHandler.cs
@@ -160,12 +160,16 @@ public partial class WorldSocket
                     GetSession().GameState.NoteMailTimeQuerySent(isRespecFence: true);
                     SendPacketToServer(new WorldPacket(Opcode.MSG_QUERY_NEXT_MAIL_TIME));
                 }
-                Log.Event("spell.respec_lock.armed", new
-                {
-                    locked_count = lockedCount,
-                    known_count = GetSession().GameState.CurrentPlayerKnownSpells.Count,
-                    player_class = GetSession().GameState.CurrentPlayerClass,
-                });
+                // Fix-working breadcrumb (with drained / cleared): DebugOutput-gated at review. The
+                // blocked_respec_pending / blocked_at_held_release / expired events stay unconditional
+                // because each marks an edge the lock exists to catch.
+                if (Framework.Settings.DebugOutput)
+                    Log.Event("spell.respec_lock.armed", new
+                    {
+                        locked_count = lockedCount,
+                        known_count = GetSession().GameState.CurrentPlayerKnownSpells.Count,
+                        player_class = GetSession().GameState.CurrentPlayerClass,
+                    });
                 break;
             }
             case SpecResetType.PetTalents:

--- a/HermesProxy/World/Server/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/NPCHandler.cs
@@ -148,9 +148,24 @@ public partial class WorldSocket
         {
             case SpecResetType.Talents:
             {
+                // JimsProxy (respec cast lock): lock this class's talent spells BEFORE the confirm
+                // leaves, then queue the in-order fence right behind it — its reply proves the
+                // server has processed the wipe (see GameSessionData.ArmRespecCastLock).
+                int lockedCount = GetSession().GameState.ArmRespecCastLock(Environment.TickCount64);
                 WorldPacket packet = new WorldPacket(Opcode.MSG_TALENT_WIPE_CONFIRM);
                 packet.WriteGuid(respec.TrainerGUID.To64());
                 SendPacketToServer(packet);
+                if (lockedCount > 0)
+                {
+                    GetSession().GameState.NoteMailTimeQuerySent(isRespecFence: true);
+                    SendPacketToServer(new WorldPacket(Opcode.MSG_QUERY_NEXT_MAIL_TIME));
+                }
+                Log.Event("spell.respec_lock.armed", new
+                {
+                    locked_count = lockedCount,
+                    known_count = GetSession().GameState.CurrentPlayerKnownSpells.Count,
+                    player_class = GetSession().GameState.CurrentPlayerClass,
+                });
                 break;
             }
             case SpecResetType.PetTalents:

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -188,6 +188,27 @@ public partial class WorldSocket
             return;
         }
 
+        // JimsProxy (respec cast lock): the talent wipe is in flight — the server may already have
+        // removed this spell without the removal having reached us. Reject locally exactly like an
+        // unknown spell; the lock releases per real removal / fence reply (GameSessionData).
+        if (GetSession().GameState.IsRespecCastLocked(guardSpellId, Environment.TickCount64, out int respecLockExpired))
+        {
+            Log.Event("spell.cast.blocked_respec_pending", new
+            {
+                spell_id = guardSpellId,
+                client_cast_id = cast.Cast.CastID.ToString(),
+            });
+            CastFailed failed = new();
+            failed.SpellID = guardSpellId;
+            failed.SpellXSpellVisualID = cast.Cast.SpellXSpellVisualID;
+            failed.Reason = (uint)SpellCastResultClassic.NotKnown;
+            failed.CastID = cast.Cast.CastID;
+            SendPacket(failed);
+            return;
+        }
+        if (respecLockExpired > 0)
+            Log.Event("spell.respec_lock.expired", new { released_count = respecLockExpired });
+
         // JimsProxy (PR #161 follow-up): self-heal any leaked peek-without-CAST_FAILED
         // before HasStartedNormalCast / HasNonStartedPendingCastForSpell run their
         // gate checks below. Without this, a Kronos-style "no trailing CAST_FAILED"
@@ -864,6 +885,23 @@ public partial class WorldSocket
                 spell_id = cast.SpellId,
                 client_cast_id = cast.ClientGUID.ToString(),
             });
+            return;
+        }
+
+        // JimsProxy (respec cast lock): a press parked for the GCD / a cast time passed the
+        // spellbook guard when it arrived; a respec or a removal can land while it waits, and
+        // forwarding it now is the same autoban path. Re-run both checks at release.
+        var heldKnown = gameState.CurrentPlayerKnownSpells;
+        bool heldUnknown = heldKnown.Count > 0 && !heldKnown.Contains(cast.SpellId);
+        if (heldUnknown || gameState.IsRespecCastLocked(cast.SpellId, Environment.TickCount64, out _))
+        {
+            Log.Event("spell.cast.blocked_at_held_release", new
+            {
+                spell_id = cast.SpellId,
+                client_cast_id = cast.ClientGUID.ToString(),
+                reason = heldUnknown ? "unknown_spell" : "respec_pending",
+            });
+            SendCastFailedWithoutPrepare(cast, SpellCastResultClassic.NotKnown);
             return;
         }
 


### PR DESCRIPTION
## Problem

A player respecced during a lag spike, pressed Shadowform while the spellbook was still draining, and got the Kronos "Spell not in player book" kick + ban (since lifted).

The cast-block-unknown-spells guard (#185) is intact and does cover respecs, but it is reactive: it only drops a spell from `CurrentPlayerKnownSpells` when the server's `SMSG_REMOVED_SPELL` reaches the proxy. The server wipes every talent spell the instant it processes `MSG_TALENT_WIPE_CONFIRM`. Between the client's confirm leaving and the removal burst arriving there is a full round trip — seconds under a lag spike — in which a lingering action-bar press is forwarded for a spell the server no longer has. A native 1.12 client has the same race, so this is a hole the reactive design cannot reach rather than a parity divergence.

## Fix

Arm a speculative lock at `CMSG_CONFIRM_RESPEC_WIPE`, before the confirm is forwarded:

- **What gets locked:** every known spell that is, or descends by rank chain from, a talent spell of the player's class (`GameSessionData.CollectRespecLockSpells`). That catches the talent itself (Shadowform) and the trainer-bought higher ranks the server unlearns with it (Mortal Strike R3, whose R1 talent was superseded out of the known set long ago). Class filtering uses a new `GameData.TalentSpellClassMask` built from the ClassMask column already in `TalentSpellRanks.csv`; class 0 (not yet seen) locks every talent-rooted spell.
- **Enforcement:** `HandleCastSpell` rejects locked casts locally with the same `NotKnown` CastFailed the existing guard uses. `ForwardHeldGcdCast` re-runs both the known-set check and the lock at release, since a press parked for the GCD or a cast time can outlive a respec.
- **Release:** each real removal (`SMSG_UNLEARNED_SPELLS` / `SMSG_SEND_UNLEARN_SPELLS`) releases its spell. Right behind the confirm the proxy queues `MSG_QUERY_NEXT_MAIL_TIME`; the server handles both in order, so its reply fences the wipe — success or silent rejection — and stands down whatever the server kept. The reply is matched by ordinal so a reply to the client's own mail-time query from before the confirm can't stand the lock down early. Explicit rejections (empty-guid `MSG_TALENT_WIPE_CONFIRM` = "no talents", `SMSG_BUY_FAILED` = insufficient funds) and a fresh `SMSG_SEND_KNOWN_SPELLS` clear it too. A 120 s lazy timeout is the lost-fence backstop.
- The known-set mirror is never speculatively mutated; the lock is a veto layered on top of the guard.

## Wire confirmation on Kronos

Real respec on a paladin, log `jimsproxy-20260907-141942`: `spell.respec_lock.armed locked_count=28` → exactly 28 `SMSG_UNLEARNED_SPELLS` → `spell.respec_lock.drained` → `SMSG_SPELL_GO` 14867 (untalent visual) → `MSG_QUERY_NEXT_MAIL_TIME` reply, all within one 172 ms round trip. Locked set == server wipe set exactly (trainer ranks like Holy Shock R3 included), and Kronos answers the fence after the burst, i.e. in order.

## Edge cases covered by tests (`RespecCastLockTests`, 17 tests, suite 978/978)

- confirm → press before removal → blocked (the ban case)
- removal releases only its spell; last removal drains
- fence releases what the server kept; stale client-origin mail-time reply does not
- re-arm unions, restarts the timeout, moves the fence forward
- explicit clear forgets the fence, so a late reply can't stand down a new lock
- timeout backstop releases and reports
- other-class talents skipped; class unknown locks all
- never-armed state is inert on the uninitialized mock

## Residual gaps (unchanged from #185 v1)

Pet casts are still ungated. Talent-taught child spells that are not rank successors are not locked (none known in 1.12). The new lock state is synchronized; the pre-existing `CurrentPlayerKnownSpells` set is untouched.

## Log events

`spell.respec_lock.{armed,drained,cleared,expired}`, `spell.cast.blocked_respec_pending`, `spell.cast.blocked_at_held_release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsYcTs9JWTydFtP2tEbe5z
