### PR TITLE
JimsPlus: make the ApiCompat shims opt-in (off by default)

### DIFF
--- a/Addons/JimsPlus/ApiCompat.lua
+++ b/Addons/JimsPlus/ApiCompat.lua
@@ -18,8 +18,9 @@
 --     HermesCompat alongside JimsPlus (every shim on both sides is guarded, so
 --     whichever loads first wins and the other no-ops).
 --
--- Toggled by Options > "Modern addon API shims" (JimsPlusDB.apiCompat, default on,
--- /reload to apply). Shims install at our ADDON_LOADED, i.e. before any addon that
+-- Toggled by Options > "Modern addon API shims" (JimsPlusDB.apiCompat, OFF by default
+-- since 1.2.4: opt in only when an addon needs it; /reload to apply). Shims install at
+-- our ADDON_LOADED, i.e. before any addon that
 -- loads after JimsPlus and before PLAYER_LOGIN. Addons that loaded before us and
 -- feature-detect at their own load time are out of reach either way; in practice
 -- these APIs are called at runtime (events), where late definitions cover them.
@@ -144,6 +145,7 @@ f:SetScript("OnEvent", function(self, _, addon)
     self:UnregisterEvent("ADDON_LOADED")
     -- Core.lua registered its ADDON_LOADED handler first (earlier file in the .toc),
     -- so namespace.db is populated by the time this runs.
-    if namespace.db and namespace.db.apiCompat == false then return end
+    -- Opt-in: install only when the player turned the option on (nil or false = off).
+    if not (namespace.db and namespace.db.apiCompat == true) then return end
     InstallShims()
 end)

--- a/Addons/JimsPlus/Core.lua
+++ b/Addons/JimsPlus/Core.lua
@@ -36,6 +36,14 @@ f:SetScript("OnEvent", function(_, _, addon)
     if JimsPlusDB.taxiFix == nil then JimsPlusDB.taxiFix = true end
     if JimsPlusDB.bagSortOrder == nil then JimsPlusDB.bagSortOrder = false end
     if JimsPlusDB.performanceMode == nil then JimsPlusDB.performanceMode = false end
-    if JimsPlusDB.apiCompat == nil then JimsPlusDB.apiCompat = true end
+    -- ApiCompat shims are opt-in from 1.2.4. 1.2.3 turned them on by default and wrote
+    -- apiCompat = true into every SavedVariables on first load without the player choosing
+    -- it, so a plain nil-default would leave every existing install on. Reset once to off;
+    -- after that the player's own setting sticks.
+    if JimsPlusDB.apiCompatDefaultsVersion ~= 2 then
+        JimsPlusDB.apiCompat = false
+        JimsPlusDB.apiCompatDefaultsVersion = 2
+    end
+    if JimsPlusDB.apiCompat == nil then JimsPlusDB.apiCompat = false end
     namespace.db = JimsPlusDB
 end)

--- a/Addons/JimsPlus/Options.lua
+++ b/Addons/JimsPlus/Options.lua
@@ -169,7 +169,7 @@ local cbMoonkinSound = CreateCheckbox(panel, y,
 -- so new rows go sideways rather than down).
 local cbApiCompat = CreateCheckbox(panel, y,
     "Modern addon API shims  |cFFFF6600(reload)|r",
-    "Fills in modern APIs that are missing on the 1.14.2 client so newer\naddons and WeakAuras packs stop erroring: C_Container, the\nC_Spell range check, vehicle API stubs, and a scroll-frame helper.\n\nOnly ever adds what is missing; never overrides anything the\nclient already provides.\n\nBased on HermesCompat by techgeekpr (MIT).\n\nChanges take effect after /reload.",
+    "Fills in modern APIs that are missing on the 1.14.2 client so newer\naddons and WeakAuras packs stop erroring: C_Container, the\nC_Spell range check, vehicle API stubs, and a scroll-frame helper.\n\nOnly ever adds what is missing; never overrides anything the\nclient already provides.\n\nBased on HermesCompat by techgeekpr (MIT).\n\nOff by default; turn it on only if an addon you use needs it.\nChanges take effect after /reload.",
     330)
 y = y - 28
 
@@ -231,7 +231,7 @@ local function RefreshCheckboxes()
     local db = namespace.db or JimsPlusDB or {}
     cbTooltipFix:SetChecked(db.tooltipFix == true)
     cbMoonkinSound:SetChecked(db.moonkinSound ~= false)
-    cbApiCompat:SetChecked(db.apiCompat ~= false)
+    cbApiCompat:SetChecked(db.apiCompat == true)
     cbBowSheathe:SetChecked(db.bowSheatheFix ~= false)
     cbBagSort:SetChecked(db.bagSortOrder ~= false)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,26 @@ A fork of [WowLegacyCore/HermesProxy](https://github.com/WowLegacyCore/HermesPro
 
 ---
 
+## 2026-09-11 — JimsPlus: the ApiCompat shims are opt-in (off by default)
+
+**Issue:** the shims shipped in v5.2.1-beta.2 on by default (#507) and one of them tainted the
+action-bar paging for every stance and form user in combat (#520). Most players run no addon that
+needs the modern APIs, so a default-on compatibility layer exposes everyone to that class of risk
+for the benefit of a few.
+
+**Change:** `Addons/JimsPlus/Core.lua` — `apiCompat` defaults to `false`, with a one-time reset:
+1.2.3 wrote `apiCompat = true` into every SavedVariables on first load without the player choosing
+it, so the defaults are re-applied once (`apiCompatDefaultsVersion = 2`) and the player's own
+choice sticks from then on. `ApiCompat.lua` installs only when the option is explicitly on;
+`Options.lua` reflects the same and the tooltip says the option is off by default. Owner's call
+(2026-09-11). Players who need the shims (WeakAuras packs or addons written for newer clients)
+turn on "Modern addon API shims" in the JimsPlus options and /reload.
+
+**Verification:** Lua 5.1 parse of the three changed files against the beta baseline; the option
+round-trip is part of the beta.3 in-game pass.
+
+---
+
 ## 2026-09-10 — ApiCompat: nil-guard the shim assignments so existing bar functions are never re-written (#520, Mirasu)
 
 **Issue:** on v5.2.1-beta.2 a warrior changing stance in combat no longer got the main bar paged; the


### PR DESCRIPTION
Owner's call for v5.2.1-beta.3: the shims shipped on by default in beta.2 and one of them tainted action-bar paging for every stance and form user in combat (#520). Most players run nothing that needs the modern APIs, so the layer is now off unless turned on in the JimsPlus options (Modern addon API shims, then /reload). 1.2.3 wrote apiCompat = true into every SavedVariables on first load without the player choosing it, so Core.lua re-applies the default once (apiCompatDefaultsVersion = 2) and the player's own choice sticks from then on. ApiCompat.lua installs only when the option is explicitly on; the checkbox and tooltip match. Lua 5.1 parse checked against the beta baseline. CHANGES.md entry included.