### PR TITLE
ApiCompat: nil-guard the shim assignments so existing bar functions are never re-written and tainted (#507 stance paging)

### DIFF
--- a/Addons/JimsPlus/ApiCompat.lua
+++ b/Addons/JimsPlus/ApiCompat.lua
@@ -105,32 +105,36 @@ local function InstallShims()
     end
 
     -- 4) Vehicle API: added in Wrath, so "no vehicle" is simply the correct answer on
-    --    a vanilla server. Each is defined only when missing; on a client where these
-    --    do not exist, no secure Blizzard code path can be reading them, so
-    --    addon-defined stubs cannot taint anything.
+    --    a vanilla server. Each is defined only when missing, and the assignment itself
+    --    must only run when missing: a global written by addon code is tainted even when
+    --    the value is unchanged, and some of these DO exist on 1.14.2 and are read by secure
+    --    Blizzard code (ActionBarController_UpdateAll calls HasTempShapeshiftActionBar and
+    --    GetTempShapeshiftBarIndex on every bonus-bar update). The old "X = X or stub" form
+    --    re-assigned those and tainted the action bar paging: stance changes stopped
+    --    switching the buttons.
     local function retFalse() return false end
     local function retNil() return nil end
     local function retZero() return 0 end
     local function noop() end
 
-    UnitHasVehicleUI            = UnitHasVehicleUI            or retFalse
-    UnitHasVehiclePlayerFrameUI = UnitHasVehiclePlayerFrameUI or retFalse
-    UnitInVehicle               = UnitInVehicle               or retFalse
-    UnitControllingVehicle      = UnitControllingVehicle      or retFalse
-    UnitInVehicleControlSeat    = UnitInVehicleControlSeat    or retFalse
-    UnitTargetsVehicleInRaidUI  = UnitTargetsVehicleInRaidUI  or retFalse
-    CanExitVehicle              = CanExitVehicle              or retFalse
-    CanSwitchVehicleSeats       = CanSwitchVehicleSeats       or retFalse
-    UnitVehicleSkin             = UnitVehicleSkin             or retNil
-    UnitVehicleSeatCount        = UnitVehicleSeatCount        or retZero
-    HasVehicleActionBar         = HasVehicleActionBar         or retFalse
-    HasOverrideActionBar        = HasOverrideActionBar        or retFalse
-    HasTempShapeshiftActionBar  = HasTempShapeshiftActionBar  or retFalse
-    GetVehicleBarIndex          = GetVehicleBarIndex          or retNil
-    GetOverrideBarIndex         = GetOverrideBarIndex         or retNil
-    GetTempShapeshiftBarIndex   = GetTempShapeshiftBarIndex   or retNil
-    VehicleExit                 = VehicleExit                 or noop
-    UnitSwitchToVehicleSeat     = UnitSwitchToVehicleSeat     or noop
+    if UnitHasVehicleUI == nil then UnitHasVehicleUI = retFalse end
+    if UnitHasVehiclePlayerFrameUI == nil then UnitHasVehiclePlayerFrameUI = retFalse end
+    if UnitInVehicle == nil then UnitInVehicle = retFalse end
+    if UnitControllingVehicle == nil then UnitControllingVehicle = retFalse end
+    if UnitInVehicleControlSeat == nil then UnitInVehicleControlSeat = retFalse end
+    if UnitTargetsVehicleInRaidUI == nil then UnitTargetsVehicleInRaidUI = retFalse end
+    if CanExitVehicle == nil then CanExitVehicle = retFalse end
+    if CanSwitchVehicleSeats == nil then CanSwitchVehicleSeats = retFalse end
+    if UnitVehicleSkin == nil then UnitVehicleSkin = retNil end
+    if UnitVehicleSeatCount == nil then UnitVehicleSeatCount = retZero end
+    if HasVehicleActionBar == nil then HasVehicleActionBar = retFalse end
+    if HasOverrideActionBar == nil then HasOverrideActionBar = retFalse end
+    if HasTempShapeshiftActionBar == nil then HasTempShapeshiftActionBar = retFalse end
+    if GetVehicleBarIndex == nil then GetVehicleBarIndex = retNil end
+    if GetOverrideBarIndex == nil then GetOverrideBarIndex = retNil end
+    if GetTempShapeshiftBarIndex == nil then GetTempShapeshiftBarIndex = retNil end
+    if VehicleExit == nil then VehicleExit = noop end
+    if UnitSwitchToVehicleSeat == nil then UnitSwitchToVehicleSeat = noop end
 end
 
 local f = CreateFrame("Frame")


### PR DESCRIPTION
## Symptom

On v5.2.1-beta.2, a warrior changing stance no longer gets the main bar paged: the buttons stay on the previous stance's page (reported by Drek, default action bars). Any class with a bonus bar is affected (stances, druid forms, shadowform).

## Cause

`ApiCompat.lua`'s vehicle block writes every name with `X = X or stub`. The `or` protects the value, not the write: the assignment executes whether or not `X` exists, and a global written by addon code is tainted regardless of the value stored.

Two of those names exist on 1.14.2 and are read by secure Blizzard code on every bonus-bar update, in `ActionBarController_UpdateAll`:

```lua
if ( HasBonusActionBar() or HasTempShapeshiftActionBar() ) then
    if (HasTempShapeshiftActionBar()) then
        MainMenuBarArtFrame:SetAttribute("actionpage", GetTempShapeshiftBarIndex());
```

After the re-assignment that path runs tainted, and its `actionpage` attribute set no longer pages the bar.

The restricted environment is not the route: `RestrictedEnvironment.lua` copies those names into the secure scope at Blizzard load, before any addon runs, so secure snippets never see the stubs.

## Fix

Only assign when the global is nil:

```lua
if HasTempShapeshiftActionBar == nil then HasTempShapeshiftActionBar = retFalse end
```

Applied to all eighteen names in the block, so a function the client provides is never written. Comment rewritten to state the rule. No behaviour change for any name that is actually missing.

## Verify

- Before: warrior, default bars, `/console taintLog 1`, change stance: `taint.log` names JimsPlus and `HasTempShapeshiftActionBar`; bar does not page.
- After: bar pages; the shims still install for the missing names.
- Workaround for anyone on beta-2 meanwhile: JimsPlus options, untick "Modern addon API shims", `/reload`.

HermesCompat upstream uses the same idiom and has the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft26iseCDWJSEuo1kPUUUH
