### PR TITLE
Forward SMSG_FEIGN_DEATH_RESISTED so a resisted Feign Death is reported instead of silently greying the button

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3336,6 +3336,16 @@ public partial class WorldClient
         return dbdata;
     }
 
+    // JimsProxy: a creature in combat with the player can resist Feign Death. The server then keeps the aura (the
+    // button greys for the cooldown) but never sets the dead flags, and this packet is the only word the client gets.
+    // Unforwarded, the player sees a greyed button and nothing else (Kronos, 2026-09-11, idle in combat at a dummy).
+    [PacketHandler(Opcode.SMSG_FEIGN_DEATH_RESISTED)]
+    void HandleFeignDeathResisted(WorldPacket packet)
+    {
+        Log.Event("spell.feign_death_resisted", new { });
+        SendPacketToClient(new FeignDeathResisted());
+    }
+
     [PacketHandler(Opcode.SMSG_CANCEL_AUTO_REPEAT)]
     void HandleCancelAutoRepeat(WorldPacket packet)
     {

--- a/HermesProxy/World/Server/Packets/SpellPackets.cs
+++ b/HermesProxy/World/Server/Packets/SpellPackets.cs
@@ -1162,6 +1162,18 @@ public class SpellCastData
     public SpellHealPrediction Predict = new();
 }
 
+// JimsProxy: the server rolled a creature through Feign Death; the client shows "Feign Death resisted" on it.
+public class FeignDeathResisted : ServerPacket, ISpanWritable
+{
+    public FeignDeathResisted() : base(Opcode.SMSG_FEIGN_DEATH_RESISTED) { }
+
+    public override void Write() { }
+
+    public int MaxSize => 0;
+
+    public int WriteToSpan(Span<byte> buffer) => 0;
+}
+
 public struct SpellMissStatus
 {
     public SpellMissStatus(SpellMissInfo reason, SpellMissInfo reflectStatus)


### PR DESCRIPTION
**Issue:** a creature in combat with the player can resist Feign Death. The server then keeps the aura, so the button greys for the cooldown, but never sets the dead flags, and the only word the client gets is `SMSG_FEIGN_DEATH_RESISTED`. The proxy had no handler for that opcode (it logged as `packet.untranslated`), so on a resist the player saw a greyed button and nothing else: no pose, no message, no way to tell a resist from a failed cast.

**Evidence:** Kronos, hunter at a target dummy, `jimsproxy-20260911-102024.jsonl`, with a temporary diagnostic on the local player's `UNIT_DYNAMIC_FLAGS` updates. Three presses. The first two feigned normally: the server set the dead dynamic flag and `UpdateHandler` forwarded it with `UnitFlags2.FeignDeath`. The third, after idling in combat, arrived with `SMSG_FEIGN_DEATH_RESISTED` and no flag change, the unit flags carrying the in-combat bit. The aura applied in all three cases, which is what greyed the button.

**Change:** `Client/PacketHandlers/SpellHandler.cs` gains `HandleFeignDeathResisted`, a passthrough that sends the new `FeignDeathResisted` server packet (`Server/Packets/SpellPackets.cs`); both the legacy and the modern packet are empty. One `spell.feign_death_resisted` event marks it in the log.

**Verification:** field-tested on Kronos: the resist now shows the client's "Feign Death resisted" text, and normal feigns are unchanged. 1075/1075 tests on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfMt474vfrxheQw8Yhm3Y5
