### PR TITLE
Answer a never-re-keyed rejected press on its client cast id, no SpellPrepare (#394 stuck button)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,9 +22,10 @@ button lit until relog: the client's CAST_FAILED lookup on the server id misses 
 and tears down a transient stub instead (client RE, round 15). Caught live three times on the
 Kronos PTR under the in-process cast-object harness (Heal rank 4, Flash Heal), about one rejected
 heal-spam frame in ten; the same rejected-press shape is routine on a warrior (Sunder Armor
-`UnitNotInfront` / `NotReady`), so the button-only sticks on Sunder, Battle Shout and mounts share
-the trigger. The stuck button is a distinct outcome from the looping cast sound (#394): the object
-never started, so it carries no wind-up effects.
+`UnitNotInfront` / `NotReady`), so it may cover some of the Sunder and Battle Shout button sticks
+(#498 stays open: its sticks self-clear, which is not the pinned shape seen here; #497's mount stick
+is a started cast after dismount and is unaffected). The stuck button is a distinct outcome from
+the looping cast sound (#394): the object never started, so it carries no wind-up effects.
 
 **Change:** `GlobalSessionData.cs` — `ClientCastRequest.PrepareSentToClient` (`HasStarted ||
 HasSentPrepare`), `FailureCastId` (the server id once a PREPARE went out, else the client id) and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,44 @@ A fork of [WowLegacyCore/HermesProxy](https://github.com/WowLegacyCore/HermesPro
 
 ---
 
+## 2026-09-08 — Answer a never-re-keyed rejected press on its client cast id, no SpellPrepare (#517)
+
+**Issue:** a press the server rejects before it STARTs was answered with `SMSG_SPELL_PREPARE`
+(client cast id to server cast id) followed by `SMSG_CAST_FAILED` on the server id. On the 1.14.2
+client that re-key leaves the press's cast object pinned in its casting state with the action
+button lit until relog: the client's CAST_FAILED lookup on the server id misses the re-keyed object
+and tears down a transient stub instead (client RE, round 15). Caught live three times on the
+Kronos PTR under the in-process cast-object harness (Heal rank 4, Flash Heal), about one rejected
+heal-spam frame in ten; the same rejected-press shape is routine on a warrior (Sunder Armor
+`UnitNotInfront` / `NotReady`), so the button-only sticks on Sunder, Battle Shout and mounts share
+the trigger. The stuck button is a distinct outcome from the looping cast sound (#394): the object
+never started, so it carries no wind-up effects.
+
+**Change:** `GlobalSessionData.cs` — `ClientCastRequest.PrepareSentToClient` (`HasStarted ||
+HasSentPrepare`), `FailureCastId` (the server id once a PREPARE went out, else the client id) and
+`NeedsPrepareBeforeFailure` (only an off-GCD press re-keyed at forward time and never started
+repeats its PREPARE). Every emitter that fails a pending press reads them: `WorldSocket.
+SendCastRequestFailed` (`Server/PacketHandlers/SpellHandler.cs`; a never-re-keyed non-pet request
+goes to `SendCastFailedWithoutPrepare` with the caller's reason), the `SMSG_CAST_FAILED` handler
+(`Client/PacketHandlers/SpellHandler.cs`; the dup PREPARE is built only for the off-GCD shape, the
+#491 held item then carries just the CastFailed), and, added at review, the destroy eviction and
+the watchdog eviction (`GlobalSessionData.EvictPendingCastsForDestroyedTarget` /
+`RunWatchdogEviction`), which used the same PREPARE-then-server-id shape for never-started presses.
+The special-slot accept (Shoot / next-melee) now records its forward-time PREPARE in
+`HasSentPrepare` so the rule is complete for those requests too. Unchanged: started casts (re-keyed
+at START, failures keep the server id and the FIFO-pinned id), off-GCD presses, pets, the
+special-slot failure handler. Side change: a movement-cancelled never-started press, previously
+answered on the server id with no PREPARE, now carries the client id the client actually holds.
+
+**Verification:** `RejectedPressFailureShapeTests` (8 cases) pins the rule for every state the
+emitters see. Field A/B on the Kronos PTR, same character, same play, same harness: 3 stuck
+buttons in 28 rejected never-started presses (9 min) before; 0 in 197 (6 min, priest heal spam plus
+warrior Sunder, Bloodthirst, Heroic Strike spam) with the fix, every rejection on the client id
+with no PREPARE. The eviction emitters are covered by the same rule but were not exercised in that
+run; field gate on the next beta.
+
+---
+
 ## 2026-09-06 — Fishing: keep the new channel open when the previous bobber's timeout ends it (#510, Mirasu)
 
 **Issue:** recasting fishing while the previous bobber still exists makes mangos-family servers run

--- a/HermesProxy.Tests/World/RejectedPressFailureShapeTests.cs
+++ b/HermesProxy.Tests/World/RejectedPressFailureShapeTests.cs
@@ -11,9 +11,10 @@ namespace HermesProxy.Tests.World;
 // the proxy sends at SPELL_START (on-GCD) or at forward time (off-GCD). A press that was never
 // re-keyed must fail on the CLIENT id with no PREPARE: re-keying it only to fail it on the
 // server id left the object pinned in its casting state with the action button lit until relog
-// (three live PTR specimens, about one in ten rejected heal-spam frames). Both proxy emitters
-// (WorldSocket.SendCastRequestFailed and the SMSG_CAST_FAILED handler) route through these
-// two members, so pinning them pins the wire shape.
+// (three live PTR specimens, about one in ten rejected heal-spam frames). All four proxy
+// emitters that fail a pending press (WorldSocket.SendCastRequestFailed, the SMSG_CAST_FAILED
+// handler, and the destroy and watchdog evictions in GlobalSessionData) route through
+// FailureCastId and NeedsPrepareBeforeFailure, so pinning them pins the wire shape.
 public class RejectedPressFailureShapeTests
 {
     private static readonly WowGuid128 ClientId = new WowGuid128(5, 0xBC0000000005EC02);
@@ -86,5 +87,43 @@ public class RejectedPressFailureShapeTests
         press.HasSentPrepare = true;
 
         Assert.Equal(ServerId, press.FailureCastId);
+    }
+
+    // === Eviction emitters (destroy eviction, watchdog eviction) share the shape ===
+    // Both used to send a PREPARE for any not-started press and then fail it on the server id,
+    // the exact stranding shape. They now read the same two members as the other emitters.
+
+    [Fact]
+    public void Evicted_NeverPrepared_GetsNoPrepareAndClientId()
+    {
+        // A never-started press whose target was destroyed, or whose SPELL_FAILURE armed the
+        // watchdog and whose trailing CAST_FAILED never came: the client still holds it under
+        // the client id, so no PREPARE and the client id on the failure.
+        var press = MakeCast();
+
+        Assert.False(press.NeedsPrepareBeforeFailure);
+        Assert.Equal(ClientId, press.FailureCastId);
+    }
+
+    [Fact]
+    public void Evicted_OffGcdPrepared_KeepsRepeatPrepareAndServerId()
+    {
+        // An off-GCD press was re-keyed at forward time: the emitter repeats the PREPARE (the
+        // shape that has always been used for it) and fails on the server id.
+        var press = MakeCast(started: false, prepareSent: true);
+
+        Assert.True(press.NeedsPrepareBeforeFailure);
+        Assert.Equal(ServerId, press.FailureCastId);
+    }
+
+    [Fact]
+    public void Evicted_Started_GetsNoPrepareAndServerId()
+    {
+        // A started cast was re-keyed by the START-time PREPARE; the watchdog force-close must
+        // not repeat it and must fail on the server id the FIFO release above it also uses.
+        var cast = MakeCast(started: true, prepareSent: true);
+
+        Assert.False(cast.NeedsPrepareBeforeFailure);
+        Assert.Equal(ServerId, cast.FailureCastId);
     }
 }

--- a/HermesProxy.Tests/World/RejectedPressFailureShapeTests.cs
+++ b/HermesProxy.Tests/World/RejectedPressFailureShapeTests.cs
@@ -1,0 +1,90 @@
+using System;
+using HermesProxy;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// JimsProxy (stuck action button, RE round 15, 2026-09-08): a CAST_FAILED answering a client
+// press must carry the id the 1.14 client's cast object is keyed by at that moment. The client
+// re-keys the object from its own cast id to the server's when it receives SpellPrepare, which
+// the proxy sends at SPELL_START (on-GCD) or at forward time (off-GCD). A press that was never
+// re-keyed must fail on the CLIENT id with no PREPARE: re-keying it only to fail it on the
+// server id left the object pinned in its casting state with the action button lit until relog
+// (three live PTR specimens, about one in ten rejected heal-spam frames). Both proxy emitters
+// (WorldSocket.SendCastRequestFailed and the SMSG_CAST_FAILED handler) route through these
+// two members, so pinning them pins the wire shape.
+public class RejectedPressFailureShapeTests
+{
+    private static readonly WowGuid128 ClientId = new WowGuid128(5, 0xBC0000000005EC02);
+    private static readonly WowGuid128 ServerId = new WowGuid128(10005, 0xBC0004000005EC03);
+
+    private static ClientCastRequest MakeCast(bool started = false, bool prepareSent = false)
+    {
+        return new ClientCastRequest
+        {
+            SpellId = 6064, // Heal rank 4, the first live specimen
+            Timestamp = Environment.TickCount,
+            HasStarted = started,
+            HasSentPrepare = prepareSent,
+            ClientGUID = ClientId,
+            ServerGUID = ServerId,
+        };
+    }
+
+    [Fact]
+    public void NeverStartedNeverPrepared_FailsOnClientId()
+    {
+        // The specimen: press A rejected with SpellInProgress before any START. The client still
+        // holds the object under the client id, so that is the id the failure must carry.
+        var press = MakeCast();
+
+        Assert.False(press.PrepareSentToClient);
+        Assert.Equal(ClientId, press.FailureCastId);
+        Assert.NotEqual(ServerId, press.FailureCastId);
+    }
+
+    [Fact]
+    public void Started_FailsOnServerId()
+    {
+        // A real failure of a cast that STARTED: the client was re-keyed by the START-time
+        // PREPARE, so the failure keeps the server id (unchanged behaviour).
+        var cast = MakeCast(started: true);
+
+        Assert.True(cast.PrepareSentToClient);
+        Assert.Equal(ServerId, cast.FailureCastId);
+    }
+
+    [Fact]
+    public void OffGcdPreparedAtForward_FailsOnServerId()
+    {
+        // An off-GCD press gets its PREPARE at forward time, before any START. Its client object
+        // is already keyed by the server id, so a client-id failure would miss it and strand the
+        // button. It must keep the server id even though it never started.
+        var press = MakeCast(started: false, prepareSent: true);
+
+        Assert.True(press.PrepareSentToClient);
+        Assert.Equal(ServerId, press.FailureCastId);
+    }
+
+    [Fact]
+    public void StartedAndPrepared_FailsOnServerId()
+    {
+        var cast = MakeCast(started: true, prepareSent: true);
+
+        Assert.True(cast.PrepareSentToClient);
+        Assert.Equal(ServerId, cast.FailureCastId);
+    }
+
+    [Fact]
+    public void ForwardTimePrepareFlipsTheRule()
+    {
+        // The same press before and after the off-GCD forward path marks its PREPARE sent.
+        var press = MakeCast();
+        Assert.Equal(ClientId, press.FailureCastId);
+
+        press.HasSentPrepare = true;
+
+        Assert.Equal(ServerId, press.FailureCastId);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -4097,6 +4097,14 @@ public class ClientCastRequest
     // specimens under the in-process harness, about one in ten rejected heal-spam frames).
     public WowGuid128 FailureCastId => PrepareSentToClient ? ServerGUID : ClientGUID;
 
+    // Whether a failure emitted for this press must be preceded by a (repeat) SpellPrepare: only
+    // an off-GCD press that was re-keyed at forward time and never started keeps that shape. A
+    // never-re-keyed press gets no PREPARE at all (the failure goes out on its client id above),
+    // and a started cast was re-keyed by the START-time PREPARE already. Every proxy emitter that
+    // fails a pending press (the request-failed helper, the CAST_FAILED handler, the destroy and
+    // watchdog evictions) reads this and FailureCastId so all four agree on the wire shape.
+    public bool NeedsPrepareBeforeFailure => !HasStarted && HasSentPrepare;
+
     // JimsProxy (held-aware GCD anchoring): true once this press was released from the GCD
     // hold slot by the release timer (ForwardHeldGcdCast) — i.e. the proxy RE-TIMED it.
     // The synthetic GCD-anchor packets (#124 cooldown synth, bb4bb18 GO.CastTime stamp) exist
@@ -4307,7 +4315,12 @@ public class GlobalSessionData
                 target_low = cast.TargetGuid.GetCounter(),
                 had_started = cast.HasStarted,
             });
-            if (!cast.HasStarted)
+            // JimsProxy (stuck action button, review of the client-id failure rule): a never-started
+            // press the client was never told to re-key is failed on its CLIENT id with no PREPARE.
+            // Re-keying it here only to fail it on the server id was the shape that pins the 1.14
+            // client's press object with the action button lit until relog. An off-GCD press that
+            // was re-keyed at forward time keeps the repeat-PREPARE shape (NeedsPrepareBeforeFailure).
+            if (cast.NeedsPrepareBeforeFailure)
             {
                 SpellPrepare prepare = new();
                 prepare.ClientCastID = cast.ClientGUID;
@@ -4318,7 +4331,7 @@ public class GlobalSessionData
             failed.SpellID = cast.SpellId;
             failed.SpellXSpellVisualID = cast.SpellXSpellVisualId;
             failed.Reason = (byte)SpellCastResultClassic.BadTargets;
-            failed.CastID = cast.ServerGUID;
+            failed.CastID = cast.FailureCastId;
             InstanceSocket.SendPacket(failed);
         }
 
@@ -4375,7 +4388,13 @@ public class GlobalSessionData
             // head). The synthetic CastFailed below already carries cast.ServerGUID == that CastID.
             if (cast.HasStarted)
                 GameState.RemoveForwardedStartCastId(cast.SpellId, cast.ServerGUID);
-            if (!cast.HasStarted)
+            // JimsProxy (stuck action button, review of the client-id failure rule): a never-started
+            // press (a SPELL_FAILURE armed the watchdog and Kronos dropped the trailing CAST_FAILED)
+            // is failed on its CLIENT id with no PREPARE, the same rule as the CAST_FAILED handler;
+            // re-keying it here only to fail it on the server id pinned the press object with the
+            // button lit. Started casts keep the server id (FailureCastId) so the FIFO release above
+            // and the failure agree; off-GCD presses keep the repeat-PREPARE shape.
+            if (cast.NeedsPrepareBeforeFailure)
             {
                 SpellPrepare prepare = new();
                 prepare.ClientCastID = cast.ClientGUID;
@@ -4386,7 +4405,7 @@ public class GlobalSessionData
             failed.SpellID = cast.SpellId;
             failed.SpellXSpellVisualID = cast.SpellXSpellVisualId;
             failed.Reason = (byte)SpellCastResultClassic.DontReport;
-            failed.CastID = cast.ServerGUID;
+            failed.CastID = cast.FailureCastId;
             InstanceSocket.SendPacket(failed);
 
             // JimsProxy (transient-no-dismiss-started): under LowLatencyMode, HandleSpellFailure

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -4084,6 +4084,19 @@ public class ClientCastRequest
 
     public bool HasSentPrepare;
 
+    // JimsProxy (stuck action button, RE round 15, 2026-09-08): true once a SpellPrepare
+    // (client cast id -> server cast id) has gone to the client for this press, which is the
+    // moment the 1.14 client re-keys its cast object from the client id to the server id. That
+    // happens at SPELL_START for on-GCD casts and at forward time for off-GCD casts.
+    public bool PrepareSentToClient => HasStarted || HasSentPrepare;
+
+    // The CastID a CAST_FAILED answering this press must carry: the id the client's cast object
+    // is keyed by right now. A press that was never re-keyed stays on its client id. Re-keying it
+    // with a PREPARE only to fail it on the server id is what left the client's press object
+    // pinned in its casting state with the action button lit until relog (three live PTR
+    // specimens under the in-process harness, about one in ten rejected heal-spam frames).
+    public WowGuid128 FailureCastId => PrepareSentToClient ? ServerGUID : ClientGUID;
+
     // JimsProxy (held-aware GCD anchoring): true once this press was released from the GCD
     // hold slot by the release timer (ForwardHeldGcdCast) — i.e. the proxy RE-TIMED it.
     // The synthetic GCD-anchor packets (#124 cooldown synth, bb4bb18 GO.CastTime stamp) exist

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -701,7 +701,7 @@ public partial class WorldClient
             // forward time, so it keeps the old shape (the same PREPARE again, then the server
             // id); a started cast keeps the server id it was re-keyed to at START.
             SpellPrepare? dupPrepare = null;
-            if (!movementSuppressed && !pendingCast.HasStarted && pendingCast.HasSentPrepare)
+            if (!movementSuppressed && pendingCast.NeedsPrepareBeforeFailure)
             {
                 SpellPrepare prepare2 = new SpellPrepare();
                 prepare2.ClientCastID = pendingCast.ClientGUID;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -690,8 +690,18 @@ public partial class WorldClient
             bool holdAsDup = !pendingCast.HasStarted && !movementSuppressed &&
                 GetSession().GameState.HasStartedPendingCastForSpell(spellId);
 
+            // JimsProxy (stuck action button, RE round 15, 2026-09-08): a never-started press used
+            // to get a SpellPrepare (client id -> server id) here and then the CastFailed on the
+            // server id. That re-key left the client's press object pinned in its casting state
+            // with the action button lit until relog (three live PTR specimens under the harness,
+            // about one in ten rejected heal-spam frames, all on this path). A press the client
+            // has never been told to re-key now fails on its CLIENT id with no PREPARE, the
+            // duplicate-drop shape that has never stuck; a rejected press never gets a START or
+            // GO, so the client has no use for the server id. An off-GCD press was re-keyed at
+            // forward time, so it keeps the old shape (the same PREPARE again, then the server
+            // id); a started cast keeps the server id it was re-keyed to at START.
             SpellPrepare? dupPrepare = null;
-            if (!movementSuppressed && !pendingCast.HasStarted)
+            if (!movementSuppressed && !pendingCast.HasStarted && pendingCast.HasSentPrepare)
             {
                 SpellPrepare prepare2 = new SpellPrepare();
                 prepare2.ClientCastID = pendingCast.ClientGUID;
@@ -706,7 +716,7 @@ public partial class WorldClient
             failed.SpellID = pendingCast.SpellId;
             failed.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
             failed.Reason = effectiveReason;
-            failed.CastID = pendingCast.ServerGUID;
+            failed.CastID = pendingCast.FailureCastId;
             // T1 (identity-pinned): a real failure terminates the STARTED cast — stamp it with the
             // recorded START CastID (popped FIFO) and consume the FIFO entry so a later same-spell
             // GO can't pop this now-resolved cast's CastID. Transient dup rejections resolve the

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -83,6 +83,23 @@ public partial class WorldSocket
     }
     public void SendCastRequestFailed(ClientCastRequest castRequest, bool isPet, SpellCastResultClassic reason = SpellCastResultClassic.SpellInProgress)
     {
+        // JimsProxy (stuck action button, RE round 15, 2026-09-08): a player press the client has
+        // never been told to re-key (no SpellPrepare yet: not started, not an off-GCD forward) is
+        // answered on the CLIENT cast id with no SpellPrepare. Re-keying it to a server id only to
+        // fail it is what left the 1.14 client's press object pinned in its casting state with the
+        // action button lit until relog (three live specimens on the PTR under the in-process
+        // harness, about one in ten rejected heal-spam frames: the object survives CAST_FAILED on
+        // the server id because that lookup misses it and tears down a transient stub instead).
+        // The client-id shape is the one the duplicate drop has always used and it has never
+        // stuck, and a rejected press never gets a START or GO, so the client has no use for the
+        // server id. Presses already re-keyed (started, or off-GCD prepared at forward time) and
+        // pets keep the shape below unchanged.
+        if (!castRequest.PrepareSentToClient && !isPet)
+        {
+            SendCastFailedWithoutPrepare(castRequest, reason);
+            return;
+        }
+
         if (!castRequest.HasStarted)
         {
             SpellPrepare prepare2 = new SpellPrepare();

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -314,6 +314,11 @@ public partial class WorldSocket
                 prepare.ClientCastID = cast.Cast.CastID;
                 prepare.ServerCastID = castRequest.ServerGUID;
                 SendPacket(prepare);
+                // JimsProxy (stuck action button, client-id failure rule): this PREPARE re-keys the
+                // client's press object to the server id at forward time, exactly like the off-GCD
+                // path. Record it so any failure emitted for this request later keeps the server id
+                // (FailureCastId) instead of a client id the client no longer holds.
+                castRequest.HasSentPrepare = true;
 
                 currentCast = castRequest;
             }


### PR DESCRIPTION
# What

A player press the server rejects before it STARTs used to be answered with `SMSG_SPELL_PREPARE` (client cast id to server cast id) followed by `SMSG_CAST_FAILED` on the server id. On the 1.14.2 client that re-key leaves the press's cast object pinned in its casting state with the action button lit until relog. The failure now goes out on the client cast id with no PREPARE, the shape the duplicate-drop path has always used.

# The specimen

Caught live three times on the Kronos PTR on 2026-09-07 under an in-process cast-object harness, wire and object side by side (Heal rank 4 cast id 10005, Flash Heal 10087 and 10102):

```
C2S CMSG_CAST_SPELL                 client id 5        press, 156 ms before the running Heal's GO
S2C SMSG_SPELL_GO                   cast id 10003      the running Heal completes
S2C SMSG_SPELL_PREPARE              client 5 -> 10005
S2C SMSG_CAST_FAILED                cast id 10005, SpellInProgress
```

No START for 10005 ever. The harness shows the press object created under the client id, re-keyed to 10005 at the PREPARE, and then never closing: `state=2`, empty held-effect rings, no sound, no pose, for 229 s, 97 s and 33 s until the world teardown at relog. Recasts closed normally beside it and did not clear it. The same frame shape occurred 28 times in nine minutes of heal spam (press 150 to 350 ms before the previous GO, SpellInProgress or NotReady); 3 stuck.

Because the stuck object never started, it carries no wind-up effects, so this is a button-only stick on any spell, cast-time or not. Sunder Armor, Battle Shout and the mounts can only ever present this way (their kits have no looping wind-up sound), and the same rejected-press shape is routine on a warrior: a June Sunder capture has it on Sunder itself (UnitNotInfront) 1.4 minutes before the logout, an August one has fourteen such frames.

# Why the client sticks (client reverse-engineering)

The button highlight is object identity: it stays lit while the press marker resolves to a live cast object in the client's cast-id hash. PREPARE re-keys the press object from the client id to the server id (hash key and the caster-side sibling tables). The CAST_FAILED handler then looks the server id up, misses the re-keyed object, tears down a transient stub instead, and never runs the state recompute that would have written state 0 and unhashed it. State 2 does not decay and the periodic cleanup frees only state-0 objects, so the object and the highlight outlive everything but the world teardown. Without the re-key the object stays under the client id, CAST_FAILED on the client id finds it directly, and the recompute closes it. That is the path the duplicate drop has used for every dropped press without ever sticking. The fix was rated high confidence independent of which function stamps state 2, because it removes the precondition they share. The co-flush with the previous GO (the #491 hold) was checked and is incidental: the exposure exists from the press regardless of flush timing.

# The fix

`ClientCastRequest` gains the rule, and both emitters route through it:

```csharp
public bool PrepareSentToClient => HasStarted || HasSentPrepare;
public WowGuid128 FailureCastId => PrepareSentToClient ? ServerGUID : ClientGUID;
```

- `WorldSocket.SendCastRequestFailed`: a non-pet request the client was never told to re-key goes to `SendCastFailedWithoutPrepare` (client id, the caller's reason). Covers the special-slot "already in progress" reject, abandoned casts, item casts, held dup acks, held cast-time drops and the generic failure ack.
- The `SMSG_CAST_FAILED` handler (the path the specimens took): the failure's `CastID` is `FailureCastId`; the extra PREPARE is built only for a press that was re-keyed at forward time and not started (the off-GCD shape, unchanged). The #491 held item then carries just the `CastFailed`.

Unchanged: started casts (the START-time PREPARE already re-keyed them; a real failure keeps the server id, still pinned to the recorded START id where the FIFO applies); off-GCD presses (PREPARE at forward time, so the client object is already keyed by the server id; a client-id failure would strand them, so they keep the old shape); pets; the special-slot failure path (its PREPARE is sent at forward time); the #491 hold and its release timing.

One side change: a movement-cancelled never-started press, which was answered on the server id with no PREPARE, now also carries the client id, the id the client actually holds for it.

# Testing

- `RejectedPressFailureShapeTests` (5 tests) pins the rule: never re-keyed gives the client id; started gives the server id; off-GCD prepared at forward time gives the server id; the forward-time PREPARE flips the rule. Full suite 966/966. Handler paths are not unit-testable here (no socket fixtures), as for every fix in this area.
- Field A/B on the Kronos PTR, same character, same play, same harness (Build 12, trigger-agnostic stuck-object rule):

| | rejected never-started presses | stuck buttons |
|---|---|---|
| before (2026-09-07, 9 min of heal spam) | 28 | 3 |
| with the fix (2026-09-08, 6 min, priest heal spam plus warrior Sunder, Bloodthirst and Heroic Strike spam) | 197 (SpellInProgress 144, NotReady 40, UnitNotInfront 11, OutOfRange 2) | 0 |

Every rejection went out as `CAST_FAILED` on the client id with no PREPARE (press to answer 109 to 344 ms, median 187). The only PREPARE-then-CAST_FAILED row in the capture is a Heroic Strike re-keyed at forward time and interrupted 735 ms later, the special-slot shape that is unchanged by design. Harness: no object in state 2 with empty rings older than 0.9 s, no persist, no stick. Tester: "No stuck buttons through both sessions. Everything felt fine." At the baseline rate of about one stick in ten frames, 197 clean frames is far outside chance.

# Field gate

Ship on the next beta cut and watch for any lit-button report on a rejected press. A stick that survives this change is a different trigger (an object pinned in state 2 by some other writer) and goes back to the client RE with the harness timeline; the harness rule is trigger-agnostic, so it names the object.

# Interactions

- #394: the stuck button is a distinct outcome from the looping sound (an object with no wind-up attached), so this changes nothing about the sound family; the wind-up mitigations (#488 refire, the by-kit cancel) are separate and not in this PR.
- #498 (Sunder button, self-clears in 20 to 60 s): the rejected-press trigger this removes is routine on Sunder (NotReady, UnitNotInfront), so it may cover some of those sticks; a self-clearing stick is not the pinned shape seen here, so #498 stays open for the field to answer.
- #497 (mount button after dismount): not this shape (that press starts and completes); unaffected.
- #491: the hold and its release timing are unchanged; the held item simply no longer includes a PREPARE.
- #496 (next-melee cast id reuse): the special-slot failure path is untouched.


# Review update (2026-09-10)

The review traced every SpellPrepare emission (12 sites) and every path that fails a pending press. Two more emitters used the same PREPARE-then-server-id shape for a never-started press and were not covered above: the destroy eviction (`EvictPendingCastsForDestroyedTarget`, a press whose target was destroyed before the server answered) and the watchdog eviction (`RunWatchdogEviction`, a press whose SPELL_FAILURE armed the watchdog and whose trailing CAST_FAILED never came). Commit 8cd557a routes both through the same rule (`FailureCastId` plus a new `NeedsPrepareBeforeFailure`, which the CAST_FAILED handler now reads too), records the special-slot forward-time PREPARE in `HasSentPrepare` so the rule is complete for Shoot and next-melee requests, adds three shape tests for the eviction states (suite 1058/1058), and adds the CHANGES.md entry. The branch is rebased onto the current beta.

Holding for an in-game pass before merge: heal spam with presses 150 to 350 ms before the running cast's GO; Sunder and Heroic Strike spam facing away and during the GCD; a queued Heroic Strike interrupted by turning away; a press on a target that despawns before the cast starts; an out-of-range rejection with SuppressSpellCastErrors on and off; an off-GCD press rejected (bandage or potion on cooldown); an item use with no valid target; wand and Auto Shot toggled with the target out of range; a pet ability on cooldown.


Client RE round 18 (2026-09-10, byte-verified): only the proxy's own SpellPrepare ever re-keys a press object, so `HasSentPrepare` is an exact mirror of the re-key; a client-id CAST_FAILED against a re-keyed object strands it (the false-negative direction the special-slot flag guards against; the round-15 specimens themselves failed on the server id after the PREPARE, and their miss is still with the RE), a repeat SpellPrepare on a re-keyed object is an idempotent no-op. Round 19 (same day) then corrected its own account of a lost failure: a never-answered press rests in state 2 and is never swept, so it sits lit until relog unless a CAST_FAILED reaches it under the id the client holds. That makes the client-id failure from the destroy and watchdog evictions load-bearing, not redundant, and reconciles the round-15 specimens as a within-flush binding race on the PREPARE-then-server-id shape, which this PR no longer produces for a never-started press.


