### PR TITLE
CHANGES.md entry and comment qualifier for the explored-zones partial-update fix (#511)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,32 @@ A fork of [WowLegacyCore/HermesProxy](https://github.com/WowLegacyCore/HermesPro
 
 ---
 
+## 2026-09-01 — Map exploration no longer wipes on every new discovery (#511, Mirasu)
+
+**Issue:** each newly discovered subzone darkened a chunk of previously explored world map
+until relog. Two legacy 32-bit `PLAYER_EXPLORED_ZONES` fields pack into one modern 64-bit
+element and the modern update builder always writes the whole element; a mid-session discovery
+dirties exactly ONE legacy field, and `StoreObjectUpdateInternal` composed the untouched half
+from the outgoing `ObjectUpdate` being staged (a fresh object per values block, so always empty
+there), writing 32 zone bits as zero. The 2026-05-01 fix (`cfe445b0`) only corrected the
+parity asymmetry and left that null source in place, so the wipe survived for both parities.
+
+**Change:** `World/Client/PacketHandlers/UpdateHandler.cs`: new `TranslateExploredZones`
+composes each 64-bit element from BOTH 32-bit halves out of the cumulative legacy field dict.
+On the values path `ReadValuesUpdateBlock` merges every update into the session's cached fields
+in place (`ObjectCacheLegacy`, seeded at create), so that dict always holds the latest value of
+both halves. A field the server never sent is genuinely unexplored (zero at create is omitted
+from the mask); untouched pairs stay null so the builder does not resend full exploration
+state on every update. No diagnostics added.
+
+**Verification:** 6 tests (`ExploredZonesTranslationTests`): partial even/odd updates preserve
+the cached half, full-pair composition, unmasked pairs stay null, a missing partner composes as
+unexplored, multiple pairs in one update. Author-verified in-game on Kronos V (three mid-session
+discoveries with the map intact, held across a relog). Review 2026-09-05: values-path dict
+identity traced end to end; suite 967/967 on the PR head.
+
+---
+
 ## 2026-08-29 — Cure the post-Charge stuck-strafe latch (orphaned pending-strafe flag)
 
 **Issue:** after a Charge the character sometimes came out of the spline stuck strafing —

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2028,8 +2028,8 @@ public partial class WorldClient
     // paired half must come from the cumulative `updates` dict (the values path merges into
     // the session's cached fields in place), never from the outgoing update being staged.
     // Composing against the outgoing update zeroed the paired 32 zones on every new
-    // discovery, wiping chunks of the explored map until relog (#331's revert, still
-    // reachable through partial updates).
+    // discovery, wiping chunks of the explored map until relog (the WowLegacyCore/HermesProxy#331
+    // revert, still reachable through partial updates; not this repo's #331).
     internal static void TranslateExploredZones(int legacyBaseField, int legacyFieldCount, BitArray updateMaskArray, Dictionary<int, UpdateField> updates, ulong?[] modernExploredZones)
     {
         for (int i = 0; i < legacyFieldCount; i += 2)


### PR DESCRIPTION
Review housekeeping for #511, now merged: adds the fork-changelog entry the PR lacked, and qualifies the "#331" reference in the new TranslateExploredZones comment as WowLegacyCore/HermesProxy#331, since this repo's own #331 is the unrelated BG-exit movement wedge. No code change.